### PR TITLE
Automatically disable atom hovering for large structures and fix TS transpilation

### DIFF
--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -61,7 +61,7 @@
       ]
     }
   },
-  "dependencies": {},
+  "dependencies": { },
   "scripts": {
     "create-version": "npx genversion -e -p ./package.json -d -s ./src/version.js",
     "transpile-ts-worker": "npx tsc --module es2015 --lib webworker --skipLibCheck public/baby-gru/CootWorker.ts && sed -i.bak '/export {}/d' public/baby-gru/CootWorker.js && rm public/baby-gru/CootWorker.js.bak",

--- a/baby-gru/public/baby-gru/moorhen.css
+++ b/baby-gru/public/baby-gru/moorhen.css
@@ -139,6 +139,7 @@ div.darkly text.end-label {fill:#FFF !important;}
 }
 
 .moorhen-draggable-action-card {
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
   position: absolute;
   width: 15rem;
 }

--- a/baby-gru/src/components/MoorhenApp.tsx
+++ b/baby-gru/src/components/MoorhenApp.tsx
@@ -15,13 +15,11 @@ export const MoorhenApp = (props: { forwardControls: (controls: any) => any }) =
     const moleculesRef = useRef<null | moorhen.Molecule[]>(null)
     const mapsRef = useRef<null | moorhen.Map[]>(null)
     const activeMapRef = useRef<null | moorhen.Map>(null)
-    const consoleDivRef = useRef<null | HTMLDivElement>(null)
     const lastHoveredAtom = useRef<null | moorhen.HoveredAtom>(null)
     const prevActiveMoleculeRef = useRef<null | moorhen.Molecule>(null)
     const [activeMap, setActiveMap] = useState<null | moorhen.Map>(null)
     const [activeMolecule, setActiveMolecule] = useState<null | moorhen.Molecule>(null)
     const [hoveredAtom, setHoveredAtom] = useState<moorhen.HoveredAtom>({ molecule: null, cid: null })
-    const [consoleMessage, setConsoleMessage] = useState<string>("")
     const [cursorStyle, setCursorStyle] = useState<string>("default")
     const [busy, setBusy] = useState<boolean>(false)
     const [windowWidth, setWindowWidth] = useState<number>(window.innerWidth)
@@ -41,14 +39,13 @@ export const MoorhenApp = (props: { forwardControls: (controls: any) => any }) =
 
     const collectedProps = {
         glRef, timeCapsuleRef, commandCentre, moleculesRef, mapsRef, activeMapRef,
-        consoleDivRef, lastHoveredAtom, prevActiveMoleculeRef, activeMap, 
-        setActiveMap, activeMolecule, setActiveMolecule, hoveredAtom, setHoveredAtom,
-        consoleMessage, setConsoleMessage, cursorStyle, setCursorStyle, busy, setBusy,
+         lastHoveredAtom, prevActiveMoleculeRef, activeMap, hoveredAtom, setHoveredAtom,
+        setActiveMap, activeMolecule, setActiveMolecule, molecules: molecules as moorhen.Molecule[],
+        cursorStyle, setCursorStyle, busy, setBusy, maps: maps as moorhen.Map[],
         windowWidth, setWindowWidth, windowHeight, setWindowHeight, appTitle, setAppTitle,
         changeMolecules, changeMaps, backgroundColor, setBackgroundColor, cootInitialized,
         setCootInitialized, theme, setTheme, showToast, setShowToast, toastContent,
-        setToastContent, forwardControls: props.forwardControls, maps: maps as moorhen.Map[],
-        molecules: molecules as moorhen.Molecule[]
+        setToastContent, forwardControls: props.forwardControls
     }
 
     return <MoorhenContainer {...collectedProps}/>

--- a/baby-gru/src/components/MoorhenContainer.tsx
+++ b/baby-gru/src/components/MoorhenContainer.tsx
@@ -302,6 +302,24 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
         }
     }, [])
 
