### PR TITLE
Handle outdate session backups

### DIFF
--- a/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
@@ -199,6 +199,10 @@ export const MoorhenFileMenu = (props: MoorhenNavBarExtendedControlsInterface) =
 
         if (!sessionData) {
             return
+        } else if (!Object.hasOwn(sessionData, 'version') || props.timeCapsuleRef.current.version !== sessionData.version) {
+            props.setToastContent(getWarningToast(`Failed to read backup (deprecated format)`))
+            console.log('Outdated session backup version, wont load...')
+            return
         }
         
         // Delete current scene

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -348,6 +348,7 @@ export namespace moorhen {
     }
     
     type backupSession = {
+        version: string;
         includesAdditionalMapData: boolean;
         moleculeData: moleculeSessionData[];
         mapData: mapDataSession[];

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -887,7 +887,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
     async drawUnitCell() {
         const representation = new MoorhenMoleculeRepresentation('unitCell', '/*/*/*/*', this.commandCentre, this.glRef)
         representation.setParentMolecule(this)
-        representation.hasAtomBuffers = false
         await representation.draw()
         this.representations.push(representation)
     }
@@ -906,7 +905,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
         } else {
             representation = new MoorhenMoleculeRepresentation('hover', selectionString, this.commandCentre, this.glRef)
             representation.setParentMolecule(this)
-            representation.hasAtomBuffers = false
             await representation.draw()
             this.representations.push(representation)
         }
@@ -1517,7 +1515,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
         } else {
             representation = new MoorhenMoleculeRepresentation('environment', selectionCid, this.commandCentre, this.glRef)
             representation.setParentMolecule(this)
-            representation.hasAtomBuffers = false
             await representation.draw()
             this.representations.push(representation)
         }

--- a/baby-gru/src/utils/MoorhenMoleculeRepresentation.tsx
+++ b/baby-gru/src/utils/MoorhenMoleculeRepresentation.tsx
@@ -177,6 +177,7 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
     }
 
     async getEnvironmentBuffers(cid: string, labelled: boolean = false) {
+        this.hasAtomBuffers = false
         const resSpec = cidToSpec(cid)
         const response = await this.commandCentre.current.cootCommand({
             returnType: "generic_3d_lines_bonds_box",
@@ -352,6 +353,7 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
     }
 
     async getResidueHighlightBuffers(selectionString: string, colour: number[]) {
+        this.hasAtomBuffers = false
         if (typeof selectionString === 'string') {
             const resSpec: moorhen.ResidueSpec = cidToSpec(selectionString)
             let modifiedSelection = `/*/${resSpec.chain_id}/${resSpec.res_no}-${resSpec.res_no}/*${resSpec.alt_conf === "" ? "" : ":"}${resSpec.alt_conf}`
@@ -379,6 +381,7 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
     }
 
     async getCootContactDotsCidBuffers(style: string) {
+        this.hasAtomBuffers = false
         const cid = style.substr("contact_dots-".length)
         try {
             const response = await this.commandCentre.current.cootCommand({
@@ -403,6 +406,7 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
     }
 
     async getHBondBuffers(oneCid: string, labelled: boolean = false) {
+        this.hasAtomBuffers = false
         const response = await this.commandCentre.current.cootCommand({
             returnType: "vector_hbond",
             command: "get_h_bonds",
@@ -450,6 +454,7 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
     }
 
     async getCootChemicalFeaturesCidBuffers(style: string) {
+        this.hasAtomBuffers = false
         const cid = style.substr("chemical_features-".length)
         const response = await this.commandCentre.current.cootCommand({
             returnType: "mesh",
@@ -466,6 +471,7 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
 
 
     async getRamachandranBallBuffers() {
+        this.hasAtomBuffers = false
         const response = await this.commandCentre.current.cootCommand({
             returnType: "mesh",
             command: "get_ramachandran_validation_markup_mesh",
@@ -505,6 +511,7 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
     }
 
     async getCootContactDotsBuffers() {
+        this.hasAtomBuffers = false
         const response = await this.commandCentre.current.cootCommand({
             returnType: "instanced_mesh",
             command: "all_molecule_contact_dots",
@@ -519,6 +526,7 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
     }
 
     async getRotamerDodecahedraBuffers() {
+        this.hasAtomBuffers = false
         const response = await this.commandCentre.current.cootCommand({
             returnType: "instanced_mesh_perm",
             command: "get_rotamer_dodecs_instanced",
@@ -533,6 +541,7 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
     }
 
     getUnitCellRepresentationBuffers() {
+        this.hasAtomBuffers = false
         const unitCell = this.parentMolecule.gemmiStructure.cell
         const lines = getCubeLines(unitCell)
         unitCell.delete()

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -48,7 +48,7 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
         this.modificationCount = 0
         this.modificationCountBackupThreshold = 5
         this.maxBackupCount = 10
-        this.version = 'v8'
+        this.version = 'v9'
         this.disableBackups = false
         this.storageInstance = null    
     }
@@ -223,7 +223,8 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
             doDrawClickedAtomLines: this.glRef.current.doDrawClickedAtomLines,
             clipStart: (this.glRef.current.gl_clipPlane0[3] + this.glRef.current.fogClipOffset) * -1,
             clipEnd: this.glRef.current.gl_clipPlane1[3] - this.glRef.current.fogClipOffset,
-            quat4: this.glRef.current.myQuat
+            quat4: this.glRef.current.myQuat,
+            version: this.version
         }
 
         return session


### PR DESCRIPTION
After #52 old session backups are no longer compatible with the current version. Display warning message on session load and handle the error.