### PR TITLE
Generate/clear self-restraints and jiggle fit with blur

### DIFF
--- a/baby-gru/public/baby-gru/moorhen.css
+++ b/baby-gru/public/baby-gru/moorhen.css
@@ -138,7 +138,7 @@ div.darkly text.end-label {fill:#FFF !important;}
   display: none !important;
 }
 
-.moorhen-draggable-action-card {
+.moorhen-notification-div {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
   width: 14rem;
   min-height: 3rem;

--- a/baby-gru/public/baby-gru/moorhen.css
+++ b/baby-gru/public/baby-gru/moorhen.css
@@ -140,20 +140,13 @@ div.darkly text.end-label {fill:#FFF !important;}
 
 .moorhen-draggable-action-card {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
-  width: 15rem;
-}
-
-.moorhen-draggable-action-card > .card-header {
-  cursor: move;
-}
-
-.moorhen-draggable-action-card > .card-body {
-  align-items: center;
-  align-content: center;
-  justify-content: center;
-}
-
-.moorhen-draggable-action-card > .card-body {
+  width: 14rem;
+  min-height: 3rem;
+  height: fit-content;
+  max-height: 10rem;
+  padding: 0.5rem;
+  display: flex;
+  border-radius: 2rem;
   align-items: center;
   align-content: center;
   justify-content: center;

--- a/baby-gru/src/components/button/MoorhenDragAtomsButton.tsx
+++ b/baby-gru/src/components/button/MoorhenDragAtomsButton.tsx
@@ -255,26 +255,18 @@ export const MoorhenDragAtomsButton = (props: moorhen.EditButtonProps | moorhen.
 
         const contextMenuOverride = (
             <Zoom in={true}>
-            <Fab
-            disableRipple={true}
-            variant='extended'
-            size="large"
-            sx={{
-                width: convertRemToPx(14),
+            <div
+            className="moorhen-draggable-action-card"
+            style={{
                 position: 'absolute',
                 top: canvasTop + convertRemToPx(0.5),
                 left: canvasLeft + (props.windowWidth / 2) - convertRemToPx(7),
-                display: 'flex',
                 color: props.isDark ? 'white' : 'grey',
-                bgcolor: props.isDark ? 'grey' : 'white',
-                '&:hover': {
-                    bgcolor: props.isDark ? 'grey' : 'white',
-                }
+                backgroundColor: props.isDark ? 'grey' : 'white',
             }}>
                 <Stack gap={2} direction='horizontal' style={{width: '100%', display:'flex', justifyContent: 'space-between'}}>
                     <div>
-                        <span style={{textTransform: 'capitalize'}}>A</span>
-                        <span style={{textTransform: 'lowercase'}}>ccept changes?</span>
+                        <span>Accept changes?</span>
                     </div>
                     <div>
                     <IconButton style={{padding: 0, color: props.isDark ? 'white' : 'grey', }} onClick={async () => {
@@ -299,7 +291,7 @@ export const MoorhenDragAtomsButton = (props: moorhen.EditButtonProps | moorhen.
                     </IconButton>
                     </div>
                 </Stack>
-            </Fab>
+            </div>
             </Zoom>
         )
 

--- a/baby-gru/src/components/button/MoorhenDragAtomsButton.tsx
+++ b/baby-gru/src/components/button/MoorhenDragAtomsButton.tsx
@@ -256,7 +256,7 @@ export const MoorhenDragAtomsButton = (props: moorhen.EditButtonProps | moorhen.
         const contextMenuOverride = (
             <Zoom in={true}>
             <div
-            className="moorhen-draggable-action-card"
+            className="moorhen-notification-div"
             style={{
                 position: 'absolute',
                 top: canvasTop + convertRemToPx(0.5),

--- a/baby-gru/src/components/button/MoorhenDragAtomsButton.tsx
+++ b/baby-gru/src/components/button/MoorhenDragAtomsButton.tsx
@@ -8,7 +8,7 @@ import { MoorhenMolecule } from "../../utils/MoorhenMolecule"
 import Draggable from "react-draggable";
 import { cidToSpec, convertRemToPx } from "../../utils/MoorhenUtils";
 import { libcootApi } from "../../types/libcoot";
-import { Fab, IconButton, Zoom } from "@mui/material";
+import { IconButton, Zoom } from "@mui/material";
 
 export const MoorhenDragAtomsButton = (props: moorhen.EditButtonProps | moorhen.ContextButtonProps) => {
     const [showAccept, setShowAccept] = useState<boolean>(false)

--- a/baby-gru/src/components/button/MoorhenRotamerChangeButton.tsx
+++ b/baby-gru/src/components/button/MoorhenRotamerChangeButton.tsx
@@ -4,9 +4,9 @@ import { moorhen } from "../../types/moorhen";
 import { MoorhenContextButtonBase } from "./MoorhenContextButtonBase";
 import { libcootApi } from "../../types/libcoot";
 import { Button, Card, Stack } from "react-bootstrap";
-import { ArrowBackIosOutlined, ArrowForwardIosOutlined, CancelOutlined, CheckCircleOutlined, CheckOutlined, CloseOutlined, FirstPageOutlined, NavigateBeforeOutlined, NavigateNextOutlined } from "@mui/icons-material";
+import { ArrowBackIosOutlined, ArrowForwardIosOutlined, CheckOutlined, CloseOutlined, FirstPageOutlined, NavigateBeforeOutlined, NavigateNextOutlined } from "@mui/icons-material";
 import Draggable from "react-draggable";
-import { Fab, IconButton, Zoom } from "@mui/material";
+import { IconButton, Zoom } from "@mui/material";
 import { convertRemToPx } from '../../utils/MoorhenUtils';
 
 export const MoorhenRotamerChangeButton = (props: moorhen.EditButtonProps | moorhen.ContextButtonProps) => {

--- a/baby-gru/src/components/button/MoorhenRotamerChangeButton.tsx
+++ b/baby-gru/src/components/button/MoorhenRotamerChangeButton.tsx
@@ -119,7 +119,7 @@ export const MoorhenRotamerChangeButton = (props: moorhen.EditButtonProps | moor
             
             return <Zoom in={true}>
             <div
-            className="moorhen-draggable-action-card"
+            className="moorhen-notification-div"
             style={{
                 position: 'absolute',
                 width: '20rem',

--- a/baby-gru/src/components/button/MoorhenRotamerChangeButton.tsx
+++ b/baby-gru/src/components/button/MoorhenRotamerChangeButton.tsx
@@ -118,31 +118,22 @@ export const MoorhenRotamerChangeButton = (props: moorhen.EditButtonProps | moor
             const rotamerProbability = rotamerInfo.data.result.result.richardson_probability
             
             return <Zoom in={true}>
-            <Fab
-            variant='extended'
-            disableRipple={true}
-            size="large"
-            sx={{
-                height: 'auto',
-                width: convertRemToPx(20),
+            <div
+            className="moorhen-draggable-action-card"
+            style={{
                 position: 'absolute',
+                width: '20rem',
                 top: canvasTop + convertRemToPx(0.5),
-                left: canvasLeft + (props.windowWidth / 2) - convertRemToPx(10),
-                display: 'flex',
+                left: canvasLeft + (props.windowWidth / 2) - convertRemToPx(7),
                 color: props.isDark ? 'white' : 'grey',
-                bgcolor: props.isDark ? 'grey' : 'white',
-                '&:hover': {
-                    bgcolor: props.isDark ? 'grey' : 'white',
-                }
+                backgroundColor: props.isDark ? 'grey' : 'white',
             }}>
             <Stack direction="vertical" gap={1}>
                 <div>
-                    <span style={{textTransform: 'capitalize'}}>C</span>
-                    <span style={{textTransform: 'lowercase'}}>urrent rotamer: {rotamerName} ({rotamerRank+1}<sup>{rotamerRank === 0 ? 'st' : rotamerRank === 1 ? 'nd' : rotamerRank === 2 ? 'rd' : 'th'}</sup>)</span>
+                    <span>Current rotamer: {rotamerName} ({rotamerRank+1}<sup>{rotamerRank === 0 ? 'st' : rotamerRank === 1 ? 'nd' : rotamerRank === 2 ? 'rd' : 'th'}</sup>)</span>
                 </div>
                 <div>
-                    <span style={{textTransform: 'capitalize'}}>P</span>
-                    <span style={{textTransform: 'lowercase'}}>robability: {rotamerProbability}%</span>
+                    <span>Probability: {rotamerProbability}%</span>
                 </div>
                 <Stack gap={2} direction='horizontal' style={{width: '100%', display:'flex', justifyContent: 'center'}}>
                 <IconButton onClick={async () => {
@@ -175,7 +166,7 @@ export const MoorhenRotamerChangeButton = (props: moorhen.EditButtonProps | moor
                     </IconButton>
                 </Stack>
             </Stack>
-            </Fab>
+            </div>
             </Zoom>
         }
     

--- a/baby-gru/src/components/button/MoorhenRotamerChangeButton.tsx
+++ b/baby-gru/src/components/button/MoorhenRotamerChangeButton.tsx
@@ -4,8 +4,10 @@ import { moorhen } from "../../types/moorhen";
 import { MoorhenContextButtonBase } from "./MoorhenContextButtonBase";
 import { libcootApi } from "../../types/libcoot";
 import { Button, Card, Stack } from "react-bootstrap";
-import { ArrowBackIosOutlined, ArrowForwardIosOutlined, CheckOutlined, CloseOutlined, FirstPageOutlined } from "@mui/icons-material";
+import { ArrowBackIosOutlined, ArrowForwardIosOutlined, CancelOutlined, CheckCircleOutlined, CheckOutlined, CloseOutlined, FirstPageOutlined, NavigateBeforeOutlined, NavigateNextOutlined } from "@mui/icons-material";
 import Draggable from "react-draggable";
+import { Fab, IconButton, Zoom } from "@mui/material";
+import { convertRemToPx } from '../../utils/MoorhenUtils';
 
 export const MoorhenRotamerChangeButton = (props: moorhen.EditButtonProps | moorhen.ContextButtonProps) => {
     const theButton = useRef<null | HTMLButtonElement>(null)
@@ -92,6 +94,21 @@ export const MoorhenRotamerChangeButton = (props: moorhen.EditButtonProps | moor
         
         return rotamerInfo
     }
+
+    const canvasElement = document.getElementById('moorhen-canvas-background')
+    let canvasTop: number
+    let canvasLeft: number
+    let canvasRight: number
+    if (canvasElement !== null) {
+        const rect = canvasElement.getBoundingClientRect()
+        canvasLeft = rect.left
+        canvasTop = rect.top
+        canvasRight = rect.right
+    } else {
+        canvasLeft = 0
+        canvasTop = 0
+        canvasRight = 0
+    }
     
     if (props.mode === 'context') {
 
@@ -99,50 +116,71 @@ export const MoorhenRotamerChangeButton = (props: moorhen.EditButtonProps | moor
             const rotamerName = rotamerInfo.data.result.result.name
             const rotamerRank = rotamerInfo.data.result.result.rank
             const rotamerProbability = rotamerInfo.data.result.result.richardson_probability
-
-            return <Draggable nodeRef={draggableRef} handle=".inner-drag-handle">
-                    <Card ref={draggableRef} className="moorhen-draggable-action-card" style={{position: 'absolute'}} onMouseOver={() => props.setOpacity(1)} onMouseOut={() => props.setOpacity(0.5)}>
-                      <Card.Header className="inner-drag-handle">Accept new rotamer ?</Card.Header>
-                      <Card.Body>
-                      <span>Current rotamer: {rotamerName} ({rotamerRank+1}<sup>{rotamerRank === 0 ? 'st' : rotamerRank === 1 ? 'nd' : rotamerRank === 2 ? 'rd' : 'th'}</sup>)</span>
-                      <br></br>
-                      <span>Probability: {rotamerProbability}%</span>
-                        <Stack gap={2} direction='horizontal' style={{paddingTop: '0.5rem', alignItems: 'center', alignContent: 'center', justifyContent: 'center' }}>
-                            <Button onClick={async () => {
-                                const rotamerInfo = await changeRotamer('change_to_first_rotamer')
-                                props.setOverrideMenuContents(getPopOverContents(rotamerInfo))
-                                }}><FirstPageOutlined/></Button>
-                            <Button onClick={async () => {
-                                const rotamerInfo = await changeRotamer('change_to_previous_rotamer')
-                                props.setOverrideMenuContents(getPopOverContents(rotamerInfo))
-                            }}><ArrowBackIosOutlined/></Button>
-                            <Button onClick={async () => {
-                                const rotamerInfo = await changeRotamer('change_to_next_rotamer')
-                                props.setOverrideMenuContents(getPopOverContents(rotamerInfo))
-                            }}><ArrowForwardIosOutlined/></Button>
-                        </Stack>
-                        <Stack gap={2} direction='horizontal' style={{paddingTop: '0.5rem', alignItems: 'center', alignContent: 'center', justifyContent: 'center' }}>
-                          <Button onClick={() => {
-                                acceptTransform()
-                                props.setOpacity(0.5)
-                                props.setOverrideMenuContents(false)
-                                props.setShowContextMenu(false)
-                          }}><CheckOutlined /></Button>
-                          <Button className="mx-2" onClick={() => {
-                                rejectTransform()
-                                props.setOpacity(0.5)
-                                props.setOverrideMenuContents(false)
-                                props.setShowContextMenu(false)
-                          }}><CloseOutlined /></Button>
-                        </Stack>
-                      </Card.Body>
-                    </Card>
-                  </Draggable>
+            
+            return <Zoom in={true}>
+            <Fab
+            variant='extended'
+            disableRipple={true}
+            size="large"
+            sx={{
+                height: 'auto',
+                width: convertRemToPx(20),
+                position: 'absolute',
+                top: canvasTop + convertRemToPx(0.5),
+                left: canvasLeft + (props.windowWidth / 2) - convertRemToPx(10),
+                display: 'flex',
+                color: props.isDark ? 'white' : 'grey',
+                bgcolor: props.isDark ? 'grey' : 'white',
+                '&:hover': {
+                    bgcolor: props.isDark ? 'grey' : 'white',
+                }
+            }}>
+            <Stack direction="vertical" gap={1}>
+                <div>
+                    <span style={{textTransform: 'capitalize'}}>C</span>
+                    <span style={{textTransform: 'lowercase'}}>urrent rotamer: {rotamerName} ({rotamerRank+1}<sup>{rotamerRank === 0 ? 'st' : rotamerRank === 1 ? 'nd' : rotamerRank === 2 ? 'rd' : 'th'}</sup>)</span>
+                </div>
+                <div>
+                    <span style={{textTransform: 'capitalize'}}>P</span>
+                    <span style={{textTransform: 'lowercase'}}>robability: {rotamerProbability}%</span>
+                </div>
+                <Stack gap={2} direction='horizontal' style={{width: '100%', display:'flex', justifyContent: 'center'}}>
+                <IconButton onClick={async () => {
+                        const rotamerInfo = await changeRotamer('change_to_first_rotamer')
+                        props.setOverrideMenuContents(getPopOverContents(rotamerInfo))
+                    }}><FirstPageOutlined/></IconButton>
+                    <IconButton onClick={async () => {
+                        const rotamerInfo = await changeRotamer('change_to_previous_rotamer')
+                        props.setOverrideMenuContents(getPopOverContents(rotamerInfo))
+                    }}><NavigateBeforeOutlined/></IconButton>
+                    <IconButton onClick={async () => {
+                        const rotamerInfo = await changeRotamer('change_to_next_rotamer')
+                        props.setOverrideMenuContents(getPopOverContents(rotamerInfo))
+                    }}><NavigateNextOutlined/></IconButton>
+                    <IconButton style={{padding: 0, color: props.isDark ? 'white' : 'grey', }} onClick={async () => {
+                        acceptTransform()
+                        props.setOpacity(1)
+                        props.setOverrideMenuContents(false)
+                        props.setShowContextMenu(false)
+                    }}>
+                        <CheckOutlined/>
+                    </IconButton>
+                    <IconButton style={{padding: 0, color: props.isDark ? 'white' : 'grey'}} onClick={async() => {
+                        rejectTransform()
+                        props.setOpacity(1)
+                        props.setOverrideMenuContents(false)
+                        props.setShowContextMenu(false)
+                    }}>
+                        <CloseOutlined/>
+                    </IconButton>
+                </Stack>
+            </Stack>
+            </Fab>
+            </Zoom>
         }
     
         const nonCootCommand = async (molecule: moorhen.Molecule, chosenAtom: moorhen.ResidueSpec, p: string) => {
             const rotamerInfo = await doRotamerChange(molecule, chosenAtom, p)
-            props.setOpacity(0.5)
             props.setOverrideMenuContents(getPopOverContents(rotamerInfo))
             props.setHoveredAtom({molecule: null, cid: null})
         }

--- a/baby-gru/src/components/button/MoorhenRotateTranslateZoneButton.tsx
+++ b/baby-gru/src/components/button/MoorhenRotateTranslateZoneButton.tsx
@@ -5,7 +5,7 @@ import { MoorhenContextButtonBase } from "./MoorhenContextButtonBase";
 import { Button, Card, Container, FormGroup, FormLabel, FormSelect, Row, Stack } from "react-bootstrap";
 import { convertRemToPx, getTooltipShortcutLabel } from '../../utils/MoorhenUtils';
 import { MoorhenCidInputForm } from "../form/MoorhenCidInputForm";
-import { Fab, IconButton, Zoom } from '@mui/material';
+import { Fab, IconButton, Snackbar, Zoom } from '@mui/material';
 import { CancelOutlined, CheckCircleOutlined, CheckOutlined, CloseOutlined } from "@mui/icons-material";
 import Draggable from "react-draggable";
 
@@ -146,26 +146,18 @@ export const MoorhenRotateTranslateZoneButton = (props: moorhen.EditButtonProps 
 
         const contextMenuOverride = (
             <Zoom in={true}>
-            <Fab
-            disableRipple={true}
-            variant='extended'
-            size="large"
-            sx={{
-                width: convertRemToPx(14),
+            <div
+            className="moorhen-draggable-action-card"
+            style={{
                 position: 'absolute',
                 top: canvasTop + convertRemToPx(0.5),
                 left: canvasLeft + (props.windowWidth / 2) - convertRemToPx(7),
-                display: 'flex',
                 color: props.isDark ? 'white' : 'grey',
-                bgcolor: props.isDark ? 'grey' : 'white',
-                '&:hover': {
-                    bgcolor: props.isDark ? 'grey' : 'white',
-                }
+                backgroundColor: props.isDark ? 'grey' : 'white',
             }}>
                 <Stack gap={2} direction='horizontal' style={{width: '100%', display:'flex', justifyContent: 'space-between'}}>
                     <div>
-                        <span style={{textTransform: 'capitalize'}}>A</span>
-                        <span style={{textTransform: 'lowercase'}}>ccept changes?</span>
+                        <span>Accept changes?</span>
                     </div>
                     <div>
                     <IconButton style={{padding: 0, color: props.isDark ? 'white' : 'grey', }} onClick={async () => {
@@ -186,7 +178,7 @@ export const MoorhenRotateTranslateZoneButton = (props: moorhen.EditButtonProps 
                     </IconButton>
                     </div>
                 </Stack>
-            </Fab>
+            </div>
             </Zoom>
         )
 

--- a/baby-gru/src/components/button/MoorhenRotateTranslateZoneButton.tsx
+++ b/baby-gru/src/components/button/MoorhenRotateTranslateZoneButton.tsx
@@ -147,7 +147,7 @@ export const MoorhenRotateTranslateZoneButton = (props: moorhen.EditButtonProps 
         const contextMenuOverride = (
             <Zoom in={true}>
             <div
-            className="moorhen-draggable-action-card"
+            className="moorhen-notification-div"
             style={{
                 position: 'absolute',
                 top: canvasTop + convertRemToPx(0.5),

--- a/baby-gru/src/components/button/MoorhenRotateTranslateZoneButton.tsx
+++ b/baby-gru/src/components/button/MoorhenRotateTranslateZoneButton.tsx
@@ -2,11 +2,11 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { MoorhenEditButtonBase } from "./MoorhenEditButtonBase"
 import { moorhen } from "../../types/moorhen";
 import { MoorhenContextButtonBase } from "./MoorhenContextButtonBase";
-import { Button, Card, Container, FormGroup, FormLabel, FormSelect, Row, Stack } from "react-bootstrap";
+import { Button, Card, Container, FormGroup, FormLabel, FormSelect, OverlayTrigger, Row, Stack, Tooltip } from "react-bootstrap";
 import { convertRemToPx, getTooltipShortcutLabel } from '../../utils/MoorhenUtils';
 import { MoorhenCidInputForm } from "../form/MoorhenCidInputForm";
-import { Fab, IconButton, Snackbar, Zoom } from '@mui/material';
-import { CancelOutlined, CheckCircleOutlined, CheckOutlined, CloseOutlined } from "@mui/icons-material";
+import { IconButton, Zoom } from '@mui/material';
+import { CheckOutlined, CloseOutlined, InfoOutlined } from "@mui/icons-material";
 import Draggable from "react-draggable";
 
 
@@ -156,6 +156,19 @@ export const MoorhenRotateTranslateZoneButton = (props: moorhen.EditButtonProps 
                 backgroundColor: props.isDark ? 'grey' : 'white',
             }}>
                 <Stack gap={2} direction='horizontal' style={{width: '100%', display:'flex', justifyContent: 'space-between'}}>
+                    <OverlayTrigger
+                        placement="bottom"
+                        overlay={
+                            <Tooltip id="tip-tooltip" className="moorhen-tooltip">
+                            <div>
+                                <em>{"Hold <Shift><Alt> to translate"}</em>
+                                <br></br>
+                                <em>{props.shortCuts ? `Hold ${getTooltipShortcutLabel(JSON.parse(props.shortCuts as string).residue_camera_wiggle)} to move view` : null}</em>
+                            </div>
+                            </Tooltip>
+                        }>
+                    <InfoOutlined/>
+                    </OverlayTrigger>
                     <div>
                         <span>Accept changes?</span>
                     </div>

--- a/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
+++ b/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
@@ -7,7 +7,7 @@ import { MoorhenChainSelect } from '../select/MoorhenChainSelect';
 import { HexColorPicker } from "react-colorful";
 import { MoorhenSequenceRangeSelect } from '../sequence-viewer/MoorhenSequenceRangeSelect';
 import { webGL } from '../../types/mgWebGL';
-import MoorhenSlider from '../misc/MoorhenSlider';
+import { MoorhenSlider } from '../misc/MoorhenSlider';
 import { AddCircleOutline, RemoveCircleOutline } from '@mui/icons-material';
 
 const customRepresentations = [ 'CBs', 'CAs', 'CRs', 'ligands', 'gaussian', 'MolecularSurface', 'DishyBases', 'VdwSpheres' ]

--- a/baby-gru/src/components/card/MoorhenMapCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMapCard.tsx
@@ -7,7 +7,7 @@ import { VisibilityOffOutlined, VisibilityOutlined, ExpandMoreOutlined, ExpandLe
 import { MoorhenMapSettingsMenuItem } from "../menu-item/MoorhenMapSettingsMenuItem";
 import { MoorhenRenameDisplayObjectMenuItem } from "../menu-item/MoorhenRenameDisplayObjectMenuItem"
 import { MoorhenDeleteDisplayObjectMenuItem } from "../menu-item/MoorhenDeleteDisplayObjectMenuItem"
-import MoorhenSlider from "../misc/MoorhenSlider";
+import { MoorhenSlider } from "../misc/MoorhenSlider";
 import { IconButton, MenuItem, Popover, Tooltip } from "@mui/material"
 import { RgbColorPicker } from "react-colorful"
 import { moorhen } from "../../types/moorhen"

--- a/baby-gru/src/components/card/MoorhenMoleculeRepresentationSettingsCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeRepresentationSettingsCard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import { Form, Stack } from "react-bootstrap";
 import { IconButton, Popover, Slider } from '@mui/material';
-import MoorhenSlider from '../misc/MoorhenSlider';
+import { MoorhenSlider } from '../misc/MoorhenSlider';
 import { AddCircleOutline, RemoveCircleOutline } from '@mui/icons-material';
 import { moorhen } from "../../types/moorhen";
 import { webGL } from '../../types/mgWebGL';

--- a/baby-gru/src/components/context-menu/MoorhenContextMenu.tsx
+++ b/baby-gru/src/components/context-menu/MoorhenContextMenu.tsx
@@ -180,7 +180,7 @@ export const MoorhenContextMenu = (props: {
   const collectedProps = {selectedMolecule, chosenAtom, setOverlayContents, setShowOverlay, toolTip, setToolTip, setOpacity, setOverrideMenuContents, ...props}
 
   return <>
-      <ContextMenu ref={contextMenuRef} top={overrideMenuContents ? convertRemToPx(4) : menuPosition.top} left={overrideMenuContents ? convertRemToPx(15) : menuPosition.left} opacity={opacity}>
+      <ContextMenu ref={contextMenuRef} top={overrideMenuContents ? 0 : menuPosition.top} left={overrideMenuContents ? 0 : menuPosition.left} opacity={opacity}>
         {overrideMenuContents ? 
         overrideMenuContents 
         :

--- a/baby-gru/src/components/menu-item/MoorhenBackupPreferencesMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenBackupPreferencesMenuItem.tsx
@@ -1,5 +1,5 @@
 import { Form } from "react-bootstrap";
-import MoorhenSlider from "../misc/MoorhenSlider";
+import { MoorhenSlider } from "../misc/MoorhenSlider";
 import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem";
 
 export const MoorhenBackupPreferencesMenuItem = (props: {

--- a/baby-gru/src/components/menu-item/MoorhenBlurMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenBlurMenuItem.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useContext } from "react"
 import { Form, InputGroup } from "react-bootstrap";
-import MoorhenSlider from "../misc/MoorhenSlider"
+import { MoorhenSlider } from "../misc/MoorhenSlider"
 import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem"
 import { MoorhenContext } from "../../utils/MoorhenContext";
 import { moorhen } from "../../types/moorhen";

--- a/baby-gru/src/components/menu-item/MoorhenClipFogMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenClipFogMenuItem.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useState } from "react"
-import MoorhenSlider from "../misc/MoorhenSlider"
+import { MoorhenSlider } from "../misc/MoorhenSlider"
 import { Form, InputGroup } from "react-bootstrap"
 import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem"
 import { MoorhenContext } from "../../utils/MoorhenContext";

--- a/baby-gru/src/components/menu-item/MoorhenLightingMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenLightingMenuItem.tsx
@@ -1,5 +1,5 @@
 import { Dispatch, SetStateAction, useEffect, useRef, useState } from "react"
-import MoorhenSlider from "../misc/MoorhenSlider"
+import { MoorhenSlider } from "../misc/MoorhenSlider"
 import { MoorhenLightPosition } from "../webMG/MoorhenLightPosition"
 import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem"
 import { webGL } from "../../types/mgWebGL";

--- a/baby-gru/src/components/menu-item/MoorhenMapSettingsMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenMapSettingsMenuItem.tsx
@@ -1,6 +1,6 @@
 import { Form } from "react-bootstrap"
 import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem"
-import MoorhenSlider from "../misc/MoorhenSlider";
+import { MoorhenSlider } from "../misc/MoorhenSlider";
 
 export const MoorhenMapSettingsMenuItem = (props: {
     mapSolid: boolean;

--- a/baby-gru/src/components/menu-item/MoorhenRandomJiggleBlurMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenRandomJiggleBlurMenuItem.tsx
@@ -1,0 +1,193 @@
+import { useCallback, useRef, useState, useEffect } from "react";
+import { MoorhenMoleculeSelect } from "../select/MoorhenMoleculeSelect";
+import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem";
+import { MoorhenCidInputForm } from "../form/MoorhenCidInputForm";
+import { MoorhenSlider } from "../misc/MoorhenSlider";
+import { IconButton } from "@mui/material";
+import { AddCircleOutline, RemoveCircleOutline } from "@mui/icons-material";
+import { moorhen } from "../../types/moorhen";
+import { webGL } from "../../types/mgWebGL";
+import { MoorhenMapSelect } from "../select/MoorhenMapSelect";
+
+export const MoorhenRandomJiggleBlurMenuItem = (props: {
+    molecules: moorhen.Molecule[];
+    maps: moorhen.Map[];
+    isDark: boolean;
+    commandCentre: React.RefObject<moorhen.CommandCentre>;
+    glRef: React.RefObject<webGL.MGWebGL>;
+    popoverPlacement?: 'left' | 'right'
+    setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
+    
+    const moleculeSelectRef = useRef<null | HTMLSelectElement>(null)
+    const mapSelectRef = useRef<null | HTMLSelectElement>(null)
+    const cidSelectRef = useRef<HTMLInputElement | null>(null)
+    const bFactorSliderRef = useRef<number>(200)
+    const noTrialsSliderRef = useRef<number>(50)
+    const scaleFactorSliderRef = useRef<number>(3)
+    const [selectedMap, setSelectedMap] = useState<number | null>(null)
+    const [selectedMolNo, setSelectedMolNo] = useState<null | number>(null)
+    const [bFactor, setBFactor] = useState<number>(200)
+    const [noTrials, setNoTrials] = useState<number>(50)
+    const [scaleFactor, setScaleFactor] = useState<number>(3)
+    const [cid, setCid] = useState<string>('')
+
+    useEffect(() => {
+        if (props.molecules.length === 0) {
+            setSelectedMolNo(null)
+        } else if (selectedMolNo === null || !props.molecules.map(molecule => molecule.molNo).includes(selectedMolNo)) {
+            setSelectedMolNo(props.molecules[0].molNo)
+        }
+    }, [props.molecules.length])
+
+    const handleModelChange = (evt: React.ChangeEvent<HTMLSelectElement>) => {
+        const selectedMolecule = props.molecules.find(molecule => molecule.molNo === parseInt(evt.target.value))
+        if (selectedMolecule) {
+            setSelectedMolNo(parseInt(evt.target.value))
+        } 
+    }
+
+    const handleMapChange = (evt: React.ChangeEvent<HTMLSelectElement>) => {
+        const selectedMap = props.maps.find(map => map.molNo === parseInt(evt.target.value))
+        if (selectedMap) {
+            setSelectedMap(parseInt(evt.target.value))
+        } 
+    }
+
+    const increaseBfactorButton =  <IconButton style={{padding: 0, color: props.isDark ? 'white' : 'grey'}} onClick={() => {
+                                        const newVal = bFactor + 25
+                                        setBFactor(newVal)
+                                        bFactorSliderRef.current = newVal
+                                    }}>
+                                        <AddCircleOutline/>
+                                    </IconButton>
+    const decreaseBfactorButton =  <IconButton style={{padding: 0, color: props.isDark ? 'white' : 'grey'}} onClick={() => {
+                                        const newVal = bFactor - 25
+                                        setBFactor(newVal)
+                                        bFactorSliderRef.current = newVal
+                                    }}>
+                                        <RemoveCircleOutline/>
+                                    </IconButton>
+
+    const increaseNoTrialsButton =  <IconButton style={{padding: 0, color: props.isDark ? 'white' : 'grey'}} onClick={() => {
+                                        const newVal = noTrials + 10
+                                        setNoTrials(newVal)
+                                        noTrialsSliderRef.current = newVal
+                                    }}>
+                                        <AddCircleOutline/>
+                                    </IconButton>
+    const decreaseNoTrialsButton =  <IconButton style={{padding: 0, color: props.isDark ? 'white' : 'grey'}} onClick={() => {
+                                        const newVal = noTrials - 10
+                                        setNoTrials(newVal)
+                                        noTrialsSliderRef.current = newVal
+                                    }}>
+                                        <RemoveCircleOutline/>
+                                    </IconButton>
+
+    const increaseScaleFactorButton =  <IconButton style={{padding: 0, color: props.isDark ? 'white' : 'grey'}} onClick={() => {
+                                            const newVal = scaleFactor + 1
+                                            setScaleFactor(newVal)
+                                            scaleFactorSliderRef.current = newVal
+                                        }}>
+                                            <AddCircleOutline/>
+                                        </IconButton>
+    const decreaseScaleFactorButton =  <IconButton style={{padding: 0, color: props.isDark ? 'white' : 'grey'}} onClick={() => {
+                                            const newVal = scaleFactor - 1
+                                            setScaleFactor(newVal)
+                                            scaleFactorSliderRef.current = newVal
+                                        }}>
+                                            <RemoveCircleOutline/>
+                                        </IconButton>
+
+    const panelContent = <>
+        <MoorhenMoleculeSelect
+            ref={moleculeSelectRef}
+            molecules={props.molecules}
+            onChange={handleModelChange}/>
+        <MoorhenMapSelect
+            ref={mapSelectRef}
+            maps={props.maps}
+            onChange={handleMapChange}/>
+        <MoorhenCidInputForm
+            ref={cidSelectRef}
+            margin="0.5rem"
+            onChange={(evt) => setCid(evt.target.value)}
+            placeholder={cidSelectRef.current ? "" : "Input custom selection e.g. //A,B"}/>
+        <MoorhenSlider
+            ref={bFactorSliderRef}
+            sliderTitle="B-Factor"
+            decrementButton={decreaseBfactorButton}
+            incrementButton={increaseBfactorButton}
+            minVal={10}
+            maxVal={400}
+            showMinMaxVal={false}
+            logScale={false}
+            initialValue={bFactor}
+            externalValue={bFactor}
+            setExternalValue={setBFactor}/>
+        <MoorhenSlider
+            ref={noTrialsSliderRef}
+            sliderTitle="No. of trials"
+            decrementButton={decreaseNoTrialsButton}
+            incrementButton={increaseNoTrialsButton}
+            minVal={1}
+            maxVal={100}
+            showMinMaxVal={false}
+            logScale={false}
+            initialValue={noTrials}
+            externalValue={noTrials}
+            setExternalValue={setNoTrials}/>
+        <MoorhenSlider
+            ref={scaleFactorSliderRef}
+            sliderTitle="Scale factor"
+            decrementButton={decreaseScaleFactorButton}
+            incrementButton={increaseScaleFactorButton}
+            minVal={1}
+            maxVal={6}
+            showMinMaxVal={false}
+            logScale={false}
+            initialValue={scaleFactor}
+            externalValue={scaleFactor}
+            setExternalValue={setScaleFactor}/>
+
+    </>
+
+    const onCompleted = useCallback(async () => {
+        if (!moleculeSelectRef.current.value || !mapSelectRef.current.value || !cidSelectRef.current.value) {
+            return
+        }
+        
+        const selectedMolecule = props.molecules.find(molecule => molecule.molNo === parseInt(moleculeSelectRef.current.value))
+        if(!selectedMolecule) {
+            return
+        }
+
+        await props.commandCentre.current.cootCommand({
+            command: "fit_to_map_by_random_jiggle_with_blur_using_cid",
+            returnType: 'status',
+            commandArgs: [
+                parseInt(moleculeSelectRef.current.value),
+                parseInt(mapSelectRef.current.value),
+                cidSelectRef.current.value,
+                bFactorSliderRef.current,
+                noTrialsSliderRef.current,
+                scaleFactorSliderRef.current
+            ],
+        }, false)
+
+        selectedMolecule.setAtomsDirty(true)
+        await selectedMolecule.redraw()
+
+    }, [props.commandCentre])
+
+    return <MoorhenBaseMenuItem
+        id='jiggle-fit-blur-menu-item'
+        popoverPlacement={props.popoverPlacement}
+        popoverContent={panelContent}
+        menuItemText="Jiggle Fit with Fourier Filtering..."
+        onCompleted={onCompleted}
+        setPopoverIsShown={props.setPopoverIsShown}
+        showOkButton={true}
+    />
+
+}

--- a/baby-gru/src/components/menu-item/MoorhenSelfRestraintsMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenSelfRestraintsMenuItem.tsx
@@ -100,7 +100,6 @@ export const MoorhenSelfRestraintsMenuItem = (props: {
     </>
 
     const onCompleted = useCallback(async () => {
-        console.log(modeTypeSelectRef.current.value, maxDistSliderRef.current, chainSelectRef.current?.value, cidSelectRef.current?.value)
         if (!moleculeSelectRef.current.value || maxDistSliderRef.current === null) {
             return
         }

--- a/baby-gru/src/components/menu-item/MoorhenSelfRestraintsMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenSelfRestraintsMenuItem.tsx
@@ -6,6 +6,9 @@ import { webGL } from "../../types/mgWebGL";
 import { MoorhenChainSelect } from "../select/MoorhenChainSelect";
 import { MoorhenMoleculeSelect } from "../select/MoorhenMoleculeSelect";
 import { MoorhenCidInputForm } from "../form/MoorhenCidInputForm";
+import { MoorhenSlider } from "../misc/MoorhenSlider";
+import { IconButton } from "@mui/material";
+import { AddCircleOutline, RemoveCircleOutline } from "@mui/icons-material";
 
 export const MoorhenSelfRestraintsMenuItem = (props: {
     glRef: React.RefObject<webGL.MGWebGL>;
@@ -13,12 +16,14 @@ export const MoorhenSelfRestraintsMenuItem = (props: {
     commandCentre: React.RefObject<moorhen.CommandCentre>;
     setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>;
     popoverPlacement?: 'left' | 'right';
+    isDark: boolean;
 }) => {
 
     const modeTypeSelectRef = useRef<HTMLSelectElement | null>(null)
     const moleculeSelectRef = useRef<HTMLSelectElement | null>(null)
     const chainSelectRef = useRef<HTMLSelectElement | null>(null)
     const cidSelectRef = useRef<HTMLInputElement | null>(null)
+    const maxDistSliderRef = useRef<number>(4.5)
     const [selectedMode, setSelectedMode] = useState<string>("Molecule")
     const [selectedMolNo, setSelectedMolNo] = useState<null | number>(null)
     const [selectedChain, setSelectedChain] = useState<string>('')
@@ -41,6 +46,21 @@ export const MoorhenSelfRestraintsMenuItem = (props: {
             setSelectedChain(selectedMolecule.sequences.length > 0 ? selectedMolecule.sequences[0].chain : '')
         } 
     }
+    
+    const increaseDistButton =  <IconButton style={{padding: 0, color: props.isDark ? 'white' : 'grey'}} onClick={() => {
+                                    const newVal = maxDist + 0.25
+                                    setMaxDist(newVal)
+                                    maxDistSliderRef.current = newVal
+                                }}>
+                                    <AddCircleOutline/>
+                                </IconButton>
+    const decreaseDistButton =  <IconButton style={{padding: 0, color: props.isDark ? 'white' : 'grey'}} onClick={() => {
+                                    const newVal = maxDist - 0.25
+                                    setMaxDist(newVal)
+                                    maxDistSliderRef.current = newVal
+                                }}>
+                                    <RemoveCircleOutline/>
+                                </IconButton>
 
     const panelContent = <>
         <Form.Group className='moorhen-form-group' controlId="MoorhenSelfRestraintsMenuItem">
@@ -62,18 +82,34 @@ export const MoorhenSelfRestraintsMenuItem = (props: {
         {selectedMode === 'Atom Selection' &&
         <MoorhenCidInputForm
             ref={cidSelectRef}
+            margin="0.5rem"
             onChange={(evt) => setCid(evt.target.value)}
             placeholder={cidSelectRef.current ? "" : "Input custom selection e.g. //A,B"}/>}
+        <MoorhenSlider
+            ref={maxDistSliderRef}
+            sliderTitle="Max. dist."
+            decrementButton={decreaseDistButton}
+            incrementButton={increaseDistButton}
+            minVal={4}
+            maxVal={6}
+            showMinMaxVal={false}
+            logScale={false}
+            initialValue={maxDist}
+            externalValue={maxDist}
+            setExternalValue={setMaxDist}/>
     </>
 
     const onCompleted = useCallback(async () => {
-        console.log(modeTypeSelectRef.current.value, maxDist, chainSelectRef.current?.value, cidSelectRef.current?.value)
+        console.log(modeTypeSelectRef.current.value, maxDistSliderRef.current, chainSelectRef.current?.value, cidSelectRef.current?.value)
+        if (!moleculeSelectRef.current.value || maxDistSliderRef.current === null) {
+            return
+        }
         switch(modeTypeSelectRef.current.value) {
             case "Molecule":
                 await props.commandCentre.current.cootCommand({
                     command: "generate_self_restraints",
                     returnType: 'status',
-                    commandArgs: [parseInt(moleculeSelectRef.current.value), maxDist],
+                    commandArgs: [parseInt(moleculeSelectRef.current.value), maxDistSliderRef.current],
                 }, false)
                 break
 
@@ -81,20 +117,23 @@ export const MoorhenSelfRestraintsMenuItem = (props: {
                 await props.commandCentre.current.cootCommand({
                     command: "generate_chain_self_restraints",
                     returnType: 'status',
-                    commandArgs: [parseInt(moleculeSelectRef.current.value), maxDist, chainSelectRef.current.value],
+                    commandArgs: [parseInt(moleculeSelectRef.current.value), maxDistSliderRef.current, chainSelectRef.current.value],
                 }, false)
                 break
             case "Atom Selection":
+                if (!cidSelectRef.current.value) {
+                    break
+                }
                 await props.commandCentre.current.cootCommand({
                     command: "generate_local_self_restraints",
                     returnType: 'status',
-                    commandArgs: [parseInt(moleculeSelectRef.current.value), maxDist, cidSelectRef.current.value],
+                    commandArgs: [parseInt(moleculeSelectRef.current.value), maxDistSliderRef.current, cidSelectRef.current.value],
                 }, false)
                 break
             default:
                 console.warn('Unrecognised self restraints mode...', modeTypeSelectRef.current.value)
         }
-    }, [props.commandCentre, maxDist])
+    }, [props.commandCentre])
 
     return <MoorhenBaseMenuItem
         id='create-restraints-menu-item'

--- a/baby-gru/src/components/misc/MoorhenSlider.tsx
+++ b/baby-gru/src/components/misc/MoorhenSlider.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import React, { forwardRef, useCallback, useEffect, useRef, useState } from "react";
 import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Slider from '@mui/material/Slider';
@@ -11,7 +11,7 @@ const convertValueToScale = (logScale: boolean, minVal: number, maxVal: number, 
     }
 }
 
-export default function MoorhenSlider(props: {
+type MoorhenSliderProps = {
     logScale?: boolean;
     minVal?: number;
     maxVal?: number;
@@ -27,11 +27,15 @@ export default function MoorhenSlider(props: {
     decrementButton?: JSX.Element;
     isDisabled?: boolean;
     incrementButton?: JSX.Element; 
-}) {
+}
+
+export const MoorhenSlider = forwardRef<number, MoorhenSliderProps>((props, ref) => {
     
     const initValue = convertValueToScale(props.logScale, props.minVal, props.maxVal, props.initialValue)
     const [value, setValue] = useState<number>(initValue);
     const [externalValue, setExternalValue] = useState<number>(props.externalValue)
+    const localRef = useRef<number | null>(props.externalValue)
+    const externalValueRef = ref || localRef
 
     useEffect(() => {
         if (props.externalValue !== externalValue) {
@@ -51,22 +55,26 @@ export default function MoorhenSlider(props: {
     }, [props.externalValue])
 
     const handleChange = useCallback((evt: any, newValue: number) => {
+        let newVal: number
         setValue(props.allowFloats ? newValue : Math.round(newValue))
         if (props.logScale) {
             const log10MaxVal = Math.log10(props.maxVal)
             const log10MinVal = Math.log10(Math.max(props.minVal, 0.00000001))
             const log10NewVal = log10MinVal + (newValue/100) * (log10MaxVal-log10MinVal)
-            let newVal = Math.pow(10., log10NewVal)
+            newVal = Math.pow(10., log10NewVal)
             if (!props.allowFloats) {
                 newVal = Math.round(newVal)
             }
-            setExternalValue(newVal)
         }
         else if (props.allowFloats) {
-            setExternalValue(props.minVal + (newValue/100.)*(props.maxVal-props.minVal))
+            newVal = props.minVal + (newValue/100.)*(props.maxVal-props.minVal)
         } else {
-            setExternalValue(Math.round(props.minVal + (newValue/100.)*(props.maxVal-props.minVal)))
+            newVal = Math.round(props.minVal + (newValue/100.)*(props.maxVal-props.minVal))
         }
+
+        setExternalValue(newVal)
+        if (externalValueRef !== null && typeof externalValueRef !== 'function') externalValueRef.current = newVal
+
     }, [props.allowFloats, props.logScale, props.minVal, props.maxVal])
 
     return (
@@ -83,7 +91,7 @@ export default function MoorhenSlider(props: {
             </Stack>
         </Box>
     );
-}
+})
 
 MoorhenSlider.defaultProps={
     minVal: 0, maxVal: 100, setExternalValue: ()=>{}, logScale: false, showMinMaxVal: true, incrementButton: null,

--- a/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
@@ -9,7 +9,7 @@ import { MoorhenChainSelect } from "../select/MoorhenChainSelect";
 import { MoorhenMolecule } from "../../utils/MoorhenMolecule"
 import { MoorhenContext } from "../../utils/MoorhenContext";
 import { MoorhenDraggableModalBase } from "../modal/MoorhenDraggableModalBase"
-import MoorhenSlider from "../misc/MoorhenSlider";
+import { MoorhenSlider } from "../misc/MoorhenSlider";
 import { webGL } from "../../types/mgWebGL";
 
 export const MoorhenQuerySequenceModal = (props: {

--- a/baby-gru/src/components/navbar-menus/MoorhenCalculateMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenCalculateMenu.tsx
@@ -3,6 +3,7 @@ import { MoorhenLoadScriptMenuItem } from "../menu-item/MoorhenLoadScriptMenuIte
 import { MoorhenSuperposeMenuItem } from "../menu-item/MoorhenSuperposeMenuItem";
 import { MoorhenSelfRestraintsMenuItem } from "../menu-item/MoorhenSelfRestraintsMenuItem";
 import { MoorhenClearSelfRestraintsMenuItem } from "../menu-item/MoorhenClearSelfRestraintsMenuItem";
+import { MoorhenRandomJiggleBlurMenuItem } from "../menu-item/MoorhenRandomJiggleBlurMenuItem";
 import { MoorhenNavBarExtendedControlsInterface } from "./MoorhenNavBar";
 import { MenuItem } from "@mui/material";
 import { libcootApi } from "../../types/libcoot";
@@ -27,7 +28,15 @@ export const MoorhenCalculateMenu = (props: MoorhenNavBarExtendedControlsInterfa
                 molecules={props.molecules}
                 commandCentre={props.commandCentre}
                 setPopoverIsShown={setPopoverIsShown}
-            />  
+            />
+            <MoorhenRandomJiggleBlurMenuItem
+                glRef={props.glRef}
+                molecules={props.molecules}
+                maps={props.maps}
+                isDark={props.isDark}
+                commandCentre={props.commandCentre}
+                setPopoverIsShown={setPopoverIsShown}
+            />
             {props.allowScripting && 
             <>
                 <MoorhenLoadScriptMenuItem {...menuItemProps} />

--- a/baby-gru/src/components/navbar-menus/MoorhenCalculateMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenCalculateMenu.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { MoorhenLoadScriptMenuItem } from "../menu-item/MoorhenLoadScriptMenuItem";
 import { MoorhenSuperposeMenuItem } from "../menu-item/MoorhenSuperposeMenuItem";
-import { MenuItem } from "@mui/material";
+import { MoorhenSelfRestraintsMenuItem } from "../menu-item/MoorhenSelfRestraintsMenuItem";
+import { MoorhenClearSelfRestraintsMenuItem } from "../menu-item/MoorhenClearSelfRestraintsMenuItem";
 import { MoorhenNavBarExtendedControlsInterface } from "./MoorhenNavBar";
+import { MenuItem } from "@mui/material";
 import { libcootApi } from "../../types/libcoot";
 
 export const MoorhenCalculateMenu = (props: MoorhenNavBarExtendedControlsInterface) => {
@@ -13,6 +15,19 @@ export const MoorhenCalculateMenu = (props: MoorhenNavBarExtendedControlsInterfa
 
     return <>
             <MoorhenSuperposeMenuItem key="superpose_structures" setSuperposeResults={setSuperposeResults} {...menuItemProps} />
+            <MoorhenSelfRestraintsMenuItem
+                glRef={props.glRef}
+                molecules={props.molecules}
+                isDark={props.isDark}
+                commandCentre={props.commandCentre}
+                setPopoverIsShown={setPopoverIsShown}
+            />
+            <MoorhenClearSelfRestraintsMenuItem
+                glRef={props.glRef}
+                molecules={props.molecules}
+                commandCentre={props.commandCentre}
+                setPopoverIsShown={setPopoverIsShown}
+            />  
             {props.allowScripting && 
             <>
                 <MoorhenLoadScriptMenuItem {...menuItemProps} />

--- a/baby-gru/src/components/navbar-menus/MoorhenDevMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenDevMenu.tsx
@@ -4,12 +4,10 @@ import { MenuItem } from "@mui/material";
 import { cidToSpec } from "../../utils/MoorhenUtils";
 import { MoorhenContext } from "../../utils/MoorhenContext";
 import { MoorhenNavBarExtendedControlsInterface } from "./MoorhenNavBar";
-import { MoorhenSelfRestraintsMenuItem } from "../menu-item/MoorhenSelfRestraintsMenuItem"
-import { MoorhenClearSelfRestraintsMenuItem } from "../menu-item/MoorhenClearSelfRestraintsMenuItem"
 import { MoorhenMoleculeSelect } from "../select/MoorhenMoleculeSelect";
 import { MoorhenMoleculeRepresentation } from "../../utils/MoorhenMoleculeRepresentation";
 import { moorhen } from "../../types/moorhen";
-import MoorhenSlider from "../misc/MoorhenSlider"
+import { MoorhenSlider } from "../misc/MoorhenSlider"
 
 const doRestraintsMeshTest = async (commandCentre, glRef, molecules, moleculeSelectRef) => {
     const selectedMolecule = molecules.find(item => item.molNo === parseInt(moleculeSelectRef.current.value))
@@ -90,18 +88,6 @@ export const MoorhenDevMenu = (props: MoorhenNavBarExtendedControlsInterface) =>
                     <MenuItem onClick={() => doTest(menuItemProps)}>
                         Do a timing test...
                     </MenuItem>
-                    <MoorhenSelfRestraintsMenuItem
-                        glRef={props.glRef}
-                        molecules={props.molecules}
-                        commandCentre={props.commandCentre}
-                        setPopoverIsShown={setPopoverIsShown}
-                    />
-                    <MoorhenClearSelfRestraintsMenuItem
-                        glRef={props.glRef}
-                        molecules={props.molecules}
-                        commandCentre={props.commandCentre}
-                        setPopoverIsShown={setPopoverIsShown}
-                    />  
                     <hr></hr>
                     <Form.Group>
                         <MoorhenMoleculeSelect width="" molecules={props.molecules} ref={moleculeSelectRef}/>

--- a/baby-gru/src/components/navbar-menus/MoorhenPreferencesMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenPreferencesMenu.tsx
@@ -8,7 +8,7 @@ import { MoorhenScoresToastPreferencesMenuItem } from "../menu-item/MoorhenScore
 import { MoorhenBackupPreferencesMenuItem } from "../menu-item/MoorhenBackupPreferencesMenuItem"
 import { MoorhenDefaultBondSmoothnessPreferencesMenuItem } from "../menu-item/MoorhenDefaultBondSmoothnessPreferencesMenuItem"
 import { MoorhenMapSamplingMenuItem } from "../menu-item/MoorhenMapSamplingMenuItem"
-import MoorhenSlider from '../misc/MoorhenSlider' 
+import { MoorhenSlider } from '../misc/MoorhenSlider' 
 import { MoorhenNavBarExtendedControlsInterface } from "./MoorhenNavBar";
 import { MoorhenContext } from "../../utils/MoorhenContext";
 import { moorhen } from "../../types/moorhen";

--- a/baby-gru/src/components/validation-tools/MoorhenDifferenceMapPeaks.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenDifferenceMapPeaks.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react"
 import { Col, Form } from 'react-bootstrap';
 import { Chart, ChartEvent, ChartType, TooltipItem, registerables } from 'chart.js';
-import MoorhenSlider from '../misc/MoorhenSlider' 
+import { MoorhenSlider } from '../misc/MoorhenSlider' 
 import annotationPlugin from 'chartjs-plugin-annotation'
 import { convertViewtoPx} from '../../utils/MoorhenUtils';
 import { moorhen } from "../../types/moorhen";

--- a/baby-gru/src/components/validation-tools/MoorhenPepflipsDifferenceMap.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenPepflipsDifferenceMap.tsx
@@ -2,7 +2,7 @@ import { useContext, useState } from "react"
 import { Col, Row, Form, Card, Button } from 'react-bootstrap';
 import { MoorhenContext } from "../../utils/MoorhenContext";
 import { MoorhenValidationListWidgetBase } from "./MoorhenValidationListWidgetBase"
-import MoorhenSlider from '../misc/MoorhenSlider' 
+import { MoorhenSlider } from '../misc/MoorhenSlider' 
 import { libcootApi } from "../../types/libcoot";
 import { moorhen } from "../../types/moorhen";
 

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -610,6 +610,7 @@ export namespace moorhen {
     type ContextButtonProps = {
         mode: 'context';
         monomerLibraryPath: string;
+        windowWidth: number;
         shortCuts: string | { [label: string]: Shortcut; };
         urlPrefix: string;
         commandCentre: React.RefObject<CommandCentre>

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -705,6 +705,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("get_cell",&molecules_container_t::get_cell)
     .function("get_cell",&molecules_container_t::get_cell)
     .function("make_masked_maps_split_by_chain",&molecules_container_t::make_masked_maps_split_by_chain)
+    .function("fit_to_map_by_random_jiggle_with_blur_using_cid",&molecules_container_t::fit_to_map_by_random_jiggle_with_blur_using_cid)
      ;
     class_<molecules_container_js, base<molecules_container_t>>("molecules_container_js")
     .constructor<bool>()


### PR DESCRIPTION
This update includes:
- Revised style for Accept/Reject changes when dragging atoms, rotate/translate and change rotamer buttons.
- Generate/Clear self-restraints added to "Calculate" menu.
- Jiggle Fit with Fourier Filtering added to "Calculate" menu.