+    useEffect(() => {
+        const checkMoleculeSizes = async () => {
+            const responses = await Promise.all(molecules.map(molecule => {
+                return commandCentre.current.cootCommand({
+                    command: 'get_number_of_atoms',
+                    commandArgs: [molecule.molNo],
+                    returnType: "status"
+                }, false) as Promise<moorhen.WorkerResponse<number>>
+            }))
+            const atomCount = responses.reduce((partialAtomCount, response) => partialAtomCount + response.data.result.result, 0)
+            console.log(atomCount)
+            if (atomCount >= 80000) {
+                setEnableAtomHovering(false)
+            }
+        }
+        checkMoleculeSizes()
+    }, [molecules])
+
     const onAtomHovered = useCallback((identifier: { buffer: { id: string; }; atom: { label: string; }; }) => {
         if (identifier == null) {
             if (lastHoveredAtom.current !== null && lastHoveredAtom.current.molecule !== null) {

--- a/baby-gru/src/components/MoorhenContainer.tsx
+++ b/baby-gru/src/components/MoorhenContainer.tsx
@@ -312,7 +312,6 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
                 }, false) as Promise<moorhen.WorkerResponse<number>>
             }))
             const atomCount = responses.reduce((partialAtomCount, response) => partialAtomCount + response.data.result.result, 0)
-            console.log(atomCount)
             if (atomCount >= 80000) {
                 setEnableAtomHovering(false)
             }

--- a/baby-gru/src/components/MoorhenContainer.tsx
+++ b/baby-gru/src/components/MoorhenContainer.tsx
@@ -77,14 +77,12 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
     const innerMoleculesRef = useRef<null | moorhen.Molecule[]>(null)
     const innerMapsRef = useRef<null | moorhen.Map[]>(null)
     const innerActiveMapRef = useRef<null | moorhen.Map>(null)
-    const innerConsoleDivRef = useRef<null | HTMLDivElement>(null)
     const innerLastHoveredAtom = useRef<null | moorhen.HoveredAtom>(null)
     const innerPrevActiveMoleculeRef = useRef<null |  moorhen.Molecule>(null)
     const [innerEnableAtomHovering, setInnerEnableAtomHovering] = useState<boolean>(true)
     const [innerActiveMap, setInnerActiveMap] = useState<null | moorhen.Map>(null)
     const [innerActiveMolecule, setInnerActiveMolecule] = useState<null|  moorhen.Molecule>(null)
     const [innerHoveredAtom, setInnerHoveredAtom] = useState<null | moorhen.HoveredAtom>({ molecule: null, cid: null })
-    const [innerConsoleMessage, setInnerConsoleMessage] = useState<string>("")
     const [innerCursorStyle, setInnerCursorStyle] = useState<string>("default")
     const [innerBusy, setInnerBusy] = useState<boolean>(false)
     const [innerWindowWidth, setInnerWindowWidth] = useState<number>(window.innerWidth)
@@ -133,19 +131,19 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
     const innerStatesMap: moorhen.ContainerStates = {
         glRef: innerGlRef, timeCapsuleRef: innerTimeCapsuleRef, commandCentre: innnerCommandCentre,
         moleculesRef: innerMoleculesRef, mapsRef: innerMapsRef, activeMapRef: innerActiveMapRef,
-        consoleDivRef: innerConsoleDivRef, lastHoveredAtom: innerLastHoveredAtom, setEnableAtomHovering: setInnerEnableAtomHovering,
+        lastHoveredAtom: innerLastHoveredAtom, setEnableAtomHovering: setInnerEnableAtomHovering,
         prevActiveMoleculeRef: innerPrevActiveMoleculeRef, setAvailableFonts: setInnerAvailableFonts,
         activeMap: innerActiveMap, setActiveMap: setInnerActiveMap, activeMolecule: innerActiveMolecule,
         setActiveMolecule: setInnerActiveMolecule, hoveredAtom: innerHoveredAtom, setHoveredAtom: setInnerHoveredAtom,
-        consoleMessage: innerConsoleMessage, setConsoleMessage: setInnerConsoleMessage, cursorStyle: innerCursorStyle,
+        cursorStyle: innerCursorStyle, maps: innerMaps as moorhen.Map[], molecules: innerMolecules as moorhen.Molecule[],
         setCursorStyle: setInnerCursorStyle, busy: innerBusy, setBusy: setInnerBusy, windowHeight: innerWindowHeight, 
-        windowWidth: innerWindowWidth, setWindowWidth: setInnerWindowWidth, maps: innerMaps as moorhen.Map[],
-        changeMaps: innerChangeMaps, setWindowHeight: setInnerWindowHeight, molecules: innerMolecules as moorhen.Molecule[],
-        changeMolecules: innerChangeMolecules, backgroundColor: innerBackgroundColor, setBackgroundColor: setInnerBackgroundColor,
+        windowWidth: innerWindowWidth, setWindowWidth: setInnerWindowWidth, setBackgroundColor: setInnerBackgroundColor,
+        changeMaps: innerChangeMaps, setWindowHeight: setInnerWindowHeight, enableAtomHovering: innerEnableAtomHovering,
+        changeMolecules: innerChangeMolecules, backgroundColor: innerBackgroundColor, 
         appTitle: innerAppTitle, setAppTitle: setInnerAppTitle, cootInitialized: innerCootInitialized, 
         setCootInitialized: setInnerCootInitialized, theme: innerTheme, setTheme: setInnerTheme, 
         showToast: innerShowToast, setShowToast: setInnerShowToast, toastContent: innerToastContent, 
-        setToastContent: setInnerToastContent, availableFonts: innerAvailableFonts, enableAtomHovering: innerEnableAtomHovering,
+        setToastContent: setInnerToastContent, availableFonts: innerAvailableFonts
     }
 
     let states = {} as moorhen.ContainerStates
