### PR TITLE
Use MoorhenMoleculeRepresentations to define custom representations part II

### DIFF
--- a/baby-gru/cloud/src/components/MoorhenCloudApp.tsx
+++ b/baby-gru/cloud/src/components/MoorhenCloudApp.tsx
@@ -41,7 +41,6 @@ export const MoorhenCloudApp = (props: MoorhenCloudAppPropsInterface) => {
     const [cootInitialized, setCootInitialized] = useState<boolean>(false)
     const [showToast, setShowToast] = useState<boolean>(false)
     const [toastContent, setToastContent] = useState<JSX.Element | null>(null)
-    const [showColourRulesToast, setShowColourRulesToast] = useState<boolean>(false)
     const [legendText, setLegendText] = useState<string | JSX.Element>('Loading, please wait...')
     const [busyFetching, setBusyFetching] = useState<boolean>(false)
     const [notifyNewContent, setNotifyNewContent] = useState<boolean>(false)
@@ -62,8 +61,8 @@ export const MoorhenCloudApp = (props: MoorhenCloudAppPropsInterface) => {
         activeMapRef, lastHoveredAtom, context, activeMap, setActiveMap,
         busy, setBusy, molecules: molecules as moorhen.Molecule[], changeMolecules,
         maps: maps as moorhen.Map[], changeMaps, backgroundColor, setBackgroundColor,
-        cootInitialized, setCootInitialized, setShowColourRulesToast, hoveredAtom, setHoveredAtom,
-        showToast, setShowToast, toastContent, setToastContent, showColourRulesToast,
+        cootInitialized, setCootInitialized, hoveredAtom, setHoveredAtom,
+        showToast, setShowToast, toastContent, setToastContent,
     }
 
     const doExportCallback = useCallback(async () => {

--- a/baby-gru/src/components/MoorhenApp.tsx
+++ b/baby-gru/src/components/MoorhenApp.tsx
@@ -38,7 +38,6 @@ export const MoorhenApp = (props: { forwardControls: (controls: any) => any }) =
     const [theme, setTheme] = useState<string>("flatly")
     const [showToast, setShowToast] = useState<boolean>(false)
     const [toastContent, setToastContent] = useState<null | JSX.Element>()
-    const [showColourRulesToast, setShowColourRulesToast] = useState<boolean>(false)
     
     moleculesRef.current = molecules as moorhen.Molecule[]
     mapsRef.current = maps as moorhen.Map[]
@@ -54,8 +53,7 @@ export const MoorhenApp = (props: { forwardControls: (controls: any) => any }) =
         changeMolecules, maps: maps as moorhen.Map[], changeMaps, 
         backgroundColor, setBackgroundColor, appTitle, setAppTitle, cootInitialized,
         setCootInitialized, theme, setTheme, showToast, setShowToast, toastContent,
-        setToastContent, showColourRulesToast, setShowColourRulesToast,
-        forwardControls: props.forwardControls
+        setToastContent, forwardControls: props.forwardControls
     }
 
     return <MoorhenContainer {...collectedProps}/>

--- a/baby-gru/src/components/MoorhenContainer.tsx
+++ b/baby-gru/src/components/MoorhenContainer.tsx
@@ -98,7 +98,6 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
     const [innerTheme, setInnerTheme] = useState<string>("flatly")
     const [innerShowToast, setInnerShowToast] = useState<boolean>(false)
     const [innerToastContent, setInnerToastContent] = useState<null | JSX.Element>(null)
-    const [innerShowColourRulesToast, setInnerShowColourRulesToast] = useState<boolean>(false)
     const [innerAvailableFonts, setInnerAvailableFonts] = useState<string[]>([])
     
     innerMoleculesRef.current = innerMolecules as moorhen.Molecule[]
@@ -148,8 +147,7 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
         appTitle: innerAppTitle, setAppTitle: setInnerAppTitle, cootInitialized: innerCootInitialized, 
         setCootInitialized: setInnerCootInitialized, theme: innerTheme, setTheme: setInnerTheme,
         showToast: innerShowToast, setShowToast: setInnerShowToast, toastContent: innerToastContent, 
-        setToastContent: setInnerToastContent, showColourRulesToast: innerShowColourRulesToast, 
-        setShowColourRulesToast: setInnerShowColourRulesToast, availableFonts: innerAvailableFonts,
+        setToastContent: setInnerToastContent, availableFonts: innerAvailableFonts,
         setAvailableFonts: setInnerAvailableFonts,
     }
 
@@ -166,8 +164,7 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
         dispatchHistoryReducer, molecules, changeMolecules, maps, changeMaps,
         backgroundColor, setBackgroundColor, availableFonts, setAvailableFonts,
         appTitle, setAppTitle, cootInitialized, setCootInitialized, theme, setTheme,
-        showToast, setShowToast, toastContent, setToastContent, showColourRulesToast,
-        setShowColourRulesToast
+        showToast, setShowToast, toastContent, setToastContent
     } = states
 
     const {
@@ -411,8 +408,8 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
     const collectedProps: moorhen.Controls = {
         molecules, changeMolecules, appTitle, setAppTitle, maps, changeMaps, glRef, activeMolecule, setActiveMolecule,
         activeMap, setActiveMap, commandHistory, commandCentre, backgroundColor, setBackgroundColor, toastContent, 
-        setToastContent, hoveredAtom, setHoveredAtom, showToast, setShowToast, windowWidth, windowHeight, showColourRulesToast,
-        timeCapsuleRef, setShowColourRulesToast, isDark, disableFileUploads, urlPrefix, viewOnly,
+        setToastContent, hoveredAtom, setHoveredAtom, showToast, setShowToast, windowWidth, windowHeight,
+        timeCapsuleRef, isDark, disableFileUploads, urlPrefix, viewOnly,
         extraNavBarMenus, monomerLibraryPath, moleculesRef, extraFileMenuItems, mapsRef, allowScripting, extraCalculateMenuItems,
         extraEditMenuItems, extraDraggableModals, aceDRGInstance, availableFonts, ...context
     }
@@ -459,8 +456,6 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
                         onKeyPress={onKeyPress}
                         hoveredAtom={hoveredAtom}
                         context={context}
-                        setShowColourRulesToast={setShowColourRulesToast}
-                        showColourRulesToast={showColourRulesToast}
                         windowHeight={windowHeight}
                         windowWidth={windowWidth}
                         urlPrefix={urlPrefix}

--- a/baby-gru/src/components/button-bar/MoorhenMoleculeCardButtonBar.tsx
+++ b/baby-gru/src/components/button-bar/MoorhenMoleculeCardButtonBar.tsx
@@ -130,28 +130,18 @@ export const MoorhenMoleculeCardButtonBar = (props: MoorhenMoleculeCardButtonBar
             expanded: null
         },
         8: {
-            label: 'Copy selected residues into fragment',
-            compressed: () => { return (<MenuItem key={8} disabled={(!props.clickedResidue || !props.selectedResidues)} onClick={props.handleCopyFragment}>Copy selected residues into fragment</MenuItem>) },
+            label: 'Bond display settings',
+            compressed: () => { return (<MoorhenMoleculeBondSettingsMenuItem key={8} setPopoverIsShown={setPopoverIsShown} {...props.bondSettingsProps}/>) },
             expanded: null
         },
         9: {
-            label: 'Merge molecules',
-            compressed: () => { return (<MoorhenMergeMoleculesMenuItem key={9} glRef={props.glRef} molecules={props.molecules} setPopoverIsShown={setPopoverIsShown} menuItemText="Merge molecule into..." popoverPlacement='left' fromMolNo={props.molecule.molNo}/>) },
+            label: 'Gaussian surface display settings',
+            compressed: () => { return (<MoorhenMoleculeGaussianSurfaceSettingsMenuItem key={9} setPopoverIsShown={setPopoverIsShown} {...props.gaussianSettingsProps}/>) },
             expanded: null
         },
         10: {
-            label: 'Bond display settings',
-            compressed: () => { return (<MoorhenMoleculeBondSettingsMenuItem key={10} setPopoverIsShown={setPopoverIsShown} {...props.bondSettingsProps}/>) },
-            expanded: null
-        },
-        11: {
-            label: 'Gaussian surface display settings',
-            compressed: () => { return (<MoorhenMoleculeGaussianSurfaceSettingsMenuItem key={11} setPopoverIsShown={setPopoverIsShown} {...props.gaussianSettingsProps}/>) },
-            expanded: null
-        },
-        12: {
             label: 'Symmetry settings',
-            compressed: () => { return (<MoorhenMoleculeSymmetrySettingsMenuItem key={12} setPopoverIsShown={setPopoverIsShown} molecule={props.molecule} glRef={props.glRef}/>) },
+            compressed: () => { return (<MoorhenMoleculeSymmetrySettingsMenuItem key={10} setPopoverIsShown={setPopoverIsShown} molecule={props.molecule} glRef={props.glRef}/>) },
             expanded: null
         },
     }

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useReducer, useCallback, useImperativeHandle, forwardRef } from 'react';
+import { useEffect, useState, useRef, useReducer, useCallback, useImperativeHandle, forwardRef } from 'react';
 import { Card, Row, Col, Accordion, Stack, Button, FormSelect, Form } from "react-bootstrap";
 import { doDownload, rgbToHex, sequenceIsValid } from '../../utils/MoorhenUtils';
 import { isDarkBackground } from '../../WebGLgComponents/mgWebGL'

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -28,6 +28,9 @@ const labelMapping = {
     allHBonds: "H-Bonds"
 }
 
