### PR TITLE
Add necessary changes to test moorhenMolecule and moorhenMap methods

### DIFF
--- a/baby-gru/cloud/src/MoorhenWrapper.tsx
+++ b/baby-gru/cloud/src/MoorhenWrapper.tsx
@@ -549,7 +549,7 @@ export default class MoorhenWrapper {
     const moleculeAtoms = await Promise.all(selectedMolecules.map(molecule => molecule.getAtoms()))
 
     const molData = selectedMolecules.map((molecule, index) => {
-        return {molName: molecule.name, pdbData: moleculeAtoms[index].data.result.pdbData}
+        return {molName: molecule.name, pdbData: moleculeAtoms[index].data.result.result}
     })
 
     const viewData: moorhen.viewDataSession = {

--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -64,6 +64,7 @@
   "dependencies": {},
   "scripts": {
     "transpile-ts-worker": "npx tsc --module es2015 --lib webworker --skipLibCheck public/baby-gru/CootWorker.ts && sed -i.bak '/export {}/d' public/baby-gru/CootWorker.js && rm public/baby-gru/CootWorker.js.bak",
+    "transpile-ts-worker-jest": "npx tsc --module es2015 --lib webworker --skipLibCheck public/baby-gru/CootWorker.ts && sed -i.bak 's/export {}/export { doCootCommand, setModules }/g' public/baby-gru/CootWorker.js && sed -i.bak '/importScripts.*;/d' public/baby-gru/CootWorker.js && sed -i.bak 's/onmessage/function setModules(arg0, arg1) { molecules_container = arg0; cootModule = arg1 }; let postMessage = () => {}; let onmessage/g' public/baby-gru/CootWorker.js && rm public/baby-gru/CootWorker.js.bak",
     "prestart": "npx genversion -e -p ./package.json -d -s ./src/version.js && npm run transpile-ts-worker",
     "start": "react-scripts start",
     "prebuild": "npx genversion -e -p ./package.json -d -s ./src/version.js && npm run transpile-ts-worker",
@@ -79,7 +80,7 @@
     "make-linux": "npm run build && electron-forge make --platform linux",
     "make-win32": "npm run build && electron-forge make --platform win32",
     "create-docs": "npx genversion -e -p ./package.json -d -s ./src/version.js && npx jsdoc -c jsdoc.json",
-    "test": "npm run prebuild && npx tsc && node --trace-warnings --experimental-vm-modules --experimental-wasm-threads node_modules/jest/bin/jest.js"
+    "test": "npx tsc && npm run transpile-ts-worker-jest && node --trace-warnings --experimental-vm-modules --experimental-wasm-threads node_modules/jest/bin/jest.js"
   },
   "eslintConfig": {
     "extends": [

--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -79,7 +79,7 @@
     "make-linux": "npm run build && electron-forge make --platform linux",
     "make-win32": "npm run build && electron-forge make --platform win32",
     "create-docs": "npx genversion -e -p ./package.json -d -s ./src/version.js && npx jsdoc -c jsdoc.json",
-    "test": "npm run prebuild && npx tsc && node --experimental-vm-modules --experimental-wasm-threads node_modules/jest/bin/jest.js"
+    "test": "npm run prebuild && npx tsc && node --trace-warnings --experimental-vm-modules --experimental-wasm-threads node_modules/jest/bin/jest.js"
   },
   "eslintConfig": {
     "extends": [

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -356,7 +356,7 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
 
     const handleDownload = async () => {
         let response = await props.molecule.getAtoms()
-        doDownload([response.data.result.pdbData], `${props.molecule.name}`)
+        doDownload([response.data.result.result], `${props.molecule.name}`)
         props.setCurrentDropdownMolNo(-1)
     }
 

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -76,7 +76,7 @@ declare module 'moorhen' {
         clearBuffersOfStyle: (style: string) => void;
         loadToCootFromURL: (inputFile: string, molName: string) => Promise<_moorhen.Molecule>;
         applyTransform: () => Promise<void>;
-        getAtoms(format?: string): Promise<_moorhen.WorkerResponse>;
+        getAtoms(format?: string): Promise<_moorhen.WorkerResponse<string>>;
         hide: (style: string, cid?: string) => void;
         redraw: () => Promise<void>;
         setAtomsDirty: (newVal: boolean) => void;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -266,6 +266,7 @@ export namespace moorhen {
             result: T;
             [key: string]: any;
         }
+        command: string;
         messageId: string;
         myTimeStamp: string;
         message: string;

--- a/baby-gru/src/utils/MoorhenHistory.ts
+++ b/baby-gru/src/utils/MoorhenHistory.ts
@@ -34,6 +34,7 @@ const formatCommandArgsString = (command: string, commandArgs: (number | string)
         case 'undo':
         case 'shim_replace_map_by_mtz_from_file':
         case 'shim_replace_molecule_by_model_from_file':
+        case'close_molecule':
             formattedString = `${commandArgs[0]}`
             break
         case 'fill_partial_residue':

--- a/baby-gru/src/utils/MoorhenMap.ts
+++ b/baby-gru/src/utils/MoorhenMap.ts
@@ -111,9 +111,11 @@ export class MoorhenMap implements moorhen.Map {
         })
         this.glRef.current.drawScene()
         const promises = [
-            this.commandCentre.current.postMessage({
-                message: "delete", molNo: this.molNo
-            }),
+            this.commandCentre.current.cootCommand({
+                returnType: "status",
+                command: 'close_molecule',
+                commandArgs: [this.molNo]
+            }, true),
             this.hasReflectionData ?
                 this.commandCentre.current.postMessage({
                     message: 'delete_file_name', fileName: this.associatedReflectionFileName

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -166,8 +166,8 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
                 mapDataPromises.push(null)
             } else if (typeof promise === "object" && promise.data.message === "get_mtz_data") {
                 reflectionDataPromises.push(promise.data.result.mtzData)
-            }else if (typeof promise === "object" && promise.data.message === 'get_atoms') {
-                moleculeDataPromises.push(promise.data.result.pdbData)
+            } else if (typeof promise === "object" && promise.data.command === 'shim_get_atoms') {
+                moleculeDataPromises.push(promise.data.result.result)
             } else if (typeof promise === "object" && promise.data.message === 'get_map') {
                 mapDataPromises.push(new Uint8Array(promise.data.result.mapData))
             } else {

--- a/baby-gru/tests/__tests__/integration.test.js
+++ b/baby-gru/tests/__tests__/integration.test.js
@@ -10,8 +10,8 @@ let cleanUpVariables = []
 
 beforeAll(() => {   
     return createCootModule({
-        print(t) { async () => await console.log(["output", t]) },
-        printErr(t) { async () => await console.log(["output", t]); }
+        print(t) { () => console.log(["output", t]) },
+        printErr(t) { () => console.log(["output", t]); }
     }).then(moduleCreated => {
         cootModule = moduleCreated
         setupFunctions.copyTestDataToFauxFS()
@@ -26,7 +26,11 @@ afterAll(() => {
 describe("Testing gemmi", () => {
 
     afterEach(() => {
-        cleanUpVariables.map(item => item.delete())
+        cleanUpVariables.forEach(item => {
+            if (typeof item.delete === 'function' && !item.isDeleted()) {
+                item.delete()
+            }
+        })
         cleanUpVariables = []
     })
 
@@ -126,7 +130,11 @@ describe("Testing gemmi", () => {
 
 describe('Testing molecules_container_js', () => {
     afterEach(() => {
-        cleanUpVariables.map(item => item.delete())
+        cleanUpVariables.forEach(item => {
+            if (typeof item.delete === 'function' && !item.isDeleted()) {
+                item.delete()
+            }
+        })
         cleanUpVariables = []
     })
 
@@ -269,6 +277,7 @@ describe('Testing molecules_container_js', () => {
             const psi = phi_psi.psi()
             expect(phi).toBeCloseTo(-54.90, 1)
             expect(psi).toBeCloseTo(-57.35, 1)
+            cleanUpVariables.push(ri, phi_psi)
             break
         }
         cleanUpVariables.push(rama_info)
@@ -341,6 +350,7 @@ describe('Testing molecules_container_js', () => {
         expect(atomUpdate.x).toBeCloseTo(2.468, 3)
         expect(atomUpdate.y).toBeCloseTo(26.274, 3)
         expect(atomUpdate.z).toBeCloseTo(12.957, 3)
+        cleanUpVariables.push(atom, res, movedVector)
     })
 
     test('Test get_single_letter_codes_for_chain', () => {
@@ -375,6 +385,7 @@ describe('Testing molecules_container_js', () => {
         const dd = (CZatom.x - CZatom_x) * (CZatom.x - CZatom_x) + (CZatom.y - CZatom_y) * (CZatom.y - CZatom_y) + (CZatom.z - CZatom_z) * (CZatom.z - CZatom_z)
         const d = Math.sqrt(dd)
         expect(d).toBeCloseTo(7.28975, 5)
+        cleanUpVariables.push(res, resSpec)
     })
 
     test('Test Rama mesh', () => {
@@ -430,6 +441,7 @@ describe('Testing molecules_container_js', () => {
         expect(atom2.x).toBeCloseTo(67.271, 3)
         expect(atom2.y).toBeCloseTo(45.492, 3)
         expect(atom2.z).toBeCloseTo(24.559, 3)
+        cleanUpVariables.push(resSpec)
     })
 
     test('Test flip_peptide by residue spec', () => {
@@ -451,6 +463,8 @@ describe('Testing molecules_container_js', () => {
         const atomSpecFalse = new cootModule.atom_spec_t("A", 999, "", " N  ", "");
         const failedStatus = molecules_container.flipPeptide(coordMolNo, atomSpecFalse, "")
         expect(failedStatus).toBe(0)
+        
+        cleanUpVariables.push(atomSpec, atomSpecFalse)
     })
 
     test('Create Density Map Mesh', () => {
@@ -470,6 +484,7 @@ describe('Testing molecules_container_js', () => {
         //It seems that the number of vertices can vary depending on number of threads?
         //expect(Math.abs(nVerticesDirect - 55000)).toBeLessThanOrEqual(3000)
         expect(Math.abs(nTriangles - 47024)).toBeLessThanOrEqual(3000)
+        cleanUpVariables.push(p, nVerticesDirect, nTriangles, map_mesh, vertices, triangles)
     })
 
     test('Create test origin', () => {

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -1,4 +1,6 @@
 import { MoorhenMolecule } from "../../tsDist/src/utils/MoorhenMolecule"
+import { MockMoorhenCommandCentre } from "../helpers/mockMoorhenCommandCentre"
+import { MockWebGL } from "../helpers/mockWebGL"
 
 jest.setTimeout(40000)
 
@@ -7,23 +9,51 @@ const path = require('path')
 const createCootModule = require('../../public/baby-gru/wasm/moorhen')
 let cootModule;
 
-beforeAll(() => {
+const mockMonomerLibraryPath = "https://raw.githubusercontent.com/MRC-LMB-ComputationalStructuralBiology/monomers/master/"
+
+global.fetch = (url) => {
+    if (url.includes(mockMonomerLibraryPath)) {
+        return fetch(url)
+    } else {
+        const fileContents = fs.readFileSync(url, { encoding: 'utf8', flag: 'r' })
+        return Promise.resolve({
+            ok: true,
+            text: async () => {
+                return fileContents
+            }
+        })
+    }
+}
+
+beforeAll(() => {   
     return createCootModule({
-        print(t) { async () => await console.log(["output", t]) },
-        printErr(t) { async () => await console.log(["output", t]); }
+        print(t) { () => console.log(["output", t]) },
+        printErr(t) { () => console.log(["output", t]); }
     }).then(moduleCreated => {
         cootModule = moduleCreated
         setupFunctions.copyTestDataToFauxFS()
+        global.window = {
+            CCP4Module: cootModule,
+        }
         return Promise.resolve()
     })
 })
 
-describe("Testing moorhen utils", () => {
+describe("Testing MoorhenMolecule", () => {
 
-    test("Test MoorhenMolecule", () => {
-        const molecule = new MoorhenMolecule('a','b','c')
+    test("Test loadToCootFromURL", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl, 'mol-test')
+        expect(molecule.molNo).toBe(0)
     })
-
 })
 
 const testDataFiles = ['5fjj.pdb', '5a3h.pdb', '5a3h_no_ligand.pdb', 'LZA.cif', '5a3h_sigmaa.mtz', 'rnasa-1.8-all_refmac1.mtz', 'tm-A.pdb']

--- a/baby-gru/tests/helpers/mockMoorhenCommandCentre.js
+++ b/baby-gru/tests/helpers/mockMoorhenCommandCentre.js
@@ -1,0 +1,15 @@
+import { doCootCommand, setModules } from "../../public/baby-gru/CootWorker"
+
+export class MockMoorhenCommandCentre {
+    constructor(molecules_container, cootModule) {
+        this.messageHistory = []
+        this.commandHistory = []
+        setModules(molecules_container, cootModule)
+    }
+    
+    async cootCommand(kwargs, doJournal = true) {
+        this.commandHistory.push(kwargs)
+        const returnResult = doCootCommand(kwargs)
+        return {data: returnResult}
+    }
+}

--- a/baby-gru/tests/helpers/mockWebGL.js
+++ b/baby-gru/tests/helpers/mockWebGL.js
@@ -1,0 +1,10 @@
+
+export class MockWebGL {
+    constructor() {
+        this.renderHistory = []
+    }
+
+    async cootCommand(...args) {
+        this.commandHistory.push(args)
+    }
+}


### PR DESCRIPTION
This update introduces a mocked `moorhenCommandCentre` to the testing suite. This allows testing of methods in `moorhenMolecule` and `moorhenMap` using the original code in `CootWorker.js` but without the need of creating an actual webworker.