### PR TITLE
Disable representations when t

### DIFF
--- a/baby-gru/public/baby-gru/moorhen.css
+++ b/baby-gru/public/baby-gru/moorhen.css
@@ -186,6 +186,10 @@ div.darkly text.end-label {fill:#FFF !important;}
   padding-left: 0.5rem;
 }
 
+.moorhen-context-button:disabled > .moorhen-context-button__icon {
+  opacity: 0.15 !important;
+}
+
 .moorhen-context-button__icon {
   padding: 0.1rem;
   width: 100%;

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -605,12 +605,23 @@ const RepresentationCheckbox = (props: {
 
     const chipStyle = getChipStyle(props.molecule.defaultColourRules, repState, props.isDark)
 
+    const disabled: boolean = (
+        !props.isVisible 
+        || (props.repKey === 'ligands' && props.molecule.ligands.length === 0) 
+        || (props.repKey === 'DishyBases' && !props.molecule.hasDNA) 
+        || (props.repKey === 'glycoBlocks' && !props.molecule.hasGlycans)
+    )
+    
+    if (disabled) {
+        chipStyle['opacity'] = '0.3'
+    }
+
     useEffect(() => {
         setRepState(props.showState[props.repKey] || false)
     }, [props.showState])
 
     const handleClick = useCallback(() => {
-        if (props.isVisible) {
+        if (!disabled) {
             if (repState) {
                 props.molecule.hide(props.repKey)
             }
@@ -619,7 +630,7 @@ const RepresentationCheckbox = (props: {
             }
             props.changeShowState({ key: props.repKey, state: !repState })
         }
-    }, [repState, props.isVisible])
+    }, [repState, disabled, props])
 
     return <Chip
                 style={chipStyle}

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -79,7 +79,7 @@ export namespace moorhen {
     }
     
     interface Molecule {
-        hasGlycans(): Promise<boolean>;
+        checkHasGlycans(): Promise<boolean>;
         fitLigandHere(mapMolNo: number, ligandMolNo: number, redraw?: boolean, useConformers?: boolean, conformerCount?: number): Promise<Molecule[]>;
         isLigand(): boolean;
         removeRepresentation(representationId: string): void;
@@ -162,6 +162,8 @@ export namespace moorhen {
         hoverRepresentation: moorhen.MoleculeRepresentation;
         unitCellRepresentation: moorhen.MoleculeRepresentation;
         environmentRepresentation: moorhen.MoleculeRepresentation;
+        hasDNA: boolean;
+        hasGlycans: boolean;
     }
 
     type RepresentationStyles = 'VdwSpheres' | 'ligands' | 'CAs' | 'CBs' | 'CDs' | 'gaussian' | 'allHBonds' | 'rama' | 

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -79,6 +79,7 @@ export namespace moorhen {
     }
     
     interface Molecule {
+        hasGlycans(): Promise<boolean>;
         fitLigandHere(mapMolNo: number, ligandMolNo: number, redraw?: boolean, useConformers?: boolean, conformerCount?: number): Promise<Molecule[]>;
         isLigand(): boolean;
         removeRepresentation(representationId: string): void;

--- a/baby-gru/src/utils/MoorhenCommandCentre.ts
+++ b/baby-gru/src/utils/MoorhenCommandCentre.ts
@@ -111,10 +111,11 @@ export class MoorhenCommandCentre implements moorhen.CommandCentre {
         if (this.onNewCommand) {
             this.onNewCommand(kwargs)
         }
+        const result = await this.postMessage({ message, ...kwargs })
         if (doJournal) {
             await this.history.addEntry(kwargs)
         }
-        return this.postMessage({ message, ...kwargs })
+        return result
     }
     
     async cootCommandList(commandList: moorhen.cootCommandKwargs[], doJournal: boolean = true): Promise<moorhen.WorkerResponse> {

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1647,4 +1647,20 @@ export class MoorhenMolecule implements moorhen.Molecule {
             return newMolecules
         }
     }
+
+    async hasDNA() {
+        if (this.atomsDirty) {
+            await this.updateAtoms()
+        }
+        return this.sequences.some(sequence => [3, 4, 5].includes(sequence.type))
+    }
+
+    async hasGlycans() {
+        const result = await this.commandCentre.current.cootCommand({
+            returnType: 'boolean',
+            command: 'model_has_glycans',
+            commandArgs: [this.molNo],
+        }, false) as moorhen.WorkerResponse<boolean>
+        return result.data.result.result
+    }
 }

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -15,6 +15,8 @@ const mockMonomerLibraryPath = "https://raw.githubusercontent.com/MRC-LMB-Comput
 global.fetch = (url) => {
     if (url.includes(mockMonomerLibraryPath)) {
         return fetch(url)
+    } else if (url.includes('https:/files.rcsb.org/download/')) {
+        return fetch(url)
     } else {
         const fileContents = fs.readFileSync(url, { encoding: 'utf8', flag: 'r' })
         return Promise.resolve({
@@ -442,8 +444,39 @@ describe("Testing MoorhenMolecule", () => {
         expect(instancedMesh_2.data.result.result.instance_sizes).toEqual(instancedMesh_4.data.result.result.instance_sizes)
     })
 
+    test("Test hasDNA", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join('https://files.rcsb.org/download/3L1P.pdb')
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+        const glRef = {
+            current: new MockWebGL()
+        }
 
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl, 'mol-test-1')
+        expect(molecule.molNo).toBe(0)
+        const result = await molecule.hasDNA()
+        expect(result).toBeTruthy()
+    })
 
+    test("Test hasGlycans", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+        const glRef = {
+            current: new MockWebGL()
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl, 'mol-test-1')
+        await molecule.addLigandOfType('NAG')
+        const result = await molecule.hasGlycans()
+        expect(result).toBeTruthy()
+    })
 })
 
 const testDataFiles = ['5fjj.pdb', '5a3h.pdb', '5a3h_no_ligand.pdb', 'LZA.cif', 'nitrobenzene.cif', 'benzene.cif', '5a3h_sigmaa.mtz', 'rnasa-1.8-all_refmac1.mtz', 'tm-A.pdb']

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -246,7 +246,7 @@ describe("Testing MoorhenMolecule", () => {
         expect(gemmiAtoms.map(atomInfo => atomInfo.label)).toEqual([ "/1/A/30(LYS)/CA", "/1/A/31(GLY)/CA" ])
     })
 
-    test("Test updateGemmiStructure", async () => {
+    test("Test updateAtoms", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
@@ -262,12 +262,12 @@ describe("Testing MoorhenMolecule", () => {
         const sequence_1 = molecule.sequences.find(seq => seq.chain === 'A')
         const length_1 = sequence_1.sequence.length
         molecules_container.delete_using_cid(molecule.molNo, "A/32-33/*", "LITERAL")
-        await molecule.updateGemmiStructure()
+        await molecule.updateAtoms()
         const sequence_2 = molecule.sequences.find(seq => seq.chain === 'A')
         expect(sequence_2.sequence).toHaveLength(length_1 - 2)
        
         molecules_container.delete_using_cid(molecule.molNo, "//B", "LITERAL")
-        await molecule.updateGemmiStructure()
+        await molecule.updateAtoms()
         expect(molecule.ligands).toHaveLength(0)
     })
 
@@ -286,7 +286,8 @@ describe("Testing MoorhenMolecule", () => {
         const result_cid = molecules_container.delete_using_cid(molecule.molNo, "//A", "LITERAL")
         expect(result_cid.first).toBe(1)
 
-        await molecule.updateGemmiStructure()
+        molecule.setAtomsDirty(true)
+        await molecule.updateAtoms()
         const isLigand = molecule.isLigand()
         expect(isLigand).toBeTruthy()
     })
@@ -457,13 +458,12 @@ describe("Testing MoorhenMolecule", () => {
         const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
         await molecule.loadToCootFromURL(fileUrl, 'mol-test-1')
         expect(molecule.molNo).toBe(0)
-        const result = await molecule.hasDNA()
-        expect(result).toBeTruthy()
+        expect(molecule.hasDNA).toBeTruthy()
     })
 
     test("Test hasGlycans", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
-        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h_no_ligand.pdb')
         const commandCentre = {
             current: new MockMoorhenCommandCentre(molecules_container, cootModule)
         }
@@ -473,9 +473,9 @@ describe("Testing MoorhenMolecule", () => {
 
         const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
         await molecule.loadToCootFromURL(fileUrl, 'mol-test-1')
+        expect(molecule.hasGlycans).toBeFalsy()
         await molecule.addLigandOfType('NAG')
-        const result = await molecule.hasGlycans()
-        expect(result).toBeTruthy()
+        expect(molecule.hasGlycans).toBeTruthy()
     })
 })
 

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -132,6 +132,7 @@ struct moorhen_hbond {
 };
 
 coot::instanced_mesh_t DrawSugarBlocks(mmdb::Manager *molHnd, const std::string &cid_str);
+bool isSugar(const std::string &resName);
 
 class molecules_container_js : public molecules_container_t {
     public:
@@ -142,6 +143,26 @@ class molecules_container_js : public molecules_container_t {
         coot::instanced_mesh_t DrawGlycoBlocks(int imol, const std::string &cid_str) {
             mmdb::Manager *mol = get_mol(imol);
             return DrawSugarBlocks(mol,cid_str);
+        }
+
+        bool model_has_glycans(int imol) {
+            mmdb::Manager *mol = get_mol(imol);
+            int nmodels = mol->GetNumberOfModels();
+            for (int imodel=1; imodel <= nmodels; imodel++) {
+                mmdb::Model *model = mol->GetModel(imodel);
+                int nchains = model->GetNumberOfChains();
+                for (int ichain=0; ichain < nchains; ichain++) {
+                    mmdb::Chain *chain = model->GetChain(ichain);
+                    int nres = chain->GetNumberOfResidues();
+                    for (int ires=0; ires<nres; ires++) { 
+                        mmdb::Residue *residue = chain->GetResidue(ires);
+                        if (isSugar(residue->name)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+            return false;
         }
 
         generic_3d_lines_bonds_box_t make_exportable_environment_bond_box(int imol, const std::string &chainID, int resNo,  const std::string &altLoc){
@@ -695,6 +716,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("get_neighbours_cid",&molecules_container_js::get_neighbours_cid)
     .function("make_exportable_environment_bond_box",&molecules_container_js::make_exportable_environment_bond_box)
     .function("DrawGlycoBlocks",&molecules_container_js::DrawGlycoBlocks)
+    .function("model_has_glycans",&molecules_container_js::model_has_glycans)
     ;
     class_<generic_3d_lines_bonds_box_t>("generic_3d_lines_bonds_box_t")
     .property("line_segments", &generic_3d_lines_bonds_box_t::line_segments)


### PR DESCRIPTION
This update includes code that will disable certain types of representations depending on the contents of each molecule (e.g. glycoblocks disabled for models without glycans).