### PR TITLE
Add TS transpilation check to vite plugins

### DIFF
--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -178,6 +178,7 @@
     "util": "^0.12.5",
     "uuid": "^9.0.0",
     "vite": "^4.5.0",
+    "vite-plugin-checker": "^0.6.2",
     "vite-plugin-cross-origin-isolation": "^0.1.6",
     "vite-plugin-top-level-await": "^1.3.1",
     "vite-plugin-wasm": "^3.2.2",

--- a/baby-gru/src/components/modal/MoorhenDraggableModalBase.tsx
+++ b/baby-gru/src/components/modal/MoorhenDraggableModalBase.tsx
@@ -71,6 +71,7 @@ export const MoorhenDraggableModalBase = (props: {
     additionalChildren?: JSX.Element;
     overflowY?: 'visible' | 'hidden' | 'clip' | 'scroll' | 'auto';
     handleClassName?: string;
+    showCloseButton?: boolean;
 }) => {
     
     const [opacity, setOpacity] = useState<number>(1.0)
@@ -98,9 +99,11 @@ export const MoorhenDraggableModalBase = (props: {
                         <Button variant='white' style={{margin: '0.1rem', padding: '0.1rem'}} onClick={() => setCollapse(!collapse)}>
                             {collapse ? <AddOutlined/> : <RemoveOutlined/>}
                         </Button>
+                        {props.showCloseButton &&
                         <Button variant='white' style={{margin: '0.1rem', padding: '0.1rem'}} onClick={() => props.setShow(false)}>
                             <CloseOutlined/>
-                        </Button>
+                        </Button>                    
+                        }
                     </Stack>
                 </Card.Header>
                 <Card.Body style={{maxHeight: windowHeight ? convertViewtoPx(props.height, windowHeight) : `${props.height}vh`, overflowY: props.overflowY, display: collapse ? 'none' : 'block', justifyContent: 'center'}}>
@@ -116,4 +119,7 @@ export const MoorhenDraggableModalBase = (props: {
         </Draggable>
 }
 
-MoorhenDraggableModalBase.defaultProps = { handleClassName: 'handle', additionalHeaderButtons:null, additionalChildren: null, width: 35, height: 45, top: '5rem', left: '5rem', overflowY: 'scroll'}
+MoorhenDraggableModalBase.defaultProps = { 
+    showCloseButton: true, handleClassName: 'handle', additionalHeaderButtons:null, additionalChildren: null, 
+    width: 35, height: 45, top: '5rem', left: '5rem', overflowY: 'scroll'
+}

--- a/baby-gru/src/components/navbar-menus/MoorhenHistoryMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenHistoryMenu.tsx
@@ -94,11 +94,13 @@ export const MoorhenHistoryMenu = (props: MoorhenNavBarExtendedControlsInterface
     }, [props.commandCentre, historyHead, molecules, props.timeCapsuleRef, loadSession])
 
     return <div style={{maxHeight: convertViewtoPx(65, height), maxWidth: '20rem', overflowY: 'auto', overflowX: 'hidden'}}>
+        {props.commandCentre.current.history.entries.length === 0 ? 
+        <span>No command history</span>
+        :
         <Stepper nonLinear activeStep={historyHead} orientation="vertical">
-            {props.commandCentre.current.history.entries.length === 0 ? 
-            <span>No command history</span>
-            : props.commandCentre.current.history.entries.map((entry, index) => getHistoryStep(entry, index)) }
+            { props.commandCentre.current.history.entries.map((entry, index) => getHistoryStep(entry, index)) }
         </Stepper>
+        }
     </div>
 }
 

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -38,8 +38,8 @@ declare module 'moorhen' {
         updateWithMovedAtoms(movedResidues: _moorhen.AtomInfo[][]): Promise<void>;
         transformedCachedAtomsAsMovedAtoms(selectionCid?: string): _moorhen.AtomInfo[][];
         copyFragmentUsingCid(cid: string, doRecentre?: boolean, style?: string): Promise<_moorhen.Molecule>;
-        hideCid(cid: string): Promise<void>;
-        unhideAll(): Promise<void>;
+        hideCid(cid: string, redraw?: boolean): Promise<void>;
+        unhideAll(redraw?: boolean): Promise<void>;
         drawUnitCell(): void;
         gemmiAtomsForCid: (cid: string, omitExcludedCids?: boolean) => Promise<_moorhen.AtomInfo[]>;
         mergeMolecules(otherMolecules: _moorhen.Molecule[], doHide?: boolean): Promise<void>;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -103,8 +103,8 @@ export namespace moorhen {
         updateWithMovedAtoms(movedResidues: AtomInfo[][]): Promise<void>;
         transformedCachedAtomsAsMovedAtoms(selectionCid?: string): AtomInfo[][];
         copyFragmentUsingCid(cid: string, doRecentre?: boolean, style?: string): Promise<Molecule>;
-        hideCid(cid: string): Promise<void>;
-        unhideAll(): Promise<void>;
+        hideCid(cid: string, redraw?: boolean): Promise<void>;
+        unhideAll(redraw?: boolean): Promise<void>;
         drawUnitCell(): void;
         gemmiAtomsForCid: (cid: string, omitExcludedCids?: boolean) => Promise<AtomInfo[]>;
         mergeMolecules(otherMolecules: Molecule[], doHide?: boolean): Promise<void>;

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1552,8 +1552,9 @@ export class MoorhenMolecule implements moorhen.Molecule {
     /**
      * Hide representations for a given CID selection
      * @param {string} cid - The CID selection
+     * @param {boolean} [redraw=true] - Indicates if the molecule should be redrawn
      */
-    async hideCid(cid: string): Promise<void> {
+    async hideCid(cid: string, redraw: boolean = true): Promise<void> {
         await this.commandCentre.current.cootCommand({
             message: 'coot_command',
             command: "add_to_non_drawn_bonds",
@@ -1600,13 +1601,16 @@ export class MoorhenMolecule implements moorhen.Molecule {
         selection.delete()
 
         // Redraw to apply changes
-        await this.redraw()
+        if (redraw) {
+            await this.redraw()
+        }
     }
 
     /**
      * Unhide all the molecule representations
+     * @param {boolean} [redraw=true] - Indicates if the molecule should be redrawn
      */
-    async unhideAll() {
+    async unhideAll(redraw: boolean = true) {
         await this.commandCentre.current.cootCommand({
             message: 'coot_command',
             command: "clear_non_drawn_bonds",
@@ -1615,7 +1619,9 @@ export class MoorhenMolecule implements moorhen.Molecule {
         }, false)
         this.excludedSelections = []
         this.excludedCids = []
-        await this.redraw()
+        if (redraw) {
+            await this.redraw()
+        }
     }
 
     /**

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -669,8 +669,8 @@ export const getTooltipShortcutLabel = (shortCut: moorhen.Shortcut): string => {
 }
 
 // FIXME: Again looping thourhg atoms every where...
-const getMoleculeBfactors = (gemmiStructure: gemmi.Structure): { cid: string, bFactor: number }[] => {
-    let bFactors: { cid: string, bFactor: number }[] = []
+export const getMoleculeBfactors = (gemmiStructure: gemmi.Structure): { cid: string, bFactor: number, chainId: string, resNum: number, modelName: string }[] => {
+    let bFactors: { cid: string, bFactor: number, chainId: string, resNum: number, modelName: string }[] = []
     try {
         const models = gemmiStructure.models
         for (let modelIndex = 0; modelIndex < models.size(); modelIndex++) {
@@ -698,7 +698,10 @@ const getMoleculeBfactors = (gemmiStructure: gemmi.Structure): { cid: string, bF
                     }
                     bFactors.push({
                         cid: `/${modelName}/${chainName}/${resNum}/*`,
-                        bFactor: residueTemp / atomsSize
+                        bFactor: residueTemp / atomsSize,
+                        chainId: chainName,
+                        modelName: modelName,
+                        resNum: parseInt(resNum)
                     })
                     residue.delete()
                     residueSeqId.delete()

--- a/baby-gru/vite.config.mts
+++ b/baby-gru/vite.config.mts
@@ -1,8 +1,9 @@
-import {defineConfig} from 'vite'
+import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import crossOriginIsolation from 'vite-plugin-cross-origin-isolation'
 import wasm from "vite-plugin-wasm";
 import topLevelAwait from "vite-plugin-top-level-await";
+import checker from 'vite-plugin-checker';
 
 export default defineConfig({
     plugins: [
@@ -10,6 +11,11 @@ export default defineConfig({
         wasm(),
         topLevelAwait(),
         crossOriginIsolation(),
+        checker({ typescript: {
+            root: './',
+            tsconfigPath: 'tsconfig.json'
+
+        }}),
         {
             name: "configure-response-headers",
             configureServer: (server) => {
@@ -26,5 +32,13 @@ export default defineConfig({
             "Cross-Origin-Opener-Policy": "same-origin",
             "Cross-Origin-Embedder-Policy": "require-corp",
         },
+        watch: {
+            ignored: [
+                '**/public/baby-gru/monomers/**',
+                '**/public/baby-gru/wasm/**',
+                '**/public/baby-gru/pixmaps/**',
+                '**/public/baby-gru/tutorials/**'
+            ]
+        }
     },
-})
+});


### PR DESCRIPTION
After #153 `npm start` did not perform TS transpilation when hot-reloading. This update adds a plugin to perform TS checks when the page reloads.