### PR TITLE
Fix issue with ligand surfaces

### DIFF
--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -10,6 +10,8 @@ declare global {
 
 export namespace libcootApi {
     type CCP4ModuleType = {
+        count_residues_in_selection(gemmiStructure: gemmi.Structure, selection: gemmi.Selection): number;
+        remove_non_selected_residues(gemmiStructure: gemmi.Structure, selection: gemmi.Selection): gemmi.Structure;
         check_polymer_type(polymerConst: emscriptem.instance<number>): {value: number};
         remove_ligands_and_waters_chain(chain: gemmi.Chain): void;
         gemmi_setup_entities(gemmiStructure: gemmi.Structure): void;

--- a/baby-gru/src/utils/MoorhenMoleculeRepresentation.ts
+++ b/baby-gru/src/utils/MoorhenMoleculeRepresentation.ts
@@ -1,6 +1,6 @@
 import { moorhen } from '../types/moorhen';
 import { webGL } from '../types/mgWebGL';
-import { cidToSpec, gemmiAtomPairsToCylindersInfo, gemmiAtomsToCirclesSpheresInfo, getCubeLines, guid } from './MoorhenUtils';
+import { cidToSpec, gemmiAtomPairsToCylindersInfo, gemmiAtomsToCirclesSpheresInfo, getCubeLines, guid, countResiduesInSelection, copyStructureSelection } from './MoorhenUtils';
 import { libcootApi } from '../types/libcoot';
 import { hexToRgb } from '@mui/material';
 
@@ -361,7 +361,20 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
         }
 
         if(cidSelection) {
-            m2tSelection = `{${m2tSelection} & {${cidSelection}}}`
+            const struct_1 = copyStructureSelection(this.parentMolecule.gemmiStructure, cidSelection)
+            const count_1 = countResiduesInSelection(struct_1)
+
+            const struct_2 = copyStructureSelection(struct_1, m2tSelection)
+            const count_2 = countResiduesInSelection(struct_2)
+
+            struct_1.delete()
+            struct_2.delete()
+
+            if (count_1 > 0 && count_2 === 0) {
+                m2tSelection = cidSelection
+            } else {
+                m2tSelection = `{${m2tSelection} & {${cidSelection}}}`
+            }
         }
 
         if (this.parentMolecule.excludedCids.length > 0) {

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -1169,3 +1169,18 @@ export function getCubeLines(unitCell: gemmi.UnitCell): [{ pos: [number, number,
 
     return lines;
 }
+
+export const countResiduesInSelection = (gemmiStructure: gemmi.Structure, cidSelection?: string) => {
+    const selection = new window.CCP4Module.Selection(cidSelection ? cidSelection : '/*/*/*')
+    const count = window.CCP4Module.count_residues_in_selection(gemmiStructure, selection)
+    selection.delete()
+    return count    
+}
+
+export const copyStructureSelection = (gemmiStructure: gemmi.Structure, cidSelection?: string) => {
+    const selection = new window.CCP4Module.Selection(cidSelection ? cidSelection : '/*/*/*')
+    const newStruct = window.CCP4Module.remove_non_selected_residues(gemmiStructure, selection)
+    selection.delete()
+    return newStruct
+}
+

--- a/baby-gru/tests/__tests__/integration.test.js
+++ b/baby-gru/tests/__tests__/integration.test.js
@@ -126,6 +126,39 @@ describe("Testing gemmi", () => {
         cleanUpVariables.push(sgp1)
     })
 
+    test("Test count_residues_in_selection", () => {
+        const selection = new cootModule.Selection('//A/31-33/*')
+        const st = cootModule.read_structure_file('./5a3h.pdb', cootModule.CoorFormat.Pdb)
+        const residue_count = cootModule.count_residues_in_selection(st, selection)
+        expect(residue_count).toBe(3)
+        cleanUpVariables.push(st)
+    })
+
+    test("Test remove_non_selected_residues", () => {
+        const selection = new cootModule.Selection('//A/31-33/*')
+        const st_1 = cootModule.read_structure_file('./5a3h.pdb', cootModule.CoorFormat.Pdb)
+        cootModule.gemmi_setup_entities(st_1)
+        const st_2 = cootModule.remove_non_selected_residues(st_1, selection)
+
+        const model_1 = st_1.first_model()
+        const chains_1 = model_1.chains
+        // Expect the original structure to be unchanged
+        expect(chains_1.size()).toBe(3)
+
+        const model_2 = st_2.first_model()
+        const chains_2 = model_2.chains
+        const chain_2 = chains_2.get(0)
+        const residues_2 = chain_2.residues
+        const residue_2 = residues_2.get(0)
+        const residue_2_seqId = residue_2.seqid
+        expect(chains_2.size()).toBe(1)
+        expect(chain_2.name).toBe('A')
+        expect(residues_2.size()).toBe(3)
+        expect(residue_2_seqId.str()).toBe('31')
+
+        cleanUpVariables.push(st_1, st_2, model_1, chains_1, model_2, chains_2, chain_2, residues_2, residue_2_seqId, residue_2)
+    })
+
 })
 
 describe('Testing molecules_container_js', () => {

--- a/coot/gemmi-wrappers.cc
+++ b/coot/gemmi-wrappers.cc
@@ -90,12 +90,7 @@ int count_residues_in_selection(const gemmi::Structure &Structure, const gemmi::
 }
 
 gemmi::Structure remove_non_selected_residues(const gemmi::Structure &Structure, const gemmi::Selection &Selection) {
-    std::ostringstream oss;
-    gemmi::write_pdb(Structure, oss);
-    std::string pdb_string = oss.str();
-    char *c_data = (char *)pdb_string.c_str();
-    size_t size = pdb_string.length();
-    auto new_structure = gemmi::read_structure_from_char_array(c_data, size, "copy");
+    auto new_structure = Structure;
 
     gemmi::vector_remove_if(new_structure.models, [&](const gemmi::Model& model) { return !Selection.matches(model); });
     for (auto modelIndex = 0; modelIndex < new_structure.models.size(); modelIndex++) {

--- a/coot/gemmi-wrappers.cc
+++ b/coot/gemmi-wrappers.cc
@@ -32,6 +32,7 @@
 #include <gemmi/modify.hpp>
 #include <gemmi/assembly.hpp>
 #include <gemmi/calculate.hpp>
+#include <gemmi/util.hpp>
 
 using namespace emscripten;
 
@@ -60,6 +61,53 @@ std::vector<int> get_nearest_image_pbc_shift(const gemmi::NearestImage &ni){
     ret.push_back(ni.pbc_shift[1]);
     ret.push_back(ni.pbc_shift[2]);
     return ret;
+}
+
+int count_residues_in_selection(const gemmi::Structure &Structure, const gemmi::Selection &Selection) {
+    int result = 0;
+    auto models = Structure.models;
+    for (auto modelIndex = 0; modelIndex < models.size(); modelIndex++) {
+        const auto model = models[modelIndex];
+        if (!Selection.matches(model)) {
+            continue;
+        }
+        const auto chains = model.chains;
+        for (auto chainIndex = 0; chainIndex < chains.size(); chainIndex++) {
+            auto chain = chains[chainIndex];
+            if (!Selection.matches(chain)) {
+                continue;
+            }
+            const auto residues = chain.residues;
+            for (auto residueIndex = 0; residueIndex < residues.size(); residueIndex++) {
+                const auto residue = residues[residueIndex];
+                if (Selection.matches(residue)) {
+                    result += 1;
+                }
+            }
+        }
+    }
+    return result;
+}
+
+gemmi::Structure remove_non_selected_residues(const gemmi::Structure &Structure, const gemmi::Selection &Selection) {
+    std::ostringstream oss;
+    gemmi::write_pdb(Structure, oss);
+    std::string pdb_string = oss.str();
+    char *c_data = (char *)pdb_string.c_str();
+    size_t size = pdb_string.length();
+    auto new_structure = gemmi::read_structure_from_char_array(c_data, size, "copy");
+
+    gemmi::vector_remove_if(new_structure.models, [&](const gemmi::Model& model) { return !Selection.matches(model); });
+    for (auto modelIndex = 0; modelIndex < new_structure.models.size(); modelIndex++) {
+        gemmi::vector_remove_if(new_structure.models[modelIndex].chains, [&](const gemmi::Chain& chain) { return !Selection.matches(chain); });
+        for (auto chainIndex = 0; chainIndex < new_structure.models[modelIndex].chains.size(); chainIndex++) {
+            gemmi::vector_remove_if(new_structure.models[modelIndex].chains[chainIndex].residues, [&](const gemmi::Residue& res) { return !Selection.matches(res); });
+        }
+    }
+    
+    new_structure.remove_empty_chains();
+
+    return new_structure;
 }
 
 void set_cif_item_pair(gemmi::cif::Item &item, const gemmi::cif::Pair pair){
@@ -2221,6 +2269,8 @@ GlobWalk
     */
 
     //TODO Here we need to put *lots* of gemmi functions
+    function("remove_non_selected_residues",&remove_non_selected_residues);
+    function("count_residues_in_selection",&count_residues_in_selection);
     function("get_pdb_string_from_gemmi_struct",&get_pdb_string_from_gemmi_struct);
     function("read_structure_from_string",&read_structure_from_string);
     function("read_structure_file",&gemmi::read_structure_file);


### PR DESCRIPTION
This update fixes #76.
@stuartjamesmcnicholas I would like your opinion regarding two topics in this PR.
- First, I have created two functions in the gemmi-wrappers: `count_residues_in_selection` and `remove_non_selected_residues`. I have added tests and it seems they work as expected but let me know if you think there's a better way of doing this (I'm still new to c++). For example, something I'm not sure about is that the only way I have been able to create a deep copy of the input `gemmi::Structure` in `remove_non_selected_residues` is by getting a pdb_string for the original structure and using `gemmi::read_structure_from_char_array` to read a new one.
- Second, they way I have fixed the issue with the ligand surfaces is by adding an extra check in `MoorhenMoleculeRepresentation`. By default, the following cid is used when the user selects a surface representation:
```javascript
case "MolecularSurface":
                m2tStyle = "MolecularSurface"
                m2tSelection = "(ALA,CYS,ASP,GLU,PHE,GLY,HIS,ILE,LYS,LEU,MET,MSE,ASN,PRO,GLN,ARG,SER,THR,VAL,TRP,TYR)"
                break;
```
What I have added is the following code (where `cidSelection` is the selection that we actually want to represent with a surface, so it will be something like `/*/*/*` for default representations or `//A/105` if it is a specific ligand):
```javascript
if(cidSelection) {
            const struct_1 = copyStructureSelection(this.parentMolecule.gemmiStructure, cidSelection)
            const count_1 = countResiduesInSelection(struct_1)

            const struct_2 = copyStructureSelection(struct_1, m2tSelection)
            const count_2 = countResiduesInSelection(struct_2)

            struct_1.delete()
            struct_2.delete()

            if (count_1 > 0 && count_2 === 0) {
                m2tSelection = cidSelection
            } else {
                m2tSelection = `{${m2tSelection} & {${cidSelection}}}`
            }
}
```
So if the cid selection that we want to represent has at least one residue, and by adding the default `m2tSelection` we loose all selected residues, the selection will **only** consist of the original input cid selection. This means that the default representation for a protein+ligand will only show surface for the protein, and if the molecule is just a ligand, the surface of a ligand. Custom representations will behave the same, which I think is good as it will make it predictable.