### PR TITLE
Changes to map histogram

### DIFF
--- a/baby-gru/src/components/misc/MoorhenMapHistogram.tsx
+++ b/baby-gru/src/components/misc/MoorhenMapHistogram.tsx
@@ -34,6 +34,9 @@ export const MoorhenMapHistogram = forwardRef<Chart, MapHistogramProps>((props, 
             }
         }
 
+        const highestCount = Math.max(...histogramData.counts)
+        const secondHighestCount = Math.max(...histogramData.counts.filter(count => count !== highestCount))
+
         return {
             type: 'bar',
             options: {
@@ -44,6 +47,7 @@ export const MoorhenMapHistogram = forwardRef<Chart, MapHistogramProps>((props, 
                 },
                 scales: {
                   y: {
+                    max: secondHighestCount,
                     beginAtZero: true,
                     grid: {
                         display: true,
@@ -51,9 +55,14 @@ export const MoorhenMapHistogram = forwardRef<Chart, MapHistogramProps>((props, 
                     },
                     title: {
                         display: true,
-                        font:{size: axisLabelsFontSize, family:'Helvetica', weight:800},
+                        font: {size: axisLabelsFontSize, family:'Helvetica', weight:800},
                         text: 'Counts',
                         color: 'black'
+                    },
+                    ticks: {
+                        callback: function(val, index) {
+                          return val === secondHighestCount ? highestCount : val;
+                        }
                     }
                   },
                   x: {

--- a/baby-gru/src/utils/MoorhenMap.ts
+++ b/baby-gru/src/utils/MoorhenMap.ts
@@ -757,10 +757,10 @@ export class MoorhenMap implements moorhen.Map {
      * Get the histogram data for this map instance
      * @returns {object} - An object with the histogram data
      */
-    async getHistogram(): Promise<libcootApi.HistogramInfoJS> {
+    async getHistogram(nBins: number = 200): Promise<libcootApi.HistogramInfoJS> {
         const response = await this.commandCentre.current.cootCommand({
             command: 'get_map_histogram',
-            commandArgs: [this.molNo],
+            commandArgs: [this.molNo, nBins],
             returnType: "histogram_info_t"
         }, false) as moorhen.WorkerResponse<any>
         return response.data.result.result


### PR DESCRIPTION
After this update map histograms are scaled to the second largest bin and 200 bins are asked by default.