### PR TITLE
Fix preferences export and version bump

### DIFF
--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moorhen",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": false,
   "main": "moorhen.js",
   "types": "./types/main.d.ts",

--- a/baby-gru/src/components/MoorhenContainer.tsx
+++ b/baby-gru/src/components/MoorhenContainer.tsx
@@ -23,6 +23,7 @@ import { setEnableAtomHovering, setHoveredAtom } from '../store/hoveringStatesSl
  * @property {string} [urlPrefix='.'] - The root url used to load sources from public folder
  * @property {string} [monomerLibraryPath='./baby-gru/monomers'] - A string with the path to the monomer library, relative to the root of the app
  * @property {function} setMoorhenDimensions - Callback executed on window resize. Return type is an array of two numbers [width, height]
+ * @property {function} onUserPreferencesChange - Callback executed whenever a user-defined preference changes (key: string, value: any) => void.
  * @property {boolean} [disableFileUploads=false] - Indicates if file uploads should b disabled
  * @property {JSX.Element[]} extraNavBarMenus - A list with additional menu items rendered under the navigation menu
  * @property {JSX.Element[]} extraFileMenuItems - A list with additional menu items rendered under the "File" menu
@@ -113,14 +114,15 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
     const {
         disableFileUploads, urlPrefix, extraNavBarMenus, viewOnly, extraDraggableModals, 
         monomerLibraryPath, extraFileMenuItems, allowScripting, backupStorageInstance,
-        extraEditMenuItems, aceDRGInstance, extraCalculateMenuItems, setMoorhenDimensions
+        extraEditMenuItems, aceDRGInstance, extraCalculateMenuItems, setMoorhenDimensions,
+        onUserPreferencesChange
     } = props
 
     const collectedProps: moorhen.CollectedProps = {
         glRef, commandCentre, timeCapsuleRef, disableFileUploads, extraDraggableModals, aceDRGInstance, 
         urlPrefix, viewOnly, mapsRef, allowScripting, extraCalculateMenuItems, extraEditMenuItems,
         extraNavBarMenus, monomerLibraryPath, moleculesRef, extraFileMenuItems, activeMapRef,
-        videoRecorderRef, lastHoveredAtomRef,
+        videoRecorderRef, lastHoveredAtomRef, onUserPreferencesChange
     }
     
     useEffect(() => {
@@ -373,7 +375,7 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
         
     </div>
 
-    <MoorhenPreferencesContainer/>
+    <MoorhenPreferencesContainer onUserPreferencesChange={onUserPreferencesChange}/>
 
     <Container fluid className={`baby-gru ${theme}`}>
         <Row>
@@ -409,6 +411,7 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
 }
 
 MoorhenContainer.defaultProps = {
+    onUserPreferencesChange: () => {},
     urlPrefix: '.',
     monomerLibraryPath: './baby-gru/monomers',
     setMoorhenDimensions: null,

--- a/baby-gru/src/components/misc/MoorhenPreferencesContainer.tsx
+++ b/baby-gru/src/components/misc/MoorhenPreferencesContainer.tsx
@@ -12,7 +12,10 @@ import { setDefaultExpandDisplayCards, setEnableRefineAfterMod, setTransparentMo
 import { setDevMode, setUserPreferencesMounted } from "../../store/generalStatesSlice";
 import { moorhen } from "../../types/moorhen"
 
-export const MoorhenPreferencesContainer = (props) => {
+export const MoorhenPreferencesContainer = (props: {
+    onUserPreferencesChange?: (key: string, value: any) => void;
+}) => {
+    
     const localForageInstanceRef = useRef<null | moorhen.Preferences>(null)
     const dispatch = useDispatch()
 
@@ -124,7 +127,7 @@ export const MoorhenPreferencesContainer = (props) => {
         43: { label: "ssaoBias", value: ssaoBias, valueSetter: setSsaoBias},
     }
 
-    const restoreDefaults = (preferences: moorhen.Preferences, defaultValues: moorhen.ContextValues)=> {
+    const restoreDefaults = (preferences: moorhen.Preferences, defaultValues: moorhen.PreferencesValues)=> {
         localForageInstanceRef.current.localStorageInstance.setItem('version', defaultValues.version)
         Object.keys(preferencesMap).forEach(key => {
             if (preferencesMap[key].label === 'shortCuts') {
@@ -147,11 +150,11 @@ export const MoorhenPreferencesContainer = (props) => {
     useEffect(() => {
         const fetchStoredContext = async () => {
             try {
-                const preferences = new MoorhenPreferences('babyGru-localStorage')
+                const preferences = new MoorhenPreferences()
                 localForageInstanceRef.current = preferences
 
                 const storedVersion = await preferences.localStorageInstance.getItem('version')
-                const defaultValues = MoorhenPreferences.defaultContextValues
+                const defaultValues = MoorhenPreferences.defaultPreferencesValues
                 if (storedVersion !== defaultValues.version) {
                     restoreDefaults(preferences, defaultValues)
                     dispatch(setUserPreferencesMounted(true))
@@ -186,7 +189,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('transparentModalsOnMouseOut', transparentModalsOnMouseOut);
+        localForageInstanceRef.current?.localStorageInstance.setItem('transparentModalsOnMouseOut', transparentModalsOnMouseOut)
+        .then(_ => props.onUserPreferencesChange('transparentModalsOnMouseOut', transparentModalsOnMouseOut));
     }, [transparentModalsOnMouseOut]);
 
 
@@ -196,7 +200,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('defaultMapSamplingRate', defaultMapSamplingRate);
+        localForageInstanceRef.current?.localStorageInstance.setItem('defaultMapSamplingRate', defaultMapSamplingRate)
+        .then(_ => props.onUserPreferencesChange('defaultMapSamplingRate', defaultMapSamplingRate));
     }, [defaultMapSamplingRate]);
 
     useMemo(() => {
@@ -205,7 +210,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('shortcutOnHoveredAtom', shortcutOnHoveredAtom);
+        localForageInstanceRef.current?.localStorageInstance.setItem('shortcutOnHoveredAtom', shortcutOnHoveredAtom)
+        .then(_ => props.onUserPreferencesChange('shortcutOnHoveredAtom', shortcutOnHoveredAtom));
     }, [shortcutOnHoveredAtom]);
 
     useMemo(() => {
@@ -214,7 +220,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('devMode', devMode);
+        localForageInstanceRef.current?.localStorageInstance.setItem('devMode', devMode)
+        .then(_ => props.onUserPreferencesChange('devMode', devMode));
     }, [devMode]);
     
     useMemo(() => {
@@ -223,7 +230,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('contourWheelSensitivityFactor', contourWheelSensitivityFactor);
+        localForageInstanceRef.current?.localStorageInstance.setItem('contourWheelSensitivityFactor', contourWheelSensitivityFactor)
+        .then(_ => props.onUserPreferencesChange('contourWheelSensitivityFactor', contourWheelSensitivityFactor));
     }, [contourWheelSensitivityFactor]);
     
     useMemo(() => {
@@ -232,7 +240,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('enableTimeCapsule', enableTimeCapsule);
+        localForageInstanceRef.current?.localStorageInstance.setItem('enableTimeCapsule', enableTimeCapsule)
+        .then(_ => props.onUserPreferencesChange('enableTimeCapsule', enableTimeCapsule));
     }, [enableTimeCapsule]);
     
     useMemo(() => {
@@ -241,7 +250,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('maxBackupCount', maxBackupCount);
+        localForageInstanceRef.current?.localStorageInstance.setItem('maxBackupCount', maxBackupCount)
+        .then(_ => props.onUserPreferencesChange('maxBackupCount', maxBackupCount));
     }, [maxBackupCount]);
     
     useMemo(() => {
@@ -250,7 +260,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('modificationCountBackupThreshold', modificationCountBackupThreshold);
+        localForageInstanceRef.current?.localStorageInstance.setItem('modificationCountBackupThreshold', modificationCountBackupThreshold)
+        .then(_ => props.onUserPreferencesChange('modificationCountBackupThreshold', modificationCountBackupThreshold));
     }, [modificationCountBackupThreshold]);
 
     useMemo(() => {
@@ -259,7 +270,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
 
-        localForageInstanceRef.current?.localStorageInstance.setItem('clipCap', clipCap);
+        localForageInstanceRef.current?.localStorageInstance.setItem('clipCap', clipCap)
+        .then(_ => props.onUserPreferencesChange('clipCap', clipCap));
     }, [clipCap]);
 
     useMemo(() => {
@@ -268,7 +280,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('resetClippingFogging', resetClippingFogging);
+        localForageInstanceRef.current?.localStorageInstance.setItem('resetClippingFogging', resetClippingFogging)
+        .then(_ => props.onUserPreferencesChange('resetClippingFogging', resetClippingFogging));
     }, [resetClippingFogging]);
 
     useMemo(() => {
@@ -277,7 +290,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('zoomWheelSensitivityFactor', zoomWheelSensitivityFactor);
+        localForageInstanceRef.current?.localStorageInstance.setItem('zoomWheelSensitivityFactor', zoomWheelSensitivityFactor)
+        .then(_ => props.onUserPreferencesChange('zoomWheelSensitivityFactor', zoomWheelSensitivityFactor));
     }, [zoomWheelSensitivityFactor]);
 
     useMemo(() => {
@@ -286,7 +300,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('showShortcutToast', showShortcutToast);
+        localForageInstanceRef.current?.localStorageInstance.setItem('showShortcutToast', showShortcutToast)
+        .then(_ => props.onUserPreferencesChange('showShortcutToast', showShortcutToast));
     }, [showShortcutToast]);
     
     useMemo(() => {
@@ -295,7 +310,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('showScoresToast', showScoresToast);
+        localForageInstanceRef.current?.localStorageInstance.setItem('showScoresToast', showScoresToast)
+        .then(_ => props.onUserPreferencesChange('showScoresToast', showScoresToast));
     }, [showScoresToast]);
     
     useMemo(() => {
@@ -304,7 +320,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('defaultUpdatingScores', defaultUpdatingScores);
+        localForageInstanceRef.current?.localStorageInstance.setItem('defaultUpdatingScores', defaultUpdatingScores)
+        .then(_ => props.onUserPreferencesChange('defaultUpdatingScores', defaultUpdatingScores));
     }, [defaultUpdatingScores]);
     
     useMemo(() => {
@@ -313,7 +330,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('defaultBondSmoothness', defaultBondSmoothness);
+        localForageInstanceRef.current?.localStorageInstance.setItem('defaultBondSmoothness', defaultBondSmoothness)
+        .then(_ => props.onUserPreferencesChange('defaultBondSmoothness', defaultBondSmoothness));
     }, [defaultBondSmoothness]);
 
     useMemo(() => {
@@ -322,7 +340,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('defaultMapSurface', defaultMapSurface);
+        localForageInstanceRef.current?.localStorageInstance.setItem('defaultMapSurface', defaultMapSurface)
+        .then(_ => props.onUserPreferencesChange('defaultMapSurface', defaultMapSurface));
     }, [defaultMapSurface]);
 
     useMemo(() => {
@@ -331,7 +350,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('makeBackups', makeBackups);
+        localForageInstanceRef.current?.localStorageInstance.setItem('makeBackups', makeBackups)
+        .then(_ => props.onUserPreferencesChange('makeBackups', makeBackups));
     }, [makeBackups]);
 
     useMemo(() => {
@@ -340,7 +360,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('enableRefineAfterMod', enableRefineAfterMod);
+        localForageInstanceRef.current?.localStorageInstance.setItem('enableRefineAfterMod', enableRefineAfterMod)
+        .then(_ => props.onUserPreferencesChange('enableRefineAfterMod', enableRefineAfterMod));
     }, [enableRefineAfterMod]);
 
     useMemo(() => {
@@ -349,7 +370,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('mapLineWidth', mapLineWidth);
+        localForageInstanceRef.current?.localStorageInstance.setItem('mapLineWidth', mapLineWidth)
+        .then(_ => props.onUserPreferencesChange('mapLineWidth', mapLineWidth));
     }, [mapLineWidth]);
 
     useMemo(() => {
@@ -358,7 +380,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
 
-        localForageInstanceRef.current?.localStorageInstance.setItem('drawAxes', drawAxes);
+        localForageInstanceRef.current?.localStorageInstance.setItem('drawAxes', drawAxes)
+        .then(_ => props.onUserPreferencesChange('drawAxes', drawAxes));
     }, [drawAxes]);
 
     useMemo(() => {
@@ -367,7 +390,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('drawCrosshairs', drawCrosshairs);
+        localForageInstanceRef.current?.localStorageInstance.setItem('drawCrosshairs', drawCrosshairs)
+        .then(_ => props.onUserPreferencesChange('drawCrosshairs', drawCrosshairs));
     }, [drawCrosshairs]);
 
     useMemo(() => {
@@ -376,7 +400,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('drawFPS', drawFPS);
+        localForageInstanceRef.current?.localStorageInstance.setItem('drawFPS', drawFPS)
+        .then(_ => props.onUserPreferencesChange('drawFPS', drawFPS));
     }, [drawFPS]);
 
     useMemo(() => {
@@ -385,7 +410,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('drawMissingLoops', drawMissingLoops);
+        localForageInstanceRef.current?.localStorageInstance.setItem('drawMissingLoops', drawMissingLoops)
+        .then(_ => props.onUserPreferencesChange('drawMissingLoops', drawMissingLoops));
     }, [drawMissingLoops]);
 
     useMemo(() => {
@@ -394,7 +420,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
 
-        localForageInstanceRef.current?.localStorageInstance.setItem('doPerspectiveProjection', doPerspectiveProjection);
+        localForageInstanceRef.current?.localStorageInstance.setItem('doPerspectiveProjection', doPerspectiveProjection)
+        .then(_ => props.onUserPreferencesChange('doPerspectiveProjection', doPerspectiveProjection));
     }, [doPerspectiveProjection]);
 
     useMemo(() => {
@@ -403,7 +430,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
 
-        localForageInstanceRef.current?.localStorageInstance.setItem('depthBlurDepth', depthBlurDepth);
+        localForageInstanceRef.current?.localStorageInstance.setItem('depthBlurDepth', depthBlurDepth)
+        .then(_ => props.onUserPreferencesChange('depthBlurDepth', depthBlurDepth));
     }, [depthBlurDepth]);
 
     useMemo(() => {
@@ -412,7 +440,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
 
-        localForageInstanceRef.current?.localStorageInstance.setItem('ssaoBias', ssaoBias);
+        localForageInstanceRef.current?.localStorageInstance.setItem('ssaoBias', ssaoBias)
+        .then(_ => props.onUserPreferencesChange('ssaoBias', ssaoBias));
     }, [ssaoBias]);
 
     useMemo(() => {
@@ -421,7 +450,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
 
-        localForageInstanceRef.current?.localStorageInstance.setItem('ssaoRadius', ssaoRadius);
+        localForageInstanceRef.current?.localStorageInstance.setItem('ssaoRadius', ssaoRadius)
+        .then(_ => props.onUserPreferencesChange('ssaoRadius', ssaoRadius));
     }, [ssaoRadius]);
 
     useMemo(() => {
@@ -430,7 +460,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
 
-        localForageInstanceRef.current?.localStorageInstance.setItem('depthBlurRadius', depthBlurRadius);
+        localForageInstanceRef.current?.localStorageInstance.setItem('depthBlurRadius', depthBlurRadius)
+        .then(_ => props.onUserPreferencesChange('depthBlurRadius', depthBlurRadius));
     }, [depthBlurRadius]);
 
     useMemo(() => {
@@ -439,7 +470,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
 
-        localForageInstanceRef.current?.localStorageInstance.setItem('useOffScreenBuffers', useOffScreenBuffers);
+        localForageInstanceRef.current?.localStorageInstance.setItem('useOffScreenBuffers', useOffScreenBuffers)
+        .then(_ => props.onUserPreferencesChange('useOffScreenBuffers', useOffScreenBuffers));
     }, [useOffScreenBuffers]);
 
     useMemo(() => {
@@ -448,7 +480,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
 
-        localForageInstanceRef.current?.localStorageInstance.setItem('doShadowDepthDebug', doShadowDepthDebug);
+        localForageInstanceRef.current?.localStorageInstance.setItem('doShadowDepthDebug', doShadowDepthDebug)
+        .then(_ => props.onUserPreferencesChange('doShadowDepthDebug', doShadowDepthDebug));
     }, [doShadowDepthDebug]);
 
     useMemo(() => {
@@ -457,7 +490,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
 
-        localForageInstanceRef.current?.localStorageInstance.setItem('doOutline', doOutline);
+        localForageInstanceRef.current?.localStorageInstance.setItem('doOutline', doOutline)
+        .then(_ => props.onUserPreferencesChange('doOutline', doOutline));
     }, [doOutline]);
 
     useMemo(() => {
@@ -466,7 +500,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
 
-        localForageInstanceRef.current?.localStorageInstance.setItem('doShadow', doShadow);
+        localForageInstanceRef.current?.localStorageInstance.setItem('doShadow', doShadow)
+        .then(_ => props.onUserPreferencesChange('doShadow', doShadow));
     }, [doShadow]);
 
     useMemo(() => {
@@ -475,7 +510,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
 
-        localForageInstanceRef.current?.localStorageInstance.setItem('doSSAO', doSSAO);
+        localForageInstanceRef.current?.localStorageInstance.setItem('doSSAO', doSSAO)
+        .then(_ => props.onUserPreferencesChange('doSSAO', doSSAO));
     }, [doSSAO]);
 
     useMemo(() => {
@@ -484,7 +520,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
 
-        localForageInstanceRef.current?.localStorageInstance.setItem('GLLabelsFontFamily', GLLabelsFontFamily);
+        localForageInstanceRef.current?.localStorageInstance.setItem('GLLabelsFontFamily', GLLabelsFontFamily)
+        .then(_ => props.onUserPreferencesChange('GLLabelsFontFamily', GLLabelsFontFamily));
     }, [GLLabelsFontFamily]);
 
     useMemo(() => {
@@ -493,7 +530,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
 
-        localForageInstanceRef.current?.localStorageInstance.setItem('GLLabelsFontSize', GLLabelsFontSize);
+        localForageInstanceRef.current?.localStorageInstance.setItem('GLLabelsFontSize', GLLabelsFontSize)
+        .then(_ => props.onUserPreferencesChange('GLLabelsFontSize', GLLabelsFontSize));
     }, [GLLabelsFontSize]);
 
     useMemo(() => {
@@ -502,7 +540,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
 
-        localForageInstanceRef.current?.localStorageInstance.setItem('doSpinTest', doSpinTest);
+        localForageInstanceRef.current?.localStorageInstance.setItem('doSpinTest', doSpinTest)
+        .then(_ => props.onUserPreferencesChange('doSpinTest', doSpinTest));
     }, [doSpinTest]);
 
     useMemo(() => {
@@ -511,7 +550,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('drawInteractions', drawInteractions);
+        localForageInstanceRef.current?.localStorageInstance.setItem('drawInteractions', drawInteractions)
+        .then(_ => props.onUserPreferencesChange('drawInteractions', drawInteractions));
     }, [drawInteractions]);
 
     useMemo(() => {
@@ -520,7 +560,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('mouseSensitivity', mouseSensitivity);
+        localForageInstanceRef.current?.localStorageInstance.setItem('mouseSensitivity', mouseSensitivity)
+        .then(_ => props.onUserPreferencesChange('mouseSensitivity', mouseSensitivity));
     }, [mouseSensitivity]);
 
     useMemo(() => {
@@ -529,7 +570,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('atomLabelDepthMode', atomLabelDepthMode);
+        localForageInstanceRef.current?.localStorageInstance.setItem('atomLabelDepthMode', atomLabelDepthMode)
+        .then(_ => props.onUserPreferencesChange('atomLabelDepthMode', atomLabelDepthMode));
     }, [atomLabelDepthMode]);
  
     useMemo(() => {
@@ -538,7 +580,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('defaultBackgroundColor', defaultBackgroundColor);
+        localForageInstanceRef.current?.localStorageInstance.setItem('defaultBackgroundColor', defaultBackgroundColor)
+        .then(_ => props.onUserPreferencesChange('defaultBackgroundColor', defaultBackgroundColor));
     }, [defaultBackgroundColor]);
     
     useMemo(() => {
@@ -547,7 +590,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('defaultExpandDisplayCards', defaultExpandDisplayCards);
+        localForageInstanceRef.current?.localStorageInstance.setItem('defaultExpandDisplayCards', defaultExpandDisplayCards)
+        .then(_ => props.onUserPreferencesChange('defaultExpandDisplayCards', defaultExpandDisplayCards));
     }, [defaultExpandDisplayCards]);
 
     useMemo(() => {
@@ -556,7 +600,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('shortCuts', shortCuts);
+        localForageInstanceRef.current?.localStorageInstance.setItem('shortCuts', shortCuts)
+        .then(_ => props.onUserPreferencesChange('shortCuts', shortCuts));
     }, [shortCuts]);
 
     useMemo(() => {
@@ -565,7 +610,8 @@ export const MoorhenPreferencesContainer = (props) => {
             return
         }
        
-        localForageInstanceRef.current?.localStorageInstance.setItem('defaultMapLitLines', defaultMapLitLines);
+        localForageInstanceRef.current?.localStorageInstance.setItem('defaultMapLitLines', defaultMapLitLines)
+        .then(_ => props.onUserPreferencesChange('defaultMapLitLines', defaultMapLitLines));
     }, [defaultMapLitLines]);
 
     return  <></>

--- a/baby-gru/src/components/modal/MoorhenShortcutConfigModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenShortcutConfigModal.tsx
@@ -24,7 +24,7 @@ export const MoorhenShortcutConfigModal = (props: {
     }
 
     const restoreDefaults = () => {
-        const defaultValues = MoorhenPreferences.defaultContextValues
+        const defaultValues = MoorhenPreferences.defaultPreferencesValues
         props.setShowModal(false)
         setStagedShortCuts(defaultValues.shortCuts as {[label: string]: moorhen.Shortcut})
         dispatch(

--- a/baby-gru/src/components/navbar-menus/MoorhenNavBar.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenNavBar.tsx
@@ -223,7 +223,7 @@ export const MoorhenNavBar = forwardRef<HTMLElement, moorhen.CollectedProps>((pr
                         { currentDropdownId === 'Cryo' && <MoorhenCryoMenu dropdownId="Cryo" {...collectedProps} /> }
                         { currentDropdownId === 'Help' &&  <MoorhenHelpMenu dropdownId="Help" {...collectedProps} /> }
                         { currentDropdownId === 'Dev' &&  <MoorhenDevMenu dropdownId="Dev" {...collectedProps} /> }
-                        { props.extraNavBarMenus && props.extraNavBarMenus.find(menu => currentDropdownId === menu.name)?.JSXElement}
+                        { props.extraNavBarMenus && props.extraNavBarMenus.find(menu => currentDropdownId === menu.name)?.JSXElement }
                     </Popover.Body>
                 </Popover>
             </Overlay>

--- a/baby-gru/src/moorhen.ts
+++ b/baby-gru/src/moorhen.ts
@@ -22,6 +22,7 @@ import {
     setNotificationContent, setActiveMap, setCootInitialized, setAppTittle, 
     setUserPreferencesMounted, setDevMode, setTheme, setViewOnly
  } from './store/generalStatesSlice';
+import { addMap, addMapList, removeMap, emptyMaps } from "./store/mapsSlice";
 import { setCursorStyle, setEnableAtomHovering, setHoveredAtom } from './store/hoveringStatesSlice';
 import { addAvailableFontList, setAtomLabelDepthMode, setGLLabelsFontFamily, setGLLabelsFontSize } from './store/labelSettingsSlice';
 import { setDefaultMapSamplingRate, setDefaultMapLitLines, setMapLineWidth, setDefaultMapSurface } from './store/mapSettingsSlice';
@@ -46,5 +47,5 @@ export {
     addMolecule, removeMolecule, emptyMolecules, addMoleculeList, setContourWheelSensitivityFactor, 
     setZoomWheelSensitivityFactor, setMouseSensitivity, setShowShortcutToast, setShortcutOnHoveredAtom, setShortCuts,
     setShowScoresToast, addMapUpdatingScore, removeMapUpdatingScore, overwriteMapUpdatingScores, 
-    MoorhenPreferences
+    addMap, addMapList, removeMap, emptyMaps, MoorhenPreferences
 };

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -14,7 +14,7 @@ declare module 'moorhen' {
 
     class MoorhenPreferences implements _moorhen.Preferences {
         name: string;
-        static defaultContextValues: _moorhen.ContextValues;
+        static defaultPreferencesValues: _moorhen.PreferencesValues;
         localStorageInstance: {
             clear: () => void;
             setItem: (key: string, value: any) => Promise<string>;
@@ -190,195 +190,207 @@ declare module 'moorhen' {
     module.exports = loadSessionData;
 
 
-    function setDefaultBackgroundColor(arg0: [number, number, number, number]): void;
+    function setDefaultBackgroundColor(arg0: [number, number, number, number]): any;
     module.exports = setDefaultBackgroundColor;
     
-    function setDrawCrosshairs(arg0: boolean): void;
+    function setDrawCrosshairs(arg0: boolean): any;
     module.exports = setDrawCrosshairs;
     
-    function setDrawFPS(arg0: boolean): void;
+    function setDrawFPS(arg0: boolean): any;
     module.exports = setDrawFPS;
     
-    function setDrawMissingLoops(arg0: boolean): void;
+    function setDrawMissingLoops(arg0: boolean): any;
     module.exports = setDrawMissingLoops;
     
-    function setDefaultBondSmoothness(arg0: number): void;
+    function setDefaultBondSmoothness(arg0: number): any;
     module.exports = setDefaultBondSmoothness;
     
-    function setDrawInteractions(arg0: boolean): void;
+    function setDrawInteractions(arg0: boolean): any;
     module.exports = setDrawInteractions;
     
-    function setDoSSAO(arg0: boolean): void;
+    function setDoSSAO(arg0: boolean): any;
     module.exports = setDoSSAO;
     
-    function setSsaoRadius(arg0: number): void;
+    function setSsaoRadius(arg0: number): any;
     module.exports = setSsaoRadius;
     
-    function setSsaoBias(arg0: number): void;
+    function setSsaoBias(arg0: number): any;
     module.exports = setSsaoBias;
     
-    function setResetClippingFogging(arg0: boolean): void;
+    function setResetClippingFogging(arg0: boolean): any;
     module.exports = setResetClippingFogging;
     
-    function setClipCap(arg0: boolean): void;
+    function setClipCap(arg0: boolean): any;
     module.exports = setClipCap;
     
-    function setUseOffScreenBuffers(arg0: boolean): void;
+    function setUseOffScreenBuffers(arg0: boolean): any;
     module.exports = setUseOffScreenBuffers;
     
-    function setDoShadowDepthDebug(arg0: boolean): void;
+    function setDoShadowDepthDebug(arg0: boolean): any;
     module.exports = setDoShadowDepthDebug;
     
-    function setDoShadow(arg0: boolean): void;
+    function setDoShadow(arg0: boolean): any;
     module.exports = setDoShadow;
     
-    function setDoSpinTest(arg0: boolean): void;
+    function setDoSpinTest(arg0: boolean): any;
     module.exports = setDoSpinTest;
     
-    function setDoOutline(arg0: boolean): void;
+    function setDoOutline(arg0: boolean): any;
     module.exports = setDoOutline;
     
-    function setDepthBlurRadius(arg0: number): void;
+    function setDepthBlurRadius(arg0: number): any;
     module.exports = setDepthBlurRadius;
     
-    function setDepthBlurDepth(arg0: number): void;
+    function setDepthBlurDepth(arg0: number): any;
     module.exports = setDepthBlurDepth;
     
-    function setDrawAxes(arg0: boolean): void;
+    function setDrawAxes(arg0: boolean): any;
     module.exports = setDrawAxes;
     
-    function setDoPerspectiveProjection(arg0: boolean): void;
+    function setDoPerspectiveProjection(arg0: boolean): any;
     module.exports = setDoPerspectiveProjection;
 
-    function setEnableTimeCapsule(arg0: boolean): void;
+    function setEnableTimeCapsule(arg0: boolean): any;
     module.exports = setEnableTimeCapsule;
 
-    function setMakeBackups(arg0: boolean): void;
+    function setMakeBackups(arg0: boolean): any;
     module.exports = setMakeBackups;
 
-    function setMaxBackupCount(arg0: number): void;
+    function setMaxBackupCount(arg0: number): any;
     module.exports = setMaxBackupCount;
 
-    function setModificationCountBackupThreshold(arg0: number): void;
+    function setModificationCountBackupThreshold(arg0: number): any;
     module.exports = setModificationCountBackupThreshold;
 
-    function setHeight(arg0: number): void;
+    function setHeight(arg0: number): any;
     module.exports = setHeight;
 
-    function setWidth(arg0: number): void;
+    function setWidth(arg0: number): any;
     module.exports = setWidth;
 
-    function setIsDark(arg0: boolean): void;
+    function setIsDark(arg0: boolean): any;
     module.exports = setIsDark;
 
-    function setBackgroundColor(arg0: [number, number, number, number]): void;
+    function setBackgroundColor(arg0: [number, number, number, number]): any;
     module.exports = setBackgroundColor;
 
-    function setNotificationContent(arg0: JSX.Element): void;
+    function setNotificationContent(arg0: JSX.Element): any;
     module.exports = setNotificationContent;
 
-    function setActiveMap(arg0: _moorhen.Map): void;
+    function setActiveMap(arg0: _moorhen.Map): any;
     module.exports = setActiveMap;
 
-    function setCootInitialized(arg0: boolean): void;
+    function setCootInitialized(arg0: boolean): any;
     module.exports = setCootInitialized;
 
-    function setAppTitle(arg0: string): void;
+    function setAppTitle(arg0: string): any;
     module.exports = setAppTitle;
 
-    function setUserPreferencesMounted(arg0: boolean): void;
+    function setUserPreferencesMounted(arg0: boolean): any;
     module.exports = setUserPreferencesMounted;
 
-    function setDevMode(arg0: boolean): void;
+    function setDevMode(arg0: boolean): any;
     module.exports = setDevMode;
 
-    function setTheme(arg0: string): void;
+    function setTheme(arg0: string): any;
     module.exports = setTheme;
 
-    function setViewOnly(arg0: boolean): void;
+    function setViewOnly(arg0: boolean): any;
     module.exports = setViewOnly;
 
-    function setCursorStyle(arg0: string): void;
+    function setCursorStyle(arg0: string): any;
     module.exports = setCursorStyle;
 
-    function setEnableAtomHovering(arg0: boolean): void;
+    function setEnableAtomHovering(arg0: boolean): any;
     module.exports = setEnableAtomHovering;
 
-    function setHoveredAtom(arg0: {molecule: null | _moorhen.Molecule; cid: null | string}): void;
+    function setHoveredAtom(arg0: {molecule: null | _moorhen.Molecule; cid: null | string}): any;
     module.exports = setHoveredAtom;
 
-    function addAvailableFontList(arg0: string): void;
+    function addAvailableFontList(arg0: string): any;
     module.exports = addAvailableFontList;
 
-    function setAtomLabelDepthMode(arg0: boolean): void;
+    function setAtomLabelDepthMode(arg0: boolean): any;
     module.exports = setAtomLabelDepthMode;
 
-    function setGLLabelsFontFamily(arg0: string): void;
+    function setGLLabelsFontFamily(arg0: string): any;
     module.exports = setGLLabelsFontFamily;
 
-    function setGLLabelsFontSize(arg0: number): void;
+    function setGLLabelsFontSize(arg0: number): any;
     module.exports = setGLLabelsFontSize;
 
-    function setDefaultMapSamplingRate(arg0: number): void;
+    function setDefaultMapSamplingRate(arg0: number): any;
     module.exports = setDefaultMapSamplingRate;
 
-    function setDefaultMapLitLines(arg0: boolean): void;
+    function setDefaultMapLitLines(arg0: boolean): any;
     module.exports = setDefaultMapLitLines;
 
-    function setMapLineWidth(arg0: number): void;
+    function setMapLineWidth(arg0: number): any;
     module.exports = setMapLineWidth;
 
-    function setDefaultMapSurface(arg0: boolean): void;
+    function setDefaultMapSurface(arg0: boolean): any;
     module.exports = setDefaultMapSurface;
 
-    function setDefaultExpandDisplayCards(arg0: boolean): void;
+    function setDefaultExpandDisplayCards(arg0: boolean): any;
     module.exports = setDefaultExpandDisplayCards;
 
-    function setTransparentModalsOnMouseOut(arg0: boolean): void;
+    function setTransparentModalsOnMouseOut(arg0: boolean): any;
     module.exports = setTransparentModalsOnMouseOut;
 
-    function setEnableRefineAfterMod(arg0: boolean): void;
+    function setEnableRefineAfterMod(arg0: boolean): any;
     module.exports = setEnableRefineAfterMod;
 
-    function addMolecule(arg0: _moorhen.Molecule): void;
+    function addMolecule(arg0: _moorhen.Molecule): any;
     module.exports = addMolecule;
 
-    function removeMolecule(arg0: _moorhen.Molecule): void;
+    function removeMolecule(arg0: _moorhen.Molecule): any;
     module.exports = removeMolecule;
 
-    function emptyMolecules(): void;
+    function emptyMolecules(): any;
     module.exports = emptyMolecules;
 
-    function addMoleculeList(arg0: _moorhen.Molecule[]): void;
+    function addMoleculeList(arg0: _moorhen.Molecule[]): any;
     module.exports = addMoleculeList;
 
-    function setContourWheelSensitivityFactor(arg0: number): void;
+    function setContourWheelSensitivityFactor(arg0: number): any;
     module.exports = setContourWheelSensitivityFactor;
 
-    function setZoomWheelSensitivityFactor(arg0: number): void;
+    function setZoomWheelSensitivityFactor(arg0: number): any;
     module.exports = setZoomWheelSensitivityFactor;
 
-    function setMouseSensitivity(arg0: number): void;
+    function setMouseSensitivity(arg0: number): any;
     module.exports = setMouseSensitivity;
 
-    function setShowShortcutToast(arg0: boolean): void;
+    function setShowShortcutToast(arg0: boolean): any;
     module.exports = setShowShortcutToast;
 
-    function setShortcutOnHoveredAtom(arg0: boolean): void;
+    function setShortcutOnHoveredAtom(arg0: boolean): any;
     module.exports = setShortcutOnHoveredAtom;
 
-    function setShortCuts(arg0: string): void;
+    function setShortCuts(arg0: string): any;
     module.exports = setShortCuts;
 
-    function setShowScoresToast(arg0: boolean): void;
+    function setShowScoresToast(arg0: boolean): any;
     module.exports = setShowScoresToast;
 
-    function addMapUpdatingScore(arg0: _moorhen.Map): void;
+    function addMapUpdatingScore(arg0: _moorhen.Map): any;
     module.exports = addMapUpdatingScore;
 
-    function removeMapUpdatingScore(arg0: _moorhen.Map): void;
+    function removeMapUpdatingScore(arg0: _moorhen.Map): any;
     module.exports = removeMapUpdatingScore;
 
-    function overwriteMapUpdatingScores(arg0: _moorhen.Map[]): void;
+    function overwriteMapUpdatingScores(arg0: _moorhen.Map[]): any;
     module.exports = overwriteMapUpdatingScores;
+
+    function addMap(arg0: _moorhen.Map): any;
+    module.exports = addMap;
+
+    function removeMap(arg0: _moorhen.Map): any;
+    module.exports = removeMap;
+
+    function emptyMaps(): any;
+    module.exports = emptyMaps;
+
+    function addMapList(arg0: _moorhen.Map[]): any;
+    module.exports = addMapList;
 }

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -8,7 +8,7 @@ export namespace moorhen {
 
     interface Preferences {
         name: string;
-        static defaultContextValues: ContextValues;
+        static defaultPreferencesValues: PreferencesValues;
         localStorageInstance: {
             clear: () => void;
             setItem: (key: string, value: any) => Promise<string>;
@@ -596,7 +596,7 @@ export namespace moorhen {
         setTransparentModalsOnMouseOut: React.Dispatch<React.SetStateAction<boolean>>;
     }
     
-    interface ContextValues {
+    interface PreferencesValues {
         version?: string;
         isMounted?: boolean;
         defaultMapSamplingRate: number;
@@ -646,7 +646,7 @@ export namespace moorhen {
         };
     }
     
-    interface Context extends ContextSetters, ContextValues { }
+    interface Context extends ContextSetters, PreferencesValues { }
     
     type ContextButtonProps = {
         mode: 'context';
@@ -709,6 +709,7 @@ export namespace moorhen {
     }
       
     interface ContainerOptionalProps {
+        onUserPreferencesChange: (key: string, value: any) => void;
         disableFileUploads: boolean;
         urlPrefix: string;
         extraNavBarMenus: {name: string; ref: React.RefObject<any> ; icon: JSX.Element; JSXElement: JSX.Element}[];

--- a/baby-gru/src/utils/MoorhenPreferences.ts
+++ b/baby-gru/src/utils/MoorhenPreferences.ts
@@ -12,9 +12,9 @@ export class MoorhenPreferences implements moorhen.Preferences {
 
     localStorageInstance: LocalForage;
     name: string;
-    defaultContextValues: moorhen.ContextValues;
+    defaultPreferencesValues: moorhen.PreferencesValues;
 
-    constructor(name: string) {
+    constructor(name: string = 'babyGru-localStorage') {
         this.name = name
         this.createLocalForageInstance()
     }
@@ -31,8 +31,8 @@ export class MoorhenPreferences implements moorhen.Preferences {
         return this.localStorageInstance
     }
 
-    static defaultContextValues: moorhen.ContextValues = {
-        version: 'v30',
+    static defaultPreferencesValues: moorhen.PreferencesValues = {
+        version: 'v31',
         transparentModalsOnMouseOut: true,
         defaultBackgroundColor: [1, 1, 1, 1],
         atomLabelDepthMode: true,


### PR DESCRIPTION
This update includes:
- Minor version bump
- User preferences are exported using a callback function `onUserPreferencesChange` passed to `MoorhenContainer` in props
- TS types packed with npm package are now up-to-date.