@@ -154,13 +152,13 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
     })
 
     const { glRef, timeCapsuleRef, commandCentre, moleculesRef, mapsRef, activeMapRef,
-        consoleDivRef, lastHoveredAtom, prevActiveMoleculeRef, activeMap, maps, changeMaps,
+        lastHoveredAtom, prevActiveMoleculeRef, activeMap, maps, changeMaps,
         setActiveMap, activeMolecule, setActiveMolecule, hoveredAtom, setHoveredAtom,
-        consoleMessage, setConsoleMessage, cursorStyle, setCursorStyle, busy, setBusy,
+        cursorStyle, setCursorStyle, busy, setBusy, changeMolecules, setEnableAtomHovering,
         windowWidth, setWindowWidth, windowHeight, setWindowHeight, molecules, 
         backgroundColor, setBackgroundColor, availableFonts, setAvailableFonts, enableAtomHovering,
         appTitle, setAppTitle, cootInitialized, setCootInitialized, theme, setTheme,
-        showToast, setShowToast, toastContent, setToastContent, changeMolecules, setEnableAtomHovering
+        showToast, setShowToast, toastContent, setToastContent
     } = states
 
     const {
@@ -303,12 +301,6 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
             commandCentre.current.unhook()
         }
     }, [])
-
-    useEffect(() => {
-        if(consoleDivRef.current !== null) {
-            consoleDivRef.current.scrollTop = consoleDivRef.current.scrollHeight;
-        }
-    }, [consoleMessage])
 
     const onAtomHovered = useCallback((identifier: { buffer: { id: string; }; atom: { label: string; }; }) => {
         if (identifier == null) {

--- a/baby-gru/src/components/card/MoorhenMapCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMapCard.tsx
@@ -25,7 +25,6 @@ interface MoorhenMapCardPropsInterface extends moorhen.Controls {
     sideBarWidth: number;
     showSideBar: boolean;
     busy: boolean;
-    consoleMessage: string;
     key: number;
     index: number;
     map: moorhen.Map;

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -25,7 +25,6 @@ interface MoorhenMoleculeCardPropsInterface extends moorhen.Controls {
     sideBarWidth: number;
     showSideBar: boolean;
     busy: boolean;
-    consoleMessage: string;
     key: number;
     index: number;
     molecule: moorhen.Molecule;

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -516,7 +516,7 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
                 </Row>
             <div>
                     <Accordion disableGutters={true} elevation={0} TransitionProps={{ unmountOnExit: true }} style={{borderColor: "#f0f0f0", borderStyle: 'solid', borderWidth: '1px'}}>
-                        <AccordionSummary style={{backgroundColor: props.isDark ? '#adb5bd' : '#ecf0f1'}} expandIcon={busyLoadingSequences ? <Spinner /> : <ExpandMoreOutlined />} >
+                        <AccordionSummary style={{backgroundColor: props.isDark ? '#adb5bd' : '#ecf0f1'}} expandIcon={busyLoadingSequences ? <Spinner animation='border'/> : <ExpandMoreOutlined />} >
                             Sequences
                         </AccordionSummary>
                         <AccordionDetails style={{padding: '0.2rem', backgroundColor: props.isDark ? '#ced5d6' : 'white'}}>
@@ -534,7 +534,7 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
                         </AccordionDetails>
                 </Accordion>
                 <Accordion disableGutters={true} elevation={0} TransitionProps={{ unmountOnExit: true }} style={{borderColor: "#f0f0f0", borderStyle: 'solid', borderWidth: '1px'}}>
-                    <AccordionSummary style={{backgroundColor: props.isDark ? '#adb5bd' : '#ecf0f1'}} expandIcon={busyLoadingLigands ? <Spinner /> : <ExpandMoreOutlined />} >
+                    <AccordionSummary style={{backgroundColor: props.isDark ? '#adb5bd' : '#ecf0f1'}} expandIcon={busyLoadingLigands ? <Spinner animation='border'/> : <ExpandMoreOutlined />} >
                         Ligands
                     </AccordionSummary>
                     <AccordionDetails style={{padding: '0.2rem', backgroundColor: props.isDark ? '#ced5d6' : 'white'}}>

--- a/baby-gru/src/components/menu-item/MoorhenGetMonomerMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenGetMonomerMenuItem.tsx
@@ -72,7 +72,6 @@ export const MoorhenGetMonomerMenuItem = (props: {
             props.changeMolecules({ action: "Add", item: newMolecule })
         } else {
             console.log('Error getting monomer... Missing dictionary?')
-            props.commandCentre.current.extendConsoleMessage('Error getting monomer... Missing dictionary?')
         }
     }
 

--- a/baby-gru/src/components/menu-item/MoorhenImportLigandDictionary.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenImportLigandDictionary.tsx
@@ -226,7 +226,6 @@ export const MoorhenSMILESToLigandMenuItem = (props: {
             return result
         } else {
             console.log('Error creating molecule... Wrong SMILES?')
-            props.commandCentre.current.extendConsoleMessage('Error creating molecule... Wrong SMILES?')
         }
     }
 

--- a/baby-gru/src/components/modal/MoorhenMapsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenMapsModal.tsx
@@ -32,7 +32,6 @@ export const MoorhenMapsModal = (props: MoorhenMapsModalProps) => {
             ref={el => cardListRef.current[index] = el}
             showSideBar={true}
             busy={false}
-            consoleMessage="A"
             dropdownId={1}
             accordionDropdownId={1}
             setAccordionDropdownId={(arg0) => {}}

--- a/baby-gru/src/components/modal/MoorhenModelsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenModelsModal.tsx
@@ -32,7 +32,6 @@ export const MoorhenModelsModal = (props: MoorhenModelsModalProps) => {
             ref={el => cardListRef.current[index] = el}
             showSideBar={true}
             busy={false}
-            consoleMessage="A"
             dropdownId={1}
             accordionDropdownId={1}
             setAccordionDropdownId={(arg0) => {}}

--- a/baby-gru/src/components/modal/MoorhenValidationToolsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenValidationToolsModal.tsx
@@ -24,7 +24,7 @@ export const MoorhenValidationToolsModal = (props: MoorhenValidationModalProps) 
     const toolsAccordionSelectRef = useRef<undefined | HTMLSelectElement>()
 
     const collectedProps = {
-        sideBarWidth: convertViewtoPx(35, props.windowWidth), dropdownId: 1, busy: false, consoleMessage: '', 
+        sideBarWidth: convertViewtoPx(35, props.windowWidth), dropdownId: 1, busy: false,
         accordionDropdownId: 1, setAccordionDropdownId: (arg0) => {}, showSideBar: true, ...props
     }
 

--- a/baby-gru/src/components/navbar-menus/MoorhenViewMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenViewMenu.tsx
@@ -26,7 +26,10 @@ export const MoorhenViewMenu = (props: MoorhenNavBarExtendedControlsInterface) =
                     <Form.Check 
                         type="switch"
                         checked={props.enableAtomHovering}
-                        onChange={() => { props.setEnableAtomHovering(!props.enableAtomHovering) }}
+                        onChange={() => { 
+                            props.setEnableAtomHovering(!props.enableAtomHovering)
+                            props.setHoveredAtom({molecule: null, cid: null})
+                         }}
                         label="Enable atom hovering"/>
                 </InputGroup>
                 <InputGroup className='moorhen-input-group-check'>

--- a/baby-gru/src/components/navbar-menus/MoorhenViewMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenViewMenu.tsx
@@ -28,7 +28,9 @@ export const MoorhenViewMenu = (props: MoorhenNavBarExtendedControlsInterface) =
                         checked={props.enableAtomHovering}
                         onChange={() => { 
                             props.setEnableAtomHovering(!props.enableAtomHovering)
-                            props.setHoveredAtom({molecule: null, cid: null})
+                            if (props.enableAtomHovering) {
+                                props.setHoveredAtom({molecule: null, cid: null})
+                            }
                          }}
                         label="Enable atom hovering"/>
                 </InputGroup>

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -232,7 +232,6 @@ export namespace moorhen {
     interface CommandCentre {
         urlPrefix: string;
         cootWorker: Worker;
-        consoleMessage: string;
         history: History;
         activeMessages: WorkerMessage[];
         unhook: () => void;
@@ -243,7 +242,6 @@ export namespace moorhen {
         cootCommandList(commandList: cootCommandKwargs[]): Promise<WorkerResponse>;
         cootCommand: (kwargs: cootCommandKwargs, doJournal?: boolean) => Promise<WorkerResponse>;
         postMessage: (kwargs: cootCommandKwargs) => Promise<WorkerResponse>;
-        extendConsoleMessage: (msg: string) => void;
     }
     
     interface cootCommandKwargs { 
@@ -720,7 +718,6 @@ export namespace moorhen {
         moleculesRef: React.MutableRefObject<null | Molecule[]>;
         mapsRef: React.MutableRefObject<null | Map[]>;
         activeMapRef: React.MutableRefObject<Map>;
-        consoleDivRef: React.MutableRefObject<null | HTMLDivElement>;
         lastHoveredAtom: React.MutableRefObject<null | HoveredAtom>;
         prevActiveMoleculeRef: React.MutableRefObject<null | Molecule>;
         enableAtomHovering: boolean;
@@ -731,8 +728,6 @@ export namespace moorhen {
         setActiveMolecule: React.Dispatch<React.SetStateAction<Molecule>>;
         hoveredAtom: null | HoveredAtom;
         setHoveredAtom: React.Dispatch<React.SetStateAction<HoveredAtom>>;
-        consoleMessage: string;
-        setConsoleMessage: React.Dispatch<React.SetStateAction<string>>;
         cursorStyle: string;
         setCursorStyle: React.Dispatch<React.SetStateAction<string>>;
         busy: boolean;

--- a/baby-gru/src/utils/MoorhenCommandCentre.ts
+++ b/baby-gru/src/utils/MoorhenCommandCentre.ts
@@ -38,7 +38,6 @@ import { webGL } from '../types/mgWebGL';
 export class MoorhenCommandCentre implements moorhen.CommandCentre {
     urlPrefix: string;
     cootWorker: Worker;
-    consoleMessage: string;
     activeMessages: moorhen.WorkerMessage[];
     history: moorhen.History;
     onCootInitialized: null | ( () => void );
@@ -47,7 +46,6 @@ export class MoorhenCommandCentre implements moorhen.CommandCentre {
     onActiveMessagesChanged: null | ( (activeMessages: moorhen.WorkerMessage[]) => void );
 
     constructor(urlPrefix: string, glRef: React.RefObject<webGL.MGWebGL>, timeCapsule: React.RefObject<moorhen.TimeCapsule>, props: {[x: string]: any}) {
-        this.consoleMessage = ""
         this.activeMessages = []
         this.urlPrefix = urlPrefix
         this.history = new MoorhenHistory(glRef, timeCapsule)
@@ -66,16 +64,6 @@ export class MoorhenCommandCentre implements moorhen.CommandCentre {
     }
     
     handleMessage(reply: moorhen.WorkerResponse) {
-        if (this.onConsoleChanged && reply.data.consoleMessage) {
-            let newMessage: string
-            if (reply.data.consoleMessage.length > 160) {
-                newMessage = `TRUNCATED TO [${reply.data.consoleMessage.substring(0, 160)}]`
-            }
-            else {
-                newMessage = reply.data.consoleMessage
-            }
-            this.extendConsoleMessage(newMessage)
-        }
         this.activeMessages.filter(
             message => message.messageId && (message.messageId === reply.data.messageId)
         ).forEach(message => {
@@ -87,11 +75,6 @@ export class MoorhenCommandCentre implements moorhen.CommandCentre {
         if (this.onActiveMessagesChanged) {
             this.onActiveMessagesChanged(this.activeMessages)
         }
-    }
-    
-    extendConsoleMessage(newMessage: string) {
-        this.consoleMessage = this.consoleMessage.concat(">" + newMessage + "\n")
-        this.onConsoleChanged && this.onConsoleChanged(this.consoleMessage)
     }
     
     makeHandler(resolve) {

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1244,7 +1244,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
             return newMolecule.delete()
         } else {
             console.log('Error getting monomer... Missing dictionary?')
-            this.commandCentre.current.extendConsoleMessage('Error getting monomer... Missing dictionary?')
         }
     }
 


### PR DESCRIPTION
After this update, if there are more than 80K atoms loaded into the Moorhen session atom hovering is automatically disabled.