### PR TITLE
Enable undo/redo keyboard shortcuts

### DIFF
--- a/baby-gru/src/utils/MoorhenContext.tsx
+++ b/baby-gru/src/utils/MoorhenContext.tsx
@@ -39,7 +39,7 @@ const updateStoredContext = async (key: string, value: any): Promise<void> => {
  */
 const getDefaultContextValues = (): moorhen.ContextValues => {
     return {
-        version: 'v29',
+        version: 'v30',
         transparentModalsOnMouseOut: true,
         defaultBackgroundColor: [1, 1, 1, 1], 
         atomLabelDepthMode: true, 
@@ -144,6 +144,18 @@ const getDefaultContextValues = (): moorhen.ContextValues => {
                 modifiers: ["shiftKey"],
                 keyPress: "e",
                 label: "Eigen flip ligand",
+                viewOnly: false
+            },
+            "undo": {
+                modifiers: ["ctrlKey"],
+                keyPress: "z",
+                label: "Undo last action",
+                viewOnly: false
+            },
+            "redo": {
+                modifiers: ["ctrlKey", "shiftKey"],
+                keyPress: "z",
+                label: "Redo previous action",
                 viewOnly: false
             },
             "show_shortcuts": {

--- a/baby-gru/src/utils/MoorhenHistory.ts
+++ b/baby-gru/src/utils/MoorhenHistory.ts
@@ -195,7 +195,7 @@ export class MoorhenHistory implements moorhen.History {
     lastModifiedMolNo(): number {
         const modifications = this.entries.filter(item => item.changesMolecules?.length > 0)
         if (modifications.length > 0) {
-            const lastAction = modifications[modifications.length]
+            const lastAction = modifications[modifications.length - 1]
             return lastAction.changesMolecules[0]
         } else {
             console.warn('Could not find the last modified imol in moorhen history')


### PR DESCRIPTION
After #97 it is possible to get the last modified molecule, which allows us to enable Ctrl+Z / Ctrl+Shift+Z shortcuts.