### PR TITLE
Fix bug with plddt colours and bond settings

### DIFF
--- a/baby-gru/src/components/MoorhenApp.tsx
+++ b/baby-gru/src/components/MoorhenApp.tsx
@@ -15,8 +15,8 @@ export const MoorhenApp = (props) => {
     const prevActiveMoleculeRef = useRef<null | moorhen.Molecule>(null)
 
     const collectedProps = {
-        glRef, timeCapsuleRef, commandCentre, moleculesRef, mapsRef, activeMapRef,
-        lastHoveredAtom, prevActiveMoleculeRef,
+        glRef, timeCapsuleRef, commandCentre, moleculesRef, 
+        mapsRef, activeMapRef, lastHoveredAtom, prevActiveMoleculeRef,
     }
 
     return  <MoorhenReduxProvider>

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -121,9 +121,9 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
         if (isDirty.current) {
             busyRedrawing.current = true
             isDirty.current = false
-            await Promise.all(
-                representationIds.map(id => props.molecule.redrawRepresentation(id))
-            )
+            for (let id of representationIds) {
+                await props.molecule.redrawRepresentation(id)
+            }
             busyRedrawing.current = false
             redrawMolIfDirty(representationIds)
         }
@@ -150,6 +150,7 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
     }, [props.molecule, props.glRef])
 
     useEffect(() => {
+        console.log('HI ', drawMissingLoops)
         if (!userPreferencesMounted || drawMissingLoops === null) {
             return
         } else if (innerDrawMissingLoopsRef.current === null) {

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -150,7 +150,6 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
     }, [props.molecule, props.glRef])
 
     useEffect(() => {
-        console.log('HI ', drawMissingLoops)
         if (!userPreferencesMounted || drawMissingLoops === null) {
             return
         } else if (innerDrawMissingLoopsRef.current === null) {

--- a/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
@@ -52,9 +52,6 @@ export const MoorhenQuerySequenceModal = (props: {
         try {
             await newMolecule.loadToCootFromURL(url, molName)
             if (newMolecule.molNo === -1) throw new Error("Cannot read the fetched molecule...")
-            await newMolecule.fetchIfDirtyAndDraw(newMolecule.atomCount >= 50000 ? 'CRs' : 'CBs')
-            dispatch( addMolecule(newMolecule) )
-            newMolecule.centreOn('/*/*/*/*', false)
             return newMolecule
         } catch (err) {
             dispatch(setNotificationContent(
@@ -127,6 +124,9 @@ export const MoorhenQuerySequenceModal = (props: {
 
     const fetchAndSuperpose = async (polimerEntity: string, coordUrl: string, chainId: string, source: string) => {
         const newMolecule = await fetchMoleculeFromURL(coordUrl, polimerEntity)
+        if (!newMolecule) {
+            return
+        }
         if (source === 'AFDB') {
             const newRule = {
                 args: [getMultiColourRuleArgs(newMolecule, 'af2-plddt')],
@@ -149,8 +149,9 @@ export const MoorhenQuerySequenceModal = (props: {
             changesMolecules: [newMolecule.molNo]
         }, true)                            
         newMolecule.setAtomsDirty(true)
-        await newMolecule.redraw()
-        newMolecule.centreOn('/*/*/*/*', true)
+        await newMolecule.fetchIfDirtyAndDraw(newMolecule.atomCount >= 50000 ? 'CRs' : 'CBs')
+        await newMolecule.centreOn('/*/*/*/*', true)
+        dispatch( addMolecule(newMolecule) )
     }
 
     const getPDBHitCard = async (polimerEntity: string, source: string = 'PDB') => {


### PR DESCRIPTION
This update fixes two bugs:
- PLDDT colours were not loaded correctly when fetching a model from AFDB
- When changing the bond settings of a molecule having multiple representations with different colour rules, the colour rules for the last representation were being used for all representations.