### PR TITLE
Use MoorhenMoleculeRepresentations to define custom representations part I

### DIFF
--- a/baby-gru/src/WebGLgComponents/mgWebGL.tsx
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.tsx
@@ -7765,7 +7765,7 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
                     }
                 });
                 document.dispatchEvent(atomClicked);
-                if (this.draggableMolecule != null && Object.keys(this.draggableMolecule.displayObjects).length > 0 && this.draggableMolecule.buffersInclude(self.displayBuffers[minidx])) {
+                if (this.draggableMolecule != null && this.draggableMolecule.representations.length > 0 && this.draggableMolecule.buffersInclude(self.displayBuffers[minidx])) {
                     this.currentlyDraggedAtom = { atom: self.displayBuffers[minidx].atoms[minj], buffer: self.displayBuffers[minidx] }
                 }
                 if (self.keysDown['label_atom']) {
@@ -9164,10 +9164,10 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
     }
 
     drawSceneIfDirty() {
-        const activeMoleculeMotion = (this.activeMolecule != null) && (Object.keys(this.activeMolecule.displayObjects).length > 0) ;
-        if(this.activeMolecule){
-            if(this.activeMolecule.displayObjects){
-                const dispObjs :moorhen.DisplayObject[][] = Object.entries(this.activeMolecule.displayObjects).filter((a)=>{return a[0] !== "transformation";}).map((b)=>{return b[1]})
+        const activeMoleculeMotion = (this.activeMolecule != null) && (this.activeMolecule.representations.length > 0) ;
+        if (this.activeMolecule) {
+            if (this.activeMolecule.representations) {
+                const dispObjs: moorhen.DisplayObject[][] = this.activeMolecule.representations.filter(item => item.style !== 'transformation').map(item => item.buffers)
                 for (const value of dispObjs) {
                     for (let ibuf = 0; ibuf < value.length; ibuf++) {
                         if(!value[ibuf].transformMatrixInteractive){
@@ -9239,7 +9239,7 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
     }
 
     doMouseMove(event, self) {;
-        const activeMoleculeMotion = (this.activeMolecule != null) && (Object.keys(this.activeMolecule.displayObjects).length > 0) && !self.keysDown['residue_camera_wiggle'];
+        const activeMoleculeMotion = (this.activeMolecule != null) && (this.activeMolecule.representations.length > 0) && !self.keysDown['residue_camera_wiggle'];
 
         const centreOfMass = function (atoms) {
             let totX = 0.0;
@@ -9330,7 +9330,8 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
                 theMatrix[12] = this.activeMolecule.displayObjectsTransformation.origin[0];
                 theMatrix[13] = this.activeMolecule.displayObjectsTransformation.origin[1];
                 theMatrix[14] = this.activeMolecule.displayObjectsTransformation.origin[2];
-                for (const [key, value] of Object.entries(this.activeMolecule.displayObjects)) {
+                for (const representation of this.activeMolecule.representations) {
+                    const value = representation.buffers
                     for (let ibuf = 0; ibuf < value.length; ibuf++) {
                         value[ibuf].transformMatrixInteractive = theMatrix;
                     }
@@ -9433,8 +9434,8 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
                 //Just consider one origin.
                 let diff = [0, 0, 0];
 
-                const dispObjs :moorhen.DisplayObject[][]  = Object.entries(this.activeMolecule.displayObjects).filter((a)=>{return a[0] !== "transformation";}).map((b)=>{return b[1]})
-
+                
+                const dispObjs: moorhen.DisplayObject[][]  = this.activeMolecule.representations.filter(item => item.style !== 'transformation').map(item => item.buffers)
                 for (const value of dispObjs) {
                     if (value.length > 0) {
                         const com = centreOfMass(value[0].atoms);

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -270,17 +270,13 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
     }, [isVisible]);
 
     useEffect(() => {
-        Object.keys(props.molecule.displayObjects).forEach(key => {
-            const displayObjects = props.molecule.displayObjects[key]
+        props.molecule.representations.forEach(item => {
+            const displayObjects = item.buffers
             changeShowState({
-                key: key, state: displayObjects.length > 0 && displayObjects[0].visible
+                key: item.style, state: displayObjects.length > 0 && displayObjects[0].visible
             })
         })
-    }, [
-        props.molecule.displayObjects.rama.length,
-        props.molecule.displayObjects.rotamer.length,
-        props.molecule.displayObjects.CBs.length,
-    ])
+    }, [props.molecule.representations])
 
     useEffect(() => {
         if (!clickedResidue) {
@@ -301,14 +297,10 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
 
     const handleVisibility = () => {
         if (isVisible) {
-            Object.getOwnPropertyNames(props.molecule.displayObjects).forEach(key => {
-                if (showState[key]) { props.molecule.hide(key) }
-            })
+            props.molecule.representations.forEach(item => showState[item.style] ? item.hide() : null)
             setIsVisible(false)
         } else {
-            Object.getOwnPropertyNames(props.molecule.displayObjects).forEach(key => {
-                if (showState[key]) { props.molecule.show(key) }
-            })
+            props.molecule.representations.forEach(item => showState[item.style] ? item.show() : null)
             setIsVisible(true)
         }
         props.setCurrentDropdownMolNo(-1)
@@ -455,9 +447,7 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
                     <div style={{margin: '1px', paddingTop: '0.5rem', paddingBottom: '0.25rem',  border: '1px solid', borderRadius:'0.33rem', borderColor:
                 "#CCC"}}>
                         <FormGroup style={{ margin: "0px", padding: "0px" }} row>
-                            {Object.keys(props.molecule.displayObjects)
-                                .filter(key => !['hover', 'unitCell', 'originNeighbours', 'selection', 'transformation', 'contact_dots', 'chemical_features', 'VdWSurface'].some(style => key.includes(style)))
-                                .map(key => getCheckBox(key))}
+                            {[ 'CBs', 'CAs', 'CRs', 'ligands', 'gaussian', 'MolecularSurface', 'DishyBases', 'VdwSpheres', 'rama', 'rotamer', 'CDs', 'allHBonds' ].map(key => getCheckBox(key))}
                         </FormGroup>
                     </div>
                 </Col>
@@ -527,6 +517,7 @@ type RepresetationCheckboxPropsType = {
 
 const RepresentationCheckbox = (props: RepresetationCheckboxPropsType) => {
     const [repState, setRepState] = useState<boolean>(false)
+    
     useEffect(() => {
         setRepState(props.showState[props.repKey] || false)
     }, [props.showState])

--- a/baby-gru/src/components/context-menu/MoorhenContextMenu.tsx
+++ b/baby-gru/src/components/context-menu/MoorhenContextMenu.tsx
@@ -185,7 +185,7 @@ export const MoorhenContextMenu = (props: {
   }
 
   return <>
-      <ContextMenu ref={contextMenuRef} top={overrideMenuContents ? convertRemToPx(4) : menuPosition.top} left={overrideMenuContents ? convertRemToPx(2) : menuPosition.left} backgroundColor={backgroundColor} opacity={opacity}>
+      <ContextMenu ref={contextMenuRef} top={overrideMenuContents ? convertRemToPx(4) : menuPosition.top} left={overrideMenuContents ? convertRemToPx(15) : menuPosition.left} backgroundColor={backgroundColor} opacity={opacity}>
         {overrideMenuContents ? 
         overrideMenuContents 
         :

--- a/baby-gru/src/components/navbar-menus/MoorhenDevMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenDevMenu.tsx
@@ -1,7 +1,7 @@
 import { Form, InputGroup } from "react-bootstrap";
 import { useState } from "react";
 import { MenuItem } from "@mui/material";
-import { cidToSpec } from "../../utils/MoorhenUtils";
+import { cidToSpec, guid } from "../../utils/MoorhenUtils";
 import { MoorhenNavBarExtendedControlsInterface } from "./MoorhenNavBar";
 
 var TRIAL_COUNT = 0
@@ -68,14 +68,14 @@ const doRepresentationsTest = async (props: any) => {
     const molecule = props.molecules.find(molecule => molecule.molNo === 0)
 
     if (typeof molecule !== 'undefined') {
-        molecule.customRepresentations = [
-            {style: 'MolecularSurface', cidSelection: '//A/1-15'},
-            {style: 'CBs', cidSelection: '//A/15-30'},
-            {style: 'CRs', cidSelection: '//A/30-36'},
-            {style: 'CBs', cidSelection: '//A/46-55'},
-            {style: 'CRs', cidSelection: '//A/55-72'}
+        const customRepresentations = [
+            ['MolecularSurface', '//A/1-15'],
+            ['CBs', '//A/15-30'],
+            ['CRs', '//A/30-36'],
+            ['CBs', '//A/46-55'],
+            ['CRs', '//A/55-72']
         ]
-        await molecule.drawCustomRepresentations()
+        await Promise.all(customRepresentations.map(item => molecule.addRepresentation(...item)))
     }
 
 }

--- a/baby-gru/src/components/navbar-menus/MoorhenDevMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenDevMenu.tsx
@@ -64,11 +64,20 @@ const doColourTest = async (props: any) => {
     }
 }
 
-const doRenameChainTest = async (props: any) => {
+const doRepresentationsTest = async (props: any) => {
     const molecule = props.molecules.find(molecule => molecule.molNo === 0)
+
     if (typeof molecule !== 'undefined') {
-        await molecule.changeChainId('A', 'X')
+        molecule.customRepresentations = [
+            {style: 'MolecularSurface', cidSelection: '//A/1-15'},
+            {style: 'CBs', cidSelection: '//A/15-30'},
+            {style: 'CRs', cidSelection: '//A/30-36'},
+            {style: 'CBs', cidSelection: '//A/46-55'},
+            {style: 'CRs', cidSelection: '//A/55-72'}
+        ]
+        await molecule.drawCustomRepresentations()
     }
+
 }
 
 export const MoorhenDevMenu = (props: MoorhenNavBarExtendedControlsInterface) => {
@@ -82,8 +91,8 @@ export const MoorhenDevMenu = (props: MoorhenNavBarExtendedControlsInterface) =>
                     <MenuItem onClick={() => doColourTest(menuItemProps)}>
                         Do colouring test
                     </MenuItem>
-                    <MenuItem onClick={() => doRenameChainTest(menuItemProps)}>
-                        Do rename chain test
+                    <MenuItem onClick={() => doRepresentationsTest(menuItemProps)}>
+                        Do representations test
                     </MenuItem>
                     <InputGroup style={{ padding:'0.5rem', width: '25rem'}}>
                         <Form.Check 

--- a/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
@@ -253,8 +253,7 @@ export const MoorhenFileMenu = (props: MoorhenNavBarExtendedControlsInterface) =
         newMolecules.forEach((molecule, moleculeIndex) => {
             const storedMoleculeData = sessionData.moleculeData[moleculeIndex]
             molecule.cootBondsOptions = storedMoleculeData.cootBondsOptions
-            const styles = storedMoleculeData.displayObjectsKeys
-            styles.forEach(style => drawPromises.push(molecule.fetchIfDirtyAndDraw(style)))
+            storedMoleculeData.representations.forEach(item => molecule.addRepresentation(item.style, item.cid))
         })
 
         // Associate maps to reflection data

--- a/baby-gru/src/components/navbar-menus/MoorhenNavBar.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenNavBar.tsx
@@ -173,7 +173,7 @@ export const MoorhenNavBar = forwardRef<HTMLElement, MoorhenNavBarPropsInterface
         <ClickAwayListener onClickAway={() => { setCurrentDropdownId('-1') }}>
         <Popper open={speedDialOpen} anchorEl={speedDialRef.current} placement='bottom-start'>
             <Grow in={speedDialOpen} style={{ transformOrigin: '0 0 0' }}>
-            <MenuList style={{height: props.windowHeight - convertRemToPx(5), width: '100%', overflowY: 'scroll', direction: 'rtl'}}>
+            <MenuList style={{height: props.windowHeight - convertRemToPx(5), width: '100%', overflowY: 'auto', direction: 'rtl'}}>
                 {Object.keys(actions).map((key) => {
                 const action = actions[key]
                 return <MenuItem
@@ -201,7 +201,6 @@ export const MoorhenNavBar = forwardRef<HTMLElement, MoorhenNavBarPropsInterface
             </MenuList>
             </Grow>
             <Overlay placement='right' show={currentDropdownId !== '-1'} target={currentDropdownId !== '-1' ? popoverTargetRef : null}>
-            <Grow in={currentDropdownId !== '-1'}>
                 <Popover style={{
                     borderWidth: 0,
                     marginLeft: '1.5rem',
@@ -223,7 +222,6 @@ export const MoorhenNavBar = forwardRef<HTMLElement, MoorhenNavBarPropsInterface
                         { props.extraNavBarMenus && props.extraNavBarMenus.find(menu => currentDropdownId === menu.name)?.JSXElement}
                     </Popover.Body>
                 </Popover>
-            </Grow>
             </Overlay>
         </Popper>
         </ClickAwayListener>

--- a/baby-gru/src/components/webMG/MoorhenWebMG.tsx
+++ b/baby-gru/src/components/webMG/MoorhenWebMG.tsx
@@ -115,11 +115,7 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
     
             const mol: moorhen.Molecule = props.molecules.find(molecule => molecule.molNo === moleculeMolNo)
             if(typeof mol !== 'undefined') {
-                const cidSplit0 = residueCid.split(" ")[0]
-                const cidSplit = cidSplit0.replace(/\/+$/, "").split("/")
-                const resnum = cidSplit[cidSplit.length-1]
-                const chainID = cidSplit[cidSplit.length-2]
-                mol.drawEnvironment(chainID, parseInt(resnum), "", true)
+                mol.drawEnvironment(residueCid, true)
             }
             
             busyDrawingHBonds.current = false
@@ -131,8 +127,7 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
     const clearHBonds = useCallback(async () => {
         if(!props.context.drawInteractions) {
             props.molecules.forEach(mol => {
-                mol.drawGemmiAtomPairs([], "originNeighboursBump", [1.0, 0.0, 0.0, 1.0], true, true)
-                mol.drawGemmiAtomPairs([], "originNeighboursHBond", [1.0, 0.0, 0.0, 1.0], true, true)
+                mol.clearBuffersOfStyle('environment')
             })
         }
     }, [props.context.drawInteractions, props.molecules])

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -74,7 +74,7 @@ declare module 'moorhen' {
         gemmiStructure: gemmi.Structure;
         sequences: _moorhen.Sequence[];
         colourRules: _moorhen.ColourRule[];
-        customRepresentations: { style: string; cidSelection: string; }[];
+        customRepresentations: { style: string; cidSelection: string; id: string; buffers: moorhen.DisplayObject[]; }[];
         ligands: _moorhen.LigandInfo[];
         ligandDicts: {[comp_id: string]: string};
         connectedToMaps: number[];

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -28,7 +28,7 @@ declare module 'moorhen' {
         updateWithMovedAtoms(movedResidues: _moorhen.AtomInfo[][]): Promise<void>;
         transformedCachedAtomsAsMovedAtoms(selectionCid?: string): _moorhen.AtomInfo[][];
         drawWithStyleFromAtoms(style: string): Promise<void>;
-        copyFragmentUsingCid(cid: string, backgroundColor: [number, number, number, number], defaultBondSmoothness: number, doRecentre?: boolean): Promise<moorhen.Molecule>;
+        copyFragmentUsingCid(cid: string, backgroundColor: [number, number, number, number], defaultBondSmoothness: number, doRecentre?: boolean, style?: string): Promise<moorhen.Molecule>;
         hideCid(cid: string): Promise<void>;
         unhideAll(): Promise<void>;
         drawSelection(cid: string): Promise<void>;
@@ -74,6 +74,7 @@ declare module 'moorhen' {
         gemmiStructure: gemmi.Structure;
         sequences: _moorhen.Sequence[];
         colourRules: _moorhen.ColourRule[];
+        customRepresentations: { style: string; cidSelection: string; }[];
         ligands: _moorhen.LigandInfo[];
         ligandDicts: {[comp_id: string]: string};
         connectedToMaps: number[];
@@ -88,6 +89,7 @@ declare module 'moorhen' {
             gridScale: number;
         };
         cootBondsOptions: _moorhen.cootBondOptions;
+        customDisplayRules: {[x: string]: moorhen.DisplayObject[]};
         displayObjects: {
             CBs: _moorhen.DisplayObject[];
             CAs: _moorhen.DisplayObject[];

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -88,7 +88,7 @@ export namespace moorhen {
         updateWithMovedAtoms(movedResidues: AtomInfo[][]): Promise<void>;
         transformedCachedAtomsAsMovedAtoms(selectionCid?: string): AtomInfo[][];
         drawWithStyleFromAtoms(style: string): Promise<void>;
-        copyFragmentUsingCid(cid: string, backgroundColor: [number, number, number, number], defaultBondSmoothness: number, doRecentre?: boolean): Promise<Molecule>;
+        copyFragmentUsingCid(cid: string, backgroundColor: [number, number, number, number], defaultBondSmoothness: number, doRecentre?: boolean, style?: string): Promise<Molecule>;
         hideCid(cid: string): Promise<void>;
         unhideAll(): Promise<void>;
         drawSelection(cid: string): Promise<void>;
@@ -147,7 +147,9 @@ export namespace moorhen {
             boxRadius: number;
             gridScale: number;
         };
+        customRepresentations: { style: string; cidSelection: string; }[];
         cootBondsOptions: cootBondOptions;
+        customDisplayRules: {[x: string]: moorhen.DisplayObject[]};
         displayObjects: {
             CBs: DisplayObject[];
             CAs: DisplayObject[];

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -147,7 +147,7 @@ export namespace moorhen {
             boxRadius: number;
             gridScale: number;
         };
-        customRepresentations: { style: string; cidSelection: string; }[];
+        customRepresentations: { style: string; cidSelection: string; id: string; buffers: moorhen.DisplayObject[]; }[];
         cootBondsOptions: cootBondOptions;
         customDisplayRules: {[x: string]: moorhen.DisplayObject[]};
         displayObjects: {

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1,8 +1,9 @@
 import 'pako';
 import {
-    guid, readTextFile, readGemmiStructure, cidToSpec, residueCodesThreeToOne, centreOnGemmiAtoms, getBufferAtoms,
-    nucleotideCodesThreeToOne, hexToHsl, gemmiAtomPairsToCylindersInfo, gemmiAtomsToCirclesSpheresInfo, findConsecutiveRanges, getCubeLines
+    guid, readTextFile, readGemmiStructure, residueCodesThreeToOne, centreOnGemmiAtoms,
+    nucleotideCodesThreeToOne, hexToHsl, findConsecutiveRanges
 } from './MoorhenUtils'
+import { MoorhenMoleculeRepresentation } from "./MoorhenMoleculeRepresentation"
 import { quatToMat4 } from '../WebGLgComponents/quatToMat4.js';
 import { isDarkBackground } from '../WebGLgComponents/mgWebGL'
 import * as vec3 from 'gl-matrix/vec3';
@@ -53,7 +54,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
     type: string;
     commandCentre: React.RefObject<moorhen.CommandCentre>;
     glRef: React.RefObject<webGL.MGWebGL>;
-    HBondsAssigned: boolean;
     atomsDirty: boolean;
     isVisible: boolean;
     name: string;
@@ -61,7 +61,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
     gemmiStructure: gemmi.Structure;
     sequences: moorhen.Sequence[];
     colourRules: moorhen.ColourRule[];
-    customRepresentations: { style: string; cidSelection: string; id: string; buffers: moorhen.DisplayObject[]; }[];
+    representations: moorhen.MoleculeRepresentation[];
     ligands: moorhen.LigandInfo[];
     ligandDicts: { [comp_id: string]: string };
     connectedToMaps: number[];
@@ -77,28 +77,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
         gridScale: number;
     };
     cootBondsOptions: moorhen.cootBondOptions;
-    displayObjects: {
-        CBs: moorhen.DisplayObject[];
-        CAs: moorhen.DisplayObject[];
-        CRs: moorhen.DisplayObject[];
-        ligands: moorhen.DisplayObject[];
-        gaussian: moorhen.DisplayObject[];
-        MolecularSurface: moorhen.DisplayObject[];
-        VdWSurface: moorhen.DisplayObject[];
-        DishyBases: moorhen.DisplayObject[];
-        VdwSpheres: moorhen.DisplayObject[];
-        rama: moorhen.DisplayObject[];
-        rotamer: moorhen.DisplayObject[];
-        CDs: moorhen.DisplayObject[];
-        allHBonds: moorhen.DisplayObject[];
-        hover: moorhen.DisplayObject[];
-        selection: moorhen.DisplayObject[];
-        originNeighbours: moorhen.DisplayObject[];
-        originNeighboursHBond: moorhen.DisplayObject[];
-        originNeighboursBump: moorhen.DisplayObject[];
-        unitCell:  moorhen.DisplayObject[];
-    };
-    customDisplayRules: {[x: string]: moorhen.DisplayObject[]};
     displayObjectsTransformation: { origin: [number, number, number], quat: any, centre: [number, number, number] }
     uniqueId: string;
     monomerLibraryPath: string
@@ -107,7 +85,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
         this.type = 'molecule'
         this.commandCentre = commandCentre
         this.glRef = glRef
-        this.HBondsAssigned = false
         this.atomsDirty = true
         this.isVisible = true
         this.name = "unnamed"
@@ -118,7 +95,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         this.ligands = null
         this.ligandDicts = {}
         this.connectedToMaps = null
-        this.customRepresentations = []
+        this.representations = []
         this.excludedSegments = []
         this.excludedCids = []
         this.symmetryOn = false
@@ -135,28 +112,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
             smoothness: 1,
             width: 0.1,
             atomRadiusBondRatio: 1
-        }
-        this.customDisplayRules = { }
-        this.displayObjects = {
-            CBs: [],
-            CAs: [],
-            CRs: [],
-            ligands: [],
-            gaussian: [],
-            MolecularSurface: [],
-            VdWSurface: [],
-            DishyBases: [],
-            VdwSpheres: [],
-            rama: [],
-            rotamer: [],
-            CDs: [],
-            allHBonds: [],
-            hover: [],
-            selection: [],
-            originNeighbours: [],
-            originNeighboursHBond: [],
-            originNeighboursBump: [],
-            unitCell: [],
         }
         this.displayObjectsTransformation = { origin: [0, 0, 0], quat: null, centre: [0, 0, 0] }
         this.uniqueId = guid()
@@ -255,16 +210,9 @@ export class MoorhenMolecule implements moorhen.Molecule {
         if (fetchSymMatrix) {
             await this.fetchSymmetryMatrix()
         }
-        Object.keys(this.displayObjects)
-            .filter(key => !['hover', 'unitCell', 'originNeighbours', 'selection', 'transformation', 'contact_dots', 'chemical_features', 'VdWSurface'].some(style => key.includes(style)))
-            .forEach(displayObjectType => {
-                if (this.displayObjects[displayObjectType].length > 0) {
-                    this.displayObjects[displayObjectType].forEach((displayObject: moorhen.DisplayObject) => {
-                        displayObject.symmetryMatrices = this.symmetryMatrices
-                    })
-                }
-            })
-        this.glRef.current.drawScene()
+        this.representations
+            .filter(representation => !['hover', 'unitCell', 'originNeighbours', 'selection', 'transformation', 'contact_dots', 'chemical_features', 'VdWSurface'].some(style => representation.style.includes(style)))
+            .forEach(representation => representation.drawSymmetry())
     }
 
     /**
@@ -453,9 +401,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * Delete this molecule instance
      */
     async delete(): Promise<moorhen.WorkerResponse> {
-        Object.getOwnPropertyNames(this.displayObjects).forEach(displayObject => {
-            if (this.displayObjects[displayObject].length > 0) { this.clearBuffersOfStyle(displayObject) }
-        })
+        this.representations.forEach(representation => representation.delete())
         this.glRef.current.drawScene()
         const inputData = { message: "delete", molNo: this.molNo }
         const response = await this.commandCentre.current.postMessage(inputData)
@@ -716,9 +662,9 @@ export class MoorhenMolecule implements moorhen.Molecule {
         }
 
         const cid = "/*/*/*/*"
-        const representation = this.customRepresentations.find(item => item.style === style && item.cidSelection === cid)
+        const representation = this.representations.find(item => item.style === style && item.cid === cid)
         if (representation) {
-            await this.redrawRepresentation(representation.id)
+            await this.redrawRepresentation(representation.uniqueId)
         } else {
             await this.addRepresentation(style, cid)
         }
@@ -830,516 +776,37 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * Draw molecule from a given mesh
      * @param {string} style - Indicate the style to be drawn
      * @param {any[]} meshObjects - The mesh obects that will be drawn
-     * @param {moorhen.AtomInfo[]} [newBufferAtoms=[]] - The new buffer atoms with the atom metadata
+     * @param {string} [cid] - The new buffer CID selection
      */
-    async drawWithStyleFromMesh(style: string, meshObjects: any[], newBufferAtoms: moorhen.AtomInfo[] = []): Promise<void> {
-        this.clearBuffersOfStyle(style)
-        if (meshObjects.length > 0 && !this.gemmiStructure.isDeleted()) {
-            this.addBuffersOfStyle(meshObjects, style)
-            let bufferAtoms: moorhen.AtomInfo[]
-            if (newBufferAtoms.length > 0) {
-                bufferAtoms = newBufferAtoms
-            } else {
-                bufferAtoms = await this.gemmiAtomsForCid('/*/*/*/*')
-            }
-            this.displayObjects[style][0].atoms = bufferAtoms.filter(atom => !this.excludedCids.includes(`//${atom.chain_id}/${atom.res_no}-${atom.res_no}/*`)).map(atom => {
-                const { pos, x, y, z, charge, label, symbol } = atom
-                const tempFactor = atom.tempFactor
-                return { pos, x, y, z, charge, tempFactor, symbol, label }
-            })
+    async drawWithStyleFromMesh(style: string, meshObjects: any[], cid: string = "/*/*/*/*"): Promise<void> {
+        let representation = this.representations.find(item => item.style === style && item.cid === cid)
+        if (!representation) {
+            representation = new MoorhenMoleculeRepresentation(style, cid, this.commandCentre, this.glRef)
+            representation.setParentMolecule(this)
+            this.representations.push(representation)
         }
+
+        representation.delete()
+        representation.buildBuffers(meshObjects)
+        let bufferAtoms = await this.gemmiAtomsForCid(cid)
+        if(bufferAtoms.length > 0) {
+            representation.setAtomBuffers(bufferAtoms)
+        }
+        representation.show()
     }
 
     async addRepresentation(style: string, cid?: string) {
-        let objects: libcootApi.InstancedMeshJS[]
-        switch (style) {
-            case 'VdwSpheres':
-            case 'CAs':
-            case 'CBs':
-                objects = await this.getCootSelectionBondBuffers(style, cid)
-                break
-            case 'CRs':
-            case 'MolecularSurface':
-            case 'DishyBases':
-            case 'VdWSurface':
-            case 'Calpha':
-                objects = await this.getCootRepresentationBuffers(style, cid)
-                break
-            default:
-                return Promise.resolve()
-        }
-        
-        let buffers: moorhen.DisplayObject[] = []
-        if (objects.length > 0 && !this.gemmiStructure.isDeleted()) {
-            objects.filter(object => typeof object !== 'undefined' && object !== null).forEach(object => {
-                const a = this.glRef.current.appendOtherData(object, true)
-                buffers = buffers.concat(a)
-            })
-            this.glRef.current.buildBuffers();
-            this.glRef.current.drawScene();
-            let bufferAtoms = await this.gemmiAtomsForCid(cid)
-            if (bufferAtoms.length > 0) {
-                buffers[0].atoms = bufferAtoms.filter(atom => !this.excludedCids.includes(`//${atom.chain_id}/${atom.res_no}/*`)).map(atom => {
-                    const { pos, x, y, z, charge, label, symbol } = atom
-                    const tempFactor = atom.tempFactor
-                    return { pos, x, y, z, charge, tempFactor, symbol, label }
-                })
-            }
-        }
-
-        const representation = {
-            id: guid(),
-            style: style,
-            cidSelection: cid ? cid : '/*/*/*/*',
-            buffers: buffers
-        }
-        this.customRepresentations.push(representation)
+        const representation = new MoorhenMoleculeRepresentation(style, cid ? cid : '/*/*/*/*', this.commandCentre, this.glRef)
+        representation.setParentMolecule(this)
+        await representation.draw()
+        this.representations.push(representation)
+        await this.drawSymmetry(false)
     }
 
     async redrawRepresentation(id: string) {
-        const represnetationIndex = this.customRepresentations.findIndex(representation => representation.id === id)
-        const representation = this.customRepresentations[represnetationIndex]
-        
-        let objects: libcootApi.InstancedMeshJS[]
-        switch (representation.style) {
-            case 'VdwSpheres':
-            case 'CAs':
-            case 'CBs':
-                objects = await this.getCootSelectionBondBuffers(representation.style, representation.cidSelection)
-                break
-            case 'CRs':
-            case 'MolecularSurface':
-            case 'DishyBases':
-            case 'VdWSurface':
-            case 'Calpha':
-                objects = await this.getCootRepresentationBuffers(representation.style, representation.cidSelection)
-                break
-            default:
-                return Promise.resolve()
-        }
-
-        representation.buffers.forEach((buffer) => {
-            if ("clearBuffers" in buffer) {
-                buffer.clearBuffers()
-                if (this.glRef.current.displayBuffers) {
-                    this.glRef.current.displayBuffers = this.glRef.current.displayBuffers.filter(glBuffer => glBuffer !== buffer)
-                }
-            } else if ("labels" in buffer) {
-                this.glRef.current.labelsTextCanvasTexture.removeBigTextureTextImages(buffer.labels)
-            }
-        })
-        this.glRef.current.buildBuffers()
-        
-        representation.buffers = []
-        if (objects.length > 0 && !this.gemmiStructure.isDeleted()) {
-            objects.filter(object => typeof object !== 'undefined' && object !== null).forEach(object => {
-                const a = this.glRef.current.appendOtherData(object, true)
-                if(representation.buffers) {
-                    representation.buffers = representation.buffers.concat(a)
-                } else {
-                    representation.buffers = a
-                }
-            })
-            this.glRef.current.buildBuffers()
-            this.glRef.current.drawScene()
-            let bufferAtoms = await this.gemmiAtomsForCid(representation.cidSelection)
-            if (bufferAtoms.length > 0) {
-                representation.buffers[0].atoms = bufferAtoms.filter(atom => !this.excludedCids.includes(`//${atom.chain_id}/${atom.res_no}/*`)).map(atom => {
-                    const { pos, x, y, z, charge, label, symbol } = atom
-                    const tempFactor = atom.tempFactor
-                    return { pos, x, y, z, charge, tempFactor, symbol, label }
-                })
-            }
-        }
-        
-        this.customRepresentations[represnetationIndex] = representation
-    }
-
-    /**
-     * Draw molecule with a given style from atoms fetch from libcoot api
-     * @param {string} style - Indicate the style to be drawn
-     */
-    async drawWithStyleFromAtoms(style: string): Promise<void> {
-        switch (style) {
-            case 'allHBonds':
-                this.drawAllHBonds()
-                break;
-            case 'rama':
-                this.drawRamachandranBalls()
-                break;
-            case 'rotamer':
-                this.drawRotamerDodecahedra()
-                break;
-            case 'VdwSpheres':
-            case 'CAs':
-            case 'CBs':
-                await this.drawCootBonds(style)
-                break;
-            case 'CDs':
-                await this.drawCootContactDots()
-                break;
-            case 'gaussian':
-                await this.drawCootGaussianSurface()
-                break;
-            case 'CRs':
-            case 'MolecularSurface':
-            case 'DishyBases':
-            case 'VdWSurface':
-            case 'Calpha':
-                await this.drawCootRepresentation(style)
-                break;
-            case 'ligands':
-                await this.drawCootLigands()
-                break;
-            default:
-                if (style.startsWith("chemical_features")) {
-                    await this.drawCootChemicalFeaturesCid(style)
-                } else if (style.startsWith("contact_dots")) {
-                    await this.drawCootContactDotsCid(style)
-                }
-                break;
-        }
-    }
-
-    /**
-     * Add representation buffers of a particular style
-     * @param {any[]} objects - The representation buffers
-     * @param {string} style - The style
-     */
-    addBuffersOfStyle( objects: any[], style: string) {
-        objects.filter(object => typeof object !== 'undefined' && object !== null).forEach(object => {
-            const a = this.glRef.current.appendOtherData(object, true);
-            this.displayObjects[style] = this.displayObjects[style].concat(a)
-        })
-        this.glRef.current.buildBuffers();
-        this.glRef.current.drawScene();
-    }
-
-    /**
-     * Draw all H bonds in the molecule
-     */
-    async drawAllHBonds() {
-        const style = "allHBonds"
-        //Empty existing buffers of this type
-        this.clearBuffersOfStyle(style)
-        this.drawHBonds("/*/*/*", style, false)
-    }
-
-    /**
-     * Draw ramachandran balls representation
-     */
-    async drawRamachandranBalls() {
-        const style = "rama"
-        const response = await this.commandCentre.current.cootCommand({
-            returnType: "mesh",
-            command: "get_ramachandran_validation_markup_mesh",
-            commandArgs: [this.molNo]
-        }) as moorhen.WorkerResponse<libcootApi.SimpleMeshJS>;
-        const objects = [response.data.result.result];
-        //Empty existing buffers of this type
-        this.clearBuffersOfStyle(style);
-        this.addBuffersOfStyle(objects, style);
-    }
-
-    /**
-     * Draw contact dots using a particular style 
-     * @param {string} style - The style
-     */
-    async drawCootContactDotsCid(style: string) {
-        const cid = style.substr("contact_dots-".length)
-        try {
-            const response = await this.commandCentre.current.cootCommand({
-                returnType: "instanced_mesh",
-                command: "contact_dots_for_ligand",
-                commandArgs: [this.molNo, cid, this.cootBondsOptions.smoothness]
-            }) as moorhen.WorkerResponse<libcootApi.InstancedMeshJS>;
-            const objects = [response.data.result.result];
-            //Empty existing buffers of this type
-            this.clearBuffersOfStyle(style);
-            this.addBuffersOfStyle(objects, style);
-        } catch (err) {
-            return console.log(err);
-        }
-    }
-
-    /**
-     * Draw chemical features using a particular style
-     * @param {string} style - The style
-     */
-    async drawCootChemicalFeaturesCid(style: string) {
-        const cid = style.substr("chemical_features-".length)
-
-        const response = await this.commandCentre.current.cootCommand({
-            returnType: "mesh",
-            command: "get_chemical_features_mesh",
-            commandArgs: [this.molNo, cid]
-        }) as moorhen.WorkerResponse<libcootApi.InstancedMeshJS>
-        try {
-            const objects = [response.data.result.result]
-            //Empty existing buffers of this type
-            this.clearBuffersOfStyle(style)
-            this.addBuffersOfStyle(objects, style)
-        } catch (err) {
-            console.log(err)
-        }
-    }
-
-    /**
-     * Draw contact dots
-     */
-    async drawCootContactDots() {
-        const style = "CDs"
-
-        const response = await this.commandCentre.current.cootCommand({
-            returnType: "instanced_mesh",
-            command: "all_molecule_contact_dots",
-            commandArgs: [this.molNo, this.cootBondsOptions.smoothness]
-        }) as moorhen.WorkerResponse<libcootApi.InstancedMeshJS>
-        try {
-            const objects = [response.data.result.result]
-            //Empty existing buffers of this type
-            this.clearBuffersOfStyle(style)
-            this.addBuffersOfStyle(objects, style)
-        } catch (err) {
-            console.log(err)
-        }
-    }
-
-    /**
-     * Draw rotamer dodec. representations
-     */
-    async drawRotamerDodecahedra(): Promise<void> {
-        const style = "rotamer"
-        const response = await this.commandCentre.current.cootCommand({
-            returnType: "instanced_mesh_perm",
-            command: "get_rotamer_dodecs_instanced",
-            commandArgs: [this.molNo]
-        }) as moorhen.WorkerResponse<libcootApi.InstancedMeshJS>
-        try {
-            const objects = [response.data.result.result]
-            this.clearBuffersOfStyle(style)
-            this.addBuffersOfStyle(objects, style)
-        } catch (err) {
-            console.log(err)
-        }
-    }
-
-    /**
-     * Draw molecule ligands using coot's representations
-     */
-    drawCootLigands() {
-        const name = "ligands"
-        const ligandsCID = "/*/*/(!ALA,CYS,ASP,GLU,PHE,GLY,HIS,ILE,LYS,LEU,MET,ASN,PRO,GLN,ARG,SER,THR,VAL,TRP,TYR,WAT,HOH,THP,SEP,TPO,TYP,PTR,OH2,H2O)"
-        return this.drawCootSelectionBonds(name, ligandsCID)
-    }
-
-    /**
-     * Draw molecule bonds using coot's representations
-     * @param {string} style - The style
-     */
-    drawCootBonds(style: string) {
-        const name = style
-        return this.drawCootSelectionBonds(name, null)
-    }
-
-    async getCootSelectionBondBuffers(name: string, cid: null | string): Promise<libcootApi.InstancedMeshJS[]> {
-        let meshCommand: Promise<moorhen.WorkerResponse<libcootApi.InstancedMeshJS>>
-
-        let style = "COLOUR-BY-CHAIN-AND-DICTIONARY"
-        let returnType = "instanced_mesh"
-        if (name === "VdwSpheres") {
-            style = "VDW-BALLS"
-            returnType = "instanced_mesh_perfect_spheres"
-        } else if (name === "CAs") {
-            style = "CA+LIGANDS"
-        }
-
-        if (typeof cid === 'string') {
-            meshCommand = this.commandCentre.current.cootCommand({
-                returnType: returnType,
-                command: "get_bonds_mesh_for_selection_instanced",
-                commandArgs: [
-                    this.molNo,
-                    cid,
-                    style,
-                    this.cootBondsOptions.isDarkBackground,
-                    this.cootBondsOptions.width * 1.5,
-                    this.cootBondsOptions.atomRadiusBondRatio * 1.5,
-                    this.cootBondsOptions.smoothness
-                ]
-            })
-        } else {
-            cid = "/*/*/*/*"
-            meshCommand = this.commandCentre.current.cootCommand({
-                returnType: returnType,
-                command: "get_bonds_mesh_instanced",
-                commandArgs: [
-                    this.molNo,
-                    style,
-                    this.cootBondsOptions.isDarkBackground,
-                    this.cootBondsOptions.width,
-                    this.cootBondsOptions.atomRadiusBondRatio,
-                    this.cootBondsOptions.smoothness
-                ]
-            })
-        }
-        const response = await meshCommand
-        return [response.data.result.result]
-    }
-
-    /**
-     * Draw molecule bonds for a given set of residues selected using a CID
-     * @param {string} name - The style name
-     * @param {string} cid - The CID selection for the residues to be drawn
-     */
-    async drawCootSelectionBonds(name: string, cid: null | string, clearBuffers: boolean = true): Promise<void> {
-        const objects = await this.getCootSelectionBondBuffers(name, cid)
-        cid = typeof cid === 'string' ? cid : "/*/*/*/*"
-        if (objects.length > 0 && !this.gemmiStructure.isDeleted()) {
-            //Empty existing buffers of this type
-            if(clearBuffers) this.clearBuffersOfStyle(name)
-            this.addBuffersOfStyle(objects, name)
-            let bufferAtoms = await this.gemmiAtomsForCid(cid)
-            if (bufferAtoms.length > 0) {
-                this.displayObjects[name][0].atoms = bufferAtoms.filter(atom => !this.excludedCids.includes(`//${atom.chain_id}/${atom.res_no}/*`)).map(atom => {
-                    const { pos, x, y, z, charge, label, symbol } = atom
-                    const tempFactor = atom.tempFactor
-                    return { pos, x, y, z, charge, tempFactor, symbol, label }
-                })
-            }
-        } else if (clearBuffers) {
-            this.clearBuffersOfStyle(name)
-        }
-    }
-
-    /**
-     * Draw molecule as a gaussian surface
-     */
-    async drawCootGaussianSurface(): Promise<void> {
-        const style = "gaussian"
-        const response = await this.commandCentre.current.cootCommand({
-            returnType: "mesh",
-            command: "get_gaussian_surface",
-            commandArgs: [
-                this.molNo, this.gaussianSurfaceSettings.sigma,
-                this.gaussianSurfaceSettings.countourLevel,
-                this.gaussianSurfaceSettings.boxRadius,
-                this.gaussianSurfaceSettings.gridScale
-            ]
-        }) as moorhen.WorkerResponse<libcootApi.InstancedMeshJS>
-        try {
-            const objects = [response.data.result.result]
-            if (objects.length > 0 && !this.gemmiStructure.isDeleted()) {
-                const flippedNormalsObjects = objects.map(object => {
-                    const flippedNormalsObject = { ...object }
-                    /*
-                    flippedNormalsObject.norm_tri = object.norm_tri.map(
-                        element => element.map(subElement => subElement.map(coord => coord * -1.))
-                    )
-                    */
-                    flippedNormalsObject.idx_tri = object.idx_tri.map(
-                        element => element.map(subElement => subElement.reverse())
-                    )
-                    return flippedNormalsObject
-                })
-                //Empty existing buffers of this type
-                this.clearBuffersOfStyle(style)
-                this.addBuffersOfStyle(flippedNormalsObjects, style)
-            }
-            else {
-                this.clearBuffersOfStyle(style)
-            }
-        } catch (err) {
-            console.log(err)
-        }
-    }
-
-    async getCootRepresentationBuffers(style: string, cidSelection?: string): Promise<libcootApi.InstancedMeshJS[]> {
-        let m2tStyle: string
-        let m2tSelection: string
-
-        switch (style) {
-            case "CRs":
-                m2tStyle = "Ribbon"
-                m2tSelection = "//"
-                break;
-            case "MolecularSurface":
-                m2tStyle = "MolecularSurface"
-                m2tSelection = "(ALA,CYS,ASP,GLU,PHE,GLY,HIS,ILE,LYS,LEU,MET,MSE,ASN,PRO,GLN,ARG,SER,THR,VAL,TRP,TYR)"
-                break;
-            case "VdWSurface":
-                m2tStyle = "VdWSurface"
-                m2tSelection = "(ALA,CYS,ASP,GLU,PHE,GLY,HIS,ILE,LYS,LEU,MET,MSE,ASN,PRO,GLN,ARG,SER,THR,VAL,TRP,TYR)"
-                break;
-            case "DishyBases":
-                m2tStyle = "DishyBases"
-                m2tSelection = "(ALA,CYS,ASP,GLU,PHE,GLY,HIS,ILE,LYS,LEU,MET,ASN,PRO,GLN,ARG,SER,THR,VAL,TRP,TYR)"
-                break;
-            case "Calpha":
-                m2tStyle = "Calpha"
-                m2tSelection = "(ALA,CYS,ASP,GLU,PHE,GLY,HIS,ILE,LYS,LEU,MET,MSE,ASN,PRO,GLN,ARG,SER,THR,VAL,TRP,TYR)"
-                break;
-            case "ligands":
-                m2tStyle = "Cylinders"
-                m2tSelection = "(!ALA,CYS,ASP,GLU,PHE,GLY,HIS,ILE,LYS,LEU,MET,MSE,ASN,PRO,GLN,ARG,SER,THR,VAL,TRP,TYR,HOH)"
-                break;
-            default:
-                m2tStyle = "Ribbon"
-                m2tSelection = "//"
-                break;
-        }
-
-        if(cidSelection) {
-            m2tSelection = `{${m2tSelection} & {${cidSelection}}}`
-        }
-
-        if (this.excludedSegments.length > 0) {
-            m2tSelection = `{${m2tSelection} & !{${this.excludedSegments.join(' | ')}}}`
-        }
-
-        const response = await this.commandCentre.current.cootCommand({
-            returnType: "mesh",
-            command: "get_molecular_representation_mesh",
-            commandArgs: [
-                this.molNo, m2tSelection, "colorRampChainsScheme", m2tStyle
-            ]
-        }) as moorhen.WorkerResponse<libcootApi.InstancedMeshJS>
-
-        return [response.data.result.result]
-    }
-
-    /**
-     * Draw the molecule using a particular coot representation
-     * @param {string} style - The representation style
-     */
-    async drawCootRepresentation(style: string, clearBuffers: boolean = true, cidSelection?: string): Promise<void> {
-        let objects = await this.getCootRepresentationBuffers(style, cidSelection)
-        let m2tStyle = style === 'CRs' ? 'Ribbon' : (style === 'ligands' ? 'Cylinders' : style)
-
-        try {
-            if (objects.length > 0 && !this.gemmiStructure.isDeleted()) {
-                //Empty existing buffers of this type
-                if (["Cylinders", "DishyBases"].includes(m2tStyle)) {
-                    objects = objects.map(object => {
-                        const flippedNormalsObject = { ...object }
-                        flippedNormalsObject.idx_tri = object.idx_tri.map(
-                            element => element.map(subElement => subElement.reverse())
-                        )
-                        return flippedNormalsObject
-                    })
-                }
-                if(clearBuffers) this.clearBuffersOfStyle(style)
-                this.addBuffersOfStyle(objects, style)
-                let bufferAtoms = getBufferAtoms(this.gemmiStructure.clone())
-                if (bufferAtoms.length > 0 && this.displayObjects[style].length > 0) {
-                    this.displayObjects[style][0].atoms = bufferAtoms
-                }
-            } else if (clearBuffers) {
-                this.clearBuffersOfStyle(style)
-            }
-        } catch (err) {
-            console.log(err)
-        }
+        const representation = this.representations.find(representation => representation.uniqueId === id)
+        await representation.redraw()
+        await this.drawSymmetry(false)
     }
 
     /**
@@ -1347,20 +814,17 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @param {string} style - The representation style to show
      * @param {string} [cid=undefined] - The CID selection for the representation
      */
-    async show(style: string, cid?: string): Promise<void> {
+    show(style: string, cid?: string): void {
         if(!cid) {
             cid = '/*/*/*/*'
         }
-
         try {
-            const representation = this.customRepresentations.find(item => item.style === style && item.cidSelection === cid)
+            const representation = this.representations.find(item => item.style === style && item.cid === cid)
             if (representation) {
-                representation.buffers.forEach(buffer => buffer.visible = true)
+                representation.show()
             } else {
                 this.addRepresentation(style, cid)
             }
-            this.glRef.current.drawScene()
-            this.drawSymmetry(false)
         } catch (err) {
             console.log(err)
         }
@@ -1375,10 +839,9 @@ export class MoorhenMolecule implements moorhen.Molecule {
             cid = '/*/*/*/*'
         }
         try {
-            const representation = this.customRepresentations.find(item => item.style === style && item.cidSelection === cid)
+            const representation = this.representations.find(item => item.style === style && item.cid === cid)
             if (representation) {
-                representation.buffers.forEach(buffer => buffer.visible = false)
-                this.glRef.current.drawScene()
+                representation.hide()
             }
         } catch (err) {
             console.log(err)
@@ -1390,18 +853,8 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @param {string} style - The style to clear
      */
     clearBuffersOfStyle(style: string) {
-        this.displayObjects[style].forEach((buffer) => {
-            if ("clearBuffers" in buffer) {
-                buffer.clearBuffers()
-                if (this.glRef.current.displayBuffers) {
-                    this.glRef.current.displayBuffers = this.glRef.current.displayBuffers.filter(glBuffer => glBuffer !== buffer)
-                }
-            } else if ("labels" in buffer) {
-                this.glRef.current.labelsTextCanvasTexture.removeBigTextureTextImages(buffer.labels)
-            }
-        })
-        this.glRef.current.buildBuffers()
-        this.displayObjects[style] = []
+        this.representations.forEach(representation => representation.style === style ? representation.delete() : null)
+        this.representations = this.representations.filter(representation => representation.style !== style)
     }
 
     /**
@@ -1412,15 +865,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
     buffersInclude(bufferIn: { id: string; }): boolean {
         const BreakException = {};
         try {
-            Object.getOwnPropertyNames(this.displayObjects).forEach(style => {
-                if (Array.isArray(this.displayObjects[style])) {
-                    const objectBuffers = this.displayObjects[style].filter(buffer => bufferIn.id === buffer.id)
-                    if (objectBuffers.length > 0) {
-                        throw BreakException;
-                    }
-                }
-            })
-            this.customRepresentations.forEach(representation => {
+            this.representations.forEach(representation => {
                 if (Array.isArray(representation.buffers)) {
                     const matchedBuffer = representation.buffers.find(buffer => bufferIn.id === buffer.id)
                     if (matchedBuffer) {
@@ -1439,82 +884,12 @@ export class MoorhenMolecule implements moorhen.Molecule {
     /**
      * Draw the unit cell of this molecule
      */
-    drawUnitCell() {
-        const unitCell = this.gemmiStructure.cell
-        const lines = getCubeLines(unitCell)
-        unitCell.delete()
-
-        let objects = [
-            gemmiAtomPairsToCylindersInfo(lines, 0.1, { unit_cell: [0.7, 0.4, 0.25, 1.0] }, false, 0, 99999, false) 
-        ]
-        
-        this.addBuffersOfStyle(objects, 'unitCell')
-        this.glRef.current.drawScene()
-    }
-
-    /**
-     * Draw a line between a pair of atoms
-     * @param {moorhen.AtomInfo[][]} gemmiAtomPairs - The two atom pairs used to draw the line
-     * @param {string} style - The style used to draw the line
-     * @param {number[]} colour - The colour used to draw the line
-     * @param {boolean} [labelled=false] - Indicates whether the line should be annotated with a label
-     * @param {boolean} [clearBuffers=false] - Clear existing buffers for the line
-     */
-    drawGemmiAtomPairs(gemmiAtomPairs: [moorhen.AtomInfo, moorhen.AtomInfo][], style: string, colour: number[], labelled: boolean = false, clearBuffers: boolean = false) {
-        const atomColours = {}
-        gemmiAtomPairs.forEach(atom => { atomColours[`${atom[0].serial}`] = colour; atomColours[`${atom[1].serial}`] = colour })
-        let objects = [
-            gemmiAtomPairsToCylindersInfo(gemmiAtomPairs, 0.07, atomColours, labelled)
-        ]
-        if (clearBuffers) {
-            this.clearBuffersOfStyle(style)
-        }
-        this.addBuffersOfStyle(objects, style)
-    }
-
-    /**
-     * Draw yellow highlight balls around a particular residue selection
-     * @param {string} style - The style
-     * @param {string} selectionString - The CID selection for the residue that will be highlighted
-     * @param {number[]} colour - The colour used for the highlight
-     * @param {boolean} [clearBuffers=false] - Clear existing buffers for the line
-     */
-    async drawResidueHighlight(style: string, selectionString: string, colour: number[], clearBuffers: boolean = false): Promise<void> {
-        if (typeof selectionString === 'string') {
-            const resSpec: moorhen.ResidueSpec = cidToSpec(selectionString)
-            let modifiedSelection = `/*/${resSpec.chain_id}/${resSpec.res_no}-${resSpec.res_no}/*${resSpec.alt_conf === "" ? "" : ":"}${resSpec.alt_conf}`
-            if (this.sequences.length === 0) {
-                modifiedSelection = `/*/${resSpec.chain_id}/${resSpec.res_no}-${resSpec.res_no}/${resSpec.atom_name}${resSpec.alt_conf === "" ? "" : ":"}${resSpec.alt_conf}`
-            }
-            const selectedGemmiAtoms = await this.gemmiAtomsForCid(modifiedSelection)
-            const atomColours = {}
-            selectedGemmiAtoms.forEach(atom => { atomColours[`${atom.serial}`] = colour })
-            let sphere_size = 0.3
-            let click_tol = 0.65
-            if (this.displayObjects.VdwSpheres.length > 0 || this.displayObjects.VdWSurface.length > 0) {
-                let spheres_visible = false;
-                this.displayObjects.VdwSpheres.forEach(spheres => {
-                    if (spheres.visible) {
-                        spheres_visible = true
-                    }
-                })
-                if (spheres_visible) {
-                    sphere_size = 1.8;
-                    click_tol = 3.7;
-                }
-            }
-            let objects = [
-                gemmiAtomsToCirclesSpheresInfo(selectedGemmiAtoms, sphere_size, "PERFECT_SPHERES", atomColours)
-            ]
-            objects.forEach(object => {
-                object["clickTol"] = click_tol
-                object["doStencil"] = true
-            })
-            if (clearBuffers) {
-                this.clearBuffersOfStyle(style)
-            }
-            this.addBuffersOfStyle(objects, style)
-        }
+    async drawUnitCell() {
+        const representation = new MoorhenMoleculeRepresentation('unitCell', '/*/*/*/*', this.commandCentre, this.glRef)
+        representation.setParentMolecule(this)
+        representation.hasAtomBuffers = false
+        await representation.draw()
+        this.representations.push(representation)
     }
 
     /**
@@ -1522,38 +897,25 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @param {string} selectionString - The CID selection for the residue that will be highlighted
      */
     async drawHover(selectionString: string): Promise<void> {
-        await this.drawResidueHighlight('hover', selectionString, [1.0, 0.5, 0.0, 0.35], true)
-    }
-
-    /**
-     * Draw a selection effect over a residue
-     * @param {string} selectionString - The CID selection for the residue that will be highlighted
-     */
-    async drawSelection(selectionString: string): Promise<void> {
-        await this.drawResidueHighlight('selection', selectionString, [1.0, 0.0, 0.0, 0.35], false)
+        let representation = this.representations.find(item => item.style === 'hover')
+        if (typeof selectionString !== 'string') {
+            // pass
+        } else if (representation) {
+            representation.cid = selectionString
+            representation.redraw()
+        } else {
+            representation = new MoorhenMoleculeRepresentation('hover', selectionString, this.commandCentre, this.glRef)
+            representation.setParentMolecule(this)
+            representation.hasAtomBuffers = false
+            await representation.draw()
+            this.representations.push(representation)
+        }
     }
 
     /**
      * Redraw the molecule representations
      */
     async redraw(): Promise<void> {
-        const itemsToRedraw = []
-        Object.keys(this.displayObjects).filter(style => !["transformation", 'hover', 'unitCell', 'selection'].includes(style)).forEach(style => {
-            const objectCategoryBuffers = this.displayObjects[style]
-            //Note with transforamtion, not all properties of displayObjects are lists of buffer
-            if (Array.isArray(objectCategoryBuffers)) {
-                if (objectCategoryBuffers.length > 0) {
-                    if (objectCategoryBuffers[0].visible) {
-                        //FOr currently visible display types, put them on a list for redraw
-                        itemsToRedraw.push(style)
-                    }
-                    else {
-                        this.clearBuffersOfStyle(style)
-                    }
-                }
-            }
-        })
-
         if (this.atomsDirty) {
             try {
                 await this.updateAtoms()
@@ -1564,8 +926,17 @@ export class MoorhenMolecule implements moorhen.Molecule {
         }
 
         await Promise.all([
-            ...itemsToRedraw.map(style => this.fetchIfDirtyAndDraw(style)),
-            ...this.customRepresentations.map(representation => this.redrawRepresentation(representation.id))
+            ...this.representations
+                .filter(representation => !["transformation", 'hover', 'unitCell', 'selection'].includes(representation.style))
+                .map(representation => {
+                    if (representation.visible) {
+                        return this.redrawRepresentation(representation.uniqueId)
+                    } else {
+                        representation.buffers = []
+                        return Promise.resolve()
+                    }
+                    
+                })
         ])
 
         await this.drawSymmetry(false)
@@ -1725,11 +1096,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
             let promises = []
             otherMolecules.forEach(molecule => {
                 if (doHide) {
-                    Object.keys(molecule.displayObjects).forEach(style => {
-                        if (Array.isArray(molecule.displayObjects[style])) {
-                            molecule.hide(style)
-                        }
-                    })
+                    molecule.representations.forEach(item => item.hide())
                 }
                 Object.keys(molecule.ligandDicts).forEach(key => {
                     if (!Object.hasOwn(this.ligandDicts, key)) {
@@ -1996,10 +1363,9 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @returns {boolean} True if the molecule has any visible buffers
      */
     hasVisibleBuffers(excludeBuffers: string[] = ['hover', 'unitCell', 'originNeighbours', 'selection', 'transformation', 'contact_dots', 'chemical_features', 'VdWSurface']): boolean {
-        const styles = Object.keys(this.displayObjects).filter(key => !excludeBuffers.some(style => key.includes(style)))
-        const displayBuffers = styles.map(style => this.displayObjects[style])
-        const visibleDisplayBuffers = displayBuffers.filter(displayBuffer => displayBuffer.some(buffer => buffer.visible))
-        return visibleDisplayBuffers.length !== 0
+        const representations = this.representations.filter(item => !excludeBuffers.some(style => item.style.includes(style)))
+        const isVisible = representations.some(item => item.visible)
+        return isVisible
     }
 
     /**
@@ -2138,122 +1504,23 @@ export class MoorhenMolecule implements moorhen.Molecule {
 
     /**
      * Draw enviroment distances for a given residue
-     * @param {string} chainID - The chain ID
-     * @param {number} resNo - The residue number
-     * @param {string} altLoc - Alt. Loc. for the residue
+     * @param {string} selectionCid - The CID
      * @param {boolean} [labelled=false] - Indicates whether the distances should be labelled
      */
-    async drawEnvironment(chainID: string, resNo: number, altLoc: string, labelled: boolean = false): Promise<void> {
-
-        const response = await this.commandCentre.current.cootCommand({
-            returnType: "generic_3d_lines_bonds_box",
-            command: "make_exportable_environment_bond_box",
-            commandArgs: [this.molNo, chainID, resNo, altLoc]
-        })
-        const envDistances = response.data.result.result
-
-        const bumps = envDistances[0];
-        const hbonds = envDistances[1];
-
-        const bumpAtomsPairs = bumps.map(bump => {
-            const start = bump.start
-            const end = bump.end
-
-            const startAtomInfo = {
-                pos: [start.x, start.y, start.z],
-                x: start.x,
-                y: start.y,
-                z: start.z,
-            }
-
-            const endAtomInfo = {
-                pos: [end.x, end.y, end.z],
-                x: end.x,
-                y: end.y,
-                z: end.z,
-            }
-
-            const pair = [startAtomInfo, endAtomInfo]
-            return pair
-        })
-
-        this.drawGemmiAtomPairs(bumpAtomsPairs, "originNeighboursBump", [0.7, 0.4, 0.25, 1.0], labelled, true)
-
-        const hbondAtomsPairs = hbonds.map(hbond => {
-            const start = hbond.start
-            const end = hbond.end
-
-            const startAtomInfo = {
-                pos: [start.x, start.y, start.z],
-                x: start.x,
-                y: start.y,
-                z: start.z,
-            }
-
-            const endAtomInfo = {
-                pos: [end.x, end.y, end.z],
-                x: end.x,
-                y: end.y,
-                z: end.z,
-            }
-
-            const pair = [startAtomInfo, endAtomInfo]
-            return pair
-        })
-        this.drawGemmiAtomPairs(hbondAtomsPairs, "originNeighboursHBond", [0.7, 0.2, 0.7, 1.0], labelled, true)
-    }
-
-    /**
-     * Draw H bonds for a given CID selection
-     * @param {string} oneCid - The CID selection
-     * @param {string} style - The style for the representation
-     * @param {boolean} [labelled=false] - Indicates whether the H bonds should be labelled
-     */
-    async drawHBonds(oneCid: string, style: string, labelled: boolean = false) {
-        const response = await this.commandCentre.current.cootCommand({
-            returnType: "vector_hbond",
-            command: "get_h_bonds",
-            commandArgs: [this.molNo, oneCid, false]
-        })
-        const hBonds = response.data.result.result
-
-        const selectedGemmiAtomsPairs = hBonds.map(hbond => {
-            const donor = hbond.donor
-            const acceptor = hbond.acceptor
-
-            const donorAtomInfo = {
-                pos: [donor.x, donor.y, donor.z],
-                x: donor.x,
-                y: donor.y,
-                z: donor.z,
-                charge: donor.charge,
-                element: donor.element, // ???
-                name: donor.name,
-                symbol: donor.element, // ???
-                b_iso: donor.b_iso,
-                serial: donor.serial,
-                label: `/${donor.modelId}/${donor.chainName}/${donor.resNum}(${donor.residueName})/${donor.name}${donor.altLoc === "" ? ':' + String.fromCharCode(donor.altLoc) : ''}`
-            }
-
-            const acceptorAtomInfo = {
-                pos: [acceptor.x, acceptor.y, acceptor.z],
-                x: acceptor.x,
-                y: acceptor.y,
-                z: acceptor.z,
-                charge: acceptor.charge,
-                element: acceptor.element, // ???
-                name: acceptor.name,
-                symbol: acceptor.element, // ???
-                b_iso: acceptor.b_iso,
-                serial: acceptor.serial,
-                label: `/${acceptor.modelId}/${acceptor.chainName}/${acceptor.resNum}(${acceptor.name})/${acceptor.name}${acceptor.altLoc === "" ? ':' + String.fromCharCode(acceptor.altLoc) : ''}`
-            }
-
-            const pair = [donorAtomInfo, acceptorAtomInfo]
-            return pair
-        })
-
-        this.drawGemmiAtomPairs(selectedGemmiAtomsPairs, style, [0.7, 0.2, 0.7, 1.0], labelled, true)
+    async drawEnvironment(selectionCid: string, labelled: boolean = false): Promise<void> {
+        let representation = this.representations.find(item => item.style === 'environment')
+        if (typeof selectionCid !== 'string') {
+            // pass
+        } else if (representation) {
+            representation.cid = selectionCid
+            representation.redraw()
+        } else {
+            representation = new MoorhenMoleculeRepresentation('environment', selectionCid, this.commandCentre, this.glRef)
+            representation.setParentMolecule(this)
+            representation.hasAtomBuffers = false
+            await representation.draw()
+            this.representations.push(representation)
+        }
     }
 
     /**

--- a/baby-gru/src/utils/MoorhenMoleculeRepresentation.tsx
+++ b/baby-gru/src/utils/MoorhenMoleculeRepresentation.tsx
@@ -1,0 +1,544 @@
+import { moorhen } from '../types/moorhen';
+import { webGL } from '../types/mgWebGL';
+import { cidToSpec, gemmiAtomPairsToCylindersInfo, gemmiAtomsToCirclesSpheresInfo, getCubeLines, guid } from './MoorhenUtils';
+import { libcootApi } from '../types/libcoot';
+
+// TODO: Add colour rules controls. Set and remove them before getting the representation
+// TODO: It might be better to do this.glRef.current.drawScene() in the molecule... 
+export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresentation {
+
+    uniqueId: string;
+    style: string;
+    cid: string;
+    buffers: moorhen.DisplayObject[];
+    commandCentre: React.RefObject<moorhen.CommandCentre>;
+    glRef: React.RefObject<webGL.MGWebGL>
+    parentMolecule: moorhen.Molecule;
+    hasAtomBuffers: boolean;
+    visible: boolean;
+
+    constructor(style: string, cid: string, commandCentre: React.RefObject<moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>) {
+        this.uniqueId = guid()
+        this.style = style
+        this.cid = cid
+        this.commandCentre = commandCentre
+        this.glRef = glRef
+        this.parentMolecule = null
+        this.buffers = null
+        this.hasAtomBuffers = true
+        this.visible = false
+    }
+
+    setBuffers(buffers: moorhen.DisplayObject[]) {
+        this.buffers = buffers
+    }
+
+    setAtomBuffers(atomBuffers: moorhen.AtomInfo[]) {
+        if (this.buffers.length > 0) {
+            this.buffers[0].atoms = atomBuffers.filter(atom => !this.parentMolecule.excludedCids.includes(`//${atom.chain_id}/${atom.res_no}/*`)).map(atom => {
+                const { pos, x, y, z, charge, label, symbol } = atom
+                const tempFactor = atom.tempFactor
+                return { pos, x, y, z, charge, tempFactor, symbol, label }
+            })
+        }
+    }
+
+    setParentMolecule(molecule: moorhen.Molecule) {
+        this.parentMolecule = molecule
+    }
+
+    async buildBuffers(objects: moorhen.DisplayObject[]) {
+        if (objects.length > 0 && !this.parentMolecule.gemmiStructure.isDeleted()) {
+            objects.filter(object => typeof object !== 'undefined' && object !== null).forEach(object => {
+                const a = this.glRef.current.appendOtherData(object, true)
+                if (this.buffers) {
+                    this.buffers = this.buffers.concat(a)
+                } else {
+                    this.buffers = a
+                }
+            })
+            this.glRef.current.buildBuffers()
+        }
+        this.glRef.current.drawScene()
+    }
+
+    async draw() {
+        this.visible = true
+        const objects = await this.getBufferObjects()
+        this.buildBuffers(objects)
+        if (this.hasAtomBuffers) {
+            let atomBuffers = await this.parentMolecule.gemmiAtomsForCid(this.cid)
+            if (atomBuffers.length > 0 && this.buffers.length > 0) {
+                this.setAtomBuffers(atomBuffers)
+            }    
+        }
+    }
+
+    async redraw() {
+        this.visible = true
+        const objects = await this.getBufferObjects()
+        this.delete()
+        this.buildBuffers(objects)
+        if(this.hasAtomBuffers) {
+            let atomBuffers = await this.parentMolecule.gemmiAtomsForCid(this.cid)
+            if (atomBuffers.length > 0 && this.buffers.length > 0) {
+                this.setAtomBuffers(atomBuffers)
+            }
+        }
+    }
+
+    delete() {
+        this.buffers.forEach(buffer => {
+            if ("clearBuffers" in buffer) {
+                buffer.clearBuffers()
+                if (this.glRef.current.displayBuffers) {
+                    this.glRef.current.displayBuffers = this.glRef.current.displayBuffers.filter(glBuffer => glBuffer !== buffer)
+                }
+            } else if ("labels" in buffer) {
+                this.glRef.current.labelsTextCanvasTexture.removeBigTextureTextImages(buffer.labels)
+            }
+        })
+        this.glRef.current.buildBuffers()
+        this.buffers = []
+    }
+
+    show() {
+        try {
+            this.visible = true
+            if (this.buffers && this.buffers.length > 0) {
+                this.buffers.forEach(buffer => buffer.visible = true)
+                this.glRef.current.drawScene()
+            } else {
+                this.draw()
+            }
+        } catch (err) {
+            console.log(err)
+        }
+    }
+
+    hide() {
+        try {
+            this.visible = false
+            this.buffers.forEach(buffer => buffer.visible = false)
+            this.glRef.current.drawScene()
+        } catch (err) {
+            console.log(err)
+        }
+    }
+
+    async getBufferObjects() {
+        let objects
+        switch (this.style) {
+            case 'VdwSpheres':
+            case 'ligands':
+            case 'CAs':
+            case 'CBs':
+                objects = await this.getCootSelectionBondBuffers(this.style, this.cid)
+                break
+            case 'CDs':
+                objects = await this.getCootContactDotsBuffers()
+                break;
+            case 'gaussian':
+                objects = await this.getCootGaussianSurfaceBuffers()
+                break;
+            case 'allHBonds':
+                objects = await this.getHBondBuffers(this.cid)
+                break;
+            case 'rama':
+                objects = await this.getRamachandranBallBuffers()
+                break;
+            case 'rotamer':
+                objects = await this.getRotamerDodecahedraBuffers()
+                break;
+            case 'CRs':
+            case 'MolecularSurface':
+            case 'DishyBases':
+            case 'VdWSurface':
+            case 'Calpha':
+                objects = await this.getCootRepresentationBuffers(this.style, this.cid)
+                break
+            case 'unitCell':
+                objects = this.getUnitCellRepresentationBuffers()
+                break
+            case 'hover':
+                objects = this.getResidueHighlightBuffers(this.cid, [1.0, 0.5, 0.0, 0.35])
+                break
+            case 'environment':
+                objects = this.getEnvironmentBuffers(this.cid)
+                break
+            default:
+                if (this.style.startsWith("chemical_features")) {
+                    objects = await this.getCootChemicalFeaturesCidBuffers(this.style)
+                } else if (this.style.startsWith("contact_dots")) {
+                    objects = await this.getCootContactDotsCidBuffers(this.style)
+                }
+        }
+        return objects
+    }
+
+    async getEnvironmentBuffers(cid: string, labelled: boolean = false) {
+        const resSpec = cidToSpec(cid)
+        const response = await this.commandCentre.current.cootCommand({
+            returnType: "generic_3d_lines_bonds_box",
+            command: "make_exportable_environment_bond_box",
+            commandArgs: [this.parentMolecule.molNo, resSpec.chain_id, resSpec.res_no, resSpec.alt_conf]
+        })
+        const envDistances = response.data.result.result
+
+        const bumps = envDistances[0];
+        const hbonds = envDistances[1];
+
+        const bumpAtomsPairs = bumps.map(bump => {
+            const start = bump.start
+            const end = bump.end
+
+            const startAtomInfo = {
+                pos: [start.x, start.y, start.z],
+                x: start.x,
+                y: start.y,
+                z: start.z,
+            }
+
+            const endAtomInfo = {
+                pos: [end.x, end.y, end.z],
+                x: end.x,
+                y: end.y,
+                z: end.z,
+            }
+
+            const pair = [startAtomInfo, endAtomInfo]
+            return pair
+        })
+
+        let originNeighboursBump = this.getGemmiAtomPairsBuffers(bumpAtomsPairs, [0.7, 0.4, 0.25, 1.0], labelled)
+
+        const hbondAtomsPairs = hbonds.map(hbond => {
+            const start = hbond.start
+            const end = hbond.end
+
+            const startAtomInfo = {
+                pos: [start.x, start.y, start.z],
+                x: start.x,
+                y: start.y,
+                z: start.z,
+            }
+
+            const endAtomInfo = {
+                pos: [end.x, end.y, end.z],
+                x: end.x,
+                y: end.y,
+                z: end.z,
+            }
+
+            const pair = [startAtomInfo, endAtomInfo]
+            return pair
+        })
+        
+        let originNeighboursHBond = this.getGemmiAtomPairsBuffers(hbondAtomsPairs, [0.7, 0.2, 0.7, 1.0], labelled)
+        
+        return originNeighboursBump.concat(originNeighboursHBond)
+    }
+
+    async getCootRepresentationBuffers(style: string, cidSelection?: string): Promise<libcootApi.InstancedMeshJS[]> {
+        let m2tStyle: string
+        let m2tSelection: string
+
+        switch (style) {
+            case "CRs":
+                m2tStyle = "Ribbon"
+                m2tSelection = "//"
+                break;
+            case "MolecularSurface":
+                m2tStyle = "MolecularSurface"
+                m2tSelection = "(ALA,CYS,ASP,GLU,PHE,GLY,HIS,ILE,LYS,LEU,MET,MSE,ASN,PRO,GLN,ARG,SER,THR,VAL,TRP,TYR)"
+                break;
+            case "VdWSurface":
+                m2tStyle = "VdWSurface"
+                m2tSelection = "(ALA,CYS,ASP,GLU,PHE,GLY,HIS,ILE,LYS,LEU,MET,MSE,ASN,PRO,GLN,ARG,SER,THR,VAL,TRP,TYR)"
+                break;
+            case "DishyBases":
+                m2tStyle = "DishyBases"
+                m2tSelection = "(ALA,CYS,ASP,GLU,PHE,GLY,HIS,ILE,LYS,LEU,MET,ASN,PRO,GLN,ARG,SER,THR,VAL,TRP,TYR)"
+                break;
+            case "Calpha":
+                m2tStyle = "Calpha"
+                m2tSelection = "(ALA,CYS,ASP,GLU,PHE,GLY,HIS,ILE,LYS,LEU,MET,MSE,ASN,PRO,GLN,ARG,SER,THR,VAL,TRP,TYR)"
+                break;
+            case "ligands":
+                m2tStyle = "Cylinders"
+                m2tSelection = "(!ALA,CYS,ASP,GLU,PHE,GLY,HIS,ILE,LYS,LEU,MET,MSE,ASN,PRO,GLN,ARG,SER,THR,VAL,TRP,TYR,HOH)"
+                break;
+            default:
+                m2tStyle = "Ribbon"
+                m2tSelection = "//"
+                break;
+        }
+
+        if(cidSelection) {
+            m2tSelection = `{${m2tSelection} & {${cidSelection}}}`
+        }
+
+        if (this.parentMolecule.excludedCids.length > 0) {
+            m2tSelection = `{${m2tSelection} & !{${this.parentMolecule.excludedCids.join(' | ')}}}`
+        }
+
+        const response = await this.commandCentre.current.cootCommand({
+            returnType: "mesh",
+            command: "get_molecular_representation_mesh",
+            commandArgs: [
+                this.parentMolecule.molNo, m2tSelection, "colorRampChainsScheme", m2tStyle
+            ]
+        }) as moorhen.WorkerResponse<libcootApi.InstancedMeshJS>
+
+        return [response.data.result.result]
+    }
+
+    async getCootSelectionBondBuffers(name: string, cid: null | string): Promise<libcootApi.InstancedMeshJS[]> {
+        let meshCommand: Promise<moorhen.WorkerResponse<libcootApi.InstancedMeshJS>>
+        let style = "COLOUR-BY-CHAIN-AND-DICTIONARY"
+        let returnType = "instanced_mesh"
+        if (name === "VdwSpheres") {
+            style = "VDW-BALLS"
+            returnType = "instanced_mesh_perfect_spheres"
+        } else if (name === "CAs") {
+            style = "CA+LIGANDS"
+        }
+
+        if (typeof cid !== 'string' || cid === '/*/*/*/*') {
+            meshCommand = this.commandCentre.current.cootCommand({
+                returnType: returnType,
+                command: "get_bonds_mesh_instanced",
+                commandArgs: [
+                    this.parentMolecule.molNo,
+                    style,
+                    this.parentMolecule.cootBondsOptions.isDarkBackground,
+                    this.parentMolecule.cootBondsOptions.width,
+                    this.parentMolecule.cootBondsOptions.atomRadiusBondRatio,
+                    this.parentMolecule.cootBondsOptions.smoothness
+                ]
+            })
+        } else {
+            meshCommand = this.commandCentre.current.cootCommand({
+                returnType: returnType,
+                command: "get_bonds_mesh_for_selection_instanced",
+                commandArgs: [
+                    this.parentMolecule.molNo,
+                    cid,
+                    style,
+                    this.parentMolecule.cootBondsOptions.isDarkBackground,
+                    this.parentMolecule.cootBondsOptions.width * 1.5,
+                    this.parentMolecule.cootBondsOptions.atomRadiusBondRatio * 1.5,
+                    this.parentMolecule.cootBondsOptions.smoothness
+                ]
+            })
+        }
+
+        const response = await meshCommand
+        return [response.data.result.result]
+    }
+
+    drawSymmetry() {
+        if (this.parentMolecule.symmetryMatrices && this.buffers) {
+            this.buffers.forEach((displayObject: moorhen.DisplayObject) => {
+                displayObject.symmetryMatrices = this.parentMolecule.symmetryMatrices
+            })
+            this.glRef.current.drawScene()
+        } else {
+            console.log('Cannot draw symmetry: parent molecule has no sym. matrix...')
+        }
+    }
+
+    async getResidueHighlightBuffers(selectionString: string, colour: number[]) {
+        if (typeof selectionString === 'string') {
+            const resSpec: moorhen.ResidueSpec = cidToSpec(selectionString)
+            let modifiedSelection = `/*/${resSpec.chain_id}/${resSpec.res_no}-${resSpec.res_no}/*${resSpec.alt_conf === "" ? "" : ":"}${resSpec.alt_conf}`
+            if (this.parentMolecule.sequences.length === 0) {
+                modifiedSelection = `/*/${resSpec.chain_id}/${resSpec.res_no}-${resSpec.res_no}/${resSpec.atom_name}${resSpec.alt_conf === "" ? "" : ":"}${resSpec.alt_conf}`
+            }
+            const selectedGemmiAtoms = await this.parentMolecule.gemmiAtomsForCid(modifiedSelection)
+            const atomColours = {}
+            selectedGemmiAtoms.forEach(atom => { atomColours[`${atom.serial}`] = colour })
+            let sphere_size = 0.3
+            let click_tol = 0.65
+            if (this.parentMolecule.representations.some(item => item.style === 'VdwSpheres' && item.visible)) {
+                sphere_size = 1.8
+                click_tol = 3.7
+            }
+            let objects = [
+                gemmiAtomsToCirclesSpheresInfo(selectedGemmiAtoms, sphere_size, "PERFECT_SPHERES", atomColours)
+            ]
+            objects.forEach(object => {
+                object["clickTol"] = click_tol
+                object["doStencil"] = true
+            })
+            return objects
+        }
+    }
+
+    async getCootContactDotsCidBuffers(style: string) {
+        const cid = style.substr("contact_dots-".length)
+        try {
+            const response = await this.commandCentre.current.cootCommand({
+                returnType: "instanced_mesh",
+                command: "contact_dots_for_ligand",
+                commandArgs: [this.parentMolecule.molNo, cid, this.parentMolecule.cootBondsOptions.smoothness]
+            }) as moorhen.WorkerResponse<libcootApi.InstancedMeshJS>;
+            const objects = [response.data.result.result];
+            return objects
+        } catch (err) {
+            return console.log(err);
+        }
+    }
+
+    getGemmiAtomPairsBuffers(gemmiAtomPairs: [moorhen.AtomInfo, moorhen.AtomInfo][], colour: number[], labelled: boolean = false): libcootApi.InstancedMeshJS[] {
+        const atomColours = {}
+        gemmiAtomPairs.forEach(atom => { atomColours[`${atom[0].serial}`] = colour; atomColours[`${atom[1].serial}`] = colour })
+        let objects = [
+            gemmiAtomPairsToCylindersInfo(gemmiAtomPairs, 0.07, atomColours, labelled)
+        ]
+        return objects
+    }
+
+    async getHBondBuffers(oneCid: string, labelled: boolean = false) {
+        const response = await this.commandCentre.current.cootCommand({
+            returnType: "vector_hbond",
+            command: "get_h_bonds",
+            commandArgs: [this.parentMolecule.molNo, oneCid, false]
+        })
+        const hBonds = response.data.result.result
+
+        const selectedGemmiAtomsPairs = hBonds.map(hbond => {
+            const donor = hbond.donor
+            const acceptor = hbond.acceptor
+
+            const donorAtomInfo = {
+                pos: [donor.x, donor.y, donor.z],
+                x: donor.x,
+                y: donor.y,
+                z: donor.z,
+                charge: donor.charge,
+                element: donor.element, // ???
+                name: donor.name,
+                symbol: donor.element, // ???
+                b_iso: donor.b_iso,
+                serial: donor.serial,
+                label: `/${donor.modelId}/${donor.chainName}/${donor.resNum}(${donor.residueName})/${donor.name}${donor.altLoc === "" ? ':' + String.fromCharCode(donor.altLoc) : ''}`
+            }
+
+            const acceptorAtomInfo = {
+                pos: [acceptor.x, acceptor.y, acceptor.z],
+                x: acceptor.x,
+                y: acceptor.y,
+                z: acceptor.z,
+                charge: acceptor.charge,
+                element: acceptor.element, // ???
+                name: acceptor.name,
+                symbol: acceptor.element, // ???
+                b_iso: acceptor.b_iso,
+                serial: acceptor.serial,
+                label: `/${acceptor.modelId}/${acceptor.chainName}/${acceptor.resNum}(${acceptor.name})/${acceptor.name}${acceptor.altLoc === "" ? ':' + String.fromCharCode(acceptor.altLoc) : ''}`
+            }
+
+            const pair = [donorAtomInfo, acceptorAtomInfo]
+            return pair
+        })
+
+        return this.getGemmiAtomPairsBuffers(selectedGemmiAtomsPairs, [0.7, 0.2, 0.7, 1.0], labelled)
+    }
+
+    async getCootChemicalFeaturesCidBuffers(style: string) {
+        const cid = style.substr("chemical_features-".length)
+        const response = await this.commandCentre.current.cootCommand({
+            returnType: "mesh",
+            command: "get_chemical_features_mesh",
+            commandArgs: [this.parentMolecule.molNo, cid]
+        }) as moorhen.WorkerResponse<libcootApi.InstancedMeshJS>
+        try {
+            const objects = [response.data.result.result]
+            return objects
+        } catch (err) {
+            console.log(err)
+        }
+    }
+
+
+    async getRamachandranBallBuffers() {
+        const response = await this.commandCentre.current.cootCommand({
+            returnType: "mesh",
+            command: "get_ramachandran_validation_markup_mesh",
+            commandArgs: [this.parentMolecule.molNo]
+        }) as moorhen.WorkerResponse<libcootApi.SimpleMeshJS>;
+        const objects = [response.data.result.result];
+        return objects
+    }
+
+    async getCootGaussianSurfaceBuffers(): Promise<libcootApi.InstancedMeshJS[]> {
+        const response = await this.commandCentre.current.cootCommand({
+            returnType: "mesh",
+            command: "get_gaussian_surface",
+            commandArgs: [
+                this.parentMolecule.molNo, this.parentMolecule.gaussianSurfaceSettings.sigma,
+                this.parentMolecule.gaussianSurfaceSettings.countourLevel,
+                this.parentMolecule.gaussianSurfaceSettings.boxRadius,
+                this.parentMolecule.gaussianSurfaceSettings.gridScale
+            ]
+        }) as moorhen.WorkerResponse<libcootApi.InstancedMeshJS>
+        try {
+            const objects = [response.data.result.result]
+            if (objects.length > 0 && !this.parentMolecule.gemmiStructure.isDeleted()) {
+                const flippedNormalsObjects = objects.map(object => {
+                    const flippedNormalsObject = { ...object }
+                    flippedNormalsObject.idx_tri = object.idx_tri.map(
+                        element => element.map(subElement => subElement.reverse())
+                    )
+                    return flippedNormalsObject
+                })
+                //Empty existing buffers of this type
+                return flippedNormalsObjects
+            }
+        } catch (err) {
+            console.log(err)
+        }
+    }
+
+    async getCootContactDotsBuffers() {
+        const response = await this.commandCentre.current.cootCommand({
+            returnType: "instanced_mesh",
+            command: "all_molecule_contact_dots",
+            commandArgs: [this.parentMolecule.molNo, this.parentMolecule.cootBondsOptions.smoothness]
+        }) as moorhen.WorkerResponse<libcootApi.InstancedMeshJS>
+        try {
+            const objects = [response.data.result.result]
+            return objects
+        } catch (err) {
+            console.log(err)
+        }
+    }
+
+    async getRotamerDodecahedraBuffers() {
+        const response = await this.commandCentre.current.cootCommand({
+            returnType: "instanced_mesh_perm",
+            command: "get_rotamer_dodecs_instanced",
+            commandArgs: [this.parentMolecule.molNo]
+        }) as moorhen.WorkerResponse<libcootApi.InstancedMeshJS>
+        try {
+            const objects = [response.data.result.result]
+            return objects
+        } catch (err) {
+            console.log(err)
+        }
+    }
+
+    getUnitCellRepresentationBuffers() {
+        const unitCell = this.parentMolecule.gemmiStructure.cell
+        const lines = getCubeLines(unitCell)
+        unitCell.delete()
+
+        let objects = [
+            gemmiAtomPairsToCylindersInfo(lines, 0.1, { unit_cell: [0.7, 0.4, 0.25, 1.0] }, false, 0, 99999, false) 
+        ]
+
+        return objects
+    }
+
+}

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -180,7 +180,7 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
                 name: molecule.name,
                 molNo: molecule.molNo,
                 pdbData: moleculeDataPromises[index],
-                displayObjectsKeys: Object.keys(molecule.displayObjects).filter(key => molecule.displayObjects[key].length > 0),
+                representations: molecule.representations.map(item => { return {cid: item.cid, style: item.style} }),
                 cootBondsOptions: molecule.cootBondsOptions,
                 connectedToMaps: molecule.connectedToMaps
             }

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -520,6 +520,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     ;
     class_<molecules_container_t>("molecules_container_t")
     .constructor<bool>()
+    .function("get_suggested_initial_contour_level",&molecules_container_t::get_suggested_initial_contour_level)
     .function("clear_refinement",&molecules_container_t::clear_refinement)
     .function("get_suggested_initial_contour_level",&molecules_container_t::get_suggested_initial_contour_level)
     .function("clear_target_position_restraints",&molecules_container_t::clear_target_position_restraints)

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -520,7 +520,6 @@ EMSCRIPTEN_BINDINGS(my_module) {
     ;
     class_<molecules_container_t>("molecules_container_t")
     .constructor<bool>()
-    .function("get_suggested_initial_contour_level",&molecules_container_t::get_suggested_initial_contour_level)
     .function("clear_refinement",&molecules_container_t::clear_refinement)
     .function("get_suggested_initial_contour_level",&molecules_container_t::get_suggested_initial_contour_level)
     .function("clear_target_position_restraints",&molecules_container_t::clear_target_position_restraints)


### PR DESCRIPTION
This is the first update towards enabling the representation of molecules using multiple styles for different residue selections. A new class `MoorhenMoleculeRepresentation` is used to handle rendering and replaces the attribute `MoorhenMolecule.displayObjects`.