+const allRepresentations = [ 'CBs', 'CAs', 'CRs', 'ligands', 'gaussian', 'MolecularSurface', 'DishyBases', 'VdwSpheres', 'rama', 'rotamer', 'CDs', 'allHBonds' ]
+const customRepresentations = [ 'CBs', 'CAs', 'CRs', 'ligands', 'gaussian', 'MolecularSurface', 'DishyBases', 'VdwSpheres' ]
+
 interface MoorhenMoleculeCardPropsInterface extends moorhen.Controls {
     dropdownId: number;
     accordionDropdownId: number;
@@ -431,7 +434,7 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
                     <Col  style={{ width:'100%', height: '100%' }}>
                         <div ref={addColourRulesAnchorDivRef} style={{ margin: '1px', paddingTop: '0.25rem', paddingBottom: '0.25rem',  border: '1px solid', borderRadius:'0.33rem', borderColor: "#CCC" }}>
                             <FormGroup style={{ margin: "0px", padding: "0px"}} row>
-                                {[ 'CBs', 'CAs', 'CRs', 'ligands', 'gaussian', 'MolecularSurface', 'DishyBases', 'VdwSpheres', 'rama', 'rotamer', 'CDs', 'allHBonds' ].map(key => 
+                                {allRepresentations.map(key => 
                                     <RepresentationCheckbox
                                     key={key}
                                     repKey={key}
@@ -592,7 +595,7 @@ const CreateCustomRepresentationMenu = (props: {setShow: React.Dispatch<React.Se
             >
             <Stack gap={2} direction='horizontal' style={{width: '25rem', margin: '0.5rem'}}>
                 <FormSelect ref={styleSelectRef} size="sm" defaultValue={'Bonds'}>
-                    {Object.keys(labelMapping).map(key => {
+                    {customRepresentations.map(key => {
                         return <option value={key} key={key}>{labelMapping[key]}</option>
                     })}
                 </FormSelect>

--- a/baby-gru/src/components/modal/MoorhenColourRules.tsx
+++ b/baby-gru/src/components/modal/MoorhenColourRules.tsx
@@ -104,18 +104,20 @@ export const MoorhenColourRules = (props: {
 
     const getRules = async (imol: number, commandCentre: React.RefObject<moorhen.CommandCentre>) => {
         const selectedMolecule = props.molecules.find(molecule => molecule.molNo === imol)
+        /**
         if (!selectedMolecule) {
             return 
         } else if (!selectedMolecule.colourRules) {
-            await selectedMolecule.fetchCurrentColourRules()
+            //await selectedMolecule.fetchCurrentColourRules()
         }
         return selectedMolecule.colourRules
+         */
     }
 
     const applyRules = useCallback(async () => {
         const selectedMolecule = props.molecules.find(molecule => molecule.molNo === selectedModel)
         if (selectedMolecule) {
-            await selectedMolecule.setColourRules(ruleList, true)
+            //await selectedMolecule.setColourRules(ruleList, true)
         }
     }, [selectedModel, ruleList, props.molecules])
 
@@ -193,9 +195,11 @@ export const MoorhenColourRules = (props: {
 
     useEffect(() => {
         if (selectedModel !== null) {
+            /**
             getRules(selectedModel, props.commandCentre).then(currentRules => {
                 setRuleList({action: 'Overwrite', items: currentRules})
-            })            
+            })
+             */
         } else {
             setRuleList({action: 'Empty'})
         }

--- a/baby-gru/src/components/modal/MoorhenDraggableModalBase.tsx
+++ b/baby-gru/src/components/modal/MoorhenDraggableModalBase.tsx
@@ -19,20 +19,21 @@ export const MoorhenDraggableModalBase = (props: {
     footer: JSX.Element;
     additionalChildren?: JSX.Element;
     overflowY?: 'visible' | 'hidden' | 'clip' | 'scroll' | 'auto';
+    handleClassName?: string;
 }) => {
 
     const [opacity, setOpacity] = useState<number>(1.0)
     const [collapse, setCollapse] = useState<boolean>(false)
     const draggableNodeRef = useRef<HTMLDivElement>();
 
-    return <Draggable nodeRef={draggableNodeRef} handle=".handle" >
+    return <Draggable nodeRef={draggableNodeRef} handle={`.${props.handleClassName}`} >
             <Card
                 ref={draggableNodeRef}
                 style={{ display: props.show ? 'block' : 'none', position: 'absolute', top: props.top, left: props.left, opacity: opacity, width: props.windowWidth ? convertViewtoPx(props.width, props.windowWidth) : `${props.width}wh`}}
                 onMouseOver={() => setOpacity(1)}
                 onMouseOut={() => setOpacity(0.5)}
             >
-                <Card.Header className="handle" style={{ justifyContent: 'space-between', display: 'flex', cursor: 'move', alignItems:'center'}}>
+                <Card.Header className={props.handleClassName} style={{ justifyContent: 'space-between', display: 'flex', cursor: 'move', alignItems:'center'}}>
                     {props.headerTitle}
                     <Stack gap={2} direction="horizontal">
                         {props.additionalHeaderButtons?.map(button => button)}
@@ -57,4 +58,4 @@ export const MoorhenDraggableModalBase = (props: {
         </Draggable>
 }
 
-MoorhenDraggableModalBase.defaultProps = { additionalHeaderButtons:null, additionalChildren: null, width: 35, height: 45, top: '5rem', left: '5rem', overflowY: 'scroll'}
+MoorhenDraggableModalBase.defaultProps = { handleClassName: 'handle', additionalHeaderButtons:null, additionalChildren: null, width: 35, height: 45, top: '5rem', left: '5rem', overflowY: 'scroll'}

--- a/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
@@ -125,7 +125,7 @@ export const MoorhenQuerySequenceModal = (props: {
     const fetchAndSuperpose = async (polimerEntity: string, coordUrl: string, chainId: string, source: string) => {
         const newMolecule = await fetchMoleculeFromURL(coordUrl, polimerEntity)
         if (source === 'AFDB') {
-            const newRule = [{
+            const newRule = {
                 commandInput: {
                     message:'coot_command',
                     command: 'add_colour_rules_multi', 
@@ -135,8 +135,8 @@ export const MoorhenQuerySequenceModal = (props: {
                 isMultiColourRule: true,
                 ruleType: 'af2-plddt',
                 label: `//*`
-            }]
-            newMolecule.setColourRules(newRule, false)
+            }
+            newMolecule.defaultColourRules = [newRule]
         } 
         await props.commandCentre.current.cootCommand({
             message: 'coot_command',

--- a/baby-gru/src/components/navbar-menus/MoorhenDevMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenDevMenu.tsx
@@ -69,13 +69,17 @@ const doRepresentationsTest = async (props: any) => {
 
     if (typeof molecule !== 'undefined') {
         const customRepresentations = [
-            ['MolecularSurface', '//A/1-15'],
-            ['CBs', '//A/15-30'],
-            ['CRs', '//A/30-36'],
-            ['CBs', '//A/46-55'],
-            ['CRs', '//A/55-72']
+            ['MolecularSurface', '//A/1-15', true, '#1bd12a'],
+            ['CRs', '//A/1-15', true, '#d420bc'],
+            ['CBs', '//A/15-30', true],
+            ['CRs', '//A/30-36', true, '#3d1cd4'],
+            ['CBs', '//A/46-55', true],
+            ['MolecularSurface', '//A/55-72', true, '#d417b4'],
+            ['CRs', '//A/55-72', true, '#1bd12a']
         ]
-        await Promise.all(customRepresentations.map(item => molecule.addRepresentation(...item)))
+        for (const representation of customRepresentations) {
+            await molecule.addRepresentation(...representation)
+        }
     }
 
 }

--- a/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
@@ -117,7 +117,7 @@ export const MoorhenFileMenu = (props: MoorhenNavBarExtendedControlsInterface) =
         if (uniprotID) {
             fetchMoleculeFromURL(coordUrl, `${uniprotID}`)
                 .then(newMolecule => {
-                    const newRule = [{
+                    const newRule = {
                         commandInput: {
                             message:'coot_command',
                             command: 'add_colour_rules_multi', 
@@ -127,8 +127,8 @@ export const MoorhenFileMenu = (props: MoorhenNavBarExtendedControlsInterface) =
                         isMultiColourRule: true,
                         ruleType: 'af2-plddt',
                         label: `//*`
-                    }]
-                    newMolecule.setColourRules(newRule, false)
+                    }
+                    newMolecule.defaultColourRules = [newRule]
                 })
                 .catch(err => console.log(err))
         }

--- a/baby-gru/src/components/navbar-menus/MoorhenViewMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenViewMenu.tsx
@@ -1,12 +1,10 @@
 import { Form, InputGroup } from "react-bootstrap";
 import { useState } from "react";
-import { MenuItem } from "@mui/material";
 import { MoorhenClipFogMenuItem } from "../menu-item/MoorhenClipFogMenuItem";
 import { MoorhenLightingMenuItem } from "../menu-item/MoorhenLightingMenuItem"
 import { MoorhenBlurMenuItem } from "../menu-item/MoorhenBlurMenuItem"
 import { MoorhenBackgroundColorMenuItem } from "../menu-item/MoorhenBackgroundColorMenuItem"
 import { MoorhenNavBarExtendedControlsInterface } from "./MoorhenNavBar";
-import MoorhenSlider from '../misc/MoorhenSlider' 
 
 export const MoorhenViewMenu = (props: MoorhenNavBarExtendedControlsInterface) => {
     const [popoverIsShown, setPopoverIsShown] = useState(false)
@@ -60,11 +58,5 @@ export const MoorhenViewMenu = (props: MoorhenNavBarExtendedControlsInterface) =
                     <MoorhenClipFogMenuItem {...menuItemProps} />
                     <MoorhenLightingMenuItem {...menuItemProps} />
                     {props.glRef.current.isWebGL2 () && <MoorhenBlurMenuItem {...menuItemProps} />}
-                    <MenuItem id="change-molecule-colours-menu-item" onClick={() => {
-                        props.setShowColourRulesToast(true)
-                        document.body.click()
-                    }}>
-                        Set molecule colour rules...
-                    </MenuItem>
         </>
     }

--- a/baby-gru/src/components/webMG/MoorhenWebMG.tsx
+++ b/baby-gru/src/components/webMG/MoorhenWebMG.tsx
@@ -25,8 +25,6 @@ interface MoorhenWebMGPropsInterface {
     hoveredAtom: moorhen.HoveredAtom;
     viewOnly: boolean;
     context: moorhen.Context;
-    setShowColourRulesToast: React.Dispatch<React.SetStateAction<boolean>>;
-    showColourRulesToast: boolean;
     windowHeight: number;
     windowWidth: number;
     urlPrefix: string;
@@ -573,8 +571,6 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
                     windowHeight={props.windowHeight}
                 />}
                 
-                <MoorhenColourRules glRef={glRef as React.RefObject<webGL.MGWebGL>} {...props}/>
-
                 {props.extraDraggableModals && props.extraDraggableModals.map(modal => modal)}
 
             </>

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -113,8 +113,7 @@ export namespace moorhen {
         getUnitCellParams():  { a: number; b: number; c: number; alpha: number; beta: number; gamma: number; };
         replaceModelWithFile(fileUrl: string, molName: string): Promise<void>
         delete(): Promise<WorkerResponse> 
-        setColourRules(ruleList: ColourRule[], redraw?: boolean): Promise<void>;
-        fetchCurrentColourRules(): Promise<void>;
+        fetchDefaultColourRules(): Promise<void>;
         fetchIfDirtyAndDraw(arg0: string): Promise<void>;
         drawEnvironment: (cid: string, labelled?: boolean) => Promise<void>;
         centreOn: (selectionCid?: string, animate?: boolean) => Promise<void>;
@@ -139,7 +138,6 @@ export namespace moorhen {
         molNo: number;
         gemmiStructure: gemmi.Structure;
         sequences: Sequence[];
-        colourRules: ColourRule[];
         ligands: LigandInfo[];
         ligandDicts: {[comp_id: string]: string};
         connectedToMaps: number[];
@@ -157,8 +155,13 @@ export namespace moorhen {
         cootBondsOptions: cootBondOptions;
         displayObjectsTransformation: { origin: [number, number, number], quat: any, centre: [number, number, number] }
         uniqueId: string;
+        defaultColourRules: ColourRule[];
         monomerLibraryPath: string;
     }
+
+    type RepresentationStyles = 'VdwSpheres' | 'ligands' | 'CAs' | 'CBs' | 'CDs' | 'gaussian' | 'allHBonds' | 'rama' | 
+    'rotamer' | 'CRs' | 'MolecularSurface' | 'DishyBases' | 'VdWSurface' | 'Calpha' | 'unitCell' | 'hover' | 'environment' | 
+    'ligand_environment' | 'contact_dots' | 'chemical_features' | 'ligand_validation'
 
     interface MoleculeRepresentation {
         buildBuffers(arg0: DisplayObject[]): Promise<void>;
@@ -179,6 +182,7 @@ export namespace moorhen {
         commandCentre: React.RefObject<CommandCentre>;
         glRef: React.RefObject<webGL.MGWebGL>;
         parentMolecule: Molecule;
+        colourRules: ColourRule[];
         hasAtomBuffers: boolean;
     }
     

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -83,7 +83,8 @@ export namespace moorhen {
     }
     
     interface Molecule {
-        addRepresentation(style: string, cid?: string): Promise<void>;
+        removeRepresentation(representationId: string): void;
+        addRepresentation(style: string, cid: string, isCustom?: boolean, colour?: string): Promise<void>;
         getNeighborResiduesCids(selectionCid: string, radius: number, minDist: number, maxDist: number): Promise<string[]>;
         drawWithStyleFromMesh(style: string, meshObjects: any[], cid?: string): Promise<void>;
         updateWithMovedAtoms(movedResidues: AtomInfo[][]): Promise<void>;
@@ -157,6 +158,9 @@ export namespace moorhen {
         uniqueId: string;
         defaultColourRules: ColourRule[];
         monomerLibraryPath: string;
+        hoverRepresentation: moorhen.MoleculeRepresentation;
+        unitCellRepresentation: moorhen.MoleculeRepresentation;
+        environmentRepresentation: moorhen.MoleculeRepresentation;
     }
 
     type RepresentationStyles = 'VdwSpheres' | 'ligands' | 'CAs' | 'CBs' | 'CDs' | 'gaussian' | 'allHBonds' | 'rama' | 
@@ -164,10 +168,11 @@ export namespace moorhen {
     'ligand_environment' | 'contact_dots' | 'chemical_features' | 'ligand_validation'
 
     interface MoleculeRepresentation {
+        setColourRules(ruleList: ColourRule[]): void;
         buildBuffers(arg0: DisplayObject[]): Promise<void>;
         setBuffers(meshObjects: DisplayObject[]): void;
         drawSymmetry(): void
-        delete(): void;
+        deleteBuffers(): void;
         draw(): Promise<void>;
         redraw(): Promise<void>;
         setParentMolecule(arg0: Molecule): void;
@@ -183,7 +188,10 @@ export namespace moorhen {
         glRef: React.RefObject<webGL.MGWebGL>;
         parentMolecule: Molecule;
         colourRules: ColourRule[];
-        hasAtomBuffers: boolean;
+        styleHasAtomBuffers: boolean;
+        styleHasSymmetry: boolean;
+        isCustom: boolean;
+        styleHasColourRules: boolean;
     }
     
     type HoveredAtom = {
@@ -653,8 +661,6 @@ export namespace moorhen {
         setShowToast: React.Dispatch<React.SetStateAction<boolean>>;
         windowWidth: number;
         windowHeight: number;
-        showColourRulesToast: boolean;
-        setShowColourRulesToast: React.Dispatch<React.SetStateAction<boolean>>;
         availableFonts: string[];
     }
     
@@ -703,8 +709,6 @@ export namespace moorhen {
         setShowToast: React.Dispatch<React.SetStateAction<boolean>>;
         toastContent: null | JSX.Element;
         setToastContent: React.Dispatch<React.SetStateAction<JSX.Element>>;
-        showColourRulesToast: boolean;
-        setShowColourRulesToast: React.Dispatch<React.SetStateAction<boolean>>;
         availableFonts: string[];
         setAvailableFonts: React.Dispatch<React.SetStateAction<string[]>>
     }

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -536,6 +536,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("set_user_defined_atom_colour_by_residue",&molecules_container_t::set_user_defined_atom_colour_by_residue)
     .function("set_user_defined_bond_colours",&molecules_container_t::set_user_defined_bond_colours)
     .function("set_colour_wheel_rotation_base",&molecules_container_t::set_colour_wheel_rotation_base)
+    .function("set_base_colour_for_bonds",&molecules_container_t::set_base_colour_for_bonds)
     .function("get_symmetry",&molecules_container_t::get_symmetry)
     .function("fit_to_map_by_random_jiggle_using_cid",&molecules_container_t::fit_to_map_by_random_jiggle_using_cid)
     .function("get_active_atom",&molecules_container_t::get_active_atom)


### PR DESCRIPTION
After this update it is possible to define custom representations with their own colour rules within the UI. There have been changes to the way representations are handled that should improve performance. Further work still needs to be done in the UI.