### PR TITLE
Replace shim functions in coot worker with c++ functions in moorhen wrapper

### DIFF
--- a/baby-gru/public/baby-gru/CootWorker.ts
+++ b/baby-gru/public/baby-gru/CootWorker.ts
@@ -711,15 +711,6 @@ const auto_open_mtz = (mtzData: ArrayBufferLike) => {
     return result
 }
 
-const read_dictionary = (coordData: string, associatedMolNo: number) => {
-    const theGuid = guid()
-    cootModule.FS_createDataFile(".", `${theGuid}.cif`, coordData, true, true);
-    const tempFilename = `./${theGuid}.cif`
-    const returnVal = molecules_container.import_cif_dictionary(tempFilename, associatedMolNo)
-    cootModule.FS_unlink(tempFilename)
-    return returnVal
-}
-
 const replace_map_by_mtz_from_file = (imol: number, mtzData: ArrayBufferLike, selectedColumns: { F: string; PHI: string; }) => {
     const theGuid = guid()
     const tempFilename = `./${theGuid}.mtz`
@@ -804,34 +795,6 @@ const setUserDefinedBondColours = (imol: number, colours: { cid: string; rgb: [n
     colourMap.delete()
 }
 
-const doColourTest = (imol: number) => {
-    console.log('DEBUG: Start test...')
-
-    let colourMap = new cootModule.MapIntFloat3()
-    colourMap[20] = [1., 0., 0.]
-    colourMap[21] = [0., 1., 0.]
-    colourMap[22] = [0., 0., 1.]
-
-    let indexedResiduesVec = new cootModule.VectorStringUInt_pair()
-
-    const a = { first: '//A/1-10/', second: 20 }
-    indexedResiduesVec.push_back(a)
-
-    const b = { first: '//A/11-20/', second: 21 }
-    indexedResiduesVec.push_back(b)
-
-    const c = { first: '//A/21-30/', second: 22 }
-    indexedResiduesVec.push_back(c)
-
-    console.log('DEBUG: Running molecules_container.set_user_defined_bond_colours')
-    molecules_container.set_user_defined_bond_colours(imol, colourMap)
-    console.log('DEBUG: Running molecules_container.set_user_defined_atom_colour_by_selection')
-    molecules_container.set_user_defined_atom_colour_by_selection(imol, indexedResiduesVec, false)
-
-    indexedResiduesVec.delete()
-    colourMap.delete()
-}
-
 const doCootCommand = (messageData: { 
     myTimeStamp: number;
     chainID?: string;
@@ -859,9 +822,6 @@ const doCootCommand = (messageData: {
                 break
             case 'shim_read_ccp4_map':
                 cootResult = read_ccp4_map(...commandArgs as [ArrayBuffer, string, boolean])
-                break
-            case 'shim_read_dictionary':
-                cootResult = read_dictionary(...commandArgs as [string, number])
                 break
             case 'shim_associate_data_mtz_file_with_map':
                 cootResult = associate_data_mtz_file_with_map(...commandArgs as [number, { data: ArrayBufferLike; fileName: string; }, string, string, string])

--- a/baby-gru/public/baby-gru/CootWorker.ts
+++ b/baby-gru/public/baby-gru/CootWorker.ts
@@ -701,21 +701,6 @@ const simpleMeshToLineMeshData = (simpleMesh: libcootApi.SimpleMeshT, normalLigh
 
 }
 
-const read_pdb = (coordData: string, name: string) => {
-    const theGuid = guid()
-    let theSuffix;
-    if(coordData.startsWith("data_")){
-        theSuffix = "mmcif"
-    } else {
-        theSuffix = "pdb"
-    }
-    cootModule.FS_createDataFile(".", `${theGuid}.${theSuffix}`, coordData, true, true);
-    const tempFilename = `./${theGuid}.${theSuffix}`
-    const molNo = molecules_container.read_pdb(tempFilename)
-    cootModule.FS_unlink(tempFilename)
-    return molNo
-}
-
 const auto_open_mtz = (mtzData: ArrayBufferLike) => {
     const theGuid = guid()
     const asUint8Array = new Uint8Array(mtzData)
@@ -872,9 +857,6 @@ const doCootCommand = (messageData: {
 
         let cootResult
         switch (command) {
-            case 'shim_read_pdb':
-                cootResult = read_pdb(...commandArgs as [string, string])
-                break
             case 'shim_new_positions_for_residue_atoms':
                 cootResult = new_positions_for_residue_atoms(...commandArgs as [number, libcootApi.AtomInfo[][]])
                 break

--- a/baby-gru/public/baby-gru/CootWorker.ts
+++ b/baby-gru/public/baby-gru/CootWorker.ts
@@ -720,15 +720,6 @@ const read_dictionary = (coordData: string, associatedMolNo: number) => {
     return returnVal
 }
 
-const replace_molecule_by_model_from_file = (imol: number, coordData: string) => {
-    const theGuid = guid()
-    const tempFilename = `./${theGuid}.pdb`
-    cootModule.FS_createDataFile(".", tempFilename, coordData, true, true)
-    const result = molecules_container.replace_molecule_by_model_from_file(imol, tempFilename)
-    cootModule.FS_unlink(tempFilename)
-    return result
-}
-
 const replace_map_by_mtz_from_file = (imol: number, mtzData: ArrayBufferLike, selectedColumns: { F: string; PHI: string; }) => {
     const theGuid = guid()
     const tempFilename = `./${theGuid}.mtz`
@@ -875,14 +866,8 @@ const doCootCommand = (messageData: {
             case 'shim_associate_data_mtz_file_with_map':
                 cootResult = associate_data_mtz_file_with_map(...commandArgs as [number, { data: ArrayBufferLike; fileName: string; }, string, string, string])
                 break
-            case 'shim_replace_molecule_by_model_from_file':
-                cootResult = replace_molecule_by_model_from_file(...commandArgs as [number, string])
-                break
             case 'shim_replace_map_by_mtz_from_file':
                 cootResult = replace_map_by_mtz_from_file(...commandArgs as [number, ArrayBufferLike, { F: string; PHI: string; }])
-                break
-            case 'shim_do_colour_test':
-                cootResult = doColourTest(...commandArgs as [number])
                 break
             case 'shim_set_bond_colours':
                 cootResult = setUserDefinedBondColours(...commandArgs as [number, { cid: string; rgb: [number, number, number] }[], boolean])

--- a/baby-gru/public/baby-gru/CootWorker.ts
+++ b/baby-gru/public/baby-gru/CootWorker.ts
@@ -887,9 +887,6 @@ const doCootCommand = (messageData: {
             case 'shim_set_bond_colours':
                 cootResult = setUserDefinedBondColours(...commandArgs as [number, { cid: string; rgb: [number, number, number] }[], boolean])
                 break
-            case 'shim_smiles_to_pdb':
-                cootResult = cootModule.SmilesToPDB(...commandArgs as [string, string, number, number])
-                break
             default:
                 cootResult = molecules_container[command](...commandArgs)
                 break

--- a/baby-gru/public/baby-gru/CootWorker.ts
+++ b/baby-gru/public/baby-gru/CootWorker.ts
@@ -856,22 +856,6 @@ const doColourTest = (imol: number) => {
     colourMap.delete()
 }
 
-const get_atoms = (molNo: number, format: string) => {
-    const theGuid = guid()
-    const tempFilename = `./${theGuid}.pdb`
-    if (format === 'pdb') {
-        molecules_container.writePDBASCII(molNo, tempFilename)
-    } else if (format === 'mmcif') {
-        molecules_container.writeCIFASCII(molNo, tempFilename)
-    } else {
-        console.log(`Unrecognised format... ${format}`)
-    }
-
-    const pdbData = cootModule.FS.readFile(tempFilename, { encoding: 'utf8' });
-    cootModule.FS_unlink(tempFilename)
-    return pdbData
-}
-
 const doCootCommand = (messageData: { 
     myTimeStamp: number;
     chainID?: string;
@@ -888,9 +872,6 @@ const doCootCommand = (messageData: {
 
         let cootResult
         switch (command) {
-            case 'shim_get_atoms': 
-                cootResult = get_atoms(...commandArgs as [number, string])
-                break
             case 'shim_read_pdb':
                 cootResult = read_pdb(...commandArgs as [string, string])
                 break

--- a/baby-gru/src/components/menu-item/MoorhenImportLigandDictionary.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenImportLigandDictionary.tsx
@@ -216,7 +216,7 @@ export const MoorhenSMILESToLigandMenuItem = (props: {
         }
 
         const response = await props.commandCentre.current.cootCommand({
-            command: 'shim_smiles_to_pdb',
+            command: 'smiles_to_pdb',
             commandArgs: [smileRef.current, tlcValueRef.current, n_conformer, n_iteration],
             returnType: 'str_str_pair'
         }, true) as moorhen.WorkerResponse<libcootApi.PairType<string, string>>

--- a/baby-gru/src/components/menu-item/MoorhenImportLigandDictionary.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenImportLigandDictionary.tsx
@@ -58,7 +58,7 @@ const MoorhenImportLigandDictionary = (props: {
             await Promise.all([
                 commandCentre.current.cootCommand({
                     returnType: "status",
-                    command: 'shim_read_dictionary',
+                    command: 'read_dictionary_string',
                     commandArgs: [fileContent, selectedMoleculeIndex],
                     changesMolecules: []
                 }, false),

--- a/baby-gru/src/utils/MoorhenHistory.ts
+++ b/baby-gru/src/utils/MoorhenHistory.ts
@@ -34,7 +34,7 @@ const formatCommandArgsString = (command: string, commandArgs: (number | string)
         case 'redo':
         case 'undo':
         case 'shim_replace_map_by_mtz_from_file':
-        case 'shim_replace_molecule_by_model_from_file':
+        case 'replace_molecule_by_model_from_string':
         case 'close_molecule':
             formattedString = `${commandArgs[0]}`
             break

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -156,8 +156,9 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * Replace the current molecule with the model in a file
      * @param {string} fileUrl - The uri to the file with the new model
      * @param {string} molName - The molecule name
+     * @param {string} format - The format of the file
      */
-    async replaceModelWithFile(fileUrl: string, molName: string): Promise<void> {
+    async replaceModelWithFile(fileUrl: string, molName: string, format: string = "pdb"): Promise<void> {
         let coordData: string
         let fetchResponse: Response
 
@@ -175,8 +176,8 @@ export class MoorhenMolecule implements moorhen.Molecule {
 
         const cootResponse = await this.commandCentre.current.cootCommand({
             returnType: "status",
-            command: 'shim_replace_molecule_by_model_from_file',
-            commandArgs: [this.molNo, coordData],
+            command: 'replace_molecule_by_model_from_string',
+            commandArgs: [this.molNo, format, coordData],
             changesMolecules: [this.molNo]
         }, true)
 

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -477,7 +477,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
 
         let response = await this.commandCentre.current.cootCommand({
             returnType: "status",
-            command: 'shim_read_pdb',
+            command: 'read_pdb_string',
             commandArgs: [pdbString, newMolecule.name]
         }, true) as moorhen.WorkerResponse<number>
 
@@ -578,7 +578,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         try {
             const response = await this.commandCentre.current.cootCommand({
                 returnType: "status",
-                command: 'shim_read_pdb',
+                command: 'read_pdb_string',
                 commandArgs: [coordData, this.name],
             }, true)
             this.molNo = response.data.result.result

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -675,7 +675,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
     async getAtoms(format: string = 'pdb'): Promise<string> {
         const response = await this.commandCentre.current.cootCommand({
             returnType: "string",
-            command: 'shim_get_atoms',
+            command: 'get_molecule_atoms',
             commandArgs: [this.molNo, format],
         }, false) as moorhen.WorkerResponse<string>
         return response.data.result.result

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -624,7 +624,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
 
         await this.commandCentre.current.cootCommand({
             returnType: "status",
-            command: 'shim_read_dictionary',
+            command: 'read_dictionary_string',
             commandArgs: [dictContent, attachToMolecule],
         }, false)
         
@@ -1338,7 +1338,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
     async addDict(fileContent: string): Promise<void> {
         await this.commandCentre.current.cootCommand({
             returnType: "status",
-            command: 'shim_read_dictionary',
+            command: 'read_dictionary_string',
             commandArgs: [fileContent, this.molNo]
         }, false)
 

--- a/baby-gru/tests/__tests__/integration.test.js
+++ b/baby-gru/tests/__tests__/integration.test.js
@@ -629,6 +629,20 @@ describe('Testing molecules_container_js', () => {
         expect(result.counts.size()).toBe(51)
     })
 
+    test("Test get_molecule_atoms pdb", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
+        const pdbString  = molecules_container.get_molecule_atoms(coordMolNo, "pdb")
+        expect(pdbString).toHaveLength(258719)
+    })
+
+    test("Test get_molecule_atoms mmcif", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
+        const pdbString  = molecules_container.get_molecule_atoms(coordMolNo, "mmcif")
+        expect(pdbString).toHaveLength(297550)
+    })
+
 })
 
 const testDataFiles = ['5fjj.pdb', '5a3h.pdb', '5a3h_no_ligand.pdb', 'LZA.cif', 'nitrobenzene.cif', 'benzene.cif', '5a3h_sigmaa.mtz', 'rnasa-1.8-all_refmac1.mtz', 'tm-A.pdb']

--- a/baby-gru/tests/__tests__/integration.test.js
+++ b/baby-gru/tests/__tests__/integration.test.js
@@ -667,6 +667,16 @@ describe('Testing molecules_container_js', () => {
         // expect(pdbString_2).toBe(pdbString_1)
     })
 
+    test("Test replace_molecule_by_model_from_string", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
+        const pdbString_1  = molecules_container.get_molecule_atoms(coordMolNo_1, "pdb")
+        expect(pdbString_1).toHaveLength(258719)
+        const coordMolNo_2 = molecules_container.read_pdb('./5fjj.pdb')
+        molecules_container.replace_molecule_by_model_from_string(coordMolNo_2, "pdb", pdbString_1)
+        const pdbString_2  = molecules_container.get_molecule_atoms(coordMolNo_2, "pdb")
+        expect(pdbString_2).toBe(pdbString_1)
+    })
 })
 
 const testDataFiles = ['5fjj.pdb', '5a3h.pdb', '5a3h_no_ligand.pdb', 'LZA.cif', 'nitrobenzene.cif', 'benzene.cif', '5a3h_sigmaa.mtz', 'rnasa-1.8-all_refmac1.mtz', 'tm-A.pdb']

--- a/baby-gru/tests/__tests__/integration.test.js
+++ b/baby-gru/tests/__tests__/integration.test.js
@@ -612,8 +612,9 @@ describe('Testing molecules_container_js', () => {
         expect(simpleMesh.triangles.size()).toBeGreaterThan(100)
     })
 
-    test("Test SmilesToPDB", () => {
-        const result_1 = cootModule.SmilesToPDB('c1ccccc1', 'LIG', 10, 100)
+    test("Test smiles_to_pdb", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const result_1 = molecules_container.smiles_to_pdb('c1ccccc1', 'LIG', 10, 100)
         const fileContents_1 = fs.readFileSync(path.join(__dirname, '..', 'test_data', 'benzene.cif'), { encoding: 'utf8', flag: 'r' })
         expect(result_1.second).toBe(fileContents_1)
     })

--- a/baby-gru/tests/__tests__/integration.test.js
+++ b/baby-gru/tests/__tests__/integration.test.js
@@ -643,6 +643,29 @@ describe('Testing molecules_container_js', () => {
         expect(pdbString).toHaveLength(297550)
     })
 
+    test("Test read_pdb_string pdb-format", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
+        const pdbString_1  = molecules_container.get_molecule_atoms(coordMolNo_1, "pdb")
+        expect(pdbString_1).toHaveLength(258719)
+        const coordMolNo_2 = molecules_container.read_pdb_string(pdbString_1, "mol-name")
+        expect(coordMolNo_2).toBe(1)
+        const pdbString_2  = molecules_container.get_molecule_atoms(coordMolNo_2, "pdb")
+        expect(pdbString_2).toBe(pdbString_1)
+    })
+
+    test("Test read_pdb_string mmcif-format", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
+        const pdbString_1  = molecules_container.get_molecule_atoms(coordMolNo_1, "mmcif")
+        expect(pdbString_1).toHaveLength(297550)
+        const coordMolNo_2 = molecules_container.read_pdb_string(pdbString_1, "mol-name")
+        expect(coordMolNo_2).toBe(1)
+        // For some reason this fails, probably a coot thing
+        // const pdbString_2  = molecules_container.get_molecule_atoms(coordMolNo_2, "mmcif")
+        // expect(pdbString_2).toBe(pdbString_1)
+    })
+
 })
 
 const testDataFiles = ['5fjj.pdb', '5a3h.pdb', '5a3h_no_ligand.pdb', 'LZA.cif', 'nitrobenzene.cif', 'benzene.cif', '5a3h_sigmaa.mtz', 'rnasa-1.8-all_refmac1.mtz', 'tm-A.pdb']

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -86,7 +86,7 @@ describe("Testing MoorhenMolecule", () => {
         const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
         await molecule.loadToCootFromURL(fileUrl, 'mol-test')
         const coordData = await molecule.getAtoms('pdb')
-        expect(coordData).toHaveLength(258718)
+        expect(coordData).toHaveLength(258719)
     }) 
 
     test("Test get_number_of_atoms", async () => {

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -249,7 +249,7 @@ class molecules_container_js : public molecules_container_t {
             return "";
         }
 
-        int read_pdb_string(const std::string pdb_string, const std::string molecule_name) {
+        int read_pdb_string(const std::string &pdb_string, const std::string &molecule_name) {
             std::string file_name = generate_rand_str(32);
             if (pdb_string.find("data_") == 0) {
                 file_name += ".mmcif";
@@ -258,6 +258,15 @@ class molecules_container_js : public molecules_container_t {
             }
             write_text_file(file_name, pdb_string);
             const int imol = molecules_container_t::read_pdb(file_name);
+            remove_file(file_name);
+            return imol;
+        }
+
+        int read_dictionary_string (const std::string &dictionary_string, const int &associated_imol) {
+            std::string file_name = generate_rand_str(32);
+            file_name += ".cif";
+            write_text_file(file_name, dictionary_string);
+            const int imol = molecules_container_t::import_cif_dictionary(file_name, associated_imol);
             remove_file(file_name);
             return imol;
         }
@@ -849,6 +858,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("read_pdb_string", &molecules_container_js::read_pdb_string)
     .function("smiles_to_pdb", &molecules_container_js::smiles_to_pdb)
     .function("replace_molecule_by_model_from_string", &molecules_container_js::replace_molecule_by_model_from_string)
+    .function("read_dictionary_string", &molecules_container_js::read_dictionary_string)
     ;
     class_<generic_3d_lines_bonds_box_t>("generic_3d_lines_bonds_box_t")
     .property("line_segments", &generic_3d_lines_bonds_box_t::line_segments)

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -150,6 +150,10 @@ class molecules_container_js : public molecules_container_t {
             return DrawSugarBlocks(mol,cid_str);
         }
 
+        std::pair<std::string, std::string> smiles_to_pdb(const std::string &smile_cpp, const std::string &TLC, int nconf, int maxIters) {
+            return SmilesToPDB(smile_cpp, TLC, nconf, maxIters);
+        }
+
         bool model_has_glycans(int imol) {
             mmdb::Manager *mol = get_mol(imol);
             int nmodels = mol->GetNumberOfModels();
@@ -828,6 +832,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("model_has_glycans",&molecules_container_js::model_has_glycans)
     .function("get_molecule_atoms", &molecules_container_js::get_molecule_atoms)
     .function("read_pdb_string", &molecules_container_js::read_pdb_string)
+    .function("smiles_to_pdb", &molecules_container_js::smiles_to_pdb)
     ;
     class_<generic_3d_lines_bonds_box_t>("generic_3d_lines_bonds_box_t")
     .property("line_segments", &generic_3d_lines_bonds_box_t::line_segments)
@@ -1208,7 +1213,6 @@ EMSCRIPTEN_BINDINGS(my_module) {
     ;
 
     function("getRotamersMap",&getRotamersMap);
-    function("SmilesToPDB",&SmilesToPDB);
 
     //For testing
     //function("TakeColourMap",&TakeColourMap);

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -262,6 +262,21 @@ class molecules_container_js : public molecules_container_t {
             return imol;
         }
 
+        void replace_molecule_by_model_from_string (int imol, const std::string &format, const std::string &pdb_string) {
+            std::string file_name = generate_rand_str(32);
+            if (format == "mmcif") {
+                file_name += ".mmcif";
+            } else if (format == "pdb") {
+                file_name += ".pdb";
+            } else {
+                std::cout << "Unrecognised format " << format << std::endl;
+                return;
+            }
+            write_text_file(file_name, pdb_string);
+            molecules_container_t::replace_molecule_by_model_from_file(imol, file_name); 
+            remove_file(file_name);
+        }
+
         generic_3d_lines_bonds_box_t make_exportable_environment_bond_box(int imol, const std::string &chainID, int resNo,  const std::string &altLoc){
             coot::residue_spec_t resSpec(chainID,resNo,altLoc);
             return molecules_container_t::make_exportable_environment_bond_box(imol,resSpec);
@@ -833,6 +848,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("get_molecule_atoms", &molecules_container_js::get_molecule_atoms)
     .function("read_pdb_string", &molecules_container_js::read_pdb_string)
     .function("smiles_to_pdb", &molecules_container_js::smiles_to_pdb)
+    .function("replace_molecule_by_model_from_string", &molecules_container_js::replace_molecule_by_model_from_string)
     ;
     class_<generic_3d_lines_bonds_box_t>("generic_3d_lines_bonds_box_t")
     .property("line_segments", &generic_3d_lines_bonds_box_t::line_segments)


### PR DESCRIPTION
This refactors some of the shim functions out of the coot worker into moorhen wrappers.