### PR TITLE
Add extraNavBarModals to MoorhenContainer props

### DIFF
--- a/baby-gru/src/components/MoorhenContainer.tsx
+++ b/baby-gru/src/components/MoorhenContainer.tsx
@@ -120,14 +120,14 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
         disableFileUploads, urlPrefix, extraNavBarMenus, viewOnly, extraDraggableModals, 
         monomerLibraryPath, extraFileMenuItems, allowScripting, backupStorageInstance,
         extraEditMenuItems, aceDRGInstance, extraCalculateMenuItems, setMoorhenDimensions,
-        onUserPreferencesChange
+        onUserPreferencesChange, extraNavBarModals
     } = props
 
     const collectedProps: moorhen.CollectedProps = {
         glRef, commandCentre, timeCapsuleRef, disableFileUploads, extraDraggableModals, aceDRGInstance, 
         urlPrefix, viewOnly, mapsRef, allowScripting, extraCalculateMenuItems, extraEditMenuItems,
         extraNavBarMenus, monomerLibraryPath, moleculesRef, extraFileMenuItems, activeMapRef,
-        videoRecorderRef, lastHoveredAtomRef, onUserPreferencesChange
+        videoRecorderRef, lastHoveredAtomRef, onUserPreferencesChange, extraNavBarModals
     }
     
     useEffect(() => {
@@ -421,6 +421,7 @@ MoorhenContainer.defaultProps = {
     monomerLibraryPath: './baby-gru/monomers',
     setMoorhenDimensions: null,
     disableFileUploads: false,
+    extraNavBarModals: [],
     extraNavBarMenus: [],
     extraFileMenuItems: [],
     extraEditMenuItems: [],

--- a/baby-gru/src/components/navbar-menus/MoorhenNavBar.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenNavBar.tsx
@@ -120,7 +120,7 @@ export const MoorhenNavBar = forwardRef<HTMLElement, moorhen.CollectedProps>((pr
     }
 
     if (devMode) {
-        actions['Dev'] = { icon: <ScienceOutlined/>, name: 'Dev', ref: devDialActionRef}
+        actions['Dev'] = { icon: <ScienceOutlined/>, name: 'Dev', ref: devDialActionRef }
     }
 
     useEffect(() => {

--- a/baby-gru/src/components/navbar-menus/MoorhenNavBar.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenNavBar.tsx
@@ -18,7 +18,8 @@ import { MoorhenMapsModal } from '../modal/MoorhenMapsModal';
 import { MoorhenValidationToolsModal } from '../modal/MoorhenValidationToolsModal';
 import { 
     AcUnitOutlined, CalculateOutlined, DescriptionOutlined, EditOutlined, VisibilityOutlined,
-    FactCheckOutlined, HelpOutlineOutlined, MenuOutlined, SaveOutlined, ScienceOutlined, SettingsSuggestOutlined, CloseOutlined, HistoryOutlined,
+    FactCheckOutlined, HelpOutlineOutlined, MenuOutlined, SaveOutlined, ScienceOutlined, 
+    SettingsSuggestOutlined, CloseOutlined, HistoryOutlined,
  } from '@mui/icons-material';
 import { MoorhenQuerySequenceModal } from '../modal/MoorhenQuerySequenceModal';
 import { MoorhenScriptModal } from '../modal/MoorhenScriptModal';
@@ -27,9 +28,7 @@ import { useSelector } from 'react-redux';
 
 export interface MoorhenNavBarExtendedControlsInterface extends moorhen.CollectedProps {
     dropdownId: string;
-    currentDropdownId: string;
     setBusy: React.Dispatch<React.SetStateAction<boolean>>;
-    setCurrentDropdownId: React.Dispatch<React.SetStateAction<string>>;
     setShowQuerySequence: React.Dispatch<React.SetStateAction<boolean>>;
     setShowScripting: React.Dispatch<React.SetStateAction<boolean>>;
     setShowCreateAcedrgLinkModal: React.Dispatch<React.SetStateAction<boolean>>;
@@ -40,7 +39,7 @@ export const MoorhenNavBar = forwardRef<HTMLElement, moorhen.CollectedProps>((pr
     const [timeCapsuleBusy, setTimeCapsuleBusy] = useState<boolean>(false)
     const [busy, setBusy] = useState<boolean>(false)
     const [speedDialOpen, setSpeedDialOpen] = useState<boolean>(false)
-    const [currentDropdownId, setCurrentDropdownId] = useState<string>('-1')
+    const [navBarActiveMenu, setNavBarActiveMenu] = useState<string>('-1')
     const [showCreateAcedrgLinkModal, setShowCreateAcedrgLinkModal] = useState<boolean>(false)
     const [showValidation, setShowValidation] = useState<boolean>(false)
     const [showModels, setShowModels] = useState<boolean>(false)
@@ -90,8 +89,7 @@ export const MoorhenNavBar = forwardRef<HTMLElement, moorhen.CollectedProps>((pr
     }, [props.timeCapsuleRef.current])
 
     const collectedProps = {
-        currentDropdownId, setCurrentDropdownId, setShowQuerySequence, setShowScripting, 
-        setShowCreateAcedrgLinkModal, setBusy, ...props
+        setShowQuerySequence, setShowScripting, setShowCreateAcedrgLinkModal, setBusy, ...props
     }
 
     const actions = {
@@ -109,46 +107,57 @@ export const MoorhenNavBar = forwardRef<HTMLElement, moorhen.CollectedProps>((pr
         'Help': { icon: <HelpOutlineOutlined/>, name: 'Help', ref: helpDialActionRef},
     }
 
-    if (devMode) {
-        actions['Dev'] = { icon: <ScienceOutlined/>, name: 'Dev', ref: devDialActionRef}
-    }
-
     if (props.extraNavBarMenus) {
         props.extraNavBarMenus.forEach(menu => {
             actions[menu.name] = menu
         })
     }
 
+    if (props.extraNavBarModals) {
+        props.extraNavBarModals.forEach(modal => {
+            actions[modal.name] = modal
+        })
+    }
+
+    if (devMode) {
+        actions['Dev'] = { icon: <ScienceOutlined/>, name: 'Dev', ref: devDialActionRef}
+    }
+
     useEffect(() => {
-        switch(currentDropdownId) {
+        switch(navBarActiveMenu) {
             case "-1":
                 break
             case "Models":
                 setShowModels(true)
-                setCurrentDropdownId('-1')
+                setNavBarActiveMenu('-1')
                 break
             case "Maps":
                 setShowMaps(true)
-                setCurrentDropdownId('-1')
+                setNavBarActiveMenu('-1')
                 break
             case "Validation":
                 setShowValidation(true)
-                setCurrentDropdownId('-1')
+                setNavBarActiveMenu('-1')
                 break
             default:
-                setPopoverTargetRef(actions[currentDropdownId].ref.current)
+                const selectedExtraNavBarModal = props.extraNavBarModals.find(modal => modal.name === navBarActiveMenu)
+                if (selectedExtraNavBarModal) {
+                    selectedExtraNavBarModal.setShow(true)
+                    setNavBarActiveMenu('-1')
+                } else {
+                    setPopoverTargetRef(actions[navBarActiveMenu]?.ref.current)
+                }
                 break
         }
-    }, [currentDropdownId])
+    }, [navBarActiveMenu])
 
     const handleDialActionClick = useCallback((actionName) => {
-        if (actionName === currentDropdownId) {
-            setCurrentDropdownId('-1')
+        if (actionName === navBarActiveMenu) {
+            setNavBarActiveMenu('-1')
         } else {
-            setCurrentDropdownId(actionName)
+            setNavBarActiveMenu(actionName)
         }
-        
-    }, [currentDropdownId])
+    }, [navBarActiveMenu])
 
     const canvasElement = document.getElementById('moorhen-canvas-background')
     let canvasTop: number
@@ -168,7 +177,7 @@ export const MoorhenNavBar = forwardRef<HTMLElement, moorhen.CollectedProps>((pr
             variant={'extended'}
             size={"large"}
             onClick={() => {
-                setCurrentDropdownId('-1')
+                setNavBarActiveMenu('-1')
                 setSpeedDialOpen(!speedDialOpen)        
             }}
             sx={{
@@ -186,7 +195,7 @@ export const MoorhenNavBar = forwardRef<HTMLElement, moorhen.CollectedProps>((pr
             { (speedDialOpen) ? <CloseOutlined style={{color: 'black'}}/> : <MenuOutlined style={{color: 'black'}}/> }
             <img className='moorhen-navbar-menu-item-icon' src={`${props.urlPrefix}/baby-gru/pixmaps/MoorhenLogo.png`} alt='Moorhen' /> 
         </Fab>
-        <ClickAwayListener onClickAway={() => { setCurrentDropdownId('-1') }}>
+        <ClickAwayListener onClickAway={() => { setNavBarActiveMenu('-1') }}>
         <Popper open={speedDialOpen} anchorEl={speedDialRef.current} placement='bottom-start'>
             <Grow in={speedDialOpen} style={{ transformOrigin: '0 0 0' }}>
             <MenuList style={{height: height - convertRemToPx(5), width: '100%', overflowY: 'auto', direction: 'rtl'}}>
@@ -198,7 +207,7 @@ export const MoorhenNavBar = forwardRef<HTMLElement, moorhen.CollectedProps>((pr
                     className='moorhen-navbar-menu-item'
                     onClick={() => handleDialActionClick(action.name)}
                     style={{
-                        backgroundColor: isDark ? (currentDropdownId === action.name ? '#a8a8a8' : 'grey') : (currentDropdownId === action.name ? '#d4d4d4' : 'white') ,
+                        backgroundColor: isDark ? (navBarActiveMenu === action.name ? '#a8a8a8' : 'grey') : (navBarActiveMenu === action.name ? '#d4d4d4' : 'white') ,
                     }}>
                         <Stack gap={2} direction='horizontal' style={{display: 'flex', verticalAlign: 'middle'}}>
                             {action.name}
@@ -210,35 +219,38 @@ export const MoorhenNavBar = forwardRef<HTMLElement, moorhen.CollectedProps>((pr
                 })}
             </MenuList>
             </Grow>
-            <Overlay placement='right' show={currentDropdownId !== '-1'} target={currentDropdownId !== '-1' ? popoverTargetRef : null}>
+            <Overlay placement='right' show={navBarActiveMenu !== '-1'} target={navBarActiveMenu !== '-1' ? popoverTargetRef : null}>
                 <Popover className='moorhen-nav-popover' style={{maxWidth: convertViewtoPx(35, width)}}>
                     <Popover.Body>
-                        { currentDropdownId === 'File' && <MoorhenFileMenu dropdownId="File" {...collectedProps} /> }
-                        { currentDropdownId === 'Edit' && <MoorhenEditMenu dropdownId="Edit" {...collectedProps} /> }
-                        { currentDropdownId === 'Calculate' && <MoorhenCalculateMenu dropdownId="Calculate" {...collectedProps} /> }
-                        { currentDropdownId === 'Ligand' && <MoorhenLigandMenu dropdownId="Ligand" {...collectedProps} /> }
-                        { currentDropdownId === 'View' && <MoorhenViewMenu dropdownId="View" {...collectedProps} /> }
-                        { currentDropdownId === 'Preferences' && <MoorhenPreferencesMenu dropdownId="Preferences" {...collectedProps} /> }
-                        { currentDropdownId === 'History' && <MoorhenHistoryMenu dropdownId="History" {...collectedProps} /> }
-                        { currentDropdownId === 'Cryo' && <MoorhenCryoMenu dropdownId="Cryo" {...collectedProps} /> }
-                        { currentDropdownId === 'Help' &&  <MoorhenHelpMenu dropdownId="Help" {...collectedProps} /> }
-                        { currentDropdownId === 'Dev' &&  <MoorhenDevMenu dropdownId="Dev" {...collectedProps} /> }
-                        { props.extraNavBarMenus && props.extraNavBarMenus.find(menu => currentDropdownId === menu.name)?.JSXElement }
+                        { navBarActiveMenu === 'File' && <MoorhenFileMenu dropdownId="File" {...collectedProps} /> }
+                        { navBarActiveMenu === 'Edit' && <MoorhenEditMenu dropdownId="Edit" {...collectedProps} /> }
+                        { navBarActiveMenu === 'Calculate' && <MoorhenCalculateMenu dropdownId="Calculate" {...collectedProps} /> }
+                        { navBarActiveMenu === 'Ligand' && <MoorhenLigandMenu dropdownId="Ligand" {...collectedProps} /> }
+                        { navBarActiveMenu === 'View' && <MoorhenViewMenu dropdownId="View" {...collectedProps} /> }
+                        { navBarActiveMenu === 'Preferences' && <MoorhenPreferencesMenu dropdownId="Preferences" {...collectedProps} /> }
+                        { navBarActiveMenu === 'History' && <MoorhenHistoryMenu dropdownId="History" {...collectedProps} /> }
+                        { navBarActiveMenu === 'Cryo' && <MoorhenCryoMenu dropdownId="Cryo" {...collectedProps} /> }
+                        { navBarActiveMenu === 'Help' &&  <MoorhenHelpMenu dropdownId="Help" {...collectedProps} /> }
+                        { navBarActiveMenu === 'Dev' &&  <MoorhenDevMenu dropdownId="Dev" {...collectedProps} /> }
+                        { props.extraNavBarMenus && props.extraNavBarMenus.find(menu => navBarActiveMenu === menu.name)?.JSXElement }
                     </Popover.Body>
                 </Popover>
             </Overlay>
         </Popper>
         </ClickAwayListener>
+    
     <MoorhenModelsModal
-            show={showModels}
-            setShow={setShowModels}
-            {...props}
+        show={showModels}
+        setShow={setShowModels}
+        {...props}
     />
+    
     <MoorhenMapsModal
-            show={showMaps}
-            setShow={setShowMaps}
-            {...props}
+        show={showMaps}
+        setShow={setShowMaps}
+        {...props}
     />
+        
     {showCreateAcedrgLinkModal && 
         <MoorhenCreateAcedrgLinkModal
             width={45}
@@ -247,6 +259,7 @@ export const MoorhenNavBar = forwardRef<HTMLElement, moorhen.CollectedProps>((pr
             {...props}
         />
     }
+    
     {showValidation && 
         <MoorhenValidationToolsModal 
             show={showValidation}
@@ -254,15 +267,20 @@ export const MoorhenNavBar = forwardRef<HTMLElement, moorhen.CollectedProps>((pr
             {...props}
         />
     }
+    
     {showQuerySequence &&
         <MoorhenQuerySequenceModal
             show={showQuerySequence}
             setShow={setShowQuerySequence}
             {...props} />
     }
+    
     {showScripting &&
         <MoorhenScriptModal show={showScripting} setShow={setShowScripting} {...props} />
     }
+    
+    { props.extraNavBarModals && props.extraNavBarModals.filter(modal => modal.show).map(modal => modal.JSXElement) }
+
     <Fab
         variant='extended'
         size="large"

--- a/baby-gru/src/moorhen.ts
+++ b/baby-gru/src/moorhen.ts
@@ -2,6 +2,7 @@ import { ErrorBoundary } from "./ErrorBoundary";
 import { MoorhenApp } from './components/MoorhenApp';
 import { MoorhenContainer } from './components/MoorhenContainer';
 import { MoorhenDraggableModalBase } from "./components/modal/MoorhenDraggableModalBase";
+import { MoorhenQuerySequenceModal } from "./components/modal/MoorhenQuerySequenceModal";
 import { MoorhenMolecule } from './utils/MoorhenMolecule';
 import { MoorhenMap } from './utils/MoorhenMap';
 import { MoorhenCommandCentre } from './utils/MoorhenCommandCentre';
@@ -9,7 +10,9 @@ import { MoorhenTimeCapsule } from './utils/MoorhenTimeCapsule';
 import { MoorhenPreferences } from "./utils/MoorhenPreferences";
 import { MoorhenMoleculeSelect } from "./components/select/MoorhenMoleculeSelect";
 import { MoorhenMapSelect } from "./components/select/MoorhenMapSelect";
-import { loadSessionData } from "./utils/MoorhenUtils";
+import { MoorhenSlider } from "./components/misc/MoorhenSlider";
+import { MoorhenFetchOnlineSourcesForm } from "./components/form/MoorhenFetchOnlineSourcesForm";
+import { loadSessionData, getMoleculeBfactors } from "./utils/MoorhenUtils";
 import { MoorhenReduxProvider } from "./components/misc/MoorhenReduxProvider";
 import { setDefaultBackgroundColor, setDrawCrosshairs, setDrawFPS, setDrawMissingLoops, setDefaultBondSmoothness,
     setDrawInteractions, setDoSSAO, setSsaoRadius, setSsaoBias, setResetClippingFogging, setClipCap,  
@@ -44,8 +47,8 @@ export {
     setCursorStyle, setEnableAtomHovering, setHoveredAtom, addAvailableFontList, setAtomLabelDepthMode, 
     setGLLabelsFontFamily, setGLLabelsFontSize, setDefaultMapSamplingRate, setDefaultMapLitLines, setMapLineWidth, 
     setDefaultMapSurface, setDefaultExpandDisplayCards, setTransparentModalsOnMouseOut, setEnableRefineAfterMod,
-    addMolecule, removeMolecule, emptyMolecules, addMoleculeList, setContourWheelSensitivityFactor, 
+    addMolecule, removeMolecule, emptyMolecules, addMoleculeList, setContourWheelSensitivityFactor, MoorhenFetchOnlineSourcesForm,
     setZoomWheelSensitivityFactor, setMouseSensitivity, setShowShortcutToast, setShortcutOnHoveredAtom, setShortCuts,
-    setShowScoresToast, addMapUpdatingScore, removeMapUpdatingScore, overwriteMapUpdatingScores, 
-    addMap, addMapList, removeMap, emptyMaps, MoorhenPreferences
+    setShowScoresToast, addMapUpdatingScore, removeMapUpdatingScore, overwriteMapUpdatingScores, MoorhenSlider,
+    addMap, addMapList, removeMap, emptyMaps, getMoleculeBfactors, MoorhenQuerySequenceModal, MoorhenPreferences
 };

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -9,6 +9,28 @@ declare module 'moorhen' {
     let MoorhenContainer: any;
     module.exports = MoorhenContainer;
 
+    let MoorhenDraggableModalBase: any;
+    module.exports = MoorhenDraggableModalBase;
+
+
+    let MoorhenMoleculeSelect: any;
+    module.exports = MoorhenMoleculeSelect;
+
+    let MoorhenQuerySequenceModal: any;
+    module.exports = MoorhenQuerySequenceModal;
+
+    let MoorhenMapSelect: any;
+    module.exports = MoorhenMapSelect;
+
+
+    let MoorhenSlider: any;
+    module.exports = MoorhenSlider;
+
+
+    let MoorhenFetchOnlineSourcesForm: any;
+    module.exports = MoorhenFetchOnlineSourcesForm;
+
+
     let MoorhenReduxProvider: any;
     module.exports = MoorhenReduxProvider;
 
@@ -25,6 +47,7 @@ declare module 'moorhen' {
 
     class MoorhenMolecule implements _moorhen.Molecule {
         constructor(commandCentre: React.RefObject<_moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, monomerLibrary: string)
+        SSMSuperpose(movChainId: string, refMolNo: number, refChainId: string): Promise<_moorhen.WorkerResponse>;
         deleteCid(cid: string, redraw?: boolean): Promise<void>;
         getNumberOfAtoms(): Promise<number>;
         moveMoleculeHere(x: number, y: number, z: number): Promise<void>;
@@ -179,6 +202,9 @@ declare module 'moorhen' {
     }
     module.exports.MoorhenMap = MoorhenMap
 
+    function getMoleculeBfactors(gemmiStructure: gemmi.Structure): { cid: string, bFactor: number, chainId: string, resNum: number, modelName: string }[];
+    module.exports = getMoleculeBfactors;
+
     function loadSessionData(
         sessionDataString: string,
         monomerLibraryPath: string,
@@ -190,7 +216,6 @@ declare module 'moorhen' {
         dispatch: (reduxStoreAction: any) => void,
     ): Promise<number>;
     module.exports = loadSessionData;
-
 
     function setDefaultBackgroundColor(arg0: [number, number, number, number]): any;
     module.exports = setDefaultBackgroundColor;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -89,6 +89,7 @@ export namespace moorhen {
     }
     
     interface Molecule {
+        SSMSuperpose(movChainId: string, refMolNo: number, refChainId: string): Promise<WorkerResponse>;
         refineResiduesUsingAtomCid(cid: string, mode: string, ncyc?: number, redraw?: boolean): Promise<void>;
         deleteCid(cid: string, redraw?: boolean): Promise<void>;
         getNumberOfAtoms(): Promise<number>;
@@ -715,6 +716,7 @@ export namespace moorhen {
         disableFileUploads: boolean;
         urlPrefix: string;
         extraNavBarMenus: {name: string; ref: React.RefObject<any> ; icon: JSX.Element; JSXElement: JSX.Element}[];
+        extraNavBarModals: {name: string; ref: React.RefObject<any> ; icon: JSX.Element; JSXElement: JSX.Element; show: boolean; setShow: React.Dispatch<React.SetStateAction<boolean>>;}[];
         viewOnly: boolean;
         extraDraggableModals: JSX.Element[];
         monomerLibraryPath: string;

--- a/baby-gru/src/utils/MoorhenPreferences.ts
+++ b/baby-gru/src/utils/MoorhenPreferences.ts
@@ -33,7 +33,7 @@ export class MoorhenPreferences implements moorhen.Preferences {
 
     static defaultPreferencesValues: moorhen.PreferencesValues = {
         version: 'v31',
-        transparentModalsOnMouseOut: true,
+        transparentModalsOnMouseOut: false,
         defaultBackgroundColor: [1, 1, 1, 1],
         atomLabelDepthMode: true,
         enableTimeCapsule: true,


### PR DESCRIPTION
This update adds `extraNavBarModals` to `MoorhenContainer` props, allowing to pass navbar menu items that simply show a modal on click. It also adds new exported components to the npm module.