### PR TITLE
Refactor molecule and map constructor to accept glRef and export itemReducer in npm package

### DIFF
--- a/baby-gru/cloud/src/MoorhenWrapper.tsx
+++ b/baby-gru/cloud/src/MoorhenWrapper.tsx
@@ -227,7 +227,7 @@ export default class MoorhenWrapper {
 }
 
   async loadMtzData(uniqueId: string, inputFile: string, mapName: string, selectedColumns: moorhen.selectedMtzColumns, colour?: {[type: string]: {r: number, g: number, b: number}}): Promise<moorhen.Map> {
-    const newMap = new MoorhenMap(this.controls.commandCentre)
+    const newMap = new MoorhenMap(this.controls.commandCentre, this.controls.glRef)
     newMap.litLines = this.context.defaultMapLitLines
     newMap.uniqueId = uniqueId
     
@@ -259,7 +259,7 @@ export default class MoorhenWrapper {
   }
 
   async loadPdbData(uniqueId: string, inputFile: string, molName: string): Promise<moorhen.Molecule> {
-    const newMolecule = new MoorhenMolecule(this.controls.commandCentre, this.monomerLibrary)
+    const newMolecule = new MoorhenMolecule(this.controls.commandCentre, this.controls.glRef, this.monomerLibrary)
 
     return new Promise(async (resolve, reject) => {
       try {
@@ -268,8 +268,8 @@ export default class MoorhenWrapper {
         newMolecule.setBackgroundColour(this.controls.glRef.current.background_colour)
         await newMolecule.loadToCootFromURL(inputFile, molName)
         this.controls.changeMolecules({ action: "Add", item: newMolecule })
-        await newMolecule.fetchIfDirtyAndDraw('CBs', this.controls.glRef)
-        await newMolecule.centreOn(this.controls.glRef, '/*/*/*/*', false)
+        await newMolecule.fetchIfDirtyAndDraw('CBs')
+        await newMolecule.centreOn('/*/*/*/*', false)
         return resolve(newMolecule)
       } catch (err) {
         console.log(`Cannot fetch molecule from ${inputFile}`)
@@ -392,11 +392,11 @@ export default class MoorhenWrapper {
         return this.loadPdbData(inputFile.uniqueId, ...inputFile.args).catch((err) => console.log(err))
       } else {
         const oldUnitCellParams = JSON.stringify(loadedMolecule.getUnitCellParams())
-        return loadedMolecule.replaceModelWithFile(this.controls.glRef, ...inputFile.args)
+        return loadedMolecule.replaceModelWithFile(...inputFile.args)
           .then(_ => {
             const newUnitCellParams = JSON.stringify(loadedMolecule.getUnitCellParams())
             if (oldUnitCellParams !== newUnitCellParams) {
-              loadedMolecule.centreOn(this.controls.glRef, '/*/*/*/*', true)
+              loadedMolecule.centreOn('/*/*/*/*', true)
             }   
           })
           .catch((err) => {
@@ -413,7 +413,7 @@ export default class MoorhenWrapper {
       if (typeof loadedMap === 'undefined') {
         return this.loadMtzData(inputFile.uniqueId, ...inputFile.args).catch((err) => console.log(err))
       } else {
-        return loadedMap.replaceMapWithMtzFile(this.controls.glRef, ...inputFile.args).catch((err) => console.log(err))
+        return loadedMap.replaceMapWithMtzFile(...inputFile.args).catch((err) => console.log(err))
       }
     }))
   }

--- a/baby-gru/cloud/src/components/MoorhenCloudApp.tsx
+++ b/baby-gru/cloud/src/components/MoorhenCloudApp.tsx
@@ -2,7 +2,7 @@ import { useRef, useState, useReducer, useContext, useEffect, useCallback } from
 import { MenuItem } from '@mui/material'
 import { MoorhenContext } from "../../../src/utils/MoorhenContext"
 import { MoorhenContainer, MoorhenContainerPropsInterface, MoorhenControlsInterface } from "../../../src/components/MoorhenContainer"
-import { itemReducer } from "../../../src/components/MoorhenApp"
+import { itemReducer } from "../../../src/utils/MoorhenUtils"
 import { isDarkBackground } from "../../../src/WebGLgComponents/mgWebGL"
 import { MoorhenLegendToast } from './MoorhenLegendToast'
 import { moorhen } from "../../../src/types/moorhen";
@@ -86,7 +86,7 @@ export const MoorhenCloudApp = (props: MoorhenCloudAppPropsInterface) => {
             await Promise.all(
                 maps.map((map: moorhen.Map) => {
                   return map.doCootContour(
-                    glRef, ...glRef.current.origin.map(coord => -coord) as [number, number, number], map.mapRadius, map.contourLevel
+                    ...glRef.current.origin.map(coord => -coord) as [number, number, number], map.mapRadius, map.contourLevel
                   )     
                 })
             )
@@ -153,7 +153,7 @@ export const MoorhenCloudApp = (props: MoorhenCloudAppPropsInterface) => {
         if (props.viewOnly && maps.length > 0) {
             maps.forEach((map: moorhen.Map) => {
                 map.doCootContour(
-                    glRef, ...glRef.current.origin.map(coord => -coord) as [number, number, number], 13.0, 0.8
+                    ...glRef.current.origin.map(coord => -coord) as [number, number, number], 13.0, 0.8
               )
             })
         }
@@ -169,7 +169,7 @@ export const MoorhenCloudApp = (props: MoorhenCloudAppPropsInterface) => {
                 if (molecule.cootBondsOptions.isDarkBackground !== newBackgroundIsDark) {
                     molecule.cootBondsOptions.isDarkBackground = newBackgroundIsDark
                     molecule.setAtomsDirty(true)
-                    return molecule.redraw(glRef)
+                    return molecule.redraw()
                 }
                 return Promise.resolve()
             }))

--- a/baby-gru/src/components/MoorhenApp.tsx
+++ b/baby-gru/src/components/MoorhenApp.tsx
@@ -5,22 +5,7 @@ import { MoorhenContainer } from "./MoorhenContainer"
 import { moorhen } from '../types/moorhen';
 import { webGL } from '../types/mgWebGL';
 import { MoorhenControlsInterface } from "./MoorhenContainer"
-
-export function itemReducer<T extends moorhen.Molecule | moorhen.Map> (oldList: T[], change: moorhen.MolChange<T>): T[] {
-    if (change.action === 'Add') {
-        return [...oldList, change.item]
-    }
-    else if (change.action === 'Remove') {
-        return oldList.filter(item =>  item.molNo !== change.item.molNo)
-    }
-    else if (change.action === 'AddList') {
-        return oldList.concat(change.items)
-    }
-    else if (change.action === 'Empty') {
-        return []
-    }
-    return oldList
-}
+import { itemReducer } from '../utils/MoorhenUtils';
 
 const initialMoleculesState: moorhen.Molecule[] = []
 

--- a/baby-gru/src/components/MoorhenContainer.tsx
+++ b/baby-gru/src/components/MoorhenContainer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useCallback, useReducer, useRef, useState, useContext } from 'react';
 import { Container, Col, Row, Spinner, Toast, ToastContainer } from 'react-bootstrap';
 import { MoorhenWebMG } from './webMG/MoorhenWebMG';
-import { convertRemToPx, convertViewtoPx, getTooltipShortcutLabel, createLocalStorageInstance, allFontsSet } from '../utils/MoorhenUtils';
+import { convertRemToPx, convertViewtoPx, getTooltipShortcutLabel, createLocalStorageInstance, allFontsSet, itemReducer } from '../utils/MoorhenUtils';
 import { historyReducer, initialHistoryState } from './navbar-menus/MoorhenHistoryMenu';
 import { MoorhenCommandCentre } from "../utils/MoorhenCommandCentre"
 import { MoorhenContext } from "../utils/MoorhenContext";
@@ -14,7 +14,6 @@ import { isDarkBackground } from '../WebGLgComponents/mgWebGL'
 import { MoorhenNavBar } from "./navbar-menus/MoorhenNavBar"
 import { moorhen } from '../types/moorhen';
 import { webGL } from '../types/mgWebGL';
-import { itemReducer } from "./MoorhenApp"
 
 const initialMoleculesState: moorhen.Molecule[] = []
 
@@ -394,7 +393,7 @@ export const MoorhenContainer = (props: MoorhenContainerPropsInterface) => {
                 hoveredAtom.molecule !== lastHoveredAtom.current.molecule ||
                 hoveredAtom.cid !== lastHoveredAtom.current.cid
             ) {
-                hoveredAtom.molecule.drawHover(glRef, hoveredAtom.cid)
+                hoveredAtom.molecule.drawHover(hoveredAtom.cid)
                 //if we have changed molecule, might have to clean up hover display item of previous molecule
             }
         }
@@ -403,7 +402,7 @@ export const MoorhenContainer = (props: MoorhenContainerPropsInterface) => {
             lastHoveredAtom.current.molecule !== null &&
             lastHoveredAtom.current.molecule !== hoveredAtom.molecule
         ) {
-            lastHoveredAtom.current.molecule.clearBuffersOfStyle("hover", glRef)
+            lastHoveredAtom.current.molecule.clearBuffersOfStyle("hover")
         }
 
         lastHoveredAtom.current = hoveredAtom
@@ -432,7 +431,7 @@ export const MoorhenContainer = (props: MoorhenContainerPropsInterface) => {
                 glRef.current.setActiveMolecule(null)
         }
         if (prevActiveMoleculeRef.current) {
-            prevActiveMoleculeRef.current.applyTransform(glRef).then(() => resetActiveGL())
+            prevActiveMoleculeRef.current.applyTransform().then(() => resetActiveGL())
         } else {
             resetActiveGL()
         }

--- a/baby-gru/src/components/button/MoorhenAddSimpleButton.tsx
+++ b/baby-gru/src/components/button/MoorhenAddSimpleButton.tsx
@@ -12,7 +12,7 @@ export const MoorhenAddSimpleButton = (props: moorhen.EditButtonProps) => {
     const onTypeSelectedCallback = useCallback(async (value: string) => {
         const selectedMolecule = props.molecules.find(molecule => molecule.molNo === parseInt(selectRef.current.value))
         if (selectedMolecule) {
-            await selectedMolecule.addLigandOfType(value, props.glRef)
+            await selectedMolecule.addLigandOfType(value)
             props.setSelectedButtonIndex(null)
             const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: selectedMolecule.molNo } })
             document.dispatchEvent(scoresUpdateEvent)

--- a/baby-gru/src/components/button/MoorhenContextButtonBase.tsx
+++ b/baby-gru/src/components/button/MoorhenContextButtonBase.tsx
@@ -118,9 +118,9 @@ export const MoorhenContextButtonBase = (props: {
         const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: props.selectedMolecule.molNo } })
         document.dispatchEvent(scoresUpdateEvent)
         props.selectedMolecule.setAtomsDirty(true)
-        props.selectedMolecule.clearBuffersOfStyle('hover', props.glRef)
+        props.selectedMolecule.clearBuffersOfStyle('hover')
         await Promise.all([
-            props.selectedMolecule.redraw(props.glRef),
+            props.selectedMolecule.redraw(),
             props.timeCapsuleRef.current.addModification() 
         ])
       

--- a/baby-gru/src/components/button/MoorhenDeleteButton.tsx
+++ b/baby-gru/src/components/button/MoorhenDeleteButton.tsx
@@ -53,7 +53,7 @@ export const MoorhenDeleteButton = (props: moorhen.EditButtonProps | moorhen.Con
     const deleteMoleculeIfEmpty = (molecule: moorhen.Molecule, chosenAtom: moorhen.ResidueSpec, cootResult: moorhen.WorkerResponse<libcootApi.PairType<number, number>>) => {
         if (cootResult.data.result.result.second < 1) {
             console.log('Empty molecule detected, deleting it now...')
-            molecule.delete(props.glRef)
+            molecule.delete()
             props.changeMolecules({ action: 'Remove', item: molecule })
         }
     }

--- a/baby-gru/src/components/button/MoorhenEditButtonBase.tsx
+++ b/baby-gru/src/components/button/MoorhenEditButtonBase.tsx
@@ -75,8 +75,8 @@ export const MoorhenEditButtonBase = forwardRef<HTMLButtonElement, MoorhenEditBu
                 }
             }
             molecule.setAtomsDirty(true)
-            molecule.clearBuffersOfStyle('hover', props.glRef)
-            await molecule.redraw(props.glRef)
+            molecule.clearBuffersOfStyle('hover')
+            await molecule.redraw()
             const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: molecule.molNo } })
             document.dispatchEvent(scoresUpdateEvent)
             if (props.onExit) {

--- a/baby-gru/src/components/button/MoorhenRotamerChangeButton.tsx
+++ b/baby-gru/src/components/button/MoorhenRotamerChangeButton.tsx
@@ -25,13 +25,12 @@ export const MoorhenRotamerChangeButton = (props: moorhen.EditButtonProps | moor
         }, true) as moorhen.WorkerResponse<libcootApi.RotamerInfoJS>
         
         fragmentMolecule.current.atomsDirty = true
-        fragmentMolecule.current.clearBuffersOfStyle('selection', props.glRef)
-        fragmentMolecule.current.drawSelection(props.glRef, selectedFragmentRef.current.cid)
-        await fragmentMolecule.current.redraw(props.glRef)
+        fragmentMolecule.current.clearBuffersOfStyle('selection')
+        await fragmentMolecule.current.redraw()
         
         return rotamerInfo
     
-    }, [props.commandCentre, props.glRef])
+    }, [props.commandCentre])
 
     const acceptTransform = useCallback(async () => {
         await props.commandCentre.current.cootCommand({
@@ -41,21 +40,21 @@ export const MoorhenRotamerChangeButton = (props: moorhen.EditButtonProps | moor
         }, true)
         
         chosenMolecule.current.atomsDirty = true
-        await chosenMolecule.current.redraw(props.glRef)
+        await chosenMolecule.current.redraw()
         props.changeMolecules({ action: 'Remove', item: fragmentMolecule.current })
-        fragmentMolecule.current.delete(props.glRef)
-        chosenMolecule.current.unhideAll(props.glRef)
+        fragmentMolecule.current.delete()
+        chosenMolecule.current.unhideAll()
         
         const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: chosenMolecule.current.molNo } })
         document.dispatchEvent(scoresUpdateEvent)
     
