### PR TITLE
Store column names after auto open mtz and set colour rules after merge molecules

### DIFF
--- a/baby-gru/public/baby-gru/CootWorker.ts
+++ b/baby-gru/public/baby-gru/CootWorker.ts
@@ -605,6 +605,31 @@ const interestingPlaceDataToJSArray = (interestingPlaceData: emscriptem.vector<l
     return returnResult
 }
 
+const autoReadMtzInfoVectToJSArray = (autoReadMtzInfoArray: emscriptem.vector<libcootApi.AutoReadMtzInfo>): libcootApi.AutoReadMtzInfoJS[] => {
+    let returnResult: {idx: number;
+        F: string;
+        phi: string;
+        w: string;
+        weights_used: boolean;
+    }[] = []
+
+    const autoReadMtzInfoArraySize = autoReadMtzInfoArray.size()
+    for(let i = 0; i < autoReadMtzInfoArraySize; i++) {
+        const autoReadMtzInfo = autoReadMtzInfoArray.get(i)
+        returnResult.push({
+            idx: autoReadMtzInfo.idx,
+            F: autoReadMtzInfo.F,
+            phi: autoReadMtzInfo.phi,
+            w: autoReadMtzInfo.w,
+            weights_used: autoReadMtzInfo.weights_used,
+        })
+        autoReadMtzInfo.delete()
+    }
+    autoReadMtzInfoArray.delete()
+    
+    return returnResult
+}
+
 const ramachandranDataToJSArray = (ramachandraData: emscriptem.vector<libcootApi.CootPhiPsiProbT>, chainID: string): libcootApi.RamaDataJS[] => {
     let returnResult: { chainId: string; insCode: string; seqNum: number; restype: string; isOutlier: boolean; phi: number; psi: number; is_pre_pro: boolean; }[] = [];
     const ramachandraDataSize = ramachandraData.size()
@@ -933,6 +958,9 @@ const doCootCommand = (messageData: {
                 break;
             case 'int_array':
                 returnResult = intArrayToJSArray(cootResult)
+                break;
+            case 'auto_read_mtz_info_array':
+                returnResult = autoReadMtzInfoVectToJSArray(cootResult)
                 break;
             case 'map_molecule_centre_info_t':
                 returnResult = mapMoleculeCentreInfoToJSObject(cootResult)

--- a/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
+++ b/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
@@ -120,7 +120,7 @@ export const MoorhenModifyColourRulesCard = (props: {
         
         setIntialRules()
 
-    }, [])
+    }, [props.showColourRulesToast])
 
     const applyRules = useCallback(async () => {
         if (props.molecule?.defaultColourRules) {
@@ -301,7 +301,7 @@ export const MoorhenModifyColourRulesCard = (props: {
                             <option value={'property'} key={'property'}>By property</option>
                         </FormSelect>
                     </Form.Group>
-                    {(ruleType === 'chain' || ruleType === 'residue-range')  && <MoorhenChainSelect width="100%" margin={'0px'} molecules={props.molecules} onChange={handleChainChange} selectedCoordMolNo={props.molecule.molNo} ref={chainSelectRef} allowedTypes={[1, 2]}/>}
+                    {(ruleType === 'chain' || ruleType === 'residue-range')  && <MoorhenChainSelect width="100%" margin={'0px'} molecules={props.molecules} onChange={handleChainChange} selectedCoordMolNo={props.molecule.molNo} ref={chainSelectRef}/>}
                     {ruleType === 'cid' && <MoorhenCidInputForm margin={'0px'} width="100%" onChange={handleResidueCidChange} ref={cidFormRef}/> }
                     {ruleType === 'property' && 
                     <Form.Group style={{ margin: '0px', width: '100%' }}>
@@ -322,7 +322,7 @@ export const MoorhenModifyColourRulesCard = (props: {
                         <HexColorPicker color={selectedColour} onChange={handleColorChange}/>
                     </div>
                     <div style={{padding: '0.5rem', margin: 0, justifyContent: 'center', display: 'flex', backgroundColor: '#e3e1e1', borderRadius: '8px'}}>
-                        <CirclePicker width={convertRemToPx(15)} circleSize={convertRemToPx(15)/20} color={selectedColour} onChange={handleColourCircleClick} presetColors={["#f44336", "#e91e63", "#9c27b0", "#673ab7", "#3f51b5", "#2196f3", "#03a9f4", "#00bcd4", "#009688", "#4caf50", "#8bc34a", "#cddc39", "#ffeb3b", "#ffc107", "#ff9800", "#ff5722"]}/>
+                        <CirclePicker width={convertRemToPx(15)} circleSize={convertRemToPx(15)/20} color={selectedColour} onChange={handleColourCircleClick}/>
                     </div>
                     
                 </Stack>

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -49,6 +49,13 @@ export namespace libcootApi {
         res_name: string;
         label: string;
     }
+    interface AutoReadMtzInfo extends emscriptem.instance<AutoReadMtzInfo> {
+        idx: number;
+        F: string;
+        phi: string;
+        w: string;
+        weights_used: boolean;
+    }
     interface CootPhiPsi extends emscriptem.instance<CootPhiPsi> {
         ins_code: string;
         residue_number: number;
@@ -109,6 +116,13 @@ export namespace libcootApi {
         ligand_atom_is_donor: boolean;
         hydrogen_is_ligand_atom: boolean;
         bond_has_hydrogen_flag: boolean;
+    }
+    type AutoReadMtzInfoJS = {
+        idx: number;
+        F: string;
+        phi: string;
+        w: string;
+        weights_used: boolean;
     }
     type HBondJS = {
         hb_hydrogen: libcootApi.HBondAtom;

--- a/baby-gru/src/utils/MoorhenMap.ts
+++ b/baby-gru/src/utils/MoorhenMap.ts
@@ -568,7 +568,10 @@ export class MoorhenMap implements moorhen.Map {
 
         if (response.data.result.status === "Completed") {
             this.hasReflectionData = true
-            this.selectedColumns = selectedColumns
+            this.selectedColumns = {
+                ...this.selectedColumns,
+                ...selectedColumns
+            }
             this.associatedReflectionFileName = response.data.result.result
         } else {
             console.warn('Unable to associate reflection data with map')

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1,7 +1,7 @@
 import 'pako';
 import {
     guid, readTextFile, readGemmiStructure, residueCodesThreeToOne, centreOnGemmiAtoms,
-    nucleotideCodesThreeToOne, findConsecutiveRanges
+    nucleotideCodesThreeToOne, findConsecutiveRanges, getRandomMoleculeColour
 } from './MoorhenUtils'
 import { MoorhenMoleculeRepresentation } from "./MoorhenMoleculeRepresentation"
 import { quatToMat4 } from '../WebGLgComponents/quatToMat4.js';
@@ -1184,12 +1184,37 @@ export class MoorhenMolecule implements moorhen.Molecule {
     }
 
     /**
+     * Get a list with the names of the chains in the current model
+     * @returns {string[]} - A list of chain names in the current structure
+     */
+    getChainNames(): string[] {
+        let result: string[] = []
+        const models = this.gemmiStructure.models
+        const modelsSize = models.size()
+        for (let modelIndex = 0; modelIndex < modelsSize; modelIndex++) {
+            const model = models.get(modelIndex)
+            const chains = model.chains
+            const chainsSize = chains.size()
+            for (let chainIndex = 0; chainIndex < chainsSize; chainIndex++) {
+                const chain = chains.get(chainIndex)
+                result.push(chain.name)
+                chain.delete()
+            }
+            model.delete()
+            chains.delete()
+        }
+        models.delete()
+        return result
+    }
+
+    /**
      * Merge a set of molecules in this molecule instance
      * @param {moorhen.Molecule} otherMolecules - A list of other molecules to merge into this instance
      * @param {boolean} [doHide=false] - Indicates whether the source molecules should be hidden when finish
      */
     async mergeMolecules(otherMolecules: moorhen.Molecule[], doHide: boolean = false): Promise<void> {
         try {
+            const prevChainNames = this.getChainNames()
             await this.commandCentre.current.cootCommand({
                 command: 'merge_molecules',
                 commandArgs: [this.molNo, `${otherMolecules.map(molecule => molecule.molNo).join(':')}`],
@@ -1210,7 +1235,20 @@ export class MoorhenMolecule implements moorhen.Molecule {
             })
             await Promise.all(promises)
 
-            this.setAtomsDirty(true)
+            await this.updateAtoms()
+            const currentChains = this.getChainNames()
+            const newChains = currentChains.filter(chainName => !prevChainNames.includes(chainName))
+            newChains.forEach(chainName => {
+                const selectedColour = getRandomMoleculeColour()
+                this.defaultColourRules.push({
+                    args: [`//${chainName}`, selectedColour],
+                    isMultiColourRule: false,
+                    ruleType: 'chain',
+                    color: selectedColour,
+                    label: `//${chainName}`,
+                })
+            })
+
             await this.redraw()
 
         } catch (err) {
@@ -1498,6 +1536,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         }, false) as moorhen.WorkerResponse<libcootApi.PairType<string, string>[]>
         
         response.data.result.result.forEach(rule => {
+            console.log(rule.second)
             rules.push({
                 args: [rule.first, rule.second],
                 isMultiColourRule: false,

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -8,6 +8,16 @@ import { moorhen } from "../types/moorhen";
 import { gemmi } from "../types/gemmi";
 import { webGL } from "../types/mgWebGL";
 
+export const getRandomMoleculeColour = () => {
+    const randomComponent_A = Math.floor(Math.random() * (160 - 127 + 1)) + 127
+    const randomComponent_B = 160
+    const randomComponent_C = 127
+    let result = [randomComponent_A, randomComponent_B, randomComponent_C]
+    result = result.sort((a, b) => 0.5 - Math.random());
+    console.log(result)
+    return rgbToHex(...result as [number, number, number])
+}
+
 export function guid(): string {
     let d = Date.now();
     let uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -515,6 +515,14 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .property("z", &coot::molecule_t::moved_atom_t::z)
     .property("index", &coot::molecule_t::moved_atom_t::index)
     ;
+    class_<molecules_container_t::auto_read_mtz_info_t>("auto_read_mtz_info_t")
+    .constructor<const int &, const std::string &, const std::string &>()
+    .property("idx", &molecules_container_t::auto_read_mtz_info_t::idx)
+    .property("F", &molecules_container_t::auto_read_mtz_info_t::F)
+    .property("phi", &molecules_container_t::auto_read_mtz_info_t::phi)
+    .property("w", &molecules_container_t::auto_read_mtz_info_t::w)
+    .property("weights_used", &molecules_container_t::auto_read_mtz_info_t::weights_used)
+    ;
     class_<coot::molecule_t::interesting_place_t>("interesting_place_t")
     .constructor<const std::string &, const coot::residue_spec_t &, const clipper::Coord_orth &, const std::string &>()
     .constructor<const std::string &, const clipper::Coord_orth &, const std::string &>()
@@ -709,6 +717,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("get_map_contours_mesh_using_other_map_for_colours",&molecules_container_t::get_map_contours_mesh_using_other_map_for_colours)
     .function("set_refinement_geman_mcclure_alpha",&molecules_container_t::set_refinement_geman_mcclure_alpha)
     .function("get_geman_mcclure_alpha",&molecules_container_t::get_geman_mcclure_alpha)
+    .function("get_map_histogram",&molecules_container_t::get_map_histogram)
      ;
     class_<molecules_container_js, base<molecules_container_t>>("molecules_container_js")
     .constructor<bool>()
@@ -894,7 +903,13 @@ EMSCRIPTEN_BINDINGS(my_module) {
         .element(emscripten::index<1>())
         .element(emscripten::index<2>())
     ;
-    
+
+    value_object<coot::molecule_t::histogram_info_t>("histogram_info_t")
+        .field("base", &coot::molecule_t::histogram_info_t::base)
+        .field("bin_width", &coot::molecule_t::histogram_info_t::bin_width)
+        .field("counts", &coot::molecule_t::histogram_info_t::counts)
+    ;
+
     value_object<moorhen::h_bond>("h_bond")
         .field("hb_hydrogen",&moorhen::h_bond::hb_hydrogen)
         .field("donor",&moorhen::h_bond::donor)
@@ -927,6 +942,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
         .field("altLoc",&moorhen::h_bond_atom::altLoc)
     ;
 
+    register_vector<molecules_container_t::auto_read_mtz_info_t>("VectorAutoReadMtzInfo_t");
     register_vector<coot::CartesianPair>("VectorCootCartesianPair");
     register_vector<std::vector<coot::CartesianPair>>("VectorVectorCootCartesianPair");
     register_vector<coot::Cartesian>("VectorCootCartesian");


### PR DESCRIPTION
This contains two updates:
- Resolves #124 . Now it is possible to set updating maps for maps that were opened using "Auto open mtz".
- When merging molecules, new molecule rules are added for the new chains so that they are not colored in white