### PR TITLE
Address some performance issues

### DIFF
--- a/baby-gru/public/baby-gru/moorhen.css
+++ b/baby-gru/public/baby-gru/moorhen.css
@@ -174,6 +174,10 @@ div.darkly text.end-label {fill:#FFF !important;}
   margin-right: 0.5rem;
 }
 
+.moorhen-draggable-card {
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+}
+
 .moorhen-context-button {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
   width: 4rem;

--- a/baby-gru/src/WebGLgComponents/mgWebGL.tsx
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.tsx
@@ -3086,9 +3086,6 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
             this.glTextFont = ""+size+"px "+family;
             this.updateLabels();
             this.labelsTextCanvasTexture.clearBigTexture();
-            //This forces redrawing of environemnt distances
-            const originUpdateEvent = new CustomEvent("originUpdate", { detail: {origin: this.origin} });
-            document.dispatchEvent(originUpdateEvent);
             this.drawScene();
         }
     }
@@ -3096,9 +3093,6 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
     setBackground(col: [number, number, number, number]) : void {
         this.background_colour = col;
         this.updateLabels()
-        //This forces redrawing of environemnt distances
-        const originUpdateEvent = new CustomEvent("originUpdate", { detail: {origin: this.origin} })
-        document.dispatchEvent(originUpdateEvent);
         this.drawScene();
     }
 
