### PR TITLE
Handle map contour and other events within the app if viewOnly

### DIFF
--- a/baby-gru/cloud/src/components/MoorhenCloudApp.tsx
+++ b/baby-gru/cloud/src/components/MoorhenCloudApp.tsx
@@ -152,8 +152,9 @@ export const MoorhenCloudApp = (props: MoorhenCloudAppPropsInterface) => {
     useEffect(() => {
         if (props.viewOnly && maps.length > 0) {
             maps.forEach((map: moorhen.Map) => {
+                map.contourLevel = map.suggestedContourLevel ? map.suggestedContourLevel : 0.8
                 map.doCootContour(
-                    ...glRef.current.origin.map(coord => -coord) as [number, number, number], 13.0, 0.8
+                    ...glRef.current.origin.map(coord => -coord) as [number, number, number], 13.0, map.contourLevel
               )
             })
         }

--- a/baby-gru/src/components/MoorhenContainer.tsx
+++ b/baby-gru/src/components/MoorhenContainer.tsx
@@ -424,7 +424,7 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
             <span>Starting moorhen...</span>
         </Backdrop>
         
-        {!viewOnly && <MoorhenNavBar {...collectedProps} busy={busy}/>}
+        <MoorhenNavBar {...collectedProps} busy={busy}/>
         
     </div>
     

--- a/baby-gru/src/components/navbar-menus/MoorhenNavBar.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenNavBar.tsx
@@ -162,6 +162,7 @@ export const MoorhenNavBar = forwardRef<HTMLElement, MoorhenNavBarPropsInterface
         ariaLabel="Moorhen Navbar Speed Dial"
         direction='down'
         sx={{
+            display: props.viewOnly ? 'none' : 'flex',
             position: 'absolute', top: canvasTop + convertRemToPx(0.5), left: canvasLeft + convertRemToPx(0.5), color: props.isDark ? 'white' : 'black' ,
             "& .MuiSpeedDial-actions": {
                 paddingTop: '40px',

--- a/baby-gru/src/utils/MoorhenMap.ts
+++ b/baby-gru/src/utils/MoorhenMap.ts
@@ -625,7 +625,6 @@ export class MoorhenMap implements moorhen.Map {
         if (response.data.result.result.success) {
             this.mapCentre = response.data.result.result.updated_centre.map(coord => -coord) as [number, number, number]
             this.suggestedContourLevel = response.data.result.result.suggested_contour_level
-            console.log(this.mapCentre, this.suggestedContourLevel)
         } else {
             console.log('Problem finding map centre')
             this.mapCentre = null


### PR DESCRIPTION
After this update, map contour and other events are handled within moorhen when `viewOnly` is active. This reduces the amount of redundant code required to handle this mode in third party apps.