### PR TITLE
 Use MoorhenMoleculeRepresentations to define custom representations part III

### DIFF
--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -159,6 +159,7 @@
     "react-bootstrap-typeahead": "^6.0.0-alpha.11",
     "react-chartjs-2": "^4.1.0",
     "react-color": "^2.19.3",
+    "react-colorful": "^5.6.1",
     "react-dom": "^18.1.0",
     "react-draggable": "^4.4.5",
     "react-plotly.js": "^2.5.1",

--- a/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
+++ b/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
@@ -1,26 +1,102 @@
 import { useState, useRef, useCallback } from 'react';
-import { Stack, Button, FormSelect, Form } from "react-bootstrap";
-import { SliderPicker } from "react-color";
-import { rgbToHex, representationLabelMapping } from '../../utils/MoorhenUtils';
+import { Stack, Button, FormSelect, Form, InputGroup, Row } from "react-bootstrap";
+import { getMultiColourRuleArgs, representationLabelMapping } from '../../utils/MoorhenUtils';
 import { moorhen } from "../../types/moorhen";
 import { Popover } from '@mui/material';
+import { MoorhenChainSelect } from '../select/MoorhenChainSelect';
+import { HexColorPicker } from "react-colorful";
 
 const customRepresentations = [ 'CBs', 'CAs', 'CRs', 'ligands', 'gaussian', 'MolecularSurface', 'DishyBases', 'VdwSpheres' ]
 
 export const MoorhenAddCustomRepresentationCard = (props: {
     setShow: React.Dispatch<React.SetStateAction<boolean>>;
     show: boolean; anchorEl: React.RefObject<HTMLDivElement>;
-    molecule: moorhen.Molecule
+    molecule: moorhen.Molecule;
+    isDark: boolean;
+    molecules: moorhen.Molecule[];
+    urlPrefix: string;
 }) => {
 
+    const useDefaultColoursSwitchRef = useRef<HTMLInputElement | null>(null)
+    const ruleSelectRef = useRef<HTMLSelectElement | null>(null)
     const cidFormRef = useRef<HTMLInputElement | null>(null)
     const styleSelectRef = useRef<HTMLSelectElement | null>(null)
-    const [colour, setColour] = useState<{ r: string; g: string; b: string; }>({r: '150', g:'100', b:'50'})
+    const chainSelectRef = useRef<HTMLSelectElement | null>(null)
+    const colourModeSelectRef = useRef<HTMLSelectElement | null>(null)
+    const colourSwatchRef = useRef<HTMLDivElement | null>(null)
+    const residueRangeSelectRef = useRef<any>()
+    const [colourMode, setColourMode] = useState<string>('custom')
+    const [showColourPicker, setShowColourPicker] = useState<boolean>(false)
+    const [ruleType, setRuleType] = useState<string>('molecule')
+    const [colour, setColour] = useState<string>('#47d65f')
+    const [useDefaultColours, setUseDefaultColours] = useState<boolean>(true)
+
+    const handleChainChange =() => {
+
+    }
 
     const handleCreateRepresentation = useCallback(() => {
-        props.molecule.addRepresentation(styleSelectRef.current.value, cidFormRef.current.value, true, rgbToHex(parseInt(colour.r), parseInt(colour.g), parseInt(colour.b)))
+        let cidSelection: string
+        switch(ruleSelectRef.current.value) {
+            case "molecule":
+                cidSelection = "//*"
+                break
+            case "chain":
+                cidSelection = `//${chainSelectRef.current.value}`
+                break
+            case "residue-range":
+                const selectedResidues = residueRangeSelectRef.current.getSelectedResidues()
+                cidSelection = (selectedResidues && selectedResidues.length === 2) ? `//${chainSelectRef.current.value}/${selectedResidues[0]}-${selectedResidues[1]}` : null
+                break
+            case "cid":
+                cidSelection = cidFormRef.current.value
+                break
+            default:
+                console.log('Unrecgnised residue selection for the custom representation')    
+                break
+        }
+
+        let colourRules: moorhen.ColourRule[] = []
+        if (!useDefaultColoursSwitchRef.current.checked) {
+            switch(colourModeSelectRef.current.value) {
+                case "custom":
+                    colourRules = [{
+                        commandInput: {
+                            message: 'coot_command',
+                            command: 'add_colour_rule',
+                            returnType: 'status',
+                            commandArgs: [props.molecule.molNo, cidSelection, colour]
+                        },
+                        isMultiColourRule: false,
+                        ruleType: 'chain',
+                        color: colour,
+                        label: cidSelection
+                    }]
+                    break
+                case "b-factor":
+                case "af2-plddt":
+                    colourRules = [{
+                        commandInput: {
+                            message:'coot_command',
+                            command: 'add_colour_rules_multi', 
+                            returnType:'status',
+                            commandArgs: getMultiColourRuleArgs(props.molecule, colourModeSelectRef.current.value)
+                        },
+                        isMultiColourRule: true,
+                        color: colour,
+                        ruleType: `${colourModeSelectRef.current.value}`,
+                        label: `${colourModeSelectRef.current.value}`,
+                    }]
+                    break
+                default:
+                    console.log('Unrecognised colour mode')
+                    break
+            }
+        }
+
+        props.molecule.addRepresentation(styleSelectRef.current.value, cidSelection, true, colourRules)
         props.setShow(false)
-    }, [colour])
+    }, [colour, props.molecule])
 
     return <Popover
                 onClose={() => props.setShow(false)}
