### PR TITLE
Fix multiple issues with representations from restored session backups

### DIFF
--- a/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
+++ b/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
@@ -98,14 +98,9 @@ export const MoorhenAddCustomRepresentationCard = (props: {
             switch(colourModeSelectRef.current.value) {
                 case "custom":
                     colourRules = [{
-                        commandInput: {
-                            message: 'coot_command',
-                            command: 'add_colour_rule',
-                            returnType: 'status',
-                            commandArgs: [props.molecule.molNo, cidSelection, colour]
-                        },
+                        args: [cidSelection, colour],
                         isMultiColourRule: false,
-                        ruleType: 'chain',
+                        ruleType: ruleSelectRef.current.value,
                         color: colour,
                         label: cidSelection
                     }]
@@ -113,12 +108,7 @@ export const MoorhenAddCustomRepresentationCard = (props: {
                 case "b-factor":
                 case "af2-plddt":
                     colourRules = [{
-                        commandInput: {
-                            message:'coot_command',
-                            command: 'add_colour_rules_multi', 
-                            returnType:'status',
-                            commandArgs: getMultiColourRuleArgs(props.molecule, colourModeSelectRef.current.value)
-                        },
+                        args: [getMultiColourRuleArgs(props.molecule, colourModeSelectRef.current.value)],
                         isMultiColourRule: true,
                         color: colour,
                         ruleType: `${colourModeSelectRef.current.value}`,

--- a/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
+++ b/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
@@ -170,12 +170,7 @@ export const MoorhenModifyColourRulesCard = (props: {
             }
             if (cidLabel) {
                 newRule = {
-                    commandInput: {
-                        message:'coot_command',
-                        command: 'add_colour_rule', 
-                        returnType:'status',
-                        commandArgs: [props.molecule.molNo, cidLabel, selectedColour]
-                    },
+                    args: [cidLabel, selectedColour],
                     isMultiColourRule: false,
                     ruleType: `${ruleType}`,
                     color: selectedColour,
@@ -184,12 +179,7 @@ export const MoorhenModifyColourRulesCard = (props: {
             }
         } else {
             newRule = {
-                commandInput: {
-                    message:'coot_command',
-                    command: 'add_colour_rules_multi', 
-                    returnType:'status',
-                    commandArgs: getMultiColourRuleArgs(props.molecule, ruleSelectRef.current.value)
-                },
+                args: [getMultiColourRuleArgs(props.molecule, ruleSelectRef.current.value)],
                 isMultiColourRule: true,
                 ruleType: `${ruleSelectRef.current.value}`,
                 label: `${ruleSelectRef.current.value}`,

--- a/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
@@ -127,12 +127,7 @@ export const MoorhenQuerySequenceModal = (props: {
         const newMolecule = await fetchMoleculeFromURL(coordUrl, polimerEntity)
         if (source === 'AFDB') {
             const newRule = {
-                commandInput: {
-                    message:'coot_command',
-                    command: 'add_colour_rules_multi', 
-                    returnType:'status',
-                    commandArgs: getMultiColourRuleArgs(newMolecule, 'af2-plddt')
-                },
+                args: [getMultiColourRuleArgs(newMolecule, 'af2-plddt')],
                 isMultiColourRule: true,
                 ruleType: 'af2-plddt',
                 label: `//*`

--- a/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
@@ -118,12 +118,7 @@ export const MoorhenFileMenu = (props: MoorhenNavBarExtendedControlsInterface) =
             fetchMoleculeFromURL(coordUrl, `${uniprotID}`)
                 .then(newMolecule => {
                     const newRule = {
-                        commandInput: {
-                            message:'coot_command',
-                            command: 'add_colour_rules_multi', 
-                            returnType:'status',
-                            commandArgs: getMultiColourRuleArgs(newMolecule, 'af2-plddt')
-                        },
+                        args: [getMultiColourRuleArgs(newMolecule, 'af2-plddt')],
                         isMultiColourRule: true,
                         ruleType: 'af2-plddt',
                         label: `//*`

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -71,12 +71,7 @@ export namespace moorhen {
     }
     
     type ColourRule = {
-        commandInput: {
-            message: string;
-            command: string;
-            returnType: string;
-            commandArgs: [number, string, string?];
-        };
+        args: (string | number)[];
         color?: string;
         isMultiColourRule: boolean;
         ruleType: string;
@@ -363,6 +358,7 @@ export namespace moorhen {
         pdbData: string;
         representations: {cid: string, style: string, isCustom: boolean, colourRules: ColourRule[], bondOptions: cootBondOptions }[];
         defaultBondOptions: cootBondOptions;
+        defaultColourRules: ColourRule[];
         connectedToMaps: number[];
     }
     

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -82,7 +82,7 @@ export namespace moorhen {
         fitLigandHere(mapMolNo: number, ligandMolNo: number, redraw?: boolean, useConformers?: boolean, conformerCount?: number): Promise<Molecule[]>;
         isLigand(): boolean;
         removeRepresentation(representationId: string): void;
-        addRepresentation(style: string, cid: string, isCustom?: boolean, colour?: ColourRule[], bondOptions?: cootBondOptions): Promise<void>;
+        addRepresentation(style: string, cid: string, isCustom?: boolean, colour?: ColourRule[], bondOptions?: cootBondOptions): Promise<MoleculeRepresentation>;
         getNeighborResiduesCids(selectionCid: string, radius: number, minDist: number, maxDist: number): Promise<string[]>;
         drawWithStyleFromMesh(style: string, meshObjects: any[], cid?: string): Promise<void>;
         updateWithMovedAtoms(movedResidues: AtomInfo[][]): Promise<void>;
@@ -356,7 +356,7 @@ export namespace moorhen {
         name: string;
         molNo: number;
         pdbData: string;
-        representations: {cid: string, style: string, isCustom: boolean, colourRules: ColourRule[], bondOptions: cootBondOptions }[];
+        representations: { cid: string, style: string, isCustom: boolean, colourRules: ColourRule[], bondOptions: cootBondOptions }[];
         defaultBondOptions: cootBondOptions;
         defaultColourRules: ColourRule[];
         connectedToMaps: number[];

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -854,14 +854,8 @@ export class MoorhenMolecule implements moorhen.Molecule {
         const representation = new MoorhenMoleculeRepresentation(style, cid, this.commandCentre, this.glRef)
         representation.isCustom = isCustom
         representation.setParentMolecule(this)
-        if(colourRules && colourRules.length > 0) {
-            representation.setColourRules(colourRules)
-            representation.setUseDefaultColourRules(false)
-        }
-        if(bondOptions) {
-            representation.useDefaultBondOptions = false
-            representation.bondOptions = bondOptions
-        }
+        representation.setColourRules(colourRules)
+        representation.setBondOptions(bondOptions)
         await representation.draw()
         this.representations.push(representation)
         await this.drawSymmetry(false)

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -865,6 +865,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         await representation.draw()
         this.representations.push(representation)
         await this.drawSymmetry(false)
+        return representation
     }
 
     /**

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1477,12 +1477,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         
         response.data.result.result.forEach(rule => {
             rules.push({
-                commandInput: {
-                    message: 'coot_command',
-                    command: 'add_colour_rule',
-                    returnType: 'status',
-                    commandArgs: [this.molNo, rule.first, rule.second]
-                },
+                args: [rule.first, rule.second],
                 isMultiColourRule: false,
                 ruleType: 'chain',
                 color: rule.second,

--- a/baby-gru/src/utils/MoorhenMoleculeRepresentation.tsx
+++ b/baby-gru/src/utils/MoorhenMoleculeRepresentation.tsx
@@ -90,7 +90,12 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
     }
 
     setColourRules(colourRules: moorhen.ColourRule[]) {
-        this.colourRules = colourRules
+        if (colourRules && colourRules.length > 0) {
+            this.colourRules = colourRules
+            this.useDefaultColourRules = false
+        } else {
+            this.useDefaultColourRules = true
+        }
     }
 
     setBuffers(buffers: moorhen.DisplayObject[]) {

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -180,12 +180,12 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
                 name: molecule.name,
                 molNo: molecule.molNo,
                 pdbData: moleculeDataPromises[index],
-                representations: molecule.representations.map(item => { return {
+                representations: molecule.representations.filter(item => item.visible).map(item => { return {
                     cid: item.cid,
                     style: item.style,
                     isCustom: item.isCustom,
                     colourRules: item.useDefaultColourRules ? null : item.colourRules,
-                    bondOptions: item.bondOptions
+                    bondOptions: item.useDefaultBondOptions ? null : item.bondOptions
                 }}),
                 defaultColourRules: molecule.defaultColourRules,
                 defaultBondOptions: molecule.defaultBondOptions,

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -48,7 +48,7 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
         this.modificationCount = 0
         this.modificationCountBackupThreshold = 5
         this.maxBackupCount = 10
-        this.version = 'v12'
+        this.version = 'v13'
         this.disableBackups = false
         this.storageInstance = null    
     }
@@ -184,9 +184,10 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
                     cid: item.cid,
                     style: item.style,
                     isCustom: item.isCustom,
-                    colourRules: item.colourRules,
+                    colourRules: item.useDefaultColourRules ? null : item.colourRules,
                     bondOptions: item.bondOptions
                 }}),
+                defaultColourRules: molecule.defaultColourRules,
                 defaultBondOptions: molecule.defaultBondOptions,
                 connectedToMaps: molecule.connectedToMaps
             }


### PR DESCRIPTION
This update fixes:
- PLDDT and Bfactor colours did not work for bond representations (not only backups).
- Session backups did not store colour rules properly for bonds (fixes #94).
- Invisible representations always shown as visible after backup reload.