@@ -8002,6 +7996,7 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
     }
 
     doHover(event, self) {
+        return
         const [minidx,minj,mindist] = self.getAtomFomMouseXY(event,self);
         if (minidx > -1) {
             let theAtom : clickAtom = {

--- a/baby-gru/src/WebGLgComponents/mgWebGL.tsx
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.tsx
@@ -7996,37 +7996,34 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
     }
 
     doHover(event, self) {
-        const [minidx,minj,mindist] = self.getAtomFomMouseXY(event,self);
-        if (minidx > -1) {
-            let theAtom : clickAtom = {
-               x: self.displayBuffers[minidx].atoms[minj].x,
-               y: self.displayBuffers[minidx].atoms[minj].y,
-               z: self.displayBuffers[minidx].atoms[minj].z,
-               charge: self.displayBuffers[minidx].atoms[minj].charge,
-               label: self.displayBuffers[minidx].atoms[minj].label,
-               symbol: self.displayBuffers[minidx].atoms[minj].symbol,
-               displayBuffer: self.displayBuffers[minidx]
-            };
-            let atx = theAtom.x;
-            let aty = theAtom.y;
-            let atz = theAtom.z;
-            let label = theAtom.label;
-            let tempFactorLabel = "";
-            if (self.displayBuffers[minidx].atoms[minj].tempFactor) {
-                tempFactorLabel = ", B: " + self.displayBuffers[minidx].atoms[minj].tempFactor;
-            }
-            this.props.messageChanged({ message: label + ", xyz:(" + atx + " " + aty + " " + atz + ")" + tempFactorLabel });
-
-            if (this.props.onAtomHovered) {
+        if (this.props.onAtomHovered) {
+            const [minidx,minj,mindist] = self.getAtomFomMouseXY(event,self);
+            if (minidx > -1) {
+                let theAtom : clickAtom = {
+                   x: self.displayBuffers[minidx].atoms[minj].x,
+                   y: self.displayBuffers[minidx].atoms[minj].y,
+                   z: self.displayBuffers[minidx].atoms[minj].z,
+                   charge: self.displayBuffers[minidx].atoms[minj].charge,
+                   label: self.displayBuffers[minidx].atoms[minj].label,
+                   symbol: self.displayBuffers[minidx].atoms[minj].symbol,
+                   displayBuffer: self.displayBuffers[minidx]
+                };
+                let atx = theAtom.x;
+                let aty = theAtom.y;
+                let atz = theAtom.z;
+                let label = theAtom.label;
+                let tempFactorLabel = "";
+                if (self.displayBuffers[minidx].atoms[minj].tempFactor) {
+                    tempFactorLabel = ", B: " + self.displayBuffers[minidx].atoms[minj].tempFactor;
+                }
+                this.props.messageChanged({ message: label + ", xyz:(" + atx + " " + aty + " " + atz + ")" + tempFactorLabel });
                 this.props.onAtomHovered({ atom: self.displayBuffers[minidx].atoms[minj], buffer: self.displayBuffers[minidx] });
             }
-        }
-        else {
-            if (this.props.onAtomHovered) {
+            else {
                 this.props.onAtomHovered(null)
             }
+            self.drawScene();    
         }
-        self.drawScene();
     }
 
     doWheel(event) {

--- a/baby-gru/src/WebGLgComponents/mgWebGL.tsx
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.tsx
@@ -7996,7 +7996,6 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
     }
 
     doHover(event, self) {
-        return
         const [minidx,minj,mindist] = self.getAtomFomMouseXY(event,self);
         if (minidx > -1) {
             let theAtom : clickAtom = {

--- a/baby-gru/src/components/MoorhenContainer.tsx
+++ b/baby-gru/src/components/MoorhenContainer.tsx
@@ -80,6 +80,7 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
     const innerConsoleDivRef = useRef<null | HTMLDivElement>(null)
     const innerLastHoveredAtom = useRef<null | moorhen.HoveredAtom>(null)
     const innerPrevActiveMoleculeRef = useRef<null |  moorhen.Molecule>(null)
+    const [innerEnableAtomHovering, setInnerEnableAtomHovering] = useState<boolean>(true)
     const [innerActiveMap, setInnerActiveMap] = useState<null | moorhen.Map>(null)
     const [innerActiveMolecule, setInnerActiveMolecule] = useState<null|  moorhen.Molecule>(null)
     const [innerHoveredAtom, setInnerHoveredAtom] = useState<null | moorhen.HoveredAtom>({ molecule: null, cid: null })
@@ -132,7 +133,7 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
     const innerStatesMap: moorhen.ContainerStates = {
         glRef: innerGlRef, timeCapsuleRef: innerTimeCapsuleRef, commandCentre: innnerCommandCentre,
         moleculesRef: innerMoleculesRef, mapsRef: innerMapsRef, activeMapRef: innerActiveMapRef,
-        consoleDivRef: innerConsoleDivRef, lastHoveredAtom: innerLastHoveredAtom, 
+        consoleDivRef: innerConsoleDivRef, lastHoveredAtom: innerLastHoveredAtom, setEnableAtomHovering: setInnerEnableAtomHovering,
         prevActiveMoleculeRef: innerPrevActiveMoleculeRef, setAvailableFonts: setInnerAvailableFonts,
         activeMap: innerActiveMap, setActiveMap: setInnerActiveMap, activeMolecule: innerActiveMolecule,
         setActiveMolecule: setInnerActiveMolecule, hoveredAtom: innerHoveredAtom, setHoveredAtom: setInnerHoveredAtom,
@@ -142,9 +143,9 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
         changeMaps: innerChangeMaps, setWindowHeight: setInnerWindowHeight, molecules: innerMolecules as moorhen.Molecule[],
         changeMolecules: innerChangeMolecules, backgroundColor: innerBackgroundColor, setBackgroundColor: setInnerBackgroundColor,
         appTitle: innerAppTitle, setAppTitle: setInnerAppTitle, cootInitialized: innerCootInitialized, 
-        setCootInitialized: setInnerCootInitialized, theme: innerTheme, setTheme: setInnerTheme,
+        setCootInitialized: setInnerCootInitialized, theme: innerTheme, setTheme: setInnerTheme, 
         showToast: innerShowToast, setShowToast: setInnerShowToast, toastContent: innerToastContent, 
-        setToastContent: setInnerToastContent, availableFonts: innerAvailableFonts,
+        setToastContent: setInnerToastContent, availableFonts: innerAvailableFonts, enableAtomHovering: innerEnableAtomHovering,
     }
 
     let states = {} as moorhen.ContainerStates
@@ -157,9 +158,9 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
         setActiveMap, activeMolecule, setActiveMolecule, hoveredAtom, setHoveredAtom,
         consoleMessage, setConsoleMessage, cursorStyle, setCursorStyle, busy, setBusy,
         windowWidth, setWindowWidth, windowHeight, setWindowHeight, molecules, 
-        backgroundColor, setBackgroundColor, availableFonts, setAvailableFonts,
+        backgroundColor, setBackgroundColor, availableFonts, setAvailableFonts, enableAtomHovering,
         appTitle, setAppTitle, cootInitialized, setCootInitialized, theme, setTheme,
-        showToast, setShowToast, toastContent, setToastContent, changeMolecules,
+        showToast, setShowToast, toastContent, setToastContent, changeMolecules, setEnableAtomHovering
     } = states
 
     const {
@@ -406,7 +407,7 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
         setToastContent, hoveredAtom, setHoveredAtom, showToast, setShowToast, windowWidth, windowHeight,
         timeCapsuleRef, isDark, disableFileUploads, urlPrefix, viewOnly, mapsRef, allowScripting, extraCalculateMenuItems,
         extraNavBarMenus, monomerLibraryPath, moleculesRef, extraFileMenuItems, extraEditMenuItems, 
-        extraDraggableModals, aceDRGInstance, availableFonts
+        extraDraggableModals, aceDRGInstance, availableFonts, enableAtomHovering, setEnableAtomHovering
     }
 
     return <> 
@@ -435,6 +436,7 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
                     }}>
                     <MoorhenWebMG
                         ref={glRef}
+                        enableAtomHovering={enableAtomHovering}
                         monomerLibraryPath={monomerLibraryPath}
                         timeCapsuleRef={timeCapsuleRef}
                         commandCentre={commandCentre}

--- a/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
+++ b/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
@@ -78,7 +78,7 @@ export const MoorhenModifyColourRulesCard = (props: {
     const [selectedChain, setSelectedChain] = useState<string>(null)
     const [cid, setCid] = useState<string>(null)
     const [sequenceRangeSelect, setSequenceRangeSelect] = useState(null)
-    const [ruleList, setRuleList] = useReducer(itemReducer, initialRuleState)
+    const [ruleList, setRuleList] = useReducer(itemReducer, initialRuleState, () => { return props.molecule.defaultColourRules })
 
     const handleChainChange = (evt) => {
         setSelectedChain(evt.target.value)
@@ -124,6 +124,9 @@ export const MoorhenModifyColourRulesCard = (props: {
 
     const applyRules = useCallback(async () => {
         if (props.molecule?.defaultColourRules) {
+            if (JSON.stringify(props.molecule.defaultColourRules) === JSON.stringify(ruleList)) {
+                return
+            }
             props.molecule.defaultColourRules = ruleList
             await Promise.all(
                 props.molecule.representations.filter(representation => representation.useDefaultColourRules).map(representation => {
@@ -136,7 +139,7 @@ export const MoorhenModifyColourRulesCard = (props: {
                 })
             )
         }
-    }, [ruleList])
+    }, [ruleList, props.molecule])
 
     useEffect(() => {
         applyRules()

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -1,16 +1,17 @@
 import { useEffect, useState, useRef, useReducer, useCallback, useImperativeHandle, forwardRef, useContext } from 'react';
-import { Card, Row, Col, Accordion, Stack, Button } from "react-bootstrap";
-import { doDownload, sequenceIsValid, representationLabelMapping } from '../../utils/MoorhenUtils';
+import { Card, Row, Col, Stack, Button, Spinner } from "react-bootstrap";
+import { Accordion, AccordionDetails, AccordionSummary } from '@mui/material';
+import { doDownload, representationLabelMapping } from '../../utils/MoorhenUtils';
 import { MoorhenContext } from "../../utils/MoorhenContext";
 import { isDarkBackground } from '../../WebGLgComponents/mgWebGL'
-import { MoorhenSequenceViewer } from "../sequence-viewer/MoorhenSequenceViewer";
+import { MoorhenSequenceList } from "../list/MoorhenSequenceList";
 import { MoorhenMoleculeCardButtonBar } from "../button-bar/MoorhenMoleculeCardButtonBar"
 import { MoorhenLigandList } from "../list/MoorhenLigandList"
 import { Chip, FormGroup, hexToRgb } from "@mui/material";
 import { getNameLabel } from "./cardUtils"
 import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
-import { AddOutlined, DeleteOutlined, FormatColorFillOutlined, SettingsOutlined, EditOutlined } from '@mui/icons-material';
+import { AddOutlined, DeleteOutlined, FormatColorFillOutlined, SettingsOutlined, EditOutlined, ExpandMoreOutlined } from '@mui/icons-material';
 import { MoorhenAddCustomRepresentationCard } from "./MoorhenAddCustomRepresentationCard"
 import { MoorhenMoleculeRepresentationSettingsCard } from "./MoorhenMoleculeRepresentationSettingsCard"
 import { MoorhenModifyColourRulesCard } from './MoorhenModifyColourRulesCard';
@@ -68,6 +69,8 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
     const busyRedrawing = useRef<boolean>(false)
     const isDirty = useRef<boolean>(false)
     const innerDrawMissingLoopsRef = useRef<boolean>(null)
+    const [busyLoadingSequences, setBusyLoadingSequences] = useState<boolean>(false)
+    const [busyLoadingLigands, setBusyLoadingLigands] = useState<boolean>(false)
     const [showColourRulesModal, setShowColourRulesModal] = useState<boolean>(false)
     const [showCreateCustomRepresentation, setShowCreateCustomRepresentation] = useState<boolean>(false)
     const [showCreateRepresentationSettingsModal, setShowCreateRepresentationSettingsModal] = useState<boolean>(false)
@@ -511,55 +514,34 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
                     <MoorhenModifyColourRulesCard molecules={props.molecules} anchorEl={addColourRulesAnchorDivRef} isDark={props.isDark} urlPrefix={props.urlPrefix} glRef={props.glRef} commandCentre={props.commandCentre} molecule={props.molecule} showColourRulesToast={showColourRulesModal} setShowColourRulesToast={setShowColourRulesModal} windowHeight={props.windowHeight} windowWidth={props.sideBarWidth}/>
                     <MoorhenAddCustomRepresentationCard glRef={props.glRef} urlPrefix={props.urlPrefix} molecules={props.molecules} isDark={props.isDark} molecule={props.molecule} anchorEl={addColourRulesAnchorDivRef} show={showCreateCustomRepresentation} setShow={setShowCreateCustomRepresentation}/>
                 </Row>
-            <Accordion alwaysOpen={true} defaultActiveKey={['sequences']}>
-                <Accordion.Item eventKey="sequences" style={{ padding: '0', margin: '0' }} >
-                    <Accordion.Header style={{ padding: '0', margin: '0' }}>Sequences</Accordion.Header>
-                    <Accordion.Body style={{ padding: '0.5rem' }}>
-                        {props.molecule.sequences && props.molecule.sequences.length > 0 ?
-                            <>
-                                <Row style={{ height: '100%' }}>
-                                    <Col>
-                                        {props.molecule.sequences.map(
-                                            sequence => {
-                                                if (!sequenceIsValid(sequence.sequence)) {
-                                                    return (
-                                                        <div>
-                                                            <p>{`Unable to parse sequence data for chain ${sequence?.chain}`}</p>
-                                                        </div>
-                                                    )
-                                                }
-                                                return (<MoorhenSequenceViewer
-                                                    key={`${props.molecule.molNo}-${sequence.chain}`}
-                                                    sequence={sequence}
-                                                    molecule={props.molecule}
-                                                    glRef={props.glRef}
-                                                    clickedResidue={clickedResidue}
-                                                    setClickedResidue={setClickedResidue}
-                                                    selectedResidues={selectedResidues}
-                                                    setSelectedResidues={setSelectedResidues}
-                                                    hoveredAtom={props.hoveredAtom}
-                                                    setHoveredAtom={props.setHoveredAtom}
-                                                />)
-                                            }
-                                        )}
-                                    </Col>
-                                </Row>
-                            </>
-                            :
-                            <div>
-                                <b>No sequence data</b>
-                            </div>
-                        }
-
-                    </Accordion.Body>
-                </Accordion.Item>
-                <Accordion.Item eventKey="ligands" style={{ padding: '0', margin: '0' }} >
-                    <Accordion.Header style={{ padding: '0', margin: '0' }}>Ligands</Accordion.Header>
-                    <Accordion.Body style={{ padding: '0.5rem' }}>
-                        <MoorhenLigandList commandCentre={props.commandCentre} molecule={props.molecule} glRef={props.glRef} isDark={props.isDark}/>
-                    </Accordion.Body>
-                </Accordion.Item>
-            </Accordion>
+            <div>
+                    <Accordion disableGutters={true} elevation={0} TransitionProps={{ unmountOnExit: true }} style={{borderColor: "#f0f0f0", borderStyle: 'solid', borderWidth: '1px'}}>
+                        <AccordionSummary style={{backgroundColor: props.isDark ? '#adb5bd' : '#ecf0f1'}} expandIcon={busyLoadingSequences ? <Spinner /> : <ExpandMoreOutlined />} >
+                            Sequences
+                        </AccordionSummary>
+                        <AccordionDetails style={{padding: '0.2rem', backgroundColor: props.isDark ? '#ced5d6' : 'white'}}>
+                            <MoorhenSequenceList
+                                setBusy={setBusyLoadingSequences}
+                                molecule={props.molecule}
+                                glRef={props.glRef}
+                                clickedResidue={clickedResidue}
+                                setClickedResidue={setClickedResidue}
+                                selectedResidues={selectedResidues}
+                                setSelectedResidues={setSelectedResidues}
+                                hoveredAtom={props.hoveredAtom}
+                                setHoveredAtom={props.setHoveredAtom}                                
+                            />
+                        </AccordionDetails>
+                </Accordion>
+                <Accordion disableGutters={true} elevation={0} TransitionProps={{ unmountOnExit: true }} style={{borderColor: "#f0f0f0", borderStyle: 'solid', borderWidth: '1px'}}>
+                    <AccordionSummary style={{backgroundColor: props.isDark ? '#adb5bd' : '#ecf0f1'}} expandIcon={busyLoadingLigands ? <Spinner /> : <ExpandMoreOutlined />} >
+                        Ligands
+                    </AccordionSummary>
+                    <AccordionDetails style={{padding: '0.2rem', backgroundColor: props.isDark ? '#ced5d6' : 'white'}}>
+                        <MoorhenLigandList setBusy={setBusyLoadingLigands} commandCentre={props.commandCentre} molecule={props.molecule} glRef={props.glRef} isDark={props.isDark}/>
+                    </AccordionDetails>
+                </Accordion>
+            </div>
             </Stack>
         </Card.Body>
     </Card >

--- a/baby-gru/src/components/list/MoorhenLigandList.tsx
+++ b/baby-gru/src/components/list/MoorhenLigandList.tsx
@@ -108,11 +108,15 @@ export const MoorhenLigandList = (props: {
                 modelName: string;
             }[] = []
 
-            for (const ligand of props.molecule.ligands) {
-                const ligandSVG = await getLigandSVG(props.molecule.molNo, ligand.resName)
-                ligandList.push({svg: ligandSVG, ...ligand})
+            if (props.molecule.ligands.length > 50) {
+                ligandList = props.molecule.ligands.map(ligand => { return {...ligand, svg: null} })
+            } else {
+                for (const ligand of props.molecule.ligands) {
+                    const ligandSVG = await getLigandSVG(props.molecule.molNo, ligand.resName)
+                    ligandList.push({svg: ligandSVG, ...ligand})
+                }
             }
-    
+
             setLigandList(ligandList)
         }
 

--- a/baby-gru/src/components/list/MoorhenSequenceList.tsx
+++ b/baby-gru/src/components/list/MoorhenSequenceList.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useState } from "react";
+import { Row, Col } from "react-bootstrap";
+import { MoorhenSequenceViewer } from "../sequence-viewer/MoorhenSequenceViewer";
+import { sequenceIsValid } from '../../utils/MoorhenUtils';
+import { moorhen } from "../../types/moorhen";
+import { webGL } from "../../types/mgWebGL";
+
+export const MoorhenSequenceList = (props: { 
+    setBusy: React.Dispatch<React.SetStateAction<boolean>>;
+    molecule: moorhen.Molecule; 
+    glRef: React.RefObject<webGL.MGWebGL>;
+    hoveredAtom: moorhen.HoveredAtom;
+    setHoveredAtom: React.Dispatch<React.SetStateAction<moorhen.HoveredAtom>>;
+    selectedResidues: [number, number];
+    setSelectedResidues: React.Dispatch<React.SetStateAction<[number, number]>>;
+    clickedResidue: {
+        modelIndex: number;
+        molName: string;
+        chain: string;
+        seqNum: number;
+    };
+    setClickedResidue: React.Dispatch<React.SetStateAction<{
+        modelIndex: number;
+        molName: string;
+        chain: string;
+        seqNum: number;
+    }>>;
+}) => {
+    
+    const [sequenceList, setSequenceList] = useState<null | { chain: string; sequence: (moorhen.Sequence | null) }[]>(null)
+
+    useEffect(() => {
+        props.setBusy(true)
+        
+        const newSequenceList = props.molecule.sequences.map(
+            sequence => {
+                if (!sequenceIsValid(sequence.sequence)) {
+                    return { chain: sequence.chain, sequence: null }
+                }
+                return { chain: sequence.chain, sequence: sequence }
+            }
+        )
+        
+        setSequenceList(newSequenceList)
+        props.setBusy(false)
+
+    }, [props.molecule.sequences])
+
+    return sequenceList !== null && sequenceList.length > 0 ?
+        <>
+            <Row style={{ height: '100%' }}>
+                <Col>
+                    {props.molecule.sequences.map(
+                        sequence => {
+                            if (!sequenceIsValid(sequence.sequence)) {
+                                return (
+                                    <div>
+                                        <p>{`Unable to parse sequence data for chain ${sequence?.chain}`}</p>
+                                    </div>
+                                )
+                            }
+                            return (<MoorhenSequenceViewer
+                                key={`${props.molecule.molNo}-${sequence.chain}`}
+                                sequence={sequence}
+                                molecule={props.molecule}
+                                glRef={props.glRef}
+                                clickedResidue={props.clickedResidue}
+                                setClickedResidue={props.setClickedResidue}
+                                selectedResidues={props.selectedResidues}
+                                setSelectedResidues={props.setSelectedResidues}
+                                hoveredAtom={props.hoveredAtom}
+                                setHoveredAtom={props.setHoveredAtom}
+                            />)
+                        }
+                    )}
+                </Col>
+            </Row>
+        </>
+        :
+        <div>
+            <b>No sequence data</b>
+        </div>
+}

--- a/baby-gru/src/components/menu-item/MoorhenBackgroundColorMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenBackgroundColorMenuItem.tsx
@@ -19,7 +19,9 @@ export const MoorhenBackgroundColorMenuItem = (props: {
 
     useEffect(() => {
         try {
-            props.setBackgroundColor([ backgroundColor.r / 255., backgroundColor.g / 255., backgroundColor.b / 255., props.backgroundColor[3] ])
+            if (JSON.stringify(props.backgroundColor) !== JSON.stringify([backgroundColor.r / 255., backgroundColor.g / 255., backgroundColor.b / 255., props.backgroundColor[3]])) {
+                props.setBackgroundColor([ backgroundColor.r / 255., backgroundColor.g / 255., backgroundColor.b / 255., props.backgroundColor[3] ])
+            }
         } catch (err) {
             console.log(err)
         }    

--- a/baby-gru/src/components/modal/MoorhenDraggableModalBase.tsx
+++ b/baby-gru/src/components/modal/MoorhenDraggableModalBase.tsx
@@ -31,6 +31,7 @@ export const MoorhenDraggableModalBase = (props: {
 
     return <Draggable nodeRef={draggableNodeRef} handle={`.${props.handleClassName}`} >
             <Card
+                className="moorhen-draggable-card"
                 ref={draggableNodeRef}
                 style={{ display: props.show ? 'block' : 'none', position: 'absolute', top: props.top, left: props.left, opacity: opacity, width: props.windowWidth ? convertViewtoPx(props.width, props.windowWidth) : `${props.width}wh`}}
                 onMouseOver={() => setOpacity(1.0)}

--- a/baby-gru/src/components/navbar-menus/MoorhenViewMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenViewMenu.tsx
@@ -25,6 +25,13 @@ export const MoorhenViewMenu = (props: MoorhenNavBarExtendedControlsInterface) =
                 <InputGroup className='moorhen-input-group-check'>
                     <Form.Check 
                         type="switch"
+                        checked={props.enableAtomHovering}
+                        onChange={() => { props.setEnableAtomHovering(!props.enableAtomHovering) }}
+                        label="Enable atom hovering"/>
+                </InputGroup>
+                <InputGroup className='moorhen-input-group-check'>
+                    <Form.Check 
+                        type="switch"
                         checked={context.drawCrosshairs}
                         onChange={() => { context.setDrawCrosshairs(!context.drawCrosshairs) }}
                         label="Show crosshairs"/>

--- a/baby-gru/src/components/webMG/MoorhenWebMG.tsx
+++ b/baby-gru/src/components/webMG/MoorhenWebMG.tsx
@@ -161,7 +161,7 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
         } else {
             clearHBonds()
         }
-    }, [context.drawInteractions, props.molecules])
+    }, [context.drawInteractions, props.molecules, props.backgroundColor])
 
     useEffect(() => {
         if(glRef !== null && typeof glRef !== 'function') {
@@ -481,6 +481,14 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
     useEffect(() => {
         if (glRef !== null && typeof glRef !== 'function' && glRef.current) {
             glRef.current.setTextFont(context.GLLabelsFontFamily,context.GLLabelsFontSize)
+            if (context.drawInteractions){
+                hBondsDirty.current = true
+                if (!busyDrawingHBonds.current) {
+                    drawHBonds()
+                }
+            } else {
+                clearHBonds()
+            }
         }
     }, [context.GLLabelsFontSize, context.GLLabelsFontFamily, glRef])
 

--- a/baby-gru/src/components/webMG/MoorhenWebMG.tsx
+++ b/baby-gru/src/components/webMG/MoorhenWebMG.tsx
@@ -28,6 +28,7 @@ interface MoorhenWebMGPropsInterface {
     windowWidth: number;
     urlPrefix: string;
     extraDraggableModals: JSX.Element[];
+    enableAtomHovering: boolean;
     onAtomHovered: (identifier: { buffer: { id: string; }; atom: { label: string; }; }) => void;
     onKeyPress: (event: KeyboardEvent) =>  boolean | Promise<boolean>;
 }
@@ -555,7 +556,7 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
 
                 <MGWebGL
                     ref={glRef}
-                    onAtomHovered={props.onAtomHovered}
+                    onAtomHovered={props.enableAtomHovering ? props.onAtomHovered : null}
                     onKeyPress={props.onKeyPress}
                     messageChanged={(d) => { }}
                     mouseSensitivityFactor={context.mouseSensitivity}

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -694,6 +694,8 @@ export namespace moorhen {
         commandCentre: React.MutableRefObject<CommandCentre>;
         moleculesRef: React.MutableRefObject<null | Molecule[]>;
         mapsRef: React.MutableRefObject<null | Map[]>;
+        enableAtomHovering: boolean;
+        setEnableAtomHovering: React.Dispatch<React.SetStateAction<boolean>>;
         activeMap: Map;
         setActiveMap: React.Dispatch<React.SetStateAction<Map>>;
         activeMolecule: Molecule;
@@ -721,6 +723,8 @@ export namespace moorhen {
         consoleDivRef: React.MutableRefObject<null | HTMLDivElement>;
         lastHoveredAtom: React.MutableRefObject<null | HoveredAtom>;
         prevActiveMoleculeRef: React.MutableRefObject<null | Molecule>;
+        enableAtomHovering: boolean;
+        setEnableAtomHovering: React.Dispatch<React.SetStateAction<boolean>>;
         activeMap: Map;
         setActiveMap: React.Dispatch<React.SetStateAction<Map>>;
         activeMolecule: Molecule;

--- a/baby-gru/src/utils/MoorhenHistory.ts
+++ b/baby-gru/src/utils/MoorhenHistory.ts
@@ -30,6 +30,7 @@ const formatCommandArgsString = (command: string, commandArgs: (number | string)
         case 'get_monomer_and_position_at':
         case 'add_waters':
         case 'flip_hand':
+        case 'set_imol_refinement_map':
         case 'redo':
         case 'undo':
         case 'shim_replace_map_by_mtz_from_file':


### PR DESCRIPTION
This update includes some fixes for some of the performance issues described in #112 
- Fix issue where `mc.get_bond_mesh_instanced` gets called five times in a row when loading a molecule.
- Ligand SVGs are fetched on demand (i.e. when the "Ligands" drop-down is opened. Similarly, sequence viewers are also loaded on demand.
- Map re-contour being triggered when there is a change of background colour.