-    }, [props.changeMolecules, props.glRef, props.commandCentre])
+    }, [props.changeMolecules, props.commandCentre, props.glRef])
 
     const rejectTransform = useCallback(async () => {
         props.changeMolecules({ action: 'Remove', item: fragmentMolecule.current })
-        fragmentMolecule.current.delete(props.glRef)
-        chosenMolecule.current.unhideAll(props.glRef)
-    }, [props.changeMolecules, props.glRef])
+        fragmentMolecule.current.delete()
+        chosenMolecule.current.unhideAll()
+    }, [props.changeMolecules])
 
     const doRotamerChange = async (molecule: moorhen.Molecule, chosenAtom: moorhen.ResidueSpec, p: string = '') => {
         chosenMolecule.current = molecule
@@ -66,7 +65,7 @@ export const MoorhenRotamerChangeButton = (props: moorhen.EditButtonProps | moor
         }
         
         /* Copy the component to move into a new molecule */
-        const newMolecule = await molecule.copyFragmentUsingCid(selectedFragmentRef.current.cid, props.backgroundColor, props.defaultBondSmoothness, props.glRef, false)
+        const newMolecule = await molecule.copyFragmentUsingCid(selectedFragmentRef.current.cid, props.backgroundColor, props.defaultBondSmoothness, false)
         
         /* Next rotaner */
         const rotamerInfo = await props.commandCentre.current.cootCommand({
@@ -78,14 +77,13 @@ export const MoorhenRotamerChangeButton = (props: moorhen.EditButtonProps | moor
         
         /* redraw after delay so that the context menu does not refresh empty */
         setTimeout(() => {
-            chosenMolecule.current.hideCid(selectedFragmentRef.current.cid, props.glRef)
-            newMolecule.drawSelection(props.glRef, selectedFragmentRef.current.cid)
+            chosenMolecule.current.hideCid(selectedFragmentRef.current.cid)
             Object.keys(molecule.displayObjects)
                 .filter(style => { return ['CRs', 'CBs', 'ligands', 'gaussian', 'MolecularSurface', 'VdWSurface', 'DishyBases', 'VdwSpheres', 'allHBonds'].includes(style) })
                 .forEach(async style => {
                     if (molecule.displayObjects[style].length > 0 &&
                         molecule.displayObjects[style][0].visible) {
-                        await newMolecule.drawWithStyleFromAtoms(style, props.glRef)
+                        await newMolecule.drawWithStyleFromAtoms(style)
                     }
             })
            

--- a/baby-gru/src/components/button/MoorhenRotateTranslateZoneButton.tsx
+++ b/baby-gru/src/components/button/MoorhenRotateTranslateZoneButton.tsx
@@ -36,11 +36,11 @@ export const MoorhenRotateTranslateZoneButton = (props: moorhen.EditButtonProps 
 
     const acceptTransform = useCallback(async () => {
         props.glRef.current.setActiveMolecule(null)
-        const transformedAtoms = fragmentMolecule.current.transformedCachedAtomsAsMovedAtoms(props.glRef)
-        await chosenMolecule.current.updateWithMovedAtoms(transformedAtoms, props.glRef)
+        const transformedAtoms = fragmentMolecule.current.transformedCachedAtomsAsMovedAtoms()
+        await chosenMolecule.current.updateWithMovedAtoms(transformedAtoms)
         props.changeMolecules({ action: 'Remove', item: fragmentMolecule.current })
-        fragmentMolecule.current.delete(props.glRef)
-        chosenMolecule.current.unhideAll(props.glRef)
+        fragmentMolecule.current.delete()
+        chosenMolecule.current.unhideAll()
         const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: chosenMolecule.current.molNo } })
         document.dispatchEvent(scoresUpdateEvent)
     }, [props, chosenMolecule, fragmentMolecule])
@@ -48,8 +48,8 @@ export const MoorhenRotateTranslateZoneButton = (props: moorhen.EditButtonProps 
     const rejectTransform = useCallback(async () => {
         props.glRef.current.setActiveMolecule(null)
         props.changeMolecules({ action: 'Remove', item: fragmentMolecule.current })
-        fragmentMolecule.current.delete(props.glRef)
-        chosenMolecule.current.unhideAll(props.glRef)
+        fragmentMolecule.current.delete()
+        chosenMolecule.current.unhideAll()
     }, [props, chosenMolecule, fragmentMolecule])
 
     const startRotateTranslate = async (molecule: moorhen.Molecule, chosenAtom: moorhen.ResidueSpec, selectedMode: string) => {
@@ -83,18 +83,18 @@ export const MoorhenRotateTranslateZoneButton = (props: moorhen.EditButtonProps 
         }
         /* Copy the component to move into a new molecule */
         const newMolecule = await molecule.copyFragmentUsingCid(
-            fragmentCid.current, props.backgroundColor, props.defaultBondSmoothness, props.glRef, false
+            fragmentCid.current, props.backgroundColor, props.defaultBondSmoothness, false
         )
         await newMolecule.updateAtoms()
         /* redraw after delay so that the context menu does not refresh empty */
         setTimeout(() => {
-            chosenMolecule.current.hideCid(fragmentCid.current, props.glRef)
+            chosenMolecule.current.hideCid(fragmentCid.current)
             Object.keys(molecule.displayObjects)
             .filter(style => { return ['CRs', 'CBs', 'ligands', 'gaussian', 'MolecularSurface', 'VdWSurface', 'DishyBases', 'VdwSpheres', 'allHBonds'].includes(style) })
             .forEach(async style => {
                 if (molecule.displayObjects[style].length > 0 &&
                     molecule.displayObjects[style][0].visible) {
-                    await newMolecule.drawWithStyleFromAtoms(style, props.glRef)
+                    await newMolecule.drawWithStyleFromAtoms(style)
                 }
             })
             fragmentMolecule.current = newMolecule

--- a/baby-gru/src/components/card/MoorhenMapCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMapCard.tsx
@@ -66,7 +66,7 @@ export const MoorhenMapCard = (props: MoorhenMapCardPropsInterface) => {
 
     const handlePositiveMapColorChange = (color: { rgb: {r: number; g: number; b: number;} }) => {
         try {
-            props.map.setDiffMapColour('positiveDiffColour', color.rgb.r / 255., color.rgb.g / 255., color.rgb.b / 255., props.glRef)
+            props.map.setDiffMapColour('positiveDiffColour', color.rgb.r / 255., color.rgb.g / 255., color.rgb.b / 255.)
             setPositiveMapColour({r: color.rgb.r, g: color.rgb.g, b: color.rgb.b})
         }
         catch (err) {
@@ -76,7 +76,7 @@ export const MoorhenMapCard = (props: MoorhenMapCardPropsInterface) => {
 
     const handleNegativeMapColorChange = (color: { rgb: {r: number; g: number; b: number;} }) => {
         try {
-            props.map.setDiffMapColour('negativeDiffColour', color.rgb.r / 255., color.rgb.g / 255., color.rgb.b / 255., props.glRef)
+            props.map.setDiffMapColour('negativeDiffColour', color.rgb.r / 255., color.rgb.g / 255., color.rgb.b / 255.)
             setNegativeMapColour({r: color.rgb.r, g: color.rgb.g, b: color.rgb.b})
         }
         catch (err) {
@@ -86,7 +86,7 @@ export const MoorhenMapCard = (props: MoorhenMapCardPropsInterface) => {
 
     const handleColorChange = (color: { rgb: {r: number; g: number; b: number;} }) => {
         try {
-            props.map.setColour(color.rgb.r / 255., color.rgb.g / 255., color.rgb.b / 255., props.glRef)
+            props.map.setColour(color.rgb.r / 255., color.rgb.g / 255., color.rgb.b / 255.)
             setMapColour({r: color.rgb.r, g: color.rgb.g, b: color.rgb.b})
         }
         catch (err) {
@@ -107,10 +107,10 @@ export const MoorhenMapCard = (props: MoorhenMapCardPropsInterface) => {
     const handleVisibility = () => {
         if (!cootContour) {
             props.map.mapRadius = mapRadius
-            props.map.makeCootLive(props.glRef)
+            props.map.makeCootLive()
             setCootContour(true)
         } else {
-            props.map.makeCootUnlive(props.glRef)
+            props.map.makeCootUnlive()
             setCootContour(false)
         }
         props.setCurrentDropdownMolNo(-1)
@@ -161,7 +161,7 @@ export const MoorhenMapCard = (props: MoorhenMapCardPropsInterface) => {
         },
         6: {
             label: "Centre on map",
-            compressed: () => { return (<MenuItem key='centre-on-map'onClick={() => props.map.centreOnMap(props.glRef)}>Centre on map</MenuItem>) },
+            compressed: () => { return (<MenuItem key='centre-on-map'onClick={() => props.map.centreOnMap()}>Centre on map</MenuItem>) },
             expanded: null
         },
     }
@@ -220,14 +220,14 @@ export const MoorhenMapCard = (props: MoorhenMapCardPropsInterface) => {
         if (isDirty.current) {
             busyContouring.current = true
             isDirty.current = false
-            props.map.doCootContour(props.glRef,
+            props.map.doCootContour(
                 ...nextOrigin.current as [number, number, number],
                 props.map.mapRadius,
-                props.map.contourLevel)
-                .then(() => {
-                    busyContouring.current = false
-                    doContourIfDirty()
-                })
+                props.map.contourLevel
+            ).then(() => {
+                busyContouring.current = false
+                doContourIfDirty()
+            })
         }
     }
 
@@ -301,7 +301,7 @@ export const MoorhenMapCard = (props: MoorhenMapCardPropsInterface) => {
     }, [handleOriginUpdate, props.activeMap?.molNo]);
 
     useEffect(() => {
-        props.map.setAlpha(mapOpacity, props.glRef)
+        props.map.setAlpha(mapOpacity)
     }, [mapOpacity])
 
     useEffect(() => {

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -69,7 +69,7 @@ export const MoorhenMoleculeCard = (props: MoorhenMoleculeCardPropsInterface) =>
             busyRedrawing.current = true
             isDirty.current = false
             props.molecule.setAtomsDirty(true)
-            await props.molecule.redraw(props.glRef)
+            await props.molecule.redraw()
             busyRedrawing.current = false
             redrawMolIfDirty()
         }
@@ -79,7 +79,7 @@ export const MoorhenMoleculeCard = (props: MoorhenMoleculeCardPropsInterface) =>
         if (isDirty.current) {
             busyRedrawing.current = true
             isDirty.current = false
-            props.molecule.drawSymmetry(props.glRef)
+            props.molecule.drawSymmetry()
             .then(_ => {
                 busyRedrawing.current = false
                 redrawSymmetryIfDirty()
@@ -102,7 +102,7 @@ export const MoorhenMoleculeCard = (props: MoorhenMoleculeCardPropsInterface) =>
 
         if (isVisible && showState['CBs']) {
             props.molecule.setAtomsDirty(true)
-            props.molecule.redraw(props.glRef)
+            props.molecule.redraw()
         }
 
     }, [props.drawMissingLoops])
@@ -117,7 +117,7 @@ export const MoorhenMoleculeCard = (props: MoorhenMoleculeCardPropsInterface) =>
             if (props.molecule.cootBondsOptions.isDarkBackground !== newBackgroundIsDark) {
                 props.molecule.cootBondsOptions.isDarkBackground = newBackgroundIsDark
                 props.molecule.setAtomsDirty(true)
-                props.molecule.redraw(props.glRef)
+                props.molecule.redraw()
             }
         }
 
@@ -179,7 +179,7 @@ export const MoorhenMoleculeCard = (props: MoorhenMoleculeCardPropsInterface) =>
         if (symmetryRadius === null) {
             return
         }
-        props.molecule.setSymmetryRadius(symmetryRadius, props.glRef)
+        props.molecule.setSymmetryRadius(symmetryRadius)
     }, [symmetryRadius]);
 
     useEffect(() => {
@@ -274,7 +274,7 @@ export const MoorhenMoleculeCard = (props: MoorhenMoleculeCardPropsInterface) =>
             return
         }
 
-        props.molecule.centreOn(props.glRef, `/*/${clickedResidue.chain}/${clickedResidue.seqNum}-${clickedResidue.seqNum}/*`)
+        props.molecule.centreOn(`/*/${clickedResidue.chain}/${clickedResidue.seqNum}-${clickedResidue.seqNum}/*`)
 
     }, [clickedResidue])
 
@@ -289,12 +289,12 @@ export const MoorhenMoleculeCard = (props: MoorhenMoleculeCardPropsInterface) =>
     const handleVisibility = () => {
         if (isVisible) {
             Object.getOwnPropertyNames(props.molecule.displayObjects).forEach(key => {
-                if (showState[key]) { props.molecule.hide(key, props.glRef) }
+                if (showState[key]) { props.molecule.hide(key) }
             })
             setIsVisible(false)
         } else {
             Object.getOwnPropertyNames(props.molecule.displayObjects).forEach(key => {
-                if (showState[key]) { props.molecule.show(key, props.glRef) }
+                if (showState[key]) { props.molecule.show(key) }
             })
             setIsVisible(true)
         }
@@ -309,7 +309,7 @@ export const MoorhenMoleculeCard = (props: MoorhenMoleculeCardPropsInterface) =>
 
     const handleCopyFragment = () => {
         async function createNewFragmentMolecule() {
-            const newMolecule = await props.molecule.copyFragment(clickedResidue.chain, selectedResidues[0], selectedResidues[1], props.glRef)
+            const newMolecule = await props.molecule.copyFragment(clickedResidue.chain, selectedResidues[0], selectedResidues[1])
             props.changeMolecules({ action: "Add", item: newMolecule })
         }
 
@@ -321,7 +321,7 @@ export const MoorhenMoleculeCard = (props: MoorhenMoleculeCardPropsInterface) =>
     }
 
     const handleUndo = async () => {
-        await props.molecule.undo(props.glRef)
+        await props.molecule.undo()
         props.setCurrentDropdownMolNo(-1)
         const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", {
             detail: { origin: props.glRef.current.origin, modifiedMolecule: props.molecule.molNo } 
@@ -330,7 +330,7 @@ export const MoorhenMoleculeCard = (props: MoorhenMoleculeCardPropsInterface) =>
     }
 
     const handleRedo = async () => {
-        await props.molecule.redo(props.glRef)
+        await props.molecule.redo()
         props.setCurrentDropdownMolNo(-1)
         const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", {
             detail: { origin: props.glRef.current.origin, modifiedMolecule: props.molecule.molNo } 
@@ -339,7 +339,7 @@ export const MoorhenMoleculeCard = (props: MoorhenMoleculeCardPropsInterface) =>
     }
 
     const handleCentering = () => {
-        props.molecule.centreOn(props.glRef)
+        props.molecule.centreOn()
         props.setCurrentDropdownMolNo(-1)
     }
 
@@ -367,7 +367,7 @@ export const MoorhenMoleculeCard = (props: MoorhenMoleculeCardPropsInterface) =>
             }, true)
 
             props.molecule.setAtomsDirty(true)
-            props.molecule.redraw(props.glRef)
+            props.molecule.redraw()
         }
 
         if (clickedResidue && selectedResidues) {
@@ -523,10 +523,10 @@ const RepresentationCheckbox = (props: RepresetationCheckboxPropsType) => {
         onChange={(e) => {
             props.changeShowState({ key: props.repKey, state: e.target.checked })
             if (e.target.checked) {
-                props.molecule.show(props.repKey, props.glRef)
+                props.molecule.show(props.repKey)
             }
             else {
-                props.molecule.hide(props.repKey, props.glRef)
+                props.molecule.hide(props.repKey)
             }
         }}/>
 }

--- a/baby-gru/src/components/list/MoorhenLigandList.tsx
+++ b/baby-gru/src/components/list/MoorhenLigandList.tsx
@@ -137,7 +137,7 @@ export const MoorhenLigandList = (props: {
                                                                 title={`${ligand.chainName}/${ligand.resNum}(${ligand.resName})`}
                                                                 variant="outlined"
                                                                 >
-                                                                <MenuItem onClick={() => {props.molecule.centreOn(props.glRef, `/*/${ligand.chainName}/${ligand.resNum}-${ligand.resNum}/*`)}}>
+                                                                <MenuItem onClick={() => {props.molecule.centreOn(`/*/${ligand.chainName}/${ligand.resNum}-${ligand.resNum}/*`)}}>
                                                                     Center on ligand
                                                                 </MenuItem>
                                                                 <hr></hr>
@@ -150,13 +150,13 @@ export const MoorhenLigandList = (props: {
                                                                     checked={showState[keycd]}
                                                                     onChange={(e) => {
                                                                         if (e.target.checked) {
-                                                                            props.molecule.show(keycd, props.glRef)
+                                                                            props.molecule.show(keycd)
                                                                             const changedState = { ...showState }
                                                                             changedState[keycd] = true
                                                                             setShowState(changedState)
                                                                         }
                                                                         else {
-                                                                            props.molecule.hide(keycd, props.glRef)
+                                                                            props.molecule.hide(keycd)
                                                                             const changedState = { ...showState }
                                                                             changedState[keycd] = false
                                                                             setShowState(changedState)
@@ -170,13 +170,13 @@ export const MoorhenLigandList = (props: {
                                                                     style={{'margin': '0.5rem'}}
                                                                     onChange={(e) => {
                                                                         if (e.target.checked) {
-                                                                            props.molecule.show(keycf, props.glRef)
+                                                                            props.molecule.show(keycf)
                                                                             const changedState = { ...showState }
                                                                             changedState[keycf] = true
                                                                             setShowState(changedState)
                                                                         }
                                                                         else {
-                                                                            props.molecule.hide(keycf, props.glRef)
+                                                                            props.molecule.hide(keycf)
                                                                             const changedState = { ...showState }
                                                                             changedState[keycf] = false
                                                                             setShowState(changedState)

--- a/baby-gru/src/components/menu-item/MoorhenAddRemoveHydrogenAtomsMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenAddRemoveHydrogenAtomsMenuItem.tsx
@@ -26,11 +26,11 @@ export const MoorhenAddRemoveHydrogenAtomsMenuItem = (props: {
             })
             const selectedMolecule = props.molecules.find(molecule => molecule.molNo === selectedMolNo)
             selectedMolecule.setAtomsDirty(true)
-            selectedMolecule.redraw(props.glRef)
+            selectedMolecule.redraw()
             document.body.click()
             document.body.click()
         }
-    }, [moleculeSelectRef, props.molecules, props.glRef, props.commandCentre])
+    }, [moleculeSelectRef, props.molecules, props.commandCentre])
 
     const panelContent = <Form.Group>
         <MoorhenMoleculeSelect {...props} label="Molecule" allowAny={false} ref={moleculeSelectRef} />

--- a/baby-gru/src/components/menu-item/MoorhenAddSimpleMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenAddSimpleMenuItem.tsx
@@ -30,7 +30,7 @@ export const MoorhenAddSimpleMenuItem = (props: {
     const onCompleted = useCallback(async () => {
         const selectedMolecule = props.molecules.find(molecule => molecule.molNo === parseInt(moleculeSelectRef.current.value))
         if (selectedMolecule) {
-            await selectedMolecule.addLigandOfType(molTypeSelectRef.current.value, props.glRef)
+            await selectedMolecule.addLigandOfType(molTypeSelectRef.current.value)
             const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: selectedMolecule.molNo } })
             document.dispatchEvent(scoresUpdateEvent)    
         }

--- a/baby-gru/src/components/menu-item/MoorhenAddWatersMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenAddWatersMenuItem.tsx
@@ -40,7 +40,7 @@ export const MoorhenAddWatersMenuItem = (props: {
         }, true)
         const selectedMolecule = props.molecules.find(molecule => molecule.molNo === molNo)
         selectedMolecule.setAtomsDirty(true)
-        await selectedMolecule.redraw(props.glRef)
+        await selectedMolecule.redraw()
         const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: molNo } })
         document.dispatchEvent(scoresUpdateEvent)
 

--- a/baby-gru/src/components/menu-item/MoorhenAutoOpenMtzMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenAutoOpenMtzMenuItem.tsx
@@ -4,9 +4,11 @@ import { readDataFile } from "../../utils/MoorhenUtils"
 import { MoorhenMap } from "../../utils/MoorhenMap"
 import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem"
 import { moorhen } from "../../types/moorhen";
+import { webGL } from "../../types/mgWebGL"
 
 export const MoorhenAutoOpenMtzMenuItem = (props: {
     commandCentre: React.RefObject<moorhen.CommandCentre>;
+    glRef: React.RefObject<webGL.MGWebGL>;
     changeMaps: (arg0: moorhen.MolChange<moorhen.Map>) => void;
     setActiveMap: React.Dispatch<React.SetStateAction<moorhen.Map>>;
     setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>;
@@ -44,7 +46,7 @@ export const MoorhenAutoOpenMtzMenuItem = (props: {
         }))
 
         response.data.result.result.forEach((mapMolNo, index) => {
-            const newMap = new MoorhenMap(props.commandCentre)
+            const newMap = new MoorhenMap(props.commandCentre, props.glRef)
             newMap.molNo = mapMolNo
             newMap.name = `${file.name.replace('mtz', '')}-map-${index}`
             newMap.isDifference = isDiffMapResponses[index].data.result.result
@@ -52,7 +54,7 @@ export const MoorhenAutoOpenMtzMenuItem = (props: {
             if (index === 0) props.setActiveMap(newMap)
         })
 
-    }, [filesRef.current, props.changeMaps, props.commandCentre])
+    }, [filesRef.current, props.changeMaps, props.setActiveMap, props.commandCentre, props.glRef])
 
     return <MoorhenBaseMenuItem
         id='auto-open-mtz-menu-item'

--- a/baby-gru/src/components/menu-item/MoorhenCopyFragmentUsingCidMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenCopyFragmentUsingCidMenuItem.tsx
@@ -48,12 +48,12 @@ export const MoorhenCopyFragmentUsingCidMenuItem = (props: {
             changesMolecules: [parseInt(fromRef.current.value)]
         }, true) as moorhen.WorkerResponse<number> 
         
-        const newMolecule = new MoorhenMolecule(props.commandCentre, props.monomerLibraryPath)
+        const newMolecule = new MoorhenMolecule(props.commandCentre, props.glRef, props.monomerLibraryPath)
         newMolecule.name = `${fromMolecules[0].name} fragment`
         newMolecule.molNo = response.data.result.result
         newMolecule.setBackgroundColour(props.backgroundColor)
         newMolecule.cootBondsOptions.smoothness = props.defaultBondSmoothness
-        await newMolecule.fetchIfDirtyAndDraw('CBs', props.glRef)
+        await newMolecule.fetchIfDirtyAndDraw('CBs')
         props.changeMolecules({ action: "Add", item: newMolecule })
         
         props.setPopoverIsShown(false)

--- a/baby-gru/src/components/menu-item/MoorhenDeleteDisplayObjectMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenDeleteDisplayObjectMenuItem.tsx
@@ -20,7 +20,7 @@ export const MoorhenDeleteDisplayObjectMenuItem = (props: {
 
     const onCompleted = () => {
         props.changeItemList({ action: 'Remove', item: props.item })
-        props.item.delete(props.glRef);
+        props.item.delete();
         props.setPopoverIsShown(false)
         if (props.item.type === "map" && props.activeMap?.molNo === props.item.molNo) {
             props.setActiveMap(null)

--- a/baby-gru/src/components/menu-item/MoorhenDeleteEverythingMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenDeleteEverythingMenuItem.tsx
@@ -20,10 +20,10 @@ export const MoorhenDeleteEverythingMenuItem = (props: {
 
     const onCompleted = () => {
         props.maps.forEach(map => {
-            map.delete(props.glRef)
+            map.delete()
         })
         props.molecules.forEach(molecule => {
-            molecule.delete(props.glRef)
+            molecule.delete()
         })
         props.changeMaps({ action: 'Empty' })
         props.changeMolecules({ action: "Empty" })

--- a/baby-gru/src/components/menu-item/MoorhenDeleteUsingCidMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenDeleteUsingCidMenuItem.tsx
@@ -46,7 +46,7 @@ export const MoorhenDeleteUsingCidMenuItem = (props: {
         }, true)
             
         fromMolecules[0].setAtomsDirty(true)
-        fromMolecules[0].redraw(props.glRef)
+        fromMolecules[0].redraw()
         
         props.setPopoverIsShown(false)
     }

--- a/baby-gru/src/components/menu-item/MoorhenFitLigandRightHereMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenFitLigandRightHereMenuItem.tsx
@@ -85,12 +85,12 @@ export const MoorhenFitLigandRightHereMenuItem = (props: {
         if (result.data.result.status === "Completed") {
             await Promise.all(
                 result.data.result.result.map(async (iMol) => {
-                    const newMolecule = new MoorhenMolecule(props.commandCentre, props.monomerLibraryPath)
+                    const newMolecule = new MoorhenMolecule(props.commandCentre, props.glRef, props.monomerLibraryPath)
                     newMolecule.molNo = iMol
                     newMolecule.name = `lig_${iMol}`
                     newMolecule.setBackgroundColour(props.backgroundColor)
                     newMolecule.cootBondsOptions.smoothness = props.defaultBondSmoothness
-                    await newMolecule.fetchIfDirtyAndDraw('CBs', props.glRef)
+                    await newMolecule.fetchIfDirtyAndDraw('CBs')
                     props.changeMolecules({ action: "Add", item: newMolecule })
                 })
             )

--- a/baby-gru/src/components/menu-item/MoorhenFlipMapHandMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenFlipMapHandMenuItem.tsx
@@ -3,19 +3,21 @@ import { MoorhenMap } from "../../utils/MoorhenMap";
 import { MoorhenMapSelect } from "../select/MoorhenMapSelect";
 import { moorhen } from "../../types/moorhen";
 import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem";
+import { webGL } from "../../types/mgWebGL";
 
 export const MoorhenFlipMapHandMenuItem = (props: {
     maps: moorhen.Map[];
     changeMaps: (arg0: moorhen.MolChange<moorhen.Map>) => void;
     setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>
     commandCentre: React.RefObject<moorhen.CommandCentre>;
+    glRef: React.RefObject<webGL.MGWebGL>;
 }) => {
 
     const selectRef = useRef<HTMLSelectElement>(null)
 
     const onCompleted = async () => {
         const mapNo = parseInt(selectRef.current.value)
-        const newMap = new MoorhenMap(props.commandCentre)
+        const newMap = new MoorhenMap(props.commandCentre, props.glRef)
 
         const result  = await props.commandCentre.current.cootCommand({
             returnType: 'status',

--- a/baby-gru/src/components/menu-item/MoorhenGetMonomerMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenGetMonomerMenuItem.tsx
@@ -32,7 +32,7 @@ export const MoorhenGetMonomerMenuItem = (props: {
     const onCompleted = async () => {
         const fromMolNo = parseInt(selectRef.current.value)
         const newTlc = tlcRef.current.value.toUpperCase()
-        const newMolecule = new MoorhenMolecule(props.commandCentre, props.monomerLibraryPath)
+        const newMolecule = new MoorhenMolecule(props.commandCentre, props.glRef, props.monomerLibraryPath)
 
         const getMonomer = () => {
             return props.commandCentre.current.cootCommand({
@@ -61,7 +61,7 @@ export const MoorhenGetMonomerMenuItem = (props: {
                 const ligandDict = fromMolecule.getDict(newTlc)
                 await newMolecule.addDict(ligandDict)    
             }
-            await newMolecule.fetchIfDirtyAndDraw('CBs', props.glRef)
+            await newMolecule.fetchIfDirtyAndDraw('CBs')
             props.changeMolecules({ action: "Add", item: newMolecule })
         } else {
             console.log('Error getting monomer... Missing dictionary?')

--- a/baby-gru/src/components/menu-item/MoorhenGoToMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenGoToMenuItem.tsx
@@ -44,7 +44,7 @@ export const MoorhenGoToMenuItem = (props: {
             return
         }
 
-        molecule.centreOn(props.glRef, `/${residueSpec.mol_no ? residueSpec.mol_no : '*'}/${residueSpec.chain_id}/${residueSpec.res_no}-${residueSpec.res_no}/*`)
+        molecule.centreOn(`/${residueSpec.mol_no ? residueSpec.mol_no : '*'}/${residueSpec.chain_id}/${residueSpec.res_no}-${residueSpec.res_no}/*`)
     }
 
     return <MoorhenBaseMenuItem

--- a/baby-gru/src/components/menu-item/MoorhenImportLigandDictionary.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenImportLigandDictionary.tsx
@@ -62,7 +62,7 @@ const MoorhenImportLigandDictionary = (props: {
                 }, true),
                 ...molecules.map(molecule => {
                     molecule.addDictShim(fileContent)
-                    return molecule.redraw(glRef)
+                    return molecule.redraw()
                 })
             ])
             
@@ -78,24 +78,24 @@ const MoorhenImportLigandDictionary = (props: {
                     ...glRef.current.origin.map(coord => -coord)]
             }, true) as moorhen.WorkerResponse<number> 
             if (result.data.result.status === "Completed") {
-                newMolecule = new MoorhenMolecule(commandCentre, monomerLibraryPath)
+                newMolecule = new MoorhenMolecule(commandCentre, glRef, monomerLibraryPath)
                 newMolecule.molNo = result.data.result.result
                 newMolecule.name = instanceName
                 newMolecule.setBackgroundColour(backgroundColor)
                 newMolecule.cootBondsOptions.smoothness = defaultBondSmoothness
                 await newMolecule.addDict(fileContent)
                 changeMolecules({ action: "Add", item: newMolecule })
-                await newMolecule.fetchIfDirtyAndDraw("CBs", glRef)
+                await newMolecule.fetchIfDirtyAndDraw("CBs")
                 if (addToMoleculeValueRef.current !== -1) {
                     const toMolecule = molecules.find(molecule => molecule.molNo === addToMoleculeValueRef.current)
                     if (typeof toMolecule !== 'undefined') {
                         const otherMolecules = [newMolecule]
-                        await toMolecule.mergeMolecules(otherMolecules, glRef, true)
+                        await toMolecule.mergeMolecules(otherMolecules, true)
                         const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: glRef.current.origin, modifiedMolecule: toMolecule.molNo } })
                         document.dispatchEvent(scoresUpdateEvent)
-                        await toMolecule.redraw(glRef)
+                        await toMolecule.redraw()
                     } else {
-                        await newMolecule.redraw(glRef)
+                        await newMolecule.redraw()
                     }
                 }
             }

--- a/baby-gru/src/components/menu-item/MoorhenImportMapCoefficientsMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenImportMapCoefficientsMenuItem.tsx
@@ -1,12 +1,14 @@
-import { Dispatch, RefObject, SetStateAction, useRef, useState } from "react"
+import React, { Dispatch, RefObject, SetStateAction, useRef, useState } from "react"
 import { MoorhenMtzWrapper } from "../../utils/MoorhenMtzWrapper"
 import { MoorhenMap } from "../../utils/MoorhenMap"
 import { Col, Form, FormSelect, Row } from "react-bootstrap"
 import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem"
 import { moorhen } from "../../types/moorhen";
+import { webGL } from "../../types/mgWebGL"
 
 export const MoorhenImportMapCoefficientsMenuItem = (props: {
     commandCentre: RefObject<moorhen.CommandCentre>;
+    glRef: React.RefObject<webGL.MGWebGL>;
     changeMaps: (arg0: moorhen.MolChange<moorhen.Map>) => void;
     setActiveMap: Dispatch<SetStateAction<moorhen.Map>>
     setPopoverIsShown: Dispatch<SetStateAction<boolean>>     
@@ -32,7 +34,7 @@ export const MoorhenImportMapCoefficientsMenuItem = (props: {
     }
 
     const handleFile = async (file: Blob, selectedColumns: moorhen.selectedMtzColumns) => {
-        const newMap = new MoorhenMap(props.commandCentre)
+        const newMap = new MoorhenMap(props.commandCentre, props.glRef)
         await newMap.loadToCootFromMtzFile(file, selectedColumns)
         props.changeMaps({ action: 'Add', item: newMap })
         props.setActiveMap(newMap)

--- a/baby-gru/src/components/menu-item/MoorhenImportMapMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenImportMapMenuItem.tsx
@@ -3,10 +3,12 @@ import { Col, Form, Row } from "react-bootstrap"
 import { MoorhenMap } from "../../utils/MoorhenMap"
 import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem"
 import { moorhen } from "../../types/moorhen";
+import { webGL } from "../../types/mgWebGL";
 
 export const MoorhenImportMapMenuItem = (props: { 
     maps: moorhen.Map[];
     commandCentre: React.RefObject<moorhen.CommandCentre>;
+    glRef: React.RefObject<webGL.MGWebGL>;
     changeMaps: (arg0: moorhen.MolChange<moorhen.Map>) => void;
     setActiveMap: React.Dispatch<React.SetStateAction<moorhen.Map>>
     setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>> 
@@ -31,11 +33,11 @@ export const MoorhenImportMapMenuItem = (props: {
 
     const onCompleted = useCallback(async () => {
         const file = filesRef.current.files[0]
-        const newMap = new MoorhenMap(props.commandCentre)
+        const newMap = new MoorhenMap(props.commandCentre, props.glRef)
         await newMap.loadToCootFromMapFile(file, isDiffRef.current.checked)
         props.changeMaps({ action: 'Add', item: newMap })
         props.setActiveMap(newMap)
-    }, [props.maps, filesRef.current, isDiffRef.current])
+    }, [props.maps, filesRef.current, isDiffRef.current, props.glRef, props.setActiveMap, props.changeMaps, props.commandCentre])
 
     return <MoorhenBaseMenuItem
         id='import-map-menu-item'

--- a/baby-gru/src/components/menu-item/MoorhenLoadTutorialDataMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenLoadTutorialDataMenuItem.tsx
@@ -43,15 +43,15 @@ export const MoorhenLoadTutorialDataMenuItem = (props: {
             return
         }
         const tutorialNumber = tutorialNumberSelectorRef.current.value
-        const newMolecule = new MoorhenMolecule(props.commandCentre, props.monomerLibraryPath)
+        const newMolecule = new MoorhenMolecule(props.commandCentre, props.glRef, props.monomerLibraryPath)
         newMolecule.setBackgroundColour(props.backgroundColor)
         newMolecule.cootBondsOptions.smoothness = props.defaultBondSmoothness
-        const newMap = new MoorhenMap(props.commandCentre)
-        const newDiffMap = new MoorhenMap(props.commandCentre)
+        const newMap = new MoorhenMap(props.commandCentre, props.glRef)
+        const newDiffMap = new MoorhenMap(props.commandCentre, props.glRef)
         await newMolecule.loadToCootFromURL(`${props.urlPrefix}/baby-gru/tutorials/moorhen-tutorial-structure-number-${tutorialNumber}.pdb`, `mol-${tutorialNumber}`)
-        await newMolecule.fetchIfDirtyAndDraw('CBs', props.glRef)
+        await newMolecule.fetchIfDirtyAndDraw('CBs')
         props.changeMolecules({ action: "Add", item: newMolecule })
-        await newMolecule.centreOn(props.glRef, '/*/*/*/*', false)
+        await newMolecule.centreOn('/*/*/*/*', false)
         await newMap.loadToCootFromMtzURL(
             `${props.urlPrefix}/baby-gru/tutorials/moorhen-tutorial-map-number-${tutorialNumber}.mtz`,
             `map-${tutorialNumber}`,

--- a/baby-gru/src/components/menu-item/MoorhenMapMaskingMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenMapMaskingMenuItem.tsx
@@ -8,6 +8,7 @@ import { MoorhenCidInputForm } from "../form/MoorhenCidInputForm";
 import { MoorhenChainSelect } from "../select/MoorhenChainSelect";
 import { MoorhenLigandSelect } from "../select/MoorhenLigandSelect"
 import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem";
+import { webGL } from "../../types/mgWebGL";
 
 export const MoorhenMapMaskingMenuItem = (props: {
     molecules: moorhen.Molecule[];
@@ -15,6 +16,7 @@ export const MoorhenMapMaskingMenuItem = (props: {
     changeMaps: (arg0: moorhen.MolChange<moorhen.Map>) => void;
     setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>
     commandCentre: React.RefObject<moorhen.CommandCentre>;
+    glRef: React.RefObject<webGL.MGWebGL>;
 }) => {
 
     const [invertFlag, setInvertFlag] = useState<boolean>(false)
@@ -27,7 +29,7 @@ export const MoorhenMapMaskingMenuItem = (props: {
     const ligandSelectRef = useRef<null | HTMLSelectElement>(null)
     const cidInputRef = useRef<null | HTMLInputElement>(null)
 
-    const { commandCentre, maps, changeMaps } = props
+    const { commandCentre, maps, changeMaps, glRef } = props
 
     const panelContent = <>
         <Form.Group style={{ margin: '0.5rem', width: '20rem' }}>
@@ -60,7 +62,7 @@ export const MoorhenMapMaskingMenuItem = (props: {
     const onCompleted = useCallback(async () => {
         const mapNo = parseInt(mapSelectRef.current.value)
         const molNo = parseInt(moleculeSelectRef.current.value)
-        const newMap = new MoorhenMap(commandCentre)
+        const newMap = new MoorhenMap(commandCentre, glRef)
 
         let cidLabel: string
 
@@ -96,7 +98,7 @@ export const MoorhenMapMaskingMenuItem = (props: {
             changeMaps({ action: 'Add', item: newMap })
         }
             
-    }, [commandCentre, maps, changeMaps])
+    }, [commandCentre, maps, changeMaps, glRef])
 
     return <MoorhenBaseMenuItem
         id='mask-map-menu-item'

--- a/baby-gru/src/components/menu-item/MoorhenMergeMoleculesMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenMergeMoleculesMenuItem.tsx
@@ -29,7 +29,7 @@ export const MoorhenMergeMoleculesMenuItem = (props: {
             console.log('No valid molecules selected, skipping merge...')
             return
         }
-        await toMolecule.mergeMolecules(otherMolecules, props.glRef, true)
+        await toMolecule.mergeMolecules(otherMolecules, true)
         props.setPopoverIsShown(false)
         const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: toMolecule.molNo } })
         document.dispatchEvent(scoresUpdateEvent)

--- a/baby-gru/src/components/menu-item/MoorhenMoleculeSymmetrySettingsMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenMoleculeSymmetrySettingsMenuItem.tsx
@@ -21,7 +21,7 @@ export const MoorhenMoleculeSymmetrySettingsMenuItem = (props: {
         if (isDirty.current) {
             busyDrawing.current = true
             isDirty.current = false
-            props.molecule.drawSymmetry(props.glRef)
+            props.molecule.drawSymmetry()
                 .then(_ => {
                     busyDrawing.current = false
                     drawSymmetryIfDirty()
@@ -39,15 +39,15 @@ export const MoorhenMoleculeSymmetrySettingsMenuItem = (props: {
 
     useEffect(() => {
         if (props.molecule.symmetryOn !== symmetryOn) {
-            props.molecule.toggleSymmetry(props.glRef)
+            props.molecule.toggleSymmetry()
         }
     }, [symmetryOn])
 
     useEffect(() => {
         if (showUnitCell) {
-            props.molecule.drawUnitCell(props.glRef)
+            props.molecule.drawUnitCell()
         } else {
-            props.molecule.clearBuffersOfStyle('unitCell', props.glRef)
+            props.molecule.clearBuffersOfStyle('unitCell')
             props.glRef.current.drawScene()
         }
     }, [showUnitCell])

--- a/baby-gru/src/components/modal/MoorhenColourRules.js
+++ b/baby-gru/src/components/modal/MoorhenColourRules.js
@@ -101,8 +101,8 @@ export const MoorhenColourRules = (props) => {
             return
         }
         const selectedMolecule = props.molecules.find(molecule => molecule.molNo === selectedModel)
-        await selectedMolecule.setColourRules(props.glRef, ruleList, true)
-    }, [selectedModel, ruleList, props.molecules, props.glRef])
+        await selectedMolecule.setColourRules(ruleList, true)
+    }, [selectedModel, ruleList, props.molecules])
 
     const createRule = () => {
         const selectedMolecule = props.molecules.find(molecule => molecule.molNo === selectedModel)

--- a/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
@@ -112,7 +112,7 @@ export const MoorhenQuerySequenceModal = (props: {
                 ruleType: 'af2-plddt',
                 label: `//*`
             }]
-            newMolecule.setColourRules(props.glRef, newRule, false)
+            newMolecule.setColourRules(newRule, false)
         } 
         await props.commandCentre.current.cootCommand({
             message: 'coot_command',
@@ -126,8 +126,8 @@ export const MoorhenQuerySequenceModal = (props: {
             ],
         })                            
         newMolecule.setAtomsDirty(true)
-        await newMolecule.redraw(props.glRef)
-        newMolecule.centreOn(props.glRef, '/*/*/*/*', true)
+        await newMolecule.redraw()
+        newMolecule.centreOn('/*/*/*/*', true)
     }
 
     const getPDBHitCard = async (polimerEntity: string, source: string = 'PDB') => {

--- a/baby-gru/src/components/modal/MoorhenSuperposeResultsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenSuperposeResultsModal.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from "react";
+import Draggable from "react-draggable";
+import { IconButton } from '@mui/material';
+import { CloseOutlined } from "@mui/icons-material";
+import { convertViewtoPx } from '../../utils/MoorhenUtils';
+import { Card } from "react-bootstrap";
+import { MoorhenSequenceAlignment } from "../sequence-viewer/MoorhenSequenceAlignment"
+import { moorhen } from "../../types/moorhen";
+import { webGL } from "../../types/mgWebGL";
+import { libcootApi } from "../../types/libcoot";
+
+
+export const MoorhenSuperposeResultsModal = (props: {
+    molecules: moorhen.Molecule[];
+    maps: moorhen.Map[];
+    glRef: React.RefObject<webGL.MGWebGL>;
+    isDark: boolean;
+    windowHeight: number;
+    windowWidth: number;
+    superposeResults: false | libcootApi.SuperposeResultsJS;
+    setSuperposeResults: React.Dispatch<React.SetStateAction<false | libcootApi.SuperposeResultsJS>>;
+}) => {
+
+    const [opacity, setOpacity] = useState(0.5)
+
+
+    
+    return <Draggable handle=".handle">
+        <Card
+            style={{position: 'absolute', top: '5rem', left: '5rem', opacity: opacity, width: props.windowWidth ? convertViewtoPx(50, props.windowWidth) : '50wh', display: props.superposeResults ? '' : 'none'}}
+            onMouseOver={() => setOpacity(1)}
+            onMouseOut={() => setOpacity(0.5)}
+        >
+            <Card.Header className="handle" style={{ justifyContent: 'space-between', display: 'flex', cursor: 'move', alignItems:'center'}}>
+                Superpose results
+                <IconButton style={{margin: '0.1rem', padding: '0.1rem'}} onClick={() => props.setSuperposeResults(false)}>
+                    <CloseOutlined/>
+                </IconButton>
+            </Card.Header>
+            <Card.Body style={{maxHeight: props.windowHeight ? convertViewtoPx(60, props.windowHeight) : '60vh', overflowY: 'scroll'}}>
+                {props.superposeResults && <MoorhenSequenceAlignment alignedPairsData={props.superposeResults.alignedPairsData} movingSequence={props.superposeResults.movingSequence} referenceSequence={props.superposeResults.referenceSequence} />}
+            </Card.Body>
+        </Card>
+    </Draggable>
+}

--- a/baby-gru/src/components/navbar-menus/MoorhenCalculateMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenCalculateMenu.tsx
@@ -3,13 +3,17 @@ import { useState } from "react";
 import { MoorhenLoadScriptMenuItem } from "../menu-item/MoorhenLoadScriptMenuItem";
 import { MoorhenSuperposeMenuItem } from "../menu-item/MoorhenSuperposeMenuItem";
 import { MoorhenScriptModal } from "../modal/MoorhenScriptModal";
+import { MoorhenSuperposeResultsModal } from "../modal/MoorhenSuperposeResultsModal"
 import { MenuItem } from "@mui/material";
 import { MoorhenNavBarExtendedControlsInterface } from "./MoorhenNavBar";
+import { libcootApi } from "../../types/libcoot";
 
 export const MoorhenCalculateMenu = (props: MoorhenNavBarExtendedControlsInterface) => {
-    const [popoverIsShown, setPopoverIsShown] = useState(false)
+    const [popoverIsShown, setPopoverIsShown] = useState<boolean>(false)
+    const [showCodeEditor, setShowCodeEditor] = useState<boolean>(false)
+    const [superposeResults, setSuperposeResults] = useState<false | libcootApi.SuperposeResultsJS>(false)
+    
     const menuItemProps = { setPopoverIsShown, ...props }
-    const [showCodeEditor, setShowCodeEditor] = useState(false)
 
     return <>
         <NavDropdown
@@ -19,7 +23,7 @@ export const MoorhenCalculateMenu = (props: MoorhenNavBarExtendedControlsInterfa
             autoClose={popoverIsShown ? false : 'outside'}
             show={props.currentDropdownId === props.dropdownId}
             onToggle={() => { props.dropdownId !== props.currentDropdownId ? props.setCurrentDropdownId(props.dropdownId) : props.setCurrentDropdownId('-1') }}>
-            <MoorhenSuperposeMenuItem key="superpose_structures" {...menuItemProps} />
+            <MoorhenSuperposeMenuItem key="superpose_structures" setSuperposeResults={setSuperposeResults} {...menuItemProps} />
             {props.allowScripting && 
             <>
                 <MoorhenLoadScriptMenuItem {...menuItemProps} />
@@ -28,7 +32,8 @@ export const MoorhenCalculateMenu = (props: MoorhenNavBarExtendedControlsInterfa
             }
             {props.extraCalculateMenuItems && props.extraCalculateMenuItems.map( menu => menu)}
         </NavDropdown>
-        <MoorhenScriptModal show={showCodeEditor} setShow={setShowCodeEditor} {...menuItemProps} />            
+        <MoorhenScriptModal show={showCodeEditor} setShow={setShowCodeEditor} {...menuItemProps} />
+        {/**<MoorhenSuperposeResultsModal superposeResults={superposeResults} setSuperposeResults={setSuperposeResults} {...menuItemProps} />*/}
     </>
 }
 

--- a/baby-gru/src/components/navbar-menus/MoorhenDevMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenDevMenu.tsx
@@ -39,7 +39,7 @@ const doTest = async (props: any) => {
         console.log(`Message from worker back to main thread took ${Date.now() - test.data.messageSendTime} ms (refine_residues_using_atom_cid) - (${test.data.messageId.slice(0, 5)})`)
 
         molecule.setAtomsDirty(true)
-        await molecule.redraw(props.glRef)
+        await molecule.redraw()
         const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: molecule.molNo } })
         document.dispatchEvent(scoresUpdateEvent)
         
@@ -60,14 +60,7 @@ const doColourTest = async (props: any) => {
             commandArgs: [molecule.molNo],
         }, true)
         molecule.setAtomsDirty(true)
-        await molecule.redraw(props.glRef)
-    }
-}
-
-const doUnitCellTest = (props: any) => {
-    const molecule = props.molecules.find(molecule => molecule.molNo === 0)
-    if (typeof molecule !== 'undefined') {
-        props.molecules[0].drawUnitCell(props.glRef)
+        await molecule.redraw()
     }
 }
 
@@ -88,9 +81,6 @@ export const MoorhenDevMenu = (props: MoorhenNavBarExtendedControlsInterface) =>
                     </MenuItem>
                     <MenuItem onClick={() => doColourTest(menuItemProps)}>
                         Do colouring test
-                    </MenuItem>
-                    <MenuItem onClick={() => doUnitCellTest(menuItemProps)}>
-                        Draw unit cell...
                     </MenuItem>
                     <InputGroup style={{ padding:'0.5rem', width: '25rem'}}>
                         <Form.Check 

--- a/baby-gru/src/components/sequence-viewer/MoorhenSequenceAlignment.tsx
+++ b/baby-gru/src/components/sequence-viewer/MoorhenSequenceAlignment.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useRef, useState, useCallback } from "react"
+import ProtvistaManager from "protvista-manager";
+import ProtvistaSequence from "protvista-sequence";
+import ProtvistaNavigation from "protvista-navigation";
+import ProtvistaTrack from "protvista-track";
+import { moorhen } from "../../types/moorhen";
+import { webGL } from "../../types/mgWebGL";
+import { clickedResidueType } from '../card/MoorhenMoleculeCard';
+import { libcootApi } from "../../types/libcoot";
+
+!window.customElements.get('protvista-navigation') && window.customElements.define("protvista-navigation", ProtvistaNavigation);
+!window.customElements.get('protvista-sequence') && window.customElements.define("protvista-sequence", ProtvistaSequence);
+!window.customElements.get('protvista-track') && window.customElements.define("protvista-track", ProtvistaTrack);
+!window.customElements.get('protvista-manager') && window.customElements.define("protvista-manager", ProtvistaManager);
+
+/**
+* For a given sequence length, calculate the range of 40 residues in the middle
+* @param {Number} rulerStart integer that determines where to start the ruler numbering
+* @param {Number} sequenceLength sequence lenght
+* @returns {Array} An array containing the display start and display end consisting of a range of 40 residues
+*/
+const calculateDisplayStartAndEnd = (rulerStart: number, sequenceLength: number): [number, number] => {
+    if (sequenceLength <= 40) {
+        return [rulerStart, sequenceLength + rulerStart]
+    }
+    let middleIndex = Math.round((sequenceLength) / 2)
+    return [middleIndex - 20 + rulerStart, middleIndex + 20 + rulerStart]        
+}
+
+export const MoorhenSequenceAlignment = (props: {
+    referenceSequence: string;
+    movingSequence: string;
+    alignedPairsData: { reference: libcootApi.ValidationInformationJS, moving: libcootApi.ValidationInformationJS }[]
+}) => {
+
+    const managerRef = useRef<any>(null);
+    const refSeqRef = useRef<any>(null);
+    const movSeqRef = useRef<any>(null);
+    const navigationRef = useRef<any>(null);
+
+    const initialRulerStart = props.alignedPairsData[0].reference.seqNum
+    console.log('HI')
+    console.log(props.alignedPairsData)
+    console.log(props.referenceSequence.length)
+    const [intialStart, initialEnd] = calculateDisplayStartAndEnd(initialRulerStart, props.referenceSequence.length)
+    const hoveredResidueColor = '#FFEB3B66'
+    const transparentColor = '#FFEB3B00'
+
+    /**
+     * Hook used when the component mounts to set the display start and end.
+     */
+    useEffect(()=> {       
+        refSeqRef.current._sequence = props.referenceSequence
+        refSeqRef.current._displaystart = intialStart
+        refSeqRef.current._displayend = initialEnd
+        refSeqRef.current.trackHighlighter.element._highlightcolor = hoveredResidueColor
+        movSeqRef.current._sequence = props.movingSequence
+        movSeqRef.current._displaystart = intialStart
+        movSeqRef.current._displayend = initialEnd
+        movSeqRef.current.trackHighlighter.element._highlightcolor = hoveredResidueColor
+        navigationRef.current._displaystart = intialStart
+        navigationRef.current._displayend = initialEnd
+        
+    }, [])
+
+    return (
+        <div className='align-items-center' style={{marginBottom:'0', padding:'0'}}>
+            <div style={{width: '100%'}}>
+                <protvista-manager ref={managerRef}>
+                    <protvista-navigation 
+                        ref={navigationRef}
+                        length={props.referenceSequence.length}
+                        rulerStart={initialRulerStart}
+                        displaystart={intialStart}
+                        displayend={initialEnd}
+                        use-ctrl-to-zoom
+                    />
+                    <protvista-sequence
+                        ref={refSeqRef}
+                        sequence={props.referenceSequence}
+                        length={props.referenceSequence.length} 
+                        numberofticks="10"
+                        displaystart={intialStart}
+                        displayend={initialEnd}
+                        use-ctrl-to-zoom
+                    />
+                    <protvista-sequence
+                        ref={movSeqRef}
+                        sequence={props.movingSequence}
+                        length={props.movingSequence.length} 
+                        numberofticks="10"
+                        displaystart={intialStart}
+                        displayend={initialEnd}
+                        use-ctrl-to-zoom
+                    />
+
+                </protvista-manager>
+            </div>    
+        </div>
+    )
+    
+}

--- a/baby-gru/src/components/validation-tools/MoorhenFillMissingAtoms.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenFillMissingAtoms.tsx
@@ -23,7 +23,7 @@ export const MoorhenFillMissingAtoms = (props: MoorhenSideBarAccordionPropsInter
             }, true)    
         }
         selectedMolecule.setAtomsDirty(true)
-        selectedMolecule.redraw(props.glRef)
+        selectedMolecule.redraw()
         const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {origin: props.glRef.current.origin,  modifiedMolecule: selectedMolecule.molNo} })
         document.dispatchEvent(scoresUpdateEvent);    
     }
@@ -59,7 +59,7 @@ export const MoorhenFillMissingAtoms = (props: MoorhenSideBarAccordionPropsInter
                                 {label}
                             </Col>
                             <Col className='col-3' style={{margin: '0', padding:'0', justifyContent: 'right', display:'flex'}}>
-                                <Button style={{marginRight:'0.5rem'}} onClick={() => selectedMolecule.centreOn(props.glRef, `/*/${residue.chainId}/${residue.resNum}-${residue.resNum}/*`)}>
+                                <Button style={{marginRight:'0.5rem'}} onClick={() => selectedMolecule.centreOn(`/*/${residue.chainId}/${residue.resNum}-${residue.resNum}/*`)}>
                                     View
                                 </Button>
                                 <Button style={{marginRight:'0.5rem'}} onClick={() => {

--- a/baby-gru/src/components/validation-tools/MoorhenMMRRCCPlot.js
+++ b/baby-gru/src/components/validation-tools/MoorhenMMRRCCPlot.js
@@ -64,7 +64,7 @@ export const MoorhenMMRRCCPlot = (props) => {
         if(selectedMolecule) {
             const clickedResidue = getResidueInfo(props.molecules, selectedMolecule.molNo, chainSelectRef.current.value, residueIndex)
             if (clickedResidue) {
-                selectedMolecule.centreOn(props.glRef, `/*/${clickedResidue.chain}/${clickedResidue.seqNum}-${clickedResidue.seqNum}/*`)
+                selectedMolecule.centreOn(`/*/${clickedResidue.chain}/${clickedResidue.seqNum}-${clickedResidue.seqNum}/*`)
             }
         }
     }

--- a/baby-gru/src/components/validation-tools/MoorhenPepflipsDifferenceMap.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenPepflipsDifferenceMap.tsx
@@ -30,7 +30,7 @@ export const MoorhenPepflipsDifferenceMap = (props: MoorhenSideBarAccordionProps
 
         const selectedMolecule = props.molecules.find(molecule => molecule.molNo === selectedMolNo)
         selectedMolecule.setAtomsDirty(true)
-        selectedMolecule.redraw(props.glRef)
+        selectedMolecule.redraw()
         const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {origin: props.glRef.current.origin,  modifiedMolecule: selectedMolecule.molNo} })
         document.dispatchEvent(scoresUpdateEvent)
     }

--- a/baby-gru/src/components/validation-tools/MoorhenRamachandran.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenRamachandran.tsx
@@ -464,7 +464,7 @@ export const MoorhenRamachandran = (props: MoorhenSideBarAccordionPropsInterface
             return
         }
 
-        props.molecules[selectedMoleculeIndex].centreOn(props.glRef, `/*/${clickedResidue.chain}/${clickedResidue.seqNum}-${clickedResidue.seqNum}/*`)
+        props.molecules[selectedMoleculeIndex].centreOn(`/*/${clickedResidue.chain}/${clickedResidue.seqNum}-${clickedResidue.seqNum}/*`)
 
     }, [clickedResidue])
 

--- a/baby-gru/src/components/validation-tools/MoorhenValidation.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenValidation.tsx
@@ -131,7 +131,7 @@ export const MoorhenValidation = (props: MoorhenSideBarAccordionPropsInterface) 
             if(selectedMolecule) {
                 const clickedResidue = getResidueInfo(props.molecules, selectedMolecule.molNo, selectedChain, residueIndex)
                 if (clickedResidue) {
-                    selectedMolecule.centreOn(props.glRef, `/*/${clickedResidue.chain}/${clickedResidue.seqNum}-${clickedResidue.seqNum}/*`)
+                    selectedMolecule.centreOn(`/*/${clickedResidue.chain}/${clickedResidue.seqNum}-${clickedResidue.seqNum}/*`)
                 }
             }
         }

--- a/baby-gru/src/components/webMG/MoorhenWebMG.tsx
+++ b/baby-gru/src/components/webMG/MoorhenWebMG.tsx
@@ -89,9 +89,9 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
                 return
             }
 
-            props.hoveredAtom.molecule.centreOn(glRef, `/*/${residueSpec.chain_id}/${residueSpec.res_no}-${residueSpec.res_no}/*`)
+            props.hoveredAtom.molecule.centreOn(`/*/${residueSpec.chain_id}/${residueSpec.res_no}-${residueSpec.res_no}/*`)
         }
-    }, [props.hoveredAtom, glRef])
+    }, [props.hoveredAtom])
 
 
     const drawHBonds = useCallback(async () => {
@@ -119,22 +119,20 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
                 const cidSplit = cidSplit0.replace(/\/+$/, "").split("/")
                 const resnum = cidSplit[cidSplit.length-1]
                 const chainID = cidSplit[cidSplit.length-2]
-                // const oneCid = cidSplit.join("/")+"-"+resnum
-                // mol.drawHBonds(glRef, oneCid, 'originNeighbours', true)
-                mol.drawEnvironment(glRef, chainID, parseInt(resnum), "", true)
+                mol.drawEnvironment(chainID, parseInt(resnum), "", true)
             }
             
             busyDrawingHBonds.current = false
             drawHBonds()
         }
 
-    }, [props.commandCentre, props.molecules])
+    }, [props.commandCentre, props.molecules, glRef])
 
     const clearHBonds = useCallback(async () => {
         if(!props.context.drawInteractions) {
             props.molecules.forEach(mol => {
-                mol.drawGemmiAtomPairs(glRef, [], "originNeighboursBump", [1.0, 0.0, 0.0, 1.0], true, true)
-                mol.drawGemmiAtomPairs(glRef, [], "originNeighboursHBond", [1.0, 0.0, 0.0, 1.0], true, true)
+                mol.drawGemmiAtomPairs([], "originNeighboursBump", [1.0, 0.0, 0.0, 1.0], true, true)
+                mol.drawGemmiAtomPairs([], "originNeighboursHBond", [1.0, 0.0, 0.0, 1.0], true, true)
             })
         }
     }, [props.context.drawInteractions, props.molecules])
@@ -205,10 +203,11 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
             
             await Promise.all(
                 props.maps.filter(map => connectedMolNo.uniqueMaps.includes(map.molNo)).map(map => {
-                    return map.doCootContour(glRef,
+                    return map.doCootContour(
                         ...glRef.current.origin.map(coord => -coord) as [number, number, number],
                         map.mapRadius,
-                        map.contourLevel)
+                        map.contourLevel
+                    )
                 })
             )
             

--- a/baby-gru/src/moorhen.ts
+++ b/baby-gru/src/moorhen.ts
@@ -12,5 +12,5 @@ import { MoorhenMapSelect } from "./components/select/MoorhenMapSelect";
 export {
     ErrorBoundary, MoorhenApp, MoorhenContainer, MoorhenContextProvider, MoorhenContext,
     MoorhenMolecule, MoorhenMap, MoorhenCommandCentre, MoorhenTimeCapsule, MoorhenMoleculeSelect,
-    MoorhenMapSelect
+    MoorhenMapSelect, itemReducer
 };

--- a/baby-gru/src/moorhen.ts
+++ b/baby-gru/src/moorhen.ts
@@ -8,6 +8,7 @@ import { MoorhenCommandCentre } from './utils/MoorhenCommandCentre';
 import { MoorhenTimeCapsule } from './utils/MoorhenTimeCapsule';
 import { MoorhenMoleculeSelect } from "./components/select/MoorhenMoleculeSelect";
 import { MoorhenMapSelect } from "./components/select/MoorhenMapSelect";
+import { itemReducer } from "./utils/MoorhenUtils";
 
 export {
     ErrorBoundary, MoorhenApp, MoorhenContainer, MoorhenContextProvider, MoorhenContext,

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -57,14 +57,6 @@ export namespace moorhen {
         label: string;
     }
     
-    type MoleculeColourRule = {
-        commandInput: cootCommandKwargs;
-        isMultiColourRule: boolean;
-        ruleType: string;
-        color: string;
-        label: string;
-    }
-    
     type DisplayObject = {
         symmetryMatrices: any;
         [attr: string]: any;
@@ -82,8 +74,9 @@ export namespace moorhen {
             message: string;
             command: string;
             returnType: string;
-            commandArgs: [number, string];
+            commandArgs: [number, string, string?];
         };
+        color?: string;
         isMultiColourRule: boolean;
         ruleType: string;
         label: string;
@@ -91,46 +84,47 @@ export namespace moorhen {
     
     interface Molecule {
         getNeighborResiduesCids(selectionCid: string, radius: number, minDist: number, maxDist: number): Promise<string[]>;
-        drawWithStyleFromMesh(style: string, glRef: React.RefObject<webGL.MGWebGL>, meshObjects: any[], newBufferAtoms?: moorhen.AtomInfo[]): Promise<void>;
-        updateWithMovedAtoms(movedResidues: moorhen.AtomInfo[][], glRef: React.RefObject<webGL.MGWebGL>): Promise<void>;
-        transformedCachedAtomsAsMovedAtoms(glRef: React.RefObject<webGL.MGWebGL>, selectionCid?: string): moorhen.AtomInfo[][];
-        drawWithStyleFromAtoms(style: string, glRef: React.RefObject<webGL.MGWebGL>): Promise<boolean>;
-        copyFragmentUsingCid(cid: string, backgroundColor: [number, number, number, number], defaultBondSmoothness: number, glRef: React.RefObject<webGL.MGWebGL>, doRecentre?: boolean): Promise<Molecule>;
-        hideCid(cid: string, glRef: React.RefObject<webGL.MGWebGL>): Promise<void>;
-        unhideAll(glRef: React.RefObject<webGL.MGWebGL>): Promise<void>;
-        drawSelection(glRef: React.RefObject<webGL.MGWebGL>, cid: string): Promise<void>;
-        drawUnitCell(glRef: React.RefObject<webGL.MGWebGL>): void;
+        drawWithStyleFromMesh(style: string, meshObjects: any[], newBufferAtoms?: moorhen.AtomInfo[]): Promise<void>;
+        updateWithMovedAtoms(movedResidues: moorhen.AtomInfo[][]): Promise<void>;
+        transformedCachedAtomsAsMovedAtoms(selectionCid?: string): moorhen.AtomInfo[][];
+        drawWithStyleFromAtoms(style: string): Promise<void>;
+        copyFragmentUsingCid(cid: string, backgroundColor: [number, number, number, number], defaultBondSmoothness: number, doRecentre?: boolean): Promise<Molecule>;
+        hideCid(cid: string): Promise<void>;
+        unhideAll(): Promise<void>;
+        drawSelection(cid: string): Promise<void>;
+        drawUnitCell(): void;
         gemmiAtomsForCid: (cid: string) => Promise<AtomInfo[]>;
-        mergeMolecules(otherMolecules: Molecule[], glRef: React.RefObject<webGL.MGWebGL>, doHide?: boolean): Promise<void>;
+        mergeMolecules(otherMolecules: Molecule[], doHide?: boolean): Promise<void>;
         setBackgroundColour(backgroundColour: [number, number, number, number]): void;
         addDict(fileContent: string): Promise<void>;
         addDictShim(fileContent: string): void;
-        toggleSymmetry(glRef: React.RefObject<webGL.MGWebGL>): Promise<void>;
+        toggleSymmetry(): Promise<void>;
         getDict(newTlc: string): string;
-        addLigandOfType(resType: string, glRef: React.RefObject<webGL.MGWebGL>, fromMolNo?: number): Promise<WorkerResponse>;
+        addLigandOfType(resType: string, fromMolNo?: number): Promise<WorkerResponse>;
         updateAtoms(): Promise<void>;
         rigidBodyFit(cidsString: string, mapNo: number): Promise<WorkerResponse>;
         generateSelfRestraints(maxRadius: number): Promise<WorkerResponse>;
         clearExtraRestraints(): Promise<WorkerResponse>;
         refineResiduesUsingAtomCid(cid: string, mode: string, ncyc: number): Promise<WorkerResponse>;
-        redo(glRef: React.RefObject<webGL.MGWebGL>): Promise<void>;
-        undo(glRef: React.RefObject<webGL.MGWebGL>): Promise<void>;
-        copyFragment(chainId: string, res_no_start: number, res_no_end: number, glRef: React.RefObject<webGL.MGWebGL>, doRecentre?: boolean): Promise<Molecule>;
-        show(style: string, glRef: React.RefObject<webGL.MGWebGL>): Promise<void>;
-        setSymmetryRadius(radius: number, glRef: React.RefObject<webGL.MGWebGL>): Promise<void>;
-        drawSymmetry: (glRef: React.RefObject<webGL.MGWebGL>, fetchSymMatrix?: boolean) => Promise<void>;
+        redo(): Promise<void>;
+        undo(): Promise<void>;
+        copyFragment(chainId: string, res_no_start: number, res_no_end: number, doRecentre?: boolean): Promise<Molecule>;
+        show(style: string): Promise<void>;
+        setSymmetryRadius(radius: number): Promise<void>;
+        drawSymmetry: (fetchSymMatrix?: boolean) => Promise<void>;
         getUnitCellParams():  { a: number; b: number; c: number; alpha: number; beta: number; gamma: number; };
-        replaceModelWithFile(glRef: React.RefObject<webGL.MGWebGL>, fileUrl: string, molName: string): Promise<void>
-        delete(glRef: React.RefObject<webGL.MGWebGL>): Promise<WorkerResponse> 
-        setColourRules(glRef: React.RefObject<webGL.MGWebGL>, ruleList: ColourRule[], redraw?: boolean): void;
-        fetchIfDirtyAndDraw(arg0: string, glRef: React.MutableRefObject<webGL.MGWebGL>): Promise<boolean>;
-        drawGemmiAtomPairs: (glRef: React.ForwardedRef<webGL.MGWebGL>, gemmiAtomPairs: any[], style: string,  colour: number[], labelled?: boolean, clearBuffers?: boolean) => void;
-        drawEnvironment: (glRef: React.RefObject<webGL.MGWebGL>, chainID: string, resNo: number,  altLoc: string, labelled?: boolean) => Promise<void>;
-        centreOn: (glRef: React.ForwardedRef<webGL.MGWebGL>, selectionCid?: string, animate?: boolean) => Promise<void>;
-        drawHover: (glRef: React.MutableRefObject<webGL.MGWebGL>, cid: string) => Promise<void>;
-        clearBuffersOfStyle: (style: string, glRef: React.RefObject<webGL.MGWebGL>) => void;
+        replaceModelWithFile(fileUrl: string, molName: string): Promise<void>
+        delete(): Promise<WorkerResponse> 
+        setColourRules(ruleList: ColourRule[], redraw?: boolean): void;
+        fetchIfDirtyAndDraw(arg0: string): Promise<void>;
+        drawGemmiAtomPairs: (gemmiAtomPairs: any[], style: string,  colour: number[], labelled?: boolean, clearBuffers?: boolean) => void;
+        drawEnvironment: (chainID: string, resNo: number,  altLoc: string, labelled?: boolean) => Promise<void>;
+        centreOn: (selectionCid?: string, animate?: boolean) => Promise<void>;
+        drawHover: (cid: string) => Promise<void>;
+        clearBuffersOfStyle: (style: string) => void;
         type: string;
         commandCentre: React.RefObject<CommandCentre>;
+        glRef: React.RefObject<webGL.MGWebGL>;
         enerLib: any;
         HBondsAssigned: boolean;
         atomsDirty: boolean;
@@ -139,7 +133,7 @@ export namespace moorhen {
         molNo: number;
         gemmiStructure: gemmi.Structure;
         sequences: Sequence[];
-        colourRules: MoleculeColourRule[];
+        colourRules: ColourRule[];
         ligands: LigandInfo[];
         ligandDicts: {[comp_id: string]: string};
         connectedToMaps: number[];
@@ -176,13 +170,13 @@ export namespace moorhen {
         displayObjectsTransformation: { origin: [number, number, number], quat: any, centre: [number, number, number] }
         uniqueId: string;
         monomerLibraryPath: string;
-        applyTransform: (glRef: React.RefObject<webGL.MGWebGL>) => Promise<void>;
+        applyTransform: () => Promise<void>;
         getAtoms(format?: string): Promise<WorkerResponse>;
-        hide: (style: string, glRef: React.RefObject<webGL.MGWebGL>) => void;
-        redraw: (glRef: React.RefObject<webGL.MGWebGL>) => Promise<void>;
+        hide: (style: string) => void;
+        redraw: () => Promise<void>;
         setAtomsDirty: (newVal: boolean) => void;
         hasVisibleBuffers: (excludeBuffers?: string[]) => boolean;
-        centreAndAlignViewOn(glRef: React.RefObject<webGL.MGWebGL>, selectionCid: string, animate?: boolean): Promise<void>;
+        centreAndAlignViewOn(selectionCid: string, animate?: boolean): Promise<void>;
         buffersInclude: (bufferIn: { id: string; }) => boolean;
     }
     
@@ -267,24 +261,25 @@ export namespace moorhen {
     }
 
     interface Map {
-        setAlpha(alpha: number, glRef: React.RefObject<webGL.MGWebGL>, redraw?: boolean): Promise<void>;
-        centreOnMap(glRef: React.RefObject<webGL.MGWebGL>): Promise<void>;
+        setAlpha(alpha: number, redraw?: boolean): Promise<void>;
+        centreOnMap(): Promise<void>;
         duplicate(): Promise<Map>;
-        makeCootUnlive(glRef: React.RefObject<webGL.MGWebGL>): void;
-        makeCootLive(glRef: React.RefObject<webGL.MGWebGL>): void;
-        setColour(r: number, g: number, b: number, glRef: React.RefObject<webGL.MGWebGL>, redraw?: boolean): Promise<void> ;
-        setDiffMapColour(type: 'positiveDiffColour' | 'negativeDiffColour', r: number, g: number, b: number, glRef: React.RefObject<webGL.MGWebGL>, redraw?: boolean): Promise<void> ;
+        makeCootUnlive(): void;
+        makeCootLive(): void;
+        setColour(r: number, g: number, b: number, redraw?: boolean): Promise<void> ;
+        setDiffMapColour(type: 'positiveDiffColour' | 'negativeDiffColour', r: number, g: number, b: number, redraw?: boolean): Promise<void> ;
         fetchMapRmsd(): Promise<number>;
-        replaceMapWithMtzFile(glRef: React.RefObject<webGL.MGWebGL>, fileUrl: RequestInfo | URL, name: string, selectedColumns: selectedMtzColumns, mapColour?: { [type: string]: {r: number, g: number, b: number} }): Promise<void>;
+        replaceMapWithMtzFile(fileUrl: RequestInfo | URL, name: string, selectedColumns: selectedMtzColumns, mapColour?: { [type: string]: {r: number, g: number, b: number} }): Promise<void>;
         associateToReflectionData (selectedColumns: selectedMtzColumns, reflectionData: Uint8Array | ArrayBuffer): Promise<WorkerResponse>;
-        delete(glRef: React.RefObject<webGL.MGWebGL>): Promise<void> 
-        doCootContour(glRef: React.MutableRefObject<webGL.MGWebGL>, x: number, y: number, z: number, radius: number, contourLevel: number): Promise<void>;
-        fetchReflectionData(): Promise<WorkerResponse>;
+        delete(): Promise<void> 
+        doCootContour(x: number, y: number, z: number, radius: number, contourLevel: number): Promise<void>;
+        fetchReflectionData(): Promise<WorkerResponse<Uint8Array>>;
         getMap(): Promise<WorkerResponse>;
         type: string;
         name: string;
         molNo: number;
         commandCentre: React.RefObject<CommandCentre>;
+        glRef: React.RefObject<webGL.MGWebGL>;
         contourLevel: number;
         mapRadius: number;
         mapColour: [number, number, number, number];

--- a/baby-gru/src/utils/MoorhenKeyboardAccelerators.tsx
+++ b/baby-gru/src/utils/MoorhenKeyboardAccelerators.tsx
@@ -11,7 +11,7 @@ import { libcootApi } from "../types/libcoot";
 
 const apresEdit = (molecule: moorhen.Molecule, glRef: React.RefObject<webGL.MGWebGL>, timeCapsuleRef: React.RefObject<moorhen.TimeCapsule>, setHoveredAtom: (arg0: moorhen.HoveredAtom) => void) => {
     molecule.setAtomsDirty(true)
-    molecule.redraw(glRef)
+    molecule.redraw()
     setHoveredAtom({ molecule: null, cid: null })
     const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: glRef.current.origin,  modifiedMolecule: molecule.molNo} })
     document.dispatchEvent(scoresUpdateEvent)
@@ -529,7 +529,7 @@ export const babyGruKeyPress = (event: KeyboardEvent, collectedProps: MoorhenCon
             } else {
                 return
             }
-            selectedMolecule.centreAndAlignViewOn(glRef, `/*/${chosenAtom.chain_id}/${nextResNum}-${nextResNum}/`)
+            selectedMolecule.centreAndAlignViewOn(`/*/${chosenAtom.chain_id}/${nextResNum}-${nextResNum}/`)
         })
         .catch(err => console.log(err))
 

--- a/baby-gru/src/utils/MoorhenMap.ts
+++ b/baby-gru/src/utils/MoorhenMap.ts
@@ -6,7 +6,8 @@ import { libcootApi } from "../types/libcoot";
 /**
  * Represents a map
  * @constructor
- * @param {moorhen.CommandCentre} commandCentre - A command centre instance
+ * @param {React.RefObject<moorhen.CommandCentre>} commandCentre - A react reference to the command centre instance
+ * @param {React.RefObject<webGL.MGWebGL>} glRef - A react reference to the MGWebGL instance
 */
 export class MoorhenMap implements moorhen.Map {
     
@@ -14,6 +15,7 @@ export class MoorhenMap implements moorhen.Map {
     name: string
     molNo: number
     commandCentre: React.RefObject<moorhen.CommandCentre>
+    glRef: React.RefObject<webGL.MGWebGL>
     contourLevel: number
     mapRadius: number
     mapColour: [number, number, number, number]
@@ -36,11 +38,12 @@ export class MoorhenMap implements moorhen.Map {
         a: number;
     }
 
-    constructor(commandCentre: React.RefObject<moorhen.CommandCentre>) {
+    constructor(commandCentre: React.RefObject<moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>) {
         this.type = 'map'
         this.name = "unnamed"
         this.molNo = null
         this.commandCentre = commandCentre
+        this.glRef = glRef
         this.contourLevel = 0.8
         this.mapRadius = 13
         this.mapColour = [0.3, 0.3, 1.0, 1.0]
@@ -64,6 +67,10 @@ export class MoorhenMap implements moorhen.Map {
         }
     }
 
+    /**
+     * Get the current map RMSD
+     * @returns {number} The map RMSD
+     */
     async fetchMapRmsd(): Promise<number> {
         const result = await this.commandCentre.current.cootCommand({
             command: 'get_map_rmsd_approx',
@@ -74,19 +81,21 @@ export class MoorhenMap implements moorhen.Map {
         return result.data.result.result
     }
 
-    async delete(glRef: React.RefObject<webGL.MGWebGL>): Promise<void> {
-        const $this = this
+    /**
+     * Delete the map instance
+     */
+    async delete(): Promise<void> {
         Object.getOwnPropertyNames(this.displayObjects).forEach(displayObject => {
-            if (this.displayObjects[displayObject].length > 0) { this.clearBuffersOfStyle(glRef, displayObject) }
+            if (this.displayObjects[displayObject].length > 0) { this.clearBuffersOfStyle(displayObject) }
         })
-        glRef.current.drawScene()
+        this.glRef.current.drawScene()
         const promises = [
-            $this.commandCentre.current.postMessage({
-                message: "delete", molNo: $this.molNo
+            this.commandCentre.current.postMessage({
+                message: "delete", molNo: this.molNo
             }),
-            $this.hasReflectionData ?
-                $this.commandCentre.current.postMessage({
-                    message: 'delete_file_name', fileName: $this.associatedReflectionFileName
+            this.hasReflectionData ?
+                this.commandCentre.current.postMessage({
+                    message: 'delete_file_name', fileName: this.associatedReflectionFileName
                 })
                 :
                 Promise.resolve(true)
@@ -94,7 +103,15 @@ export class MoorhenMap implements moorhen.Map {
         await Promise.all(promises)
     }
 
-    async replaceMapWithMtzFile(glRef: React.RefObject<webGL.MGWebGL>, fileUrl: RequestInfo | URL, name: string, selectedColumns: moorhen.selectedMtzColumns, mapColour?: { [type: string]: {r: number, g: number, b: number} }): Promise<void> {
+    /**
+     * Replace the current map with the contents of a MTZ file
+     * @param {string} fileUrl - The uri to the MTZ file
+     * @param {string} name - The name of the map
+     * @param {moorhen.selectedMtzColumns} selectedColumns - Object indicating the selected MTZ columns
+     * @param { { [type: string]: {r: number, g: number, b: number} } } mapColour - The map colour
+     * @returns {Promise<void>}
+     */
+    async replaceMapWithMtzFile(fileUrl: RequestInfo | URL, name: string, selectedColumns: moorhen.selectedMtzColumns, mapColour?: { [type: string]: {r: number, g: number, b: number} }): Promise<void> {
         let mtzData: Uint8Array
         let fetchResponse: Response
 
@@ -119,15 +136,21 @@ export class MoorhenMap implements moorhen.Map {
         }, true) as moorhen.WorkerResponse<number>
 
         if (cootResponse.data.result.status === 'Completed') {
-            return this.doCootContour(glRef, ...(glRef.current.origin.map(coord => -coord) as [number, number, number]), this.mapRadius, this.contourLevel);
+            return this.doCootContour(...this.glRef.current.origin.map(coord => -coord) as [number, number, number], this.mapRadius, this.contourLevel);
         }
 
         return Promise.reject(cootResponse.data.result.status)
 
     }
 
-    loadToCootFromMtzURL = async function (url: RequestInfo | URL, name: string, selectedColumns: moorhen.selectedMtzColumns) {
-        const $this = this
+    /**
+     * Load map to moorhen using a MTZ url
+     * @param {string} url - The url to the MTZ file
+     * @param {string} name - The name that will be assigned to the map
+     * @param {moorhen.selectedMtzColumns} selectedColumns - Object indicating the selected MTZ columns
+     * @returns {Pormise<moorhen.Map>} This moorhenMap instance
+     */
+    async loadToCootFromMtzURL(url: RequestInfo | URL, name: string, selectedColumns: moorhen.selectedMtzColumns): Promise<moorhen.Map> {
 
         try {
             const response = await fetch(url)
@@ -137,20 +160,26 @@ export class MoorhenMap implements moorhen.Map {
             const reflectionData: Blob = await response.blob()
             const arrayBuffer: ArrayBuffer = await reflectionData.arrayBuffer()
             const asUIntArray: Uint8Array = new Uint8Array(arrayBuffer)
-            await $this.loadToCootFromMtzData(asUIntArray, name, selectedColumns)
+            await this.loadToCootFromMtzData(asUIntArray, name, selectedColumns)
             if (selectedColumns.calcStructFact) {
-                await $this.associateToReflectionData(selectedColumns, asUIntArray)
+                await this.associateToReflectionData(selectedColumns, asUIntArray)
             }
-            return $this
+            return this
         } catch (err) {
             console.log(err)
             return Promise.reject(err)
         }
     }
 
-    loadToCootFromMtzData(data: Uint8Array, name: string, selectedColumns: moorhen.selectedMtzColumns) {
-        const $this = this
-        $this.name = name
+    /**
+     * Load map to moorhen using MTZ data
+     * @param {Uint8Array} data - The mtz data
+     * @param {string} name - The name that will be assigned to the map
+     * @param {moorhen.selectedMtzColumns} selectedColumns - Object indicating the selected MTZ columns
+     * @returns {Pormise<moorhen.Map>} This moorhenMap instance
+     */
+    loadToCootFromMtzData(data: Uint8Array, name: string, selectedColumns: moorhen.selectedMtzColumns): Promise<moorhen.Map> {
+        this.name = name
         return new Promise((resolve, reject) => {
             return this.commandCentre.current.cootCommand({
                 returnType: "status",
@@ -161,11 +190,11 @@ export class MoorhenMap implements moorhen.Map {
                     if (reply.data.result.status === 'Exception') {
                         reject(reply.data.result.consoleMessage)
                     }
-                    $this.molNo = reply.data.result.result
+                    this.molNo = reply.data.result.result
                     if (Object.keys(selectedColumns).includes('isDifference')) {
-                        $this.isDifference = selectedColumns.isDifference
+                        this.isDifference = selectedColumns.isDifference
                     }
-                    resolve($this)
+                    resolve(this)
                 })
                 .catch((err) => {
                     return Promise.reject(err)
@@ -174,6 +203,12 @@ export class MoorhenMap implements moorhen.Map {
         })
     }
 
+    /**
+     * Load map to moorhen from a MTZ file
+     * @param {Blob} source - The MTZ file data in the form of a blob
+     * @param {moorhen.selectedMtzColumns} selectedColumns - Object indicating the selected MTZ columns
+     * @returns {Promise<moorhen.Map>} This moorhenMap instance
+     */
     loadToCootFromMtzFile = async function (source: Blob, selectedColumns: moorhen.selectedMtzColumns): Promise<moorhen.Map> {
         const $this = this
         let reflectionData = await readDataFile(source)
@@ -185,24 +220,34 @@ export class MoorhenMap implements moorhen.Map {
         return $this
     }
 
-    loadToCootFromMapURL(url: RequestInfo | URL, name: string, isDiffMap: boolean= false): Promise<moorhen.Map>  {
-        const $this = this
+    /**
+     * Load map to moorhen from a map file url
+     * @param {string} url - The url to the MTZ file
+     * @param {string} name - The name that will be assigned to the map
+     * @param {boolean} [isDiffMap=false] - Indicates whether the new map is a difference map
+     * @returns {Promise<moorhen.Map>} This moorhenMap instance
+     */
+    async loadToCootFromMapURL(url: RequestInfo | URL, name: string, isDiffMap: boolean= false): Promise<moorhen.Map>  {
 
-        return fetch(url)
-            .then(response => {
-                return response.blob()
-            }).then(mapData => mapData.arrayBuffer())
-            .then(arrayBuffer => {
-                return $this.loadToCootFromMapData(new Uint8Array(arrayBuffer), name, isDiffMap)
-            })
-            .catch((err) => {
-                return Promise.reject(err)
-            })
+        try {
+            const response = await fetch(url);
+            const mapData = await response.blob();
+            const arrayBuffer = await mapData.arrayBuffer();
+            return await this.loadToCootFromMapData(new Uint8Array(arrayBuffer), name, isDiffMap);
+        } catch (err) {
+            return await Promise.reject(err);
+        }
     }
 
+    /**
+     * Load map to moorhen from map data
+     * @param {ArrayBuffer | Uint8Array} data - The map data in the form of a array buffer
+     * @param {string} name - The name that will be assigned to the map
+     * @param {boolean} isDiffMap - Indicates whether the new map is a difference map
+     * @returns {Promise<moorhen.Map>} This moorhenMap instance
+     */
     loadToCootFromMapData(data: ArrayBuffer | Uint8Array, name: string, isDiffMap: boolean): Promise<moorhen.Map> {
-        const $this = this
-        $this.name = name
+        this.name = name
         return this.commandCentre.current.cootCommand({
             returnType: "status",
             command: "shim_read_ccp4_map",
@@ -212,16 +257,22 @@ export class MoorhenMap implements moorhen.Map {
                 if (reply.data.result?.status === 'Exception') {
                     return Promise.reject(reply.data.result.consoleMessage)
                 }
-                $this.molNo = reply.data.result.result
-                $this.isDifference = isDiffMap
-                return Promise.resolve($this)
+                this.molNo = reply.data.result.result
+                this.isDifference = isDiffMap
+                return Promise.resolve(this)
             })
             .catch((err) => {
                 return Promise.reject(err)
             })
     }
 
-    loadToCootFromMapFile = async function (source: Blob, isDiffMap: boolean): Promise<moorhen.Map> {
+    /**
+     * Load a map to moorhen from a map file data blob
+     * @param {Blob} source - The map file data in the form of a blob
+     * @param {boolean} isDiffMap - Indicates whether the new map is a difference map
+     * @returns {Promise<moorhen.Map>} This moorhenMap instance
+     */
+    async loadToCootFromMapFile (source: Blob, isDiffMap: boolean): Promise<moorhen.Map> {
         const $this = this
         return readDataFile(source)
             .then(mapData => {
@@ -230,14 +281,22 @@ export class MoorhenMap implements moorhen.Map {
             })
     }
 
+    /**
+     * Get the current map
+     * @returns {Promise<moorhen.WorkerResponse>} A worker response with the map arrayBuffer
+     */
     getMap(): Promise<moorhen.WorkerResponse> {
-        const $this = this
         return this.commandCentre.current.postMessage({
             message: 'get_map',
-            molNo: $this.molNo
+            molNo: this.molNo
         })
     }
 
+    /**
+     * Set the map weight
+     * @param {number} weight - The new map weight
+     * @returns {Promise<moorhen.WorkerResponse>} Void worker response
+     */
     setMapWeight(weight: number): Promise<moorhen.WorkerResponse> {
         return this.commandCentre.current.cootCommand({
             returnType: 'status',
@@ -246,7 +305,10 @@ export class MoorhenMap implements moorhen.Map {
         })
     }
 
-
+    /**
+     * Get the current map weight
+     * @returns {Promise<moorhen.WorkerResponse<number>>} The current map weight
+     */
     getMapWeight() {
         return this.commandCentre.current.cootCommand({
             returnType: 'status',
@@ -255,49 +317,48 @@ export class MoorhenMap implements moorhen.Map {
         }) as Promise<moorhen.WorkerResponse<number>>
     }
 
-    makeCootLive(glRef: React.RefObject<webGL.MGWebGL>): void {
-        const $this = this
-        $this.cootContour = true
-        $this.doCootContour(glRef,
-            -glRef.current.origin[0],
-            -glRef.current.origin[1],
-            -glRef.current.origin[2],
-            $this.mapRadius, $this.contourLevel)
-        glRef.current.drawScene()
+    /**
+     * Contour the map and make it live
+     */
+    makeCootLive(): void {
+        this.cootContour = true
+        this.doCootContour(...this.glRef.current.origin.map(coord => -coord) as [number, number, number], this.mapRadius, this.contourLevel)
+        this.glRef.current.drawScene()
     }
 
-    recontour(glRef: React.RefObject<webGL.MGWebGL>): void {
-        const $this = this
-        $this.cootContour = true
-        $this.doCootContour(glRef,
-            -glRef.current.origin[0],
-            -glRef.current.origin[1],
-            -glRef.current.origin[2],
-            $this.mapRadius, $this.contourLevel)
-        glRef.current.drawScene()
-    }
-
-    makeCootUnlive(glRef: React.RefObject<webGL.MGWebGL>): void {
+    /**
+     * Hide the map
+     */
+    makeCootUnlive(): void {
         const $this = this
         $this.cootContour = false
-        $this.clearBuffersOfStyle(glRef, 'Coot')
-        glRef.current.buildBuffers();
-        glRef.current.drawScene();
+        $this.clearBuffersOfStyle('Coot')
+        this.glRef.current.buildBuffers();
+        this.glRef.current.drawScene();
     }
 
-    clearBuffersOfStyle(glRef: React.RefObject<webGL.MGWebGL>, style: string): void {
-        const $this = this
+    /**
+     * Clear MGWebGL buffers of a given style for this map
+     * @param {string} style - The map style that will be cleared
+     */
+    clearBuffersOfStyle(style: string): void {
         //Empty existing buffers of this type
-        $this.displayObjects[style].forEach((buffer) => {
+        this.displayObjects[style].forEach((buffer) => {
             buffer.clearBuffers()
-            glRef.current.displayBuffers = glRef.current.displayBuffers?.filter(glBuffer => glBuffer.id !== buffer.id)
+            this.glRef.current.displayBuffers = this.glRef.current.displayBuffers?.filter(glBuffer => glBuffer.id !== buffer.id)
         })
-        $this.displayObjects[style] = []
+        this.displayObjects[style] = []
     }
 
-    async doCootContour(glRef: React.RefObject<webGL.MGWebGL>, x: number, y: number, z: number, radius: number, contourLevel: number): Promise<void> {
-
-        const $this = this
+    /**
+     * Draw the map contour around a given origin
+     * @param {number} x - Origin coord. X
+     * @param {number} y - Origin coord. Y
+     * @param {number} z - Origin coord. Z
+     * @param {number} radius - Radius around the origin that will be drawn
+     * @param {number} contourLevel - The map contour level
+     */
+    async doCootContour(x: number, y: number, z: number, radius: number, contourLevel: number): Promise<void> {
 
         let returnType: string
         if (this.solid) {
@@ -311,53 +372,62 @@ export class MoorhenMap implements moorhen.Map {
         const response = await this.commandCentre.current.cootCommand({
                 returnType: returnType,
                 command: "get_map_contours_mesh",
-                commandArgs: [$this.molNo, x, y, z, radius, contourLevel]
+                commandArgs: [this.molNo, x, y, z, radius, contourLevel]
         })
         try {
             const objects = [response.data.result.result]
             const diffMapColourBuffers = { positiveDiffColour: [], negativeDiffColour: [] }
-            $this.clearBuffersOfStyle(glRef, "Coot")
+            this.clearBuffersOfStyle("Coot")
             objects.filter(object => typeof object !== 'undefined' && object !== null).forEach(object => {
                 object.col_tri.forEach((cols: number[][]) => {
                     cols.forEach((col: number[]) => {
                         if (!this.isDifference) {
                             for (let idx = 0; idx < col.length; idx += 4) {
-                                col[idx] = $this.rgba.mapColour.r
-                                col[idx + 1] = $this.rgba.mapColour.g
-                                col[idx + 2] = $this.rgba.mapColour.b
-                                col[idx + 3] = $this.rgba.a
+                                col[idx] = this.rgba.mapColour.r
+                                col[idx + 1] = this.rgba.mapColour.g
+                                col[idx + 2] = this.rgba.mapColour.b
+                                col[idx + 3] = this.rgba.a
                             }
                         } else {
                             for (let idx = 0; idx < col.length; idx += 4) {
                                 if (col[idx] < 0.5) {
                                     diffMapColourBuffers.positiveDiffColour.push(idx)
-                                    col[idx] = $this.rgba.positiveDiffColour.r
-                                    col[idx + 1] = $this.rgba.positiveDiffColour.g
-                                    col[idx + 2] = $this.rgba.positiveDiffColour.b    
+                                    col[idx] = this.rgba.positiveDiffColour.r
+                                    col[idx + 1] = this.rgba.positiveDiffColour.g
+                                    col[idx + 2] = this.rgba.positiveDiffColour.b    
                                 } else {
                                     diffMapColourBuffers.negativeDiffColour.push(idx)
-                                    col[idx] = $this.rgba.negativeDiffColour.r
-                                    col[idx + 1] = $this.rgba.negativeDiffColour.g
-                                    col[idx + 2] = $this.rgba.negativeDiffColour.b    
+                                    col[idx] = this.rgba.negativeDiffColour.r
+                                    col[idx + 1] = this.rgba.negativeDiffColour.g
+                                    col[idx + 2] = this.rgba.negativeDiffColour.b    
                                 }
-                                col[idx + 3] = $this.rgba.a
+                                col[idx + 3] = this.rgba.a
                             }
                         }
                     })
                 })
-                let a = glRef.current.appendOtherData(object, true);
-                $this.diffMapColourBuffers.positiveDiffColour = $this.diffMapColourBuffers.positiveDiffColour.concat(diffMapColourBuffers.positiveDiffColour)
-                $this.diffMapColourBuffers.negativeDiffColour = $this.diffMapColourBuffers.negativeDiffColour.concat(diffMapColourBuffers.negativeDiffColour)
-                $this.displayObjects['Coot'] = $this.displayObjects['Coot'].concat(a)
+                let a = this.glRef.current.appendOtherData(object, true);
+                this.diffMapColourBuffers.positiveDiffColour = this.diffMapColourBuffers.positiveDiffColour.concat(diffMapColourBuffers.positiveDiffColour)
+                this.diffMapColourBuffers.negativeDiffColour = this.diffMapColourBuffers.negativeDiffColour.concat(diffMapColourBuffers.negativeDiffColour)
+                this.displayObjects['Coot'] = this.displayObjects['Coot'].concat(a)
             })
-            glRef.current.buildBuffers();
-            glRef.current.drawScene();
+            this.glRef.current.buildBuffers();
+            this.glRef.current.drawScene();
             } catch(err) {
                 console.log(err)
             }
     }
 
-    async setDiffMapColour(type: 'positiveDiffColour' | 'negativeDiffColour', r: number, g: number, b: number, glRef: React.RefObject<webGL.MGWebGL>, redraw: boolean = true): Promise<void> {
+    /**
+     * Set the colours for a difference map
+     * @param {'positiveDiffColour' | 'negativeDiffColour'} type - Indicates whether the negative or positive colours will be set
+     * @param {number} r - Red component as a fraction of 1
+     * @param {number} g - Green component as a fraction of 1
+     * @param {number} b - Blue component as a fraction of 1
+     * @param {boolean} [redraw=true] - Indicates whether the map needs to be redrawn after setting the new colours
+     * @returns {Promise<void>}
+     */
+    async setDiffMapColour(type: 'positiveDiffColour' | 'negativeDiffColour', r: number, g: number, b: number, redraw: boolean = true): Promise<void> {
         if (!this.isDifference) {
             console.error('Cannot use moorhen.Map.setDiffMapColour to change non-diff map colour. Use moorhen.Map.setColour instead...')
             return
@@ -376,14 +446,21 @@ export class MoorhenMap implements moorhen.Map {
             buffer.isDirty = true
         })
         
-        glRef.current.buildBuffers();
+        this.glRef.current.buildBuffers();
         if (redraw) {
-            glRef.current.drawScene();
+            this.glRef.current.drawScene();
         }
     }
 
-
-    async setColour(r: number, g: number, b: number, glRef: React.RefObject<webGL.MGWebGL>, redraw: boolean = true): Promise<void> {
+    /**
+     * Set the colours for a non-difference map
+     * @param {number} r - Red component as a fraction of 1
+     * @param {number} g - Green component as a fraction of 1
+     * @param {number} b - Blue component as a fraction of 1
+     * @param {boolean} [redraw=true] - Indicates whether the map needs to be redrawn after setting the new colours
+     * @returns {Promise<void>}
+     */
+    async setColour(r: number, g: number, b: number, redraw: boolean = true): Promise<void> {
         if (this.isDifference) {
             console.error('Cannot use moorhen.Map.setColour to change difference map colour. Use moorhen.Map.setDiffMapColour instead...')
             return
@@ -398,18 +475,22 @@ export class MoorhenMap implements moorhen.Map {
                     colbuffer[idx + 1] = this.rgba.mapColour.g
                     colbuffer[idx + 2] = this.rgba.mapColour.b
                 }
-                
             })
             buffer.isDirty = true
         })
 
-        glRef.current.buildBuffers();
+        this.glRef.current.buildBuffers();
         if (redraw) {
-            glRef.current.drawScene();
+            this.glRef.current.drawScene();
         }
     }
 
-    async setAlpha(alpha: number, glRef: React.RefObject<webGL.MGWebGL>, redraw: boolean = true): Promise<void> {
+    /**
+     * Set the alpha (transparency) for this map
+     * @param {number} alpha - The new alpha value as a fraction of 1
+     * @param {boolean} [redraw=true] - Indicates whether the map needs to be redrawn after setting the new alpha
+     */
+    async setAlpha(alpha: number, redraw: boolean = true): Promise<void> {
         this.rgba.a = alpha
         this.displayObjects['Coot'].forEach(buffer => {
             buffer.triangleColours.forEach(colbuffer => {
@@ -425,12 +506,18 @@ export class MoorhenMap implements moorhen.Map {
                 buffer.transparent = false
             }
         })
-        glRef.current.buildBuffers();
+        this.glRef.current.buildBuffers();
         if (redraw) {
-            glRef.current.drawScene();
+            this.glRef.current.drawScene();
         }
     }
 
+    /**
+     * Associate this map with a set of observed reflections
+     * @param {moorhen.selectedMtzColumns} selectedColumns - Object indicating the selected MTZ columns
+     * @param {Uint8Array} reflectionData - The reflection data that will be associates to this map
+     * @returns {Promise<moorhen.WorkerResponse>} - Void promise
+     */
     async associateToReflectionData (selectedColumns: moorhen.selectedMtzColumns, reflectionData: Uint8Array | ArrayBuffer): Promise<moorhen.WorkerResponse> {
         if (!selectedColumns.Fobs || !selectedColumns.SigFobs || !selectedColumns.FreeR) {
             return Promise.reject('Missing column data')
@@ -456,7 +543,11 @@ export class MoorhenMap implements moorhen.Map {
         }
     }
 
-    async fetchReflectionData(): Promise<moorhen.WorkerResponse> {
+    /**
+     * Fetch the reflection data associated with this map
+     * @returns {Promise<moorhen.WorkerResponse<Uint8Array>>} The reflection data
+     */
+    async fetchReflectionData(): Promise<moorhen.WorkerResponse<Uint8Array>> {
         if (this.hasReflectionData) {
             return await this.commandCentre.current.postMessage({
                 molNo: this.molNo,
@@ -468,12 +559,21 @@ export class MoorhenMap implements moorhen.Map {
         }
     }
 
+    /**
+     * Create a copy of the map
+     * @returns {Promise<moorhen.Map>} New map instance
+     */
     async duplicate(): Promise<moorhen.Map> {
         const reply = await this.getMap()
-        const newMap = new MoorhenMap(this.commandCentre)
+        const newMap = new MoorhenMap(this.commandCentre, this.glRef)
         return newMap.loadToCootFromMapData(reply.data.result.mapData, `Copy of ${this.name}`, this.isDifference)
     }
 
+    /**
+     * Blur the map
+     * @param {number} bFactor - The b-factor used for blurring
+     * @returns {Promise<moorhen.WorkerResponse<number>>} Status (-1 if failure)
+     */
     blur(bFactor: number): Promise<moorhen.WorkerResponse> {
         return this.commandCentre.current.cootCommand({
             command: 'sharpen_blur_map',
@@ -482,14 +582,17 @@ export class MoorhenMap implements moorhen.Map {
         }) as Promise<moorhen.WorkerResponse<number>>
     }
 
-    async centreOnMap(glRef: React.RefObject<webGL.MGWebGL>): Promise<void> {
+    /**
+     * Set the view in the centre of this map
+     */
+    async centreOnMap(): Promise<void> {
         const response = await this.commandCentre.current.cootCommand({
             command: 'get_map_molecule_centre',
             commandArgs: [this.molNo],
             returnType: "map_molecule_centre_info_t"
         }) as moorhen.WorkerResponse<libcootApi.MapMoleculeCentreInfoJS>
         if (response.data.result.result.success) {
-            glRef.current.setOriginAnimated(response.data.result.result.updated_centre.map(coord => -coord))
+            this.glRef.current.setOriginAnimated(response.data.result.result.updated_centre.map(coord => -coord))
         } else {
             console.log('Problem finding map centre')
         }

--- a/baby-gru/src/utils/MoorhenScriptAPI.ts
+++ b/baby-gru/src/utils/MoorhenScriptAPI.ts
@@ -24,7 +24,7 @@ export class MoorhenScriptApi implements MoorhenScriptApiInterface {
         if (typeof selectedMolecule !== 'undefined') {
             await selectedMolecule.rigidBodyFit(cidsString, mapNo)
             selectedMolecule.setAtomsDirty(true)
-            await selectedMolecule.redraw(this.glRef)
+            await selectedMolecule.redraw()
         } else {
             console.log(`Unable to find molecule number ${molNo}`)
         }
@@ -44,7 +44,7 @@ export class MoorhenScriptApi implements MoorhenScriptApiInterface {
         if (typeof selectedMolecule !== 'undefined') {
             await selectedMolecule.refineResiduesUsingAtomCid(cid, mode, ncyc)
             selectedMolecule.setAtomsDirty(true)
-            await selectedMolecule.redraw(this.glRef)
+            await selectedMolecule.redraw()
         } else {
             console.log(`Unable to find molecule number ${molNo}`)
         }

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -31,6 +31,22 @@ export function sequenceIsValid(sequence: moorhen.ResidueInfo[]): boolean {
     return true
 }
 
+export function itemReducer<T extends moorhen.Molecule | moorhen.Map> (oldList: T[], change: moorhen.MolChange<T>): T[] {
+    if (change.action === 'Add') {
+        return [...oldList, change.item]
+    }
+    else if (change.action === 'Remove') {
+        return oldList.filter(item =>  item.molNo !== change.item.molNo)
+    }
+    else if (change.action === 'AddList') {
+        return oldList.concat(change.items)
+    }
+    else if (change.action === 'Empty') {
+        return []
+    }
+    return oldList
+}
+
 export function convertRemToPx(rem: number): number {
     return rem * parseFloat(getComputedStyle(document.documentElement).fontSize);
 }


### PR DESCRIPTION
This update:
- Fixes #19 
- Exports `itemReducer` in morhen npm package
- Adds documentation for `MoorhenMolecule` and `MoorhenMap` (related to #11)