### PR TITLE
Fix bug when loading tutorial data

### DIFF
--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -307,7 +307,7 @@ export namespace moorhen {
         fetchSuggestedLevel(): Promise<number>;
         fetchMapCentre(): Promise<[number, number, number]>;
         replaceMapWithMtzFile(fileUrl: RequestInfo | URL, name: string, selectedColumns: selectedMtzColumns, mapColour?: { [type: string]: {r: number, g: number, b: number} }): Promise<void>;
-        associateToReflectionData (selectedColumns: selectedMtzColumns, reflectionData: Uint8Array | ArrayBuffer): Promise<WorkerResponse>;
+        associateToReflectionData (selectedColumns: selectedMtzColumns, reflectionData: Uint8Array | ArrayBuffer): Promise<void>;
         delete(): Promise<void> 
         doCootContour(x: number, y: number, z: number, radius: number, contourLevel: number): Promise<void>;
         fetchReflectionData(): Promise<WorkerResponse<Uint8Array>>;

--- a/baby-gru/src/utils/MoorhenMap.ts
+++ b/baby-gru/src/utils/MoorhenMap.ts
@@ -533,9 +533,10 @@ export class MoorhenMap implements moorhen.Map {
      * @param {Uint8Array} reflectionData - The reflection data that will be associates to this map
      * @returns {Promise<moorhen.WorkerResponse>} - Void promise
      */
-    async associateToReflectionData (selectedColumns: moorhen.selectedMtzColumns, reflectionData: Uint8Array | ArrayBuffer): Promise<moorhen.WorkerResponse> {
+    async associateToReflectionData (selectedColumns: moorhen.selectedMtzColumns, reflectionData: Uint8Array | ArrayBuffer): Promise<void> {
         if (!selectedColumns.Fobs || !selectedColumns.SigFobs || !selectedColumns.FreeR) {
-            return Promise.reject('Missing column data')
+            console.warn('WARNING: Missing column data, cannot associate reflection data with map')
+            return Promise.resolve()
         }
 
         const commandArgs = [
@@ -554,7 +555,7 @@ export class MoorhenMap implements moorhen.Map {
             this.selectedColumns = selectedColumns
             this.associatedReflectionFileName = response.data.result.result
         } else {
-            console.log('Unable to associate reflection data with map')
+            console.warn('Unable to associate reflection data with map')
         }
     }
 

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -529,6 +529,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     class_<molecules_container_t>("molecules_container_t")
     .constructor<bool>()
     .function("is_EM_map",&molecules_container_t::is_EM_map)
+    .function("set_map_sampling_rate",&molecules_container_t::set_map_sampling_rate)
     .function("get_mesh_for_ligand_validation_vs_dictionary",&molecules_container_t::get_mesh_for_ligand_validation_vs_dictionary)
     .function("clear_refinement",&molecules_container_t::clear_refinement)
     .function("get_suggested_initial_contour_level",&molecules_container_t::get_suggested_initial_contour_level)


### PR DESCRIPTION
This fixes an issue where Moorhen refuses to read a MTZ file if there is missing column information and `calStructFactors` is set to true. Now it will read the file and print a warning about missing information. This is relevant in the context of tutorial data in CCP4 Cloud.