@@ -28,18 +104,80 @@ export const MoorhenAddCustomRepresentationCard = (props: {
                 anchorEl={props.anchorEl.current}
                 anchorOrigin={{ vertical: 'center', horizontal: 'center' }}
                 transformOrigin={{ vertical: 'center', horizontal: 'center', }}
-                sx={{'& .MuiPaper-root': {backgroundColor: '#e8e8e8', marginTop: '0.1rem'}}}
+                sx={{'& .MuiPaper-root': {backgroundColor: props.isDark ? 'grey' : 'white', marginTop: '0.1rem'}}}
+                
             >
-            <Stack gap={2} direction='horizontal' style={{width: '25rem', margin: '0.5rem'}}>
-                <FormSelect ref={styleSelectRef} size="sm" defaultValue={'Bonds'}>
-                    {customRepresentations.map(key => {
-                        return <option value={key} key={key}>{representationLabelMapping[key]}</option>
-                    })}
-                </FormSelect>
-                <Form.Control ref={cidFormRef} size="sm" type='text' placeholder={'CID selection'} style={{width: "100%"}}/>
-                <div style={{width: '100%', textAlign: 'center'}}>
-                <SliderPicker color={colour} onChange={(color) => {setColour({r: color.rgb.r, g: color.rgb.g, b: color.rgb.b})}}/>
+            <Stack gap={2} direction='vertical' style={{width: '25rem', margin: '0.5rem'}}>
+                <Form.Group style={{ margin: '0px', width: '100%' }}>
+                    <Form.Label>Style</Form.Label>
+                    <FormSelect ref={styleSelectRef} size="sm" defaultValue={'Bonds'}>
+                        {customRepresentations.map(key => {
+                            return <option value={key} key={key}>{representationLabelMapping[key]}</option>
+                        })}
+                    </FormSelect>
+                </Form.Group>
+                <Form.Group style={{ width: '100%', margin: 0 }}>
+                        <Form.Label>Residue selection</Form.Label>
+                        <FormSelect size="sm" ref={ruleSelectRef} defaultValue={ruleType} onChange={(val) => setRuleType(val.target.value)}>
+                            <option value={'molecule'} key={'molecule'}>All molecule</option>
+                            <option value={'chain'} key={'chain'}>Chain</option>
+                            <option value={'cid'} key={'cid'}>CID</option>
+                        </FormSelect>
+                </Form.Group>
+                <div style={{justifyContent: 'center', display: 'flex'}}>
+                    {(ruleType === 'chain' || ruleType === 'residue-range')  && <MoorhenChainSelect molecules={props.molecules} onChange={handleChainChange} selectedCoordMolNo={props.molecule.molNo} ref={chainSelectRef} allowedTypes={[1, 2]}/>}
+                    {ruleType === 'cid' && <Form.Control ref={cidFormRef} size="sm" type='text' placeholder={'CID selection'} style={{margin: '0.5rem'}}/> }
                 </div>
+                <InputGroup style={{ padding:'0.5rem', width: '25rem'}}>
+                    <Form.Check 
+                        ref={useDefaultColoursSwitchRef}
+                        type="switch"
+                        label="Apply general colour settings"
+                        checked={useDefaultColours}
+                        onChange={() => { 
+                            setUseDefaultColours((prev) => {return !prev})
+                         }}
+                    />
+                </InputGroup>
+                {!useDefaultColours &&
+                <>
+                <Row style={{paddingLeft: '1rem'}}>
+                    <FormSelect style={{ width: '50%', marginRight: '0.5rem' }} size="sm" ref={colourModeSelectRef} defaultValue={colourMode} onChange={(val) => { setColourMode(val.target.value) }}>
+                            <option value={'custom'} key={'custom'}>User defined colour</option>
+                            <option value={'b-factor'} key={'b-factor'}>B-Factor</option>
+                            <option value={'af2-plddt'} key={'af2-plddt'}>AF2 PLDDT</option>
+                    </FormSelect>
+                    {colourMode === 'b-factor' ?
+                    <img className="colour-rule-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/temperature.svg`} alt='b-factor' style={{ width: '36px', height: '30px', borderRadius: '3px', border: '1px solid #c9c9c9', padding: 0}}/>
+                    :
+                    colourMode === 'custom' ?
+                    <div 
+                        style={{ display: colourMode === 'custom' ? 'flex' : 'none', width: '28px', height: '28px', borderRadius: '8px', border: '3px solid #fff', boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 0 0 1px rgba(0, 0, 0, 0.1)', cursor: 'pointer', backgroundColor: colour }}
+                        onClick={() => setShowColourPicker(true)}
+                        ref={colourSwatchRef}
+                    />
+                    : 
+                    <>
+                        <div style={{borderColor: 'rgb(255, 125, 69)', borderWidth:'5px', backgroundColor:  'rgb(255, 125, 69)', height:'20px', width:'5px', marginTop: '0.2rem', padding: '0rem'}}/>
+                        <div style={{borderColor: 'rgb(255, 219, 19)', borderWidth:'5px', backgroundColor: 'rgb(255, 219, 19)', height:'20px', width:'5px', marginTop: '0.2rem', padding: '0rem'}}/>
+                        <div style={{borderColor: 'rgb(101, 203, 243)', borderWidth:'5px', backgroundColor: 'rgb(101, 203, 243)', height:'20px', width:'5px', marginTop: '0.2rem', padding: '0rem'}}/>
+                        <div style={{borderColor: 'rgb(0, 83, 214)', borderWidth:'5px', backgroundColor: 'rgb(0, 83, 214)', height:'20px', width:'5px', marginTop: '0.2rem', padding: '0rem'}}/>
+                    </>
+                    }
+                </Row>
+                <Popover 
+                    anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+                    transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+                    open={!useDefaultColours && showColourPicker}
+                    onClose={() => setShowColourPicker(false)}
+                    anchorEl={colourSwatchRef.current}
+                >
+                    <HexColorPicker color={colour} onChange={(color) => setColour(color)} />
+
+                </Popover>
+                </>
+                
+                }
                 <Button onClick={handleCreateRepresentation}>
                     Create
                 </Button>

--- a/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
+++ b/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
@@ -1,0 +1,49 @@
+import { useState, useRef, useCallback } from 'react';
+import { Stack, Button, FormSelect, Form } from "react-bootstrap";
+import { SliderPicker } from "react-color";
+import { rgbToHex, representationLabelMapping } from '../../utils/MoorhenUtils';
+import { moorhen } from "../../types/moorhen";
+import { Popover } from '@mui/material';
+
+const customRepresentations = [ 'CBs', 'CAs', 'CRs', 'ligands', 'gaussian', 'MolecularSurface', 'DishyBases', 'VdwSpheres' ]
+
+export const MoorhenAddCustomRepresentationCard = (props: {
+    setShow: React.Dispatch<React.SetStateAction<boolean>>;
+    show: boolean; anchorEl: React.RefObject<HTMLDivElement>;
+    molecule: moorhen.Molecule
+}) => {
+
+    const cidFormRef = useRef<HTMLInputElement | null>(null)
+    const styleSelectRef = useRef<HTMLSelectElement | null>(null)
+    const [colour, setColour] = useState<{ r: string; g: string; b: string; }>({r: '150', g:'100', b:'50'})
+
+    const handleCreateRepresentation = useCallback(() => {
+        props.molecule.addRepresentation(styleSelectRef.current.value, cidFormRef.current.value, true, rgbToHex(parseInt(colour.r), parseInt(colour.g), parseInt(colour.b)))
+        props.setShow(false)
+    }, [colour])
+
+    return <Popover
+                onClose={() => props.setShow(false)}
+                open={props.show}
+                anchorEl={props.anchorEl.current}
+                anchorOrigin={{ vertical: 'center', horizontal: 'center' }}
+                transformOrigin={{ vertical: 'center', horizontal: 'center', }}
+                sx={{'& .MuiPaper-root': {backgroundColor: '#e8e8e8', marginTop: '0.1rem'}}}
+            >
+            <Stack gap={2} direction='horizontal' style={{width: '25rem', margin: '0.5rem'}}>
+                <FormSelect ref={styleSelectRef} size="sm" defaultValue={'Bonds'}>
+                    {customRepresentations.map(key => {
+                        return <option value={key} key={key}>{representationLabelMapping[key]}</option>
+                    })}
+                </FormSelect>
+                <Form.Control ref={cidFormRef} size="sm" type='text' placeholder={'CID selection'} style={{width: "100%"}}/>
+                <div style={{width: '100%', textAlign: 'center'}}>
+                <SliderPicker color={colour} onChange={(color) => {setColour({r: color.rgb.r, g: color.rgb.g, b: color.rgb.b})}}/>
+                </div>
+                <Button onClick={handleCreateRepresentation}>
+                    Create
+                </Button>
+            </Stack>
+        </Popover>
+ 
+}

--- a/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
+++ b/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
@@ -116,15 +116,13 @@ export const MoorhenModifyColourRulesCard = (props: {
         if (props.molecule?.defaultColourRules) {
             props.molecule.defaultColourRules = ruleList
             await Promise.all(
-                props.molecule.representations.filter(representation => !representation.isCustom).map(representation => {
-                    representation.setColourRules(ruleList)
+                props.molecule.representations.filter(representation => representation.useDefaultColourRules).map(representation => {
                     if (representation.visible) {
                         return representation.redraw()
                     } else {
                         representation.deleteBuffers()
                         return Promise.resolve()
                     }
-                    
                 })
             )
         }

--- a/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
+++ b/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
@@ -53,7 +53,7 @@ const itemReducer = (oldList: moorhen.ColourRule[], change: colourRuleChange) =>
 
 const initialRuleState: moorhen.ColourRule[] = []
 
-export const MoorhenColourRules = (props: {
+export const MoorhenModifyColourRulesCard = (props: {
     urlPrefix: string;
     commandCentre: React.RefObject<moorhen.CommandCentre>;
     glRef: React.RefObject<webGL.MGWebGL>;

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -568,10 +568,7 @@ const RepresentationCheckbox = (props: RepresetationCheckboxPropsType) => {
     }, [props.showState])
 
     const handleClick = useCallback(() => {
-        console.log('HI')
-        console.log(props.isVisible)
         if (props.isVisible) {
-            console.log(repState, props.repKey)
             if (repState) {
                 props.molecule.hide(props.repKey)
             }

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -543,11 +543,26 @@ type RepresetationCheckboxPropsType = {
 const RepresentationCheckbox = (props: RepresetationCheckboxPropsType) => {
     const [repState, setRepState] = useState<boolean>(false)
 
+    const chipStyle = {
+        marginLeft: '0.1rem',
+        marginBottom: '0.1rem',
+        width: 'calc(100% /6.15)',
+    }
+
     let [r, g, b]: number[] = [214, 214, 214]
     if (props.molecule.defaultColourRules?.length > 0) {
-        [r, g, b] = hexToRgb(props.molecule.defaultColourRules[0].color).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+        if (props.molecule.defaultColourRules[0].isMultiColourRule) {
+            const alphaHex = repState ? '99' : '33'
+            chipStyle['background'] = `linear-gradient( to right, #264CFF${alphaHex}, #3FA0FF${alphaHex}, #72D8FF${alphaHex}, #AAF7FF${alphaHex}, #E0FFFF${alphaHex}, #FFFFBF${alphaHex}, #FFE099${alphaHex}, #FFAD72${alphaHex}, #F76D5E${alphaHex}, #D82632${alphaHex}, #A50021${alphaHex} )`
+        } else {
+            [r, g, b] = hexToRgb(props.molecule.defaultColourRules[0].color).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+            chipStyle['backgroundColor'] = `rgba(${r}, ${g}, ${b}, ${repState ? 0.5 : 0.1})`
+        }        
     }
-    
+
+    chipStyle['borderColor'] = `rgb(${r}, ${g}, ${b})`
+
+
     useEffect(() => {
         setRepState(props.showState[props.repKey] || false)
     }, [props.showState])
@@ -568,7 +583,7 @@ const RepresentationCheckbox = (props: RepresetationCheckboxPropsType) => {
     }, [repState, props.isVisible])
 
     return <Chip
-                style={{marginLeft: '0.1rem', marginBottom: '0.1rem', borderColor: `rgb(${r}, ${g}, ${b})`, backgroundColor: `rgba(${r}, ${g}, ${b}, ${repState ? 0.5 : 0.1})`, width: 'calc(100% /6.15)'}}
+                style={chipStyle}
                 variant={"outlined"}
                 label={`${labelMapping[props.repKey]}`}
                 onClick={handleClick}

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -473,7 +473,7 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
                         <Button style={{ paddingTop: '0.25rem', paddingBottom: '0.25rem' }} variant='light' onClick={() => setShowCreateCustomRepresentation((prev) => {return !prev})}>
                             <AddOutlined/>
                         </Button>
-                        <MoorhenAddCustomRepresentationCard molecule={props.molecule} anchorEl={addCustomRepresentationAnchorDivRef} show={showCreateCustomRepresentation} setShow={setShowCreateCustomRepresentation}/>
+                        <MoorhenAddCustomRepresentationCard urlPrefix={props.urlPrefix} molecules={props.molecules} isDark={props.isDark} molecule={props.molecule} anchorEl={addCustomRepresentationAnchorDivRef} show={showCreateCustomRepresentation} setShow={setShowCreateCustomRepresentation}/>
                     </Col>
                 </Row>                
             <Accordion alwaysOpen={true} defaultActiveKey={['sequences']}>
@@ -532,6 +532,34 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
     </>
 })
 
+const getChipStyle = (colourRules: moorhen.ColourRule[], repIsVisible: boolean, width?: string) => {
+    const chipStyle = {
+        marginLeft: '0.1rem',
+        marginBottom: '0.1rem',
+    }
+
+    if (width) { 
+        chipStyle['width'] = width 
+    }
+
+    let [r, g, b]: number[] = [214, 214, 214]
+    if (colourRules?.length > 0) {
+        if (colourRules[0].isMultiColourRule) {
+            const alphaHex = repIsVisible ? '99' : '33'
+            chipStyle['background'] = `linear-gradient( to right, #264CFF${alphaHex}, #3FA0FF${alphaHex}, #72D8FF${alphaHex}, #AAF7FF${alphaHex}, #E0FFFF${alphaHex}, #FFFFBF${alphaHex}, #FFE099${alphaHex}, #FFAD72${alphaHex}, #F76D5E${alphaHex}, #D82632${alphaHex}, #A50021${alphaHex} )`
+        } else {
+            [r, g, b] = hexToRgb(colourRules[0].color).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+            chipStyle['backgroundColor'] = `rgba(${r}, ${g}, ${b}, ${repIsVisible ? 0.5 : 0.1})`
+        }        
+    } else {
+        chipStyle['backgroundColor'] = `rgba(${r}, ${g}, ${b}, ${repIsVisible ? 0.5 : 0.1})`
+    }
+
+    chipStyle['borderColor'] = `rgb(${r}, ${g}, ${b})`
+    
+    return chipStyle
+}
+
 const RepresentationCheckbox = (props: {
     showState: { [key: string]: boolean };
     repKey: string;
@@ -543,25 +571,7 @@ const RepresentationCheckbox = (props: {
 
     const [repState, setRepState] = useState<boolean>(false)
 
-    const chipStyle = {
-        marginLeft: '0.1rem',
-        marginBottom: '0.1rem',
-        width: 'calc(100% /6.15)',
-    }
-
-    let [r, g, b]: number[] = [214, 214, 214]
-    if (props.molecule.defaultColourRules?.length > 0) {
-        if (props.molecule.defaultColourRules[0].isMultiColourRule) {
-            const alphaHex = repState ? '99' : '33'
-            chipStyle['background'] = `linear-gradient( to right, #264CFF${alphaHex}, #3FA0FF${alphaHex}, #72D8FF${alphaHex}, #AAF7FF${alphaHex}, #E0FFFF${alphaHex}, #FFFFBF${alphaHex}, #FFE099${alphaHex}, #FFAD72${alphaHex}, #F76D5E${alphaHex}, #D82632${alphaHex}, #A50021${alphaHex} )`
-        } else {
-            [r, g, b] = hexToRgb(props.molecule.defaultColourRules[0].color).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
-            chipStyle['backgroundColor'] = `rgba(${r}, ${g}, ${b}, ${repState ? 0.5 : 0.1})`
-        }        
-    }
-
-    chipStyle['borderColor'] = `rgb(${r}, ${g}, ${b})`
-
+    const chipStyle = getChipStyle(props.molecule.defaultColourRules, repState, 'calc(100% /6.15)')
 
     useEffect(() => {
         setRepState(props.showState[props.repKey] || false)
@@ -598,7 +608,7 @@ const CustomRepresentationChip = (props: {
 
     const [representationIsVisible, setRepresentationIsVisible] = useState<boolean>(true)
     
-    let [r, g, b]: number[] = hexToRgb(representation.colourRules[0].color).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+    const chipStyle = getChipStyle(representation.colourRules, representationIsVisible)
     
     useEffect(() => {
         representationIsVisible ? representation.show() : representation.hide()
@@ -611,7 +621,7 @@ const CustomRepresentationChip = (props: {
     }, [isVisible, representationIsVisible])
 
     return <Chip
-        style={{marginLeft: '0.1rem', marginBottom: '0.1rem', borderColor: `rgb(${r}, ${g}, ${b})`, backgroundColor: `rgba(${r}, ${g}, ${b}, ${representationIsVisible ? 0.5 : 0.1})`}}
+        style={chipStyle}
         variant={"outlined"}
         label={`${representationLabelMapping[representation.style]} ${representation.cid}`}
         deleteIcon={<DeleteOutlined/>}

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -1,35 +1,19 @@
 import { useEffect, useState, useRef, useReducer, useCallback, useImperativeHandle, forwardRef } from 'react';
-import { Card, Row, Col, Accordion, Stack, Button, FormSelect, Form } from "react-bootstrap";
-import { doDownload, rgbToHex, sequenceIsValid } from '../../utils/MoorhenUtils';
+import { Card, Row, Col, Accordion, Stack, Button } from "react-bootstrap";
+import { doDownload, sequenceIsValid, representationLabelMapping } from '../../utils/MoorhenUtils';
 import { isDarkBackground } from '../../WebGLgComponents/mgWebGL'
 import { MoorhenSequenceViewer } from "../sequence-viewer/MoorhenSequenceViewer";
 import { MoorhenMoleculeCardButtonBar } from "../button-bar/MoorhenMoleculeCardButtonBar"
 import { MoorhenLigandList } from "../list/MoorhenLigandList"
-import { Chip, FormGroup, Popover, hexToRgb } from "@mui/material";
+import { Chip, FormGroup, hexToRgb } from "@mui/material";
 import { getNameLabel } from "./cardUtils"
 import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
 import { AddOutlined, DeleteOutlined, FormatColorFillOutlined } from '@mui/icons-material';
-import { SliderPicker } from "react-color";
-import { MoorhenColourRules } from '../modal/MoorhenColourRules';
-
-const labelMapping = {
-    rama: "Rama.",
-    rotamer: "Rota.",
-    CBs: "Bonds",
-    CAs: "C-As",
-    CRs: "Ribbons",
-    CDs: "Cont. dots",
-    MolecularSurface: "Surf.",
-    gaussian: "Gauss.",
-    ligands: "Ligands",
-    DishyBases: "Bases",
-    VdwSpheres: "Spheres",
-    allHBonds: "H-Bonds"
-}
+import { MoorhenAddCustomRepresentationCard } from "./MoorhenAddCustomRepresentationCard"
+import { MoorhenModifyColourRulesCard } from './MoorhenModifyColourRulesCard';
 
 const allRepresentations = [ 'CBs', 'CAs', 'CRs', 'ligands', 'gaussian', 'MolecularSurface', 'DishyBases', 'VdwSpheres', 'rama', 'rotamer', 'CDs', 'allHBonds' ]
-const customRepresentations = [ 'CBs', 'CAs', 'CRs', 'ligands', 'gaussian', 'MolecularSurface', 'DishyBases', 'VdwSpheres' ]
 
 interface MoorhenMoleculeCardPropsInterface extends moorhen.Controls {
     dropdownId: number;
@@ -469,7 +453,7 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
                             <FormatColorFillOutlined/>
                         </Button>
                     </Col>
-                    <MoorhenColourRules molecules={props.molecules} anchorEl={addColourRulesAnchorDivRef} isDark={props.isDark} urlPrefix={props.urlPrefix} glRef={props.glRef} commandCentre={props.commandCentre} molecule={props.molecule} showColourRulesToast={showColourRulesModal} setShowColourRulesToast={setShowColourRulesModal} windowHeight={props.windowHeight} windowWidth={props.sideBarWidth}/>
+                    <MoorhenModifyColourRulesCard molecules={props.molecules} anchorEl={addColourRulesAnchorDivRef} isDark={props.isDark} urlPrefix={props.urlPrefix} glRef={props.glRef} commandCentre={props.commandCentre} molecule={props.molecule} showColourRulesToast={showColourRulesModal} setShowColourRulesToast={setShowColourRulesModal} windowHeight={props.windowHeight} windowWidth={props.sideBarWidth}/>
                 </Row>
                 <Row style={{display: 'flex'}}>
                     <Col  style={{ width:'100%', height: '100%' }}>
@@ -489,7 +473,7 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
                         <Button style={{ paddingTop: '0.25rem', paddingBottom: '0.25rem' }} variant='light' onClick={() => setShowCreateCustomRepresentation((prev) => {return !prev})}>
                             <AddOutlined/>
                         </Button>
-                        <CreateCustomRepresentationMenu molecule={props.molecule} anchorEl={addCustomRepresentationAnchorDivRef} show={showCreateCustomRepresentation} setShow={setShowCreateCustomRepresentation}/>
+                        <MoorhenAddCustomRepresentationCard molecule={props.molecule} anchorEl={addCustomRepresentationAnchorDivRef} show={showCreateCustomRepresentation} setShow={setShowCreateCustomRepresentation}/>
                     </Col>
                 </Row>                
             <Accordion alwaysOpen={true} defaultActiveKey={['sequences']}>
@@ -598,49 +582,9 @@ const RepresentationCheckbox = (props: {
     return <Chip
                 style={chipStyle}
                 variant={"outlined"}
-                label={`${labelMapping[props.repKey]}`}
+                label={`${representationLabelMapping[props.repKey]}`}
                 onClick={handleClick}
             />
-}
-
-const CreateCustomRepresentationMenu = (props: {
-    setShow: React.Dispatch<React.SetStateAction<boolean>>;
-    show: boolean; anchorEl: React.RefObject<HTMLDivElement>;
-    molecule: moorhen.Molecule
-}) => {
-
-    const cidFormRef = useRef<HTMLInputElement | null>(null)
-    const styleSelectRef = useRef<HTMLSelectElement | null>(null)
-    const [colour, setColour] = useState<{ r: string; g: string; b: string; }>({r: '150', g:'100', b:'50'})
-
-    const handleCreateRepresentation = useCallback(() => {
-        props.molecule.addRepresentation(styleSelectRef.current.value, cidFormRef.current.value, true, rgbToHex(parseInt(colour.r), parseInt(colour.g), parseInt(colour.b)))
-        props.setShow(false)
-    }, [colour])
-
-    return <Popover
-                onClose={() => props.setShow(false)}
-                open={props.show}
-                anchorEl={props.anchorEl.current}
-                anchorOrigin={{ vertical: 'center', horizontal: 'center' }}
-                transformOrigin={{ vertical: 'center', horizontal: 'center', }}
-                sx={{'& .MuiPaper-root': {backgroundColor: '#e8e8e8', marginTop: '0.1rem'}}}
-            >
-            <Stack gap={2} direction='horizontal' style={{width: '25rem', margin: '0.5rem'}}>
-                <FormSelect ref={styleSelectRef} size="sm" defaultValue={'Bonds'}>
-                    {customRepresentations.map(key => {
-                        return <option value={key} key={key}>{labelMapping[key]}</option>
-                    })}
-                </FormSelect>
-                <Form.Control ref={cidFormRef} size="sm" type='text' placeholder={'CID selection'} style={{width: "100%"}}/>
-                <div style={{width: '100%', textAlign: 'center'}}>
-                <SliderPicker color={colour} onChange={(color) => {setColour({r: color.rgb.r, g: color.rgb.g, b: color.rgb.b})}}/>
-                </div>
-                <Button onClick={handleCreateRepresentation}>
-                    Create
-                </Button>
-            </Stack>
-        </Popover>
 }
 
 const CustomRepresentationChip = (props: {
@@ -669,7 +613,7 @@ const CustomRepresentationChip = (props: {
     return <Chip
         style={{marginLeft: '0.1rem', marginBottom: '0.1rem', borderColor: `rgb(${r}, ${g}, ${b})`, backgroundColor: `rgba(${r}, ${g}, ${b}, ${representationIsVisible ? 0.5 : 0.1})`}}
         variant={"outlined"}
-        label={`${labelMapping[representation.style]} ${representation.cid}`}
+        label={`${representationLabelMapping[representation.style]} ${representation.cid}`}
         deleteIcon={<DeleteOutlined/>}
         onDelete={() => {
             molecule.removeRepresentation(representation.uniqueId)

--- a/baby-gru/src/components/modal/MoorhenColourRules.tsx
+++ b/baby-gru/src/components/modal/MoorhenColourRules.tsx
@@ -292,7 +292,7 @@ export const MoorhenColourRules = (props: {
                 <Stack gap={2} direction='vertical' style={{margin: 0, padding: 0, display: 'flex', flexDirection: 'column', justifyContent: 'center'}}>
                     <Form.Group style={{ width: '100%', margin: 0 }}>
                         <Form.Label>Rule type</Form.Label>
-                        <FormSelect size="sm" ref={ruleSelectRef} defaultValue={'molecule'} onChange={(val) => setRuleType(val.target.value)}>
+                        <FormSelect size="sm" ref={ruleSelectRef} defaultValue={ruleType} onChange={(val) => setRuleType(val.target.value)}>
                             <option value={'molecule'} key={'molecule'}>By molecule</option>
                             <option value={'chain'} key={'chain'}>By chain</option>
                             <option value={'residue-range'} key={'residue-range'}>By residue range</option>

--- a/baby-gru/src/components/webMG/MoorhenWebMG.tsx
+++ b/baby-gru/src/components/webMG/MoorhenWebMG.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useCallback, forwardRef, useState, useRef } from 'react';
 import { Toast, ToastContainer } from 'react-bootstrap';
 import { MGWebGL } from '../../WebGLgComponents/mgWebGL';
-import { MoorhenColourRules } from "../modal/MoorhenColourRules"
 import { MoorhenContextMenu } from "../context-menu/MoorhenContextMenu"
 import { cidToSpec, convertViewtoPx } from '../../utils/MoorhenUtils';
 import { moorhen } from "../../types/moorhen";

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -84,7 +84,7 @@ export namespace moorhen {
     
     interface Molecule {
         removeRepresentation(representationId: string): void;
-        addRepresentation(style: string, cid: string, isCustom?: boolean, colour?: string): Promise<void>;
+        addRepresentation(style: string, cid: string, isCustom?: boolean, colour?: moorhen.ColourRule[]): Promise<void>;
         getNeighborResiduesCids(selectionCid: string, radius: number, minDist: number, maxDist: number): Promise<string[]>;
         drawWithStyleFromMesh(style: string, meshObjects: any[], cid?: string): Promise<void>;
         updateWithMovedAtoms(movedResidues: AtomInfo[][]): Promise<void>;
@@ -168,6 +168,7 @@ export namespace moorhen {
     'ligand_environment' | 'contact_dots' | 'chemical_features' | 'ligand_validation'
 
     interface MoleculeRepresentation {
+        setUseDefaultColourRules(arg0: boolean): void;
         setColourRules(ruleList: ColourRule[]): void;
         buildBuffers(arg0: DisplayObject[]): Promise<void>;
         setBuffers(meshObjects: DisplayObject[]): void;
@@ -179,6 +180,7 @@ export namespace moorhen {
         show(): void;
         hide(): void;
         setAtomBuffers(arg0: AtomInfo[]): void;
+        useDefaultColourRules: boolean;
         uniqueId: string;
         style: string;
         cid: string;

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -804,28 +804,16 @@ export class MoorhenMolecule implements moorhen.Molecule {
         representation.show()
     }
 
-    async addRepresentation(style: moorhen.RepresentationStyles, cid: string = '/*/*/*/*', isCustom: boolean = false, colour?: string) {
+    async addRepresentation(style: moorhen.RepresentationStyles, cid: string = '/*/*/*/*', isCustom: boolean = false, colourRules?: moorhen.ColourRule[]) {
         if (!this.defaultColourRules) {
             await this.fetchDefaultColourRules()
         }
         const representation = new MoorhenMoleculeRepresentation(style, cid, this.commandCentre, this.glRef)
         representation.isCustom = isCustom
         representation.setParentMolecule(this)
-        if(colour) {
-            representation.setColourRules([
-                {
-                    commandInput: {
-                        message: 'coot_command',
-                        command: 'add_colour_rule',
-                        returnType: 'status',
-                        commandArgs: [this.molNo, cid, colour]
-                    },
-                    isMultiColourRule: false,
-                    ruleType: 'chain',
-                    color: colour,
-                    label: cid
-                }
-            ])
+        if(colourRules && colourRules.length > 0) {
+            representation.setColourRules(colourRules)
+            representation.setUseDefaultColourRules(false)
         }
         await representation.draw()
         this.representations.push(representation)

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -83,6 +83,21 @@ export function convertViewtoPx(input: number, height: number): number {
     return height * (input / 100)
 }
 
+export const representationLabelMapping = {
+    rama: "Rama.",
+    rotamer: "Rota.",
+    CBs: "Bonds",
+    CAs: "C-As",
+    CRs: "Ribbons",
+    CDs: "Cont. dots",
+    MolecularSurface: "Surf.",
+    gaussian: "Gauss.",
+    ligands: "Ligands",
+    DishyBases: "Bases",
+    VdwSpheres: "Spheres",
+    allHBonds: "H-Bonds"
+}
+
 export const residueCodesOneToThree = {
     'C': 'CYS',
     'D': 'ASP',

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -537,6 +537,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("set_user_defined_bond_colours",&molecules_container_t::set_user_defined_bond_colours)
     .function("set_colour_wheel_rotation_base",&molecules_container_t::set_colour_wheel_rotation_base)
     .function("set_base_colour_for_bonds",&molecules_container_t::set_base_colour_for_bonds)
+    .function("set_use_bespoke_carbon_atom_colour",&molecules_container_t::set_use_bespoke_carbon_atom_colour)
     .function("get_symmetry",&molecules_container_t::get_symmetry)
     .function("fit_to_map_by_random_jiggle_using_cid",&molecules_container_t::fit_to_map_by_random_jiggle_using_cid)
     .function("get_active_atom",&molecules_container_t::get_active_atom)


### PR DESCRIPTION
This update includes extensive changes to the UI used to create custom representations, which is nearly operational now.