### PR TITLE
Auto set estimated map weight of active map

### DIFF
--- a/baby-gru/src/components/MoorhenContainer.tsx
+++ b/baby-gru/src/components/MoorhenContainer.tsx
@@ -368,11 +368,7 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
 
     useEffect(() => {
         if (activeMap && commandCentre.current) {
-            commandCentre.current.cootCommand({
-                returnType: "status",
-                command: "set_imol_refinement_map",
-                commandArgs: [activeMap.molNo]
-            }, false)
+            activeMap.setActive()
         }
     }, [activeMap])
 

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -147,7 +147,8 @@ declare module 'moorhen' {
         fetchReflectionData(): Promise<_moorhen.WorkerResponse<Uint8Array>>;
         getMap(): Promise<_moorhen.WorkerResponse>;
         loadToCootFromMtzURL(url: RequestInfo | URL, name: string, selectedColumns: _moorhen.selectedMtzColumns): Promise<_moorhen.Map>;
-        loadToCootFromMapURL(url: RequestInfo | URL, name: string, isDiffMap?: boolean): Promise<_moorhen.Map>
+        loadToCootFromMapURL(url: RequestInfo | URL, name: string, isDiffMap?: boolean): Promise<_moorhen.Map>;
+        setActive(): Promise<void>;
         isEM: boolean;
         suggestedContourLevel: number;
         suggestedRadius: number;
@@ -172,6 +173,7 @@ declare module 'moorhen' {
         associatedReflectionFileName: string;
         uniqueId: string;
         mapRmsd: number;
+        suggestedMapWeight: number;
         rgba: {
             mapColour: {r: number, g: number, b: number};
             positiveDiffColour: {r: number, g: number, b: number};

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -330,7 +330,8 @@ export namespace moorhen {
         fetchReflectionData(): Promise<WorkerResponse<Uint8Array>>;
         getMap(): Promise<WorkerResponse>;
         loadToCootFromMtzURL(url: RequestInfo | URL, name: string, selectedColumns: selectedMtzColumns): Promise<Map>;
-        loadToCootFromMapURL(url: RequestInfo | URL, name: string, isDiffMap?: boolean): Promise<Map>
+        loadToCootFromMapURL(url: RequestInfo | URL, name: string, isDiffMap?: boolean): Promise<Map>;
+        setActive(): Promise<void>;
         setupContourBuffers(objects: any[], keepCootColours?: boolean): void;
         isEM: boolean;
         suggestedContourLevel: number;
@@ -356,6 +357,7 @@ export namespace moorhen {
         uniqueId: string;
         otherMapMolNoForColouring: number;
         mapRmsd: number;
+        suggestedMapWeight: number;
         rgba: {
             mapColour: {r: number, g: number, b: number};
             positiveDiffColour: {r: number, g: number, b: number};


### PR DESCRIPTION
After this update maps will have an associated "suggested weight" that gets set automatically when the map becomes the active map for refinement.