### PR TITLE
Use MoorhenMoleculeRepresentations to define custom representations part IV

### DIFF
--- a/baby-gru/public/baby-gru/CootWorker.ts
+++ b/baby-gru/public/baby-gru/CootWorker.ts
@@ -778,9 +778,9 @@ const doColourTest = (imol: number) => {
     console.log('DEBUG: Start test...')
 
     const colours = {
-        0: { cid: '//A/1-10/', rgb: [255., 0., 0.] },
-        1: { cid: '//A/11-20/', rgb: [0., 255., 0.] },
-        2: { cid: '//A/21-30/', rgb: [0., 0., 255.] },
+        0: { cid: '//A/1-10/', rgb: [1., 0., 0.] },
+        1: { cid: '//A/11-20/', rgb: [0., 1., 0.] },
+        2: { cid: '//A/21-30/', rgb: [0., 0., 1.] },
     }
 
     let colourMap = new cootModule.MapIntFloat3()

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -473,7 +473,7 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
                         <Button style={{ paddingTop: '0.25rem', paddingBottom: '0.25rem' }} variant='light' onClick={() => setShowCreateCustomRepresentation((prev) => {return !prev})}>
                             <AddOutlined/>
                         </Button>
-                        <MoorhenAddCustomRepresentationCard urlPrefix={props.urlPrefix} molecules={props.molecules} isDark={props.isDark} molecule={props.molecule} anchorEl={addCustomRepresentationAnchorDivRef} show={showCreateCustomRepresentation} setShow={setShowCreateCustomRepresentation}/>
+                        <MoorhenAddCustomRepresentationCard glRef={props.glRef} urlPrefix={props.urlPrefix} molecules={props.molecules} isDark={props.isDark} molecule={props.molecule} anchorEl={addCustomRepresentationAnchorDivRef} show={showCreateCustomRepresentation} setShow={setShowCreateCustomRepresentation}/>
                     </Col>
                 </Row>                
             <Accordion alwaysOpen={true} defaultActiveKey={['sequences']}>

--- a/baby-gru/src/components/navbar-menus/MoorhenDevMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenDevMenu.tsx
@@ -61,7 +61,7 @@ const doColourTest = async (props: any) => {
             commandArgs: [molecule.molNo],
         }, true)
 
-        const representation = new MoorhenMoleculeRepresentation('CBs', '/*/A/*/*', props.commandCentre, props.glRef)
+        const representation = new MoorhenMoleculeRepresentation('CBs', '//A/1-10/', props.commandCentre, props.glRef)
         representation.setParentMolecule(molecule)
         const objects = await representation.getBufferObjects()
         representation.buildBuffers(objects)

--- a/baby-gru/src/utils/MoorhenMoleculeRepresentation.tsx
+++ b/baby-gru/src/utils/MoorhenMoleculeRepresentation.tsx
@@ -364,8 +364,8 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
                     cid,
                     style,
                     this.parentMolecule.cootBondsOptions.isDarkBackground,
-                    this.parentMolecule.cootBondsOptions.width * 1.5,
-                    this.parentMolecule.cootBondsOptions.atomRadiusBondRatio * 1.5,
+                    this.parentMolecule.cootBondsOptions.width,
+                    this.parentMolecule.cootBondsOptions.atomRadiusBondRatio,
                     this.parentMolecule.cootBondsOptions.smoothness
                 ]
             })


### PR DESCRIPTION
This update completes the set of tools needed to set custom representations for different ranges of residues with their own colour rules and resolves #51. 