### PR TITLE
Make draggable modals resiazable

### DIFF
--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -61,7 +61,7 @@
       ]
     }
   },
-"dependencies": { },
+  "dependencies": { },
   "scripts": {
     "create-version": "npx genversion -e -p ./package.json -d -s ./src/version.js",
     "transpile-ts-worker": "npx tsc --module es2015 --lib webworker --skipLibCheck public/baby-gru/CootWorker.ts && sed -i.bak '/export {}/d' public/baby-gru/CootWorker.js && rm public/baby-gru/CootWorker.js.bak",

--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -61,7 +61,7 @@
       ]
     }
   },
-  "dependencies": { },
+"dependencies": { },
   "scripts": {
     "create-version": "npx genversion -e -p ./package.json -d -s ./src/version.js",
     "transpile-ts-worker": "npx tsc --module es2015 --lib webworker --skipLibCheck public/baby-gru/CootWorker.ts && sed -i.bak '/export {}/d' public/baby-gru/CootWorker.js && rm public/baby-gru/CootWorker.js.bak",
@@ -159,6 +159,7 @@
     "protvista-sequence": "^3.5.1",
     "protvista-track": "^3.4.0",
     "rc-tree": "4.2.2",
+    "re-resizable": "^6.9.11",
     "react": "^18.1.0",
     "react-bootstrap": "^2.3.1",
     "react-bootstrap-typeahead": "^6.0.0-alpha.11",

--- a/baby-gru/src/components/card/MoorhenMapCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMapCard.tsx
@@ -459,7 +459,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
                 </OverlayTrigger>
     }
 
-    return <Card ref={cardRef} className="px-0" style={{ marginBottom: '0.5rem', padding: '0' }} key={props.map.molNo}>
+    return <Card ref={cardRef} className="px-0" style={{ display: 'flex', minWidth: props.sideBarWidth, marginBottom: '0.5rem', padding: '0' }} key={props.map.molNo}>
         <Card.Header style={{ padding: '0.1rem' }}>
             <Stack gap={2} direction='horizontal'>
                 <Col className='align-items-center' style={{ display: 'flex', justifyContent: 'left', color: isDark ? 'white' : 'black' }}>

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef, useReducer, useCallback, useImperativeHandle, forwardRef } from 'react';
 import { Card, Row, Col, Stack, Button, Spinner } from "react-bootstrap";
 import { Accordion, AccordionDetails, AccordionSummary } from '@mui/material';
-import { doDownload, representationLabelMapping } from '../../utils/MoorhenUtils';
+import { convertRemToPx, doDownload, representationLabelMapping } from '../../utils/MoorhenUtils';
 import { isDarkBackground } from '../../WebGLgComponents/mgWebGL'
 import { MoorhenSequenceList } from "../list/MoorhenSequenceList";
 import { MoorhenMoleculeCardButtonBar } from "../button-bar/MoorhenMoleculeCardButtonBar"
@@ -464,7 +464,7 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
         <Card.Body style={{ display: isCollapsed ? 'none' : '', padding: '0.25rem', justifyContent:'center' }}>
             <Stack gap={2} direction='vertical'>
                 <Row style={{display: 'flex'}}>
-                    <Col style={{ width:'100%', height: '100%' }}>
+                    <Col style={{ display: 'flex' }}>
                         <div ref={addColourRulesAnchorDivRef} style={{ margin: '1px', paddingTop: '0.25rem', paddingBottom: '0.25rem',  border: '1px solid', borderRadius:'0.33rem', borderColor: "#CCC" }}>
                             <FormGroup style={{ margin: "0px", padding: "0px", display: 'flex', justifyContent: 'center'}} row>
                                 {allRepresentations.map(key => 
@@ -591,7 +591,7 @@ const RepresentationCheckbox = (props: {
     const [repState, setRepState] = useState<boolean>(false)
     const isDark = useSelector((state: moorhen.State) => state.canvasStates.isDark)
 
-    const chipStyle = getChipStyle(props.molecule.defaultColourRules, repState, isDark)
+    const chipStyle = getChipStyle(props.molecule.defaultColourRules, repState, isDark, `${convertRemToPx(6.5)}px`)
     const disabled: boolean = (
         !props.isVisible 
         || (props.repKey === 'ligands' && props.molecule.ligands.length === 0) 

--- a/baby-gru/src/components/menu-item/MapContourSettingsMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MapContourSettingsMenuItem.tsx
@@ -1,10 +1,13 @@
-import { Slider } from "@mui/material";
+import { IconButton, Slider } from "@mui/material";
 import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem";
 import { useEffect, useState } from "react";
 import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
 import { useDispatch, useSelector } from "react-redux";
-import { setDefaultMapSamplingRate } from "../../store/mapSettingsSlice";
+import { setDefaultMapSamplingRate, setMapLineWidth } from "../../store/mapSettingsSlice";
+import { Form } from "react-bootstrap";
+import { MoorhenSlider } from "../misc/MoorhenSlider";
+import { AddCircleOutline, RemoveCircleOutline } from "@mui/icons-material";
 
 const convertPercentageToSamplingRate = (oldValue: number, reverse: boolean = false) => {
     let [oldMax, oldMin, newMax, newMin]: number[] = []
@@ -23,7 +26,7 @@ const convertPercentageToSamplingRate = (oldValue: number, reverse: boolean = fa
 
 const samplingRateMarks = [1, 13, 25, 40, 60, 80, 100]
 
-export const MoorhenMapSamplingMenuItem = (props: {
+export const MapContourSettingsMenuItem = (props: {
     setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>; 
     popoverPlacement?: "left" | "right";
     commandCentre: React.RefObject<moorhen.CommandCentre>;
@@ -33,6 +36,8 @@ export const MoorhenMapSamplingMenuItem = (props: {
     const dispatch = useDispatch()
     const maps = useSelector((state: moorhen.State) => state.maps)
     const defaultMapSamplingRate = useSelector((state: moorhen.State) => state.mapSettings.defaultMapSamplingRate)
+    const mapLineWidth = useSelector((state: moorhen.State) => state.mapSettings.mapLineWidth)
+    const isDark = useSelector((state: moorhen.State) => state.canvasStates.isDark)
 
     const [mapSampling, setMapSampling] = useState<number>(convertPercentageToSamplingRate(defaultMapSamplingRate, true))
 
@@ -70,8 +75,18 @@ export const MoorhenMapSamplingMenuItem = (props: {
         setMapSamplingRate()
 
      }, [mapSampling])
-    
-    const panelContent =
+
+    const panelContent = <>
+        <Form.Group controlId="mapLineWidthSlider" style={{ paddingLeft: '0.5rem', paddingRight: '0.5rem' }}>
+            <MoorhenSlider
+            minVal={0.1}
+            maxVal={1.5}
+            logScale={true}
+            sliderTitle="Map lines thickness"
+            initialValue={mapLineWidth}
+            externalValue={mapLineWidth}
+            setExternalValue={(val: number) => dispatch(setMapLineWidth(val))}/>
+        </Form.Group>
         <div style={{width: '17rem', padding: '1rem'}}>
             <span>Map sampling rate</span>
             <Slider
@@ -91,17 +106,18 @@ export const MoorhenMapSamplingMenuItem = (props: {
                 marks={samplingRateMarks.map(mark => {return {value: mark, label:  convertPercentageToSamplingRate(mark).toFixed(1).toString()}})}
             />
         </div>
+    </>
 
     return <MoorhenBaseMenuItem
         popoverPlacement={props.popoverPlacement}
         popoverContent={panelContent}
         showOkButton={false}
-        menuItemText={"Set map sampling rate..."}
+        menuItemText={"Map contour settings..."}
         setPopoverIsShown={props.setPopoverIsShown}
         onCompleted={() => {}}
     />
 }
 
-MoorhenMapSamplingMenuItem.defaultProps = {
+MapContourSettingsMenuItem.defaultProps = {
     popoverPlacement: 'right'
 }

--- a/baby-gru/src/components/modal/MoorhenCreateAcedrgLinkModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenCreateAcedrgLinkModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useImperativeHandle, forwardRef } from 'react';
-import { cidToSpec } from "../../utils/MoorhenUtils";
+import { cidToSpec, convertRemToPx, convertViewtoPx } from "../../utils/MoorhenUtils";
 import { Button, Card, Dropdown, Form, InputGroup, Row, Spinner, SplitButton, Stack } from "react-bootstrap";
 import { Backdrop, TextField } from "@mui/material";
 import { moorhen } from "../../types/moorhen";
@@ -132,7 +132,7 @@ const AceDRGtomPicker = forwardRef<any, AceDRGtomPickerProps>((props, ref) => {
         }
     }, [props.awaitAtomClick])
 
-    return <Card style={{margin: 0, padding: '0.5rem', borderColor: 'grey', borderWidth: 3}}>
+    return <Card style={{width: '100%', height: '100%', margin: 0, padding: '0.5rem', borderColor: 'grey', borderWidth: 3}}>
             <Stack direction='vertical' gap={2}>
             <InputGroup>
                 <Button variant="primary" onClick={() => props.setAwaitAtomClick(props.id)}>
@@ -233,6 +233,10 @@ export const MoorhenCreateAcedrgLinkModal = (props: {
     
     const [awaitAtomClick, setAwaitAtomClick] = useState<number>(-1)
     const [errorMessage, setErrorMessage] = useState<string>('')
+    
+    const height = useSelector((state: moorhen.State) => state.canvasStates.height)
+    const width = useSelector((state: moorhen.State) => state.canvasStates.width)
+    
     const atomPickerOneRef = useRef(null)
     const atomPickerTwoRef = useRef(null)
 
@@ -260,6 +264,16 @@ export const MoorhenCreateAcedrgLinkModal = (props: {
 
     return <MoorhenDraggableModalBase 
                 headerTitle="Create covalent link"
+                left={`${width / 2}px`}
+                top={`${height / 3}px`}
+                show={props.show}
+                setShow={props.setShow}
+                defaultHeight={convertViewtoPx(10, height)}
+                defaultWidth={convertViewtoPx(10, width)}
+                minHeight={convertViewtoPx(10, height)}
+                minWidth={convertRemToPx(37)}
+                maxHeight={convertViewtoPx(90, height)}
+                maxWidth={convertRemToPx(55)}
                 additionalChildren={
                     <Backdrop sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1 }} open={awaitAtomClick !== -1}>
                         <Stack gap={2} direction='vertical'style={{justifyContent: 'center', alignItems: 'center'}}>
@@ -270,7 +284,7 @@ export const MoorhenCreateAcedrgLinkModal = (props: {
                     </Backdrop>
                 }
                 body={
-                    <Stack direction='horizontal' gap={2} style={{display: 'flex', justifyContent: 'space-between'}}>
+                    <Stack direction='horizontal' gap={2} style={{display: 'flex', flexDirection: 'row', justifyContent: 'space-between', height: '100%'}}>
                         <AceDRGtomPicker id={1} ref={atomPickerOneRef} awaitAtomClick={awaitAtomClick} setAwaitAtomClick={setAwaitAtomClick} {...props}/>
                         <AceDRGtomPicker id={2} ref={atomPickerTwoRef} awaitAtomClick={awaitAtomClick} setAwaitAtomClick={setAwaitAtomClick} {...props}/>
                     </Stack>

--- a/baby-gru/src/components/modal/MoorhenDraggableModalBase.tsx
+++ b/baby-gru/src/components/modal/MoorhenDraggableModalBase.tsx
@@ -1,10 +1,10 @@
 import { useRef, useState } from "react";
 import { Button, Card, Stack } from "react-bootstrap";
 import Draggable from "react-draggable";
-import { convertViewtoPx } from "../../utils/MoorhenUtils";
-import { AddOutlined, CloseOutlined, RemoveOutlined } from "@mui/icons-material";
+import { AddOutlined, CloseOutlined, RemoveOutlined, SquareFootOutlined } from "@mui/icons-material";
 import { moorhen } from "../../types/moorhen";
 import { useSelector } from "react-redux";
+import { Resizable } from "re-resizable";
 
 /**
  * The base component used to create draggable modals.
@@ -58,10 +58,14 @@ import { useSelector } from "react-redux";
  * 
  */
 export const MoorhenDraggableModalBase = (props: {
-    width?: number;
+    defaultWidth?: number;
+    defaultHeight?: number;
+    maxWidth?: number;
+    maxHeight?: number;
+    minWidth?: number;
+    minHeight?: number;
     top?: string;
     left?: string;
-    height?: number;
     additionalHeaderButtons?: JSX.Element[];
     headerTitle: string;
     show: boolean;
@@ -70,8 +74,12 @@ export const MoorhenDraggableModalBase = (props: {
     footer: JSX.Element;
     additionalChildren?: JSX.Element;
     overflowY?: 'visible' | 'hidden' | 'clip' | 'scroll' | 'auto';
+    overflowX?: 'visible' | 'hidden' | 'clip' | 'scroll' | 'auto';
     handleClassName?: string;
     showCloseButton?: boolean;
+    lockAspectRatio?: boolean;
+    enableResize?: false | {[key: string]: boolean};
+    onResizeStop?: (evt: MouseEvent | TouchEvent, direction: 'top' | 'right' | 'bottom' | 'left' | 'topRight' | 'bottomRight' | 'bottomLeft' | 'topLeft', ref: HTMLDivElement, delta: {width: number, height: number}) => void;
 }) => {
     
     const [opacity, setOpacity] = useState<number>(1.0)
@@ -86,13 +94,13 @@ export const MoorhenDraggableModalBase = (props: {
             <Card
                 className="moorhen-draggable-card"
                 ref={draggableNodeRef}
-                style={{ display: props.show ? 'block' : 'none', position: 'absolute', top: props.top, left: props.left, opacity: opacity, width: windowWidth ? convertViewtoPx(props.width, windowWidth) : `${props.width}wh`}}
+                style={{ display: props.show ? 'block' : 'none', position: 'absolute', top: props.top, left: props.left, opacity: opacity}}
                 onMouseOver={() => setOpacity(1.0)}
                 onMouseOut={() => {
                     if(transparentModalsOnMouseOut) setOpacity(0.5)
                 }}
             >
-                <Card.Header className={props.handleClassName} style={{ justifyContent: 'space-between', display: 'flex', cursor: 'move', alignItems:'center'}}>
+                <Card.Header className={props.handleClassName} style={{ minWidth: props.minWidth, justifyContent: 'space-between', display: 'flex', cursor: 'move', alignItems:'center'}}>
                     {props.headerTitle}
                     <Stack gap={2} direction="horizontal">
                         {props.additionalHeaderButtons?.map(button => button)}
@@ -106,8 +114,31 @@ export const MoorhenDraggableModalBase = (props: {
                         }
                     </Stack>
                 </Card.Header>
-                <Card.Body style={{maxHeight: windowHeight ? convertViewtoPx(props.height, windowHeight) : `${props.height}vh`, overflowY: props.overflowY, display: collapse ? 'none' : 'block', justifyContent: 'center'}}>
-                    {props.body}
+                <Card.Body style={{display: collapse ? 'none' : 'flex', justifyContent: 'center', flexDirection: 'column'}}>
+                    <Resizable
+                    maxWidth={props.maxWidth}
+                    maxHeight={props.maxHeight}
+                    minWidth={props.minWidth}
+                    minHeight={props.minHeight}
+                    bounds={'window'}
+                    resizeRatio={1.3}
+                    lockAspectRatio={props.lockAspectRatio}
+                    enable={props.enableResize}
+                    handleComponent={{bottomRight: props.enableResize ? <SquareFootOutlined style={{transform: 'rotate(270deg)'}}/> : <></>}}
+                    onResizeStop={props.onResizeStop}
+                    >
+                    <div style={{
+                            overflowY: props.overflowY,
+                            overflowX: props.overflowX,
+                            height: '100%',
+                            width: '100%',
+                            display: 'block',
+                            alignItems: 'center',
+                            justifyContent: 'center'
+                            }}>
+                        {props.body}
+                    </div>
+                    </Resizable>
                 </Card.Body>
                 {props.footer && 
                 <Card.Footer style={{display: collapse ? 'none' : 'flex', alignItems: 'center', justifyContent: 'right'}}>
@@ -121,5 +152,7 @@ export const MoorhenDraggableModalBase = (props: {
 
 MoorhenDraggableModalBase.defaultProps = { 
     showCloseButton: true, handleClassName: 'handle', additionalHeaderButtons:null, additionalChildren: null, 
-    width: 35, height: 45, top: '5rem', left: '5rem', overflowY: 'scroll'
+    enableResize: { top: false, right: true, bottom: true, left: false, topRight: false, bottomRight: true, bottomLeft: true, topLeft: false },
+    top: '5rem', left: '5rem', overflowY: 'auto', overflowX: 'hidden', lockAspectRatio: false, maxHeight: 100, maxWidth: 100, 
+    minHeight: 100, minWidth: 100, deafultWidth: 100, defaultHeight: 100, onResizeStop: () => {}
 }

--- a/baby-gru/src/components/modal/MoorhenMapsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenMapsModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { MoorhenDraggableModalBase } from "./MoorhenDraggableModalBase"
 import { MoorhenMapCard } from "../card/MoorhenMapCard";
-import { convertRemToPx } from "../../utils/MoorhenUtils";
+import { convertRemToPx, convertViewtoPx } from "../../utils/MoorhenUtils";
 import { moorhen } from "../../types/moorhen";
 import { UnfoldLessOutlined } from '@mui/icons-material';
 import { Button } from 'react-bootstrap';
@@ -19,6 +19,7 @@ export const MoorhenMapsModal = (props: MoorhenMapsModalProps) => {
     const [currentDropdownMolNo, setCurrentDropdownMolNo] = useState<number>(-1)
 
     const width = useSelector((state: moorhen.State) => state.canvasStates.width)
+    const height = useSelector((state: moorhen.State) => state.canvasStates.height)
     const maps = useSelector((state: moorhen.State) => state.maps)
 
     useEffect(() => {
@@ -39,7 +40,7 @@ export const MoorhenMapsModal = (props: MoorhenMapsModalProps) => {
             dropdownId={1}
             accordionDropdownId={1}
             setAccordionDropdownId={(arg0) => {}}
-            sideBarWidth={convertRemToPx(26)}
+            sideBarWidth={convertRemToPx(37)}
             key={map.molNo}
             index={map.molNo}
             map={map}
@@ -54,10 +55,15 @@ export const MoorhenMapsModal = (props: MoorhenMapsModalProps) => {
 
     return <MoorhenDraggableModalBase
                 left={`${width / 2}px`}
+                top={`${height / 3}px`}
                 show={props.show}
                 setShow={props.setShow}
-                height={70}
-                width={37}
+                defaultHeight={convertViewtoPx(10, height)}
+                defaultWidth={convertViewtoPx(10, width)}
+                minHeight={convertViewtoPx(10, height)}
+                minWidth={convertRemToPx(37)}
+                maxHeight={convertViewtoPx(90, height)}
+                maxWidth={convertRemToPx(55)}
                 headerTitle={'Maps'}
                 additionalHeaderButtons={[
                     <Button variant="white" key='collapse-all-maps' style={{margin: '0.1rem', padding: '0.1rem'}} onClick={handleCollapseAll}>

--- a/baby-gru/src/components/modal/MoorhenModelsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenModelsModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { MoorhenDraggableModalBase } from "./MoorhenDraggableModalBase"
 import { MoorhenMoleculeCard } from "../card/MoorhenMoleculeCard";
-import { convertRemToPx } from "../../utils/MoorhenUtils";
+import { convertRemToPx, convertViewtoPx } from "../../utils/MoorhenUtils";
 import { moorhen } from "../../types/moorhen";
 import { Button } from "react-bootstrap";
 import { UnfoldLessOutlined } from "@mui/icons-material";
@@ -14,7 +14,10 @@ interface MoorhenModelsModalProps extends moorhen.CollectedProps {
 
 export const MoorhenModelsModal = (props: MoorhenModelsModalProps) => {
     const cardListRef = useRef([])
+    
     const [currentDropdownMolNo, setCurrentDropdownMolNo] = useState<number>(-1)
+    
+    const height = useSelector((state: moorhen.State) => state.canvasStates.height)
     const width = useSelector((state: moorhen.State) => state.canvasStates.width)
     const molecules = useSelector((state: moorhen.State) => state.molecules)
 
@@ -36,7 +39,7 @@ export const MoorhenModelsModal = (props: MoorhenModelsModalProps) => {
             dropdownId={1}
             accordionDropdownId={1}
             setAccordionDropdownId={(arg0) => {}}
-            sideBarWidth={convertRemToPx(26)}
+            sideBarWidth={convertRemToPx(37)}
             key={molecule.molNo}
             index={molecule.molNo}
             molecule={molecule}
@@ -50,8 +53,12 @@ export const MoorhenModelsModal = (props: MoorhenModelsModalProps) => {
                 left={`${width / 2}px`}
                 show={props.show}
                 setShow={props.setShow}
-                height={70}
-                width={37}
+                defaultHeight={convertViewtoPx(10, height)}
+                defaultWidth={convertViewtoPx(10, width)}
+                minHeight={convertViewtoPx(10, height)}
+                minWidth={convertRemToPx(37)}
+                maxHeight={convertViewtoPx(90, height)}
+                maxWidth={convertRemToPx(55)}
                 headerTitle={'Models'}
                 additionalHeaderButtons={[
                     <Button variant="white" key='collapse-all-maps' style={{margin: '0.1rem', padding: '0.1rem'}} onClick={handleCollapseAll}>

--- a/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { Backdrop } from '@mui/material';
 import { ArrowBackIosOutlined, ArrowForwardIosOutlined, FirstPageOutlined, WarningOutlined } from "@mui/icons-material";
-import { getMultiColourRuleArgs, guid } from '../../utils/MoorhenUtils';
+import { convertRemToPx, convertViewtoPx, getMultiColourRuleArgs, guid } from '../../utils/MoorhenUtils';
 import { Card, Row, Col, Form, FormSelect, Button, Spinner, Stack } from "react-bootstrap";
 import { moorhen } from "../../types/moorhen";
 import { MoorhenMoleculeSelect } from "../select/MoorhenMoleculeSelect";
@@ -42,6 +42,8 @@ export const MoorhenQuerySequenceModal = (props: {
 
     const dispatch = useDispatch()
     const molecules = useSelector((state: moorhen.State) => state.molecules)
+    const height = useSelector((state: moorhen.State) => state.canvasStates.height)
+    const width = useSelector((state: moorhen.State) => state.canvasStates.width)
     const defaultBondSmoothness = useSelector((state: moorhen.State) => state.sceneSettings.defaultBondSmoothness)
     const backgroundColor = useSelector((state: moorhen.State) => state.canvasStates.backgroundColor)
 
@@ -284,6 +286,13 @@ export const MoorhenQuerySequenceModal = (props: {
     }, [numberOfHits])
 
     return <MoorhenDraggableModalBase
+        left={`${width / 4}px`}
+        defaultHeight={convertViewtoPx(10, height)}
+        defaultWidth={convertViewtoPx(10, width)}
+        minHeight={convertViewtoPx(15, height)}
+        minWidth={convertRemToPx(37)}
+        maxHeight={convertViewtoPx(50, height)}
+        maxWidth={convertViewtoPx(50, width)}
         additionalChildren={
             <Backdrop sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1 }} open={busy}>
                 <Spinner animation="border" style={{ marginRight: '0.5rem' }}/>
@@ -325,7 +334,7 @@ export const MoorhenQuerySequenceModal = (props: {
             <hr></hr>
             <Row>
                 {queryResults?.length > 0 ? <span>Found {numberOfHits} hits</span> : null}
-                {queryResults?.length > 0 ? queryResults : <span>No results found...</span>}
+                {queryResults?.length > 0 ? <div style={{height: '100px', width: '100%'}}>{queryResults}</div> : <span>No results found...</span>}
             </Row>
             </>
         }

--- a/baby-gru/src/components/modal/MoorhenScriptModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenScriptModal.tsx
@@ -11,6 +11,7 @@ import 'prismjs/themes/prism.css';
 import 'prismjs/components/prism-clike';
 import 'prismjs/components/prism-javascript';
 import { useSelector } from "react-redux";
+import { convertRemToPx, convertViewtoPx } from "../../utils/MoorhenUtils";
 
 export const MoorhenScriptModal = (props: {
     glRef: React.RefObject<webGL.MGWebGL>;
@@ -21,6 +22,9 @@ export const MoorhenScriptModal = (props: {
 }) => {
 
     const [code, setCode] = useState<string>("")
+    
+    const width = useSelector((state: moorhen.State) => state.canvasStates.width)
+    const height = useSelector((state: moorhen.State) => state.canvasStates.height)
     const isDark = useSelector((state: moorhen.State) => state.canvasStates.isDark)
     const molecules = useSelector((state: moorhen.State) => state.molecules)
     const maps = useSelector((state: moorhen.State) => state.maps)
@@ -42,19 +46,29 @@ export const MoorhenScriptModal = (props: {
     }, [])
 
     return <MoorhenDraggableModalBase
+                left={`${width / 5}px`}
+                top={`${height / 6}px`}
                 headerTitle="Interactive scripting"
+                defaultHeight={convertViewtoPx(10, height)}
+                defaultWidth={convertViewtoPx(10, width)}
+                minHeight={convertViewtoPx(10, height)}
+                minWidth={convertRemToPx(37)}
+                maxHeight={convertViewtoPx(60, height)}
+                maxWidth={convertRemToPx(55)}
                 body={
-                    <div style={{backgroundColor: isDark ? 'white' : '#e6e6e6', borderColor:'black'}}>
+                    <div style={{display: 'flex', maxHeight: convertViewtoPx(60, height), minHeight: convertViewtoPx(10, height) , overflowY: 'auto', backgroundColor: isDark ? 'white' : '#e6e6e6', borderColor:'black'}}>
+                        <div style={{height: '100%', width: '100%'}}>
                         <Editor
-                            value={code}
-                            onValueChange={code => setCode(code)}
-                            highlight={code => highlight(code, languages.js)}
-                            padding={10}
-                            style={{
-                                fontFamily: '"Fira code", "Fira Mono", monospace',
-                                fontSize: 16
-                            }}
-                        /> 
+                                value={code}
+                                onValueChange={code => setCode(code)}
+                                highlight={code => highlight(code, languages.js)}
+                                padding={10}
+                                style={{
+                                    fontFamily: '"Fira code", "Fira Mono", monospace',
+                                    fontSize: 16
+                                }}
+                            /> 
+                        </div>
                     </div>
                 }
                 footer={

--- a/baby-gru/src/components/modal/MoorhenValidationToolsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenValidationToolsModal.tsx
@@ -11,7 +11,7 @@ import { MoorhenMMRRCCPlot } from "../validation-tools/MoorhenMMRRCCPlot"
 import { MoorhenWaterValidation } from "../validation-tools/MoorhenWaterValidation"
 import { MoorhenLigandValidation } from "../validation-tools/MoorhenLigandValidation"
 import { MoorhenUnmodelledBlobs } from "../validation-tools/MoorhenUnmodelledBlobs"
-import { convertViewtoPx} from '../../utils/MoorhenUtils';
+import { convertRemToPx, convertViewtoPx} from '../../utils/MoorhenUtils';
 import { useSelector } from "react-redux";
 
 interface MoorhenValidationModalProps extends moorhen.CollectedProps {
@@ -21,6 +21,7 @@ interface MoorhenValidationModalProps extends moorhen.CollectedProps {
 
 export const MoorhenValidationToolsModal = (props: MoorhenValidationModalProps) => {    
     const [selectedTool, setSelectedTool] = useState<null | number>(null)
+    const [draggableResizeTrigger, setDraggableResizeTrigger] = useState<boolean>(true)
     const toolsAccordionSelectRef = useRef<undefined | HTMLSelectElement>()
     const width = useSelector((state: moorhen.State) => state.canvasStates.width)
     const height = useSelector((state: moorhen.State) => state.canvasStates.height)
@@ -32,7 +33,7 @@ export const MoorhenValidationToolsModal = (props: MoorhenValidationModalProps) 
 
     const toolOptions = [
             {label: "Difference Map Peaks", toolWidget: <MoorhenDifferenceMapPeaks {...collectedProps}/>},
-            {label: "Ramachandran Plot", toolWidget: <MoorhenRamachandran {...collectedProps}/>},
+            {label: "Ramachandran Plot", toolWidget: <MoorhenRamachandran resizeTrigger={draggableResizeTrigger} {...collectedProps}/>},
             {label: "Validation Plot", toolWidget: <MoorhenValidation {...collectedProps}/>},
             {label: "Ligand Validation", toolWidget: <MoorhenLigandValidation {...collectedProps}/>},
             {label: "Peptide flips using difference map", toolWidget: <MoorhenPepflipsDifferenceMap {...collectedProps}/>},
@@ -51,17 +52,30 @@ export const MoorhenValidationToolsModal = (props: MoorhenValidationModalProps) 
         }
     }
 
+    const chartWidgets = [
+        'Difference Map Peaks',
+        'Validation Plot',
+        'MMRRCC plot'
+    ]
+
     return <MoorhenDraggableModalBase
-                left={`${width / 2}px`}
+                left={`${width / 6}px`}
+                top={`${height / 3}px`}
                 show={props.show}
                 setShow={props.setShow}
-                height={70}
-                width={37}
-                overflowY='hidden'
+                defaultHeight={convertViewtoPx(70, height)}
+                defaultWidth={convertViewtoPx(37, width)}
+                minHeight={convertViewtoPx(30, height)}
+                minWidth={convertRemToPx(37)}
+                maxHeight={convertViewtoPx(90, height)}
+                maxWidth={convertViewtoPx(80, width)}
+                overflowY={chartWidgets.includes(toolOptions[selectedTool]?.label) ? 'hidden' : 'auto'}
+                overflowX='auto'
                 headerTitle='Validation tools'
                 footer={null}
+                onResizeStop={() => { setDraggableResizeTrigger((prev) => !prev) }}
                 body={
-                    <div style={{width: convertViewtoPx(35, width), height: convertViewtoPx(70, height)}} >
+                    <div style={{height: '100%'}} >
                         <Row style={{padding: '0.5rem', width:'100%', display:'inline-flex'}}>
                             <Form.Select id='validation-tool-select' ref={toolsAccordionSelectRef} onChange={handleChange} defaultValue={'placeHolder'}>
                                 <option key="placeHolder" value="placeHolder" disabled hidden>Tool...</option>

--- a/baby-gru/src/components/navbar-menus/MoorhenCalculateMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenCalculateMenu.tsx
@@ -4,6 +4,7 @@ import { MoorhenSuperposeMenuItem } from "../menu-item/MoorhenSuperposeMenuItem"
 import { MoorhenSelfRestraintsMenuItem } from "../menu-item/MoorhenSelfRestraintsMenuItem";
 import { MoorhenClearSelfRestraintsMenuItem } from "../menu-item/MoorhenClearSelfRestraintsMenuItem";
 import { MoorhenRandomJiggleBlurMenuItem } from "../menu-item/MoorhenRandomJiggleBlurMenuItem";
+import { MoorhenAddWatersMenuItem } from "../menu-item/MoorhenAddWatersMenuItem"
 import { MoorhenNavBarExtendedControlsInterface } from "./MoorhenNavBar";
 import { MenuItem } from "@mui/material";
 import { libcootApi } from "../../types/libcoot";
@@ -15,6 +16,7 @@ export const MoorhenCalculateMenu = (props: MoorhenNavBarExtendedControlsInterfa
     const menuItemProps = { setPopoverIsShown, ...props }
 
     return <>
+            <MoorhenAddWatersMenuItem {...menuItemProps} />
             <MoorhenSuperposeMenuItem key="superpose_structures" setSuperposeResults={setSuperposeResults} {...menuItemProps} />
             <MoorhenSelfRestraintsMenuItem
                 glRef={props.glRef}

--- a/baby-gru/src/components/navbar-menus/MoorhenLigandMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenLigandMenu.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { MoorhenCentreOnLigandMenuItem } from "../menu-item/MoorhenCentreOnLigandMenuItem"
-import { MoorhenAddWatersMenuItem } from "../menu-item/MoorhenAddWatersMenuItem"
 import { MoorhenSMILESToLigandMenuItem, MoorhenImportDictionaryMenuItem } from "../menu-item/MoorhenImportLigandDictionary";
 import { MoorhenFitLigandRightHereMenuItem } from "../menu-item/MoorhenFitLigandRightHereMenuItem"
 import { MoorhenGetMonomerMenuItem } from "../menu-item/MoorhenGetMonomerMenuItem"
@@ -15,7 +14,6 @@ export const MoorhenLigandMenu = (props: MoorhenNavBarExtendedControlsInterface)
             <MoorhenImportDictionaryMenuItem {...menuItemProps} />
             <MoorhenSMILESToLigandMenuItem {...menuItemProps} />
             <MoorhenCentreOnLigandMenuItem {...menuItemProps} />
-            <MoorhenAddWatersMenuItem {...menuItemProps} />
             <MoorhenFitLigandRightHereMenuItem {...menuItemProps} />
     </>
 }

--- a/baby-gru/src/components/navbar-menus/MoorhenPreferencesMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenPreferencesMenu.tsx
@@ -7,14 +7,14 @@ import { MoorhenGLFontMenuItem } from '../menu-item/MoorhenGLFontMenuItem'
 import { MoorhenScoresToastPreferencesMenuItem } from "../menu-item/MoorhenScoresToastPreferencesMenuItem"
 import { MoorhenBackupPreferencesMenuItem } from "../menu-item/MoorhenBackupPreferencesMenuItem"
 import { MoorhenDefaultBondSmoothnessPreferencesMenuItem } from "../menu-item/MoorhenDefaultBondSmoothnessPreferencesMenuItem"
-import { MoorhenMapSamplingMenuItem } from "../menu-item/MoorhenMapSamplingMenuItem"
+import { MapContourSettingsMenuItem } from "../menu-item/MapContourSettingsMenuItem"
 import { MoorhenSlider } from '../misc/MoorhenSlider' 
 import { MoorhenNavBarExtendedControlsInterface } from "./MoorhenNavBar";
 import { useSelector, useDispatch } from "react-redux";
 import { setDefaultExpandDisplayCards, setEnableRefineAfterMod, setTransparentModalsOnMouseOut } from "../../store/miscAppSettingsSlice";
 import { setAtomLabelDepthMode } from "../../store/labelSettingsSlice";
-import { setDefaultMapLitLines, setDefaultMapSurface, setMapLineWidth } from "../../store/mapSettingsSlice";
-import { setShortCuts, setShortcutOnHoveredAtom, setShowShortcutToast } from "../../store/shortCutsSlice";
+import { setDefaultMapLitLines, setDefaultMapSurface } from "../../store/mapSettingsSlice";
+import { setShortcutOnHoveredAtom, setShowShortcutToast } from "../../store/shortCutsSlice";
 import { setMakeBackups } from "../../store/backupSettingsSlice";
 import { setDevMode } from "../../store/generalStatesSlice";
 import { setContourWheelSensitivityFactor, setMouseSensitivity, setZoomWheelSensitivityFactor } from "../../store/mouseSettings";
@@ -25,7 +25,6 @@ export const MoorhenPreferencesMenu = (props: MoorhenNavBarExtendedControlsInter
     const dispatch = useDispatch()
     const devMode = useSelector((state: moorhen.State) => state.generalStates.devMode)
     const defaultMapLitLines = useSelector((state: moorhen.State) => state.mapSettings.defaultMapLitLines)
-    const mapLineWidth = useSelector((state: moorhen.State) => state.mapSettings.mapLineWidth)
     const defaultMapSurface = useSelector((state: moorhen.State) => state.mapSettings.defaultMapSurface)
     const enableTimeCapsule = useSelector((state: moorhen.State) => state.backupSettings.enableTimeCapsule)
     const makeBackups = useSelector((state: moorhen.State) => state.backupSettings.makeBackups)
@@ -136,9 +135,6 @@ export const MoorhenPreferencesMenu = (props: MoorhenNavBarExtendedControlsInter
                     <Form.Group controlId="mapWheelSensitivitySlider" style={{paddingTop:'0.5rem', paddingBottom:'0rem', paddingRight:'0.5rem', paddingLeft:'1rem', width: '25rem'}}>
                         <MoorhenSlider minVal={0.01} maxVal={0.1} logScale={false} sliderTitle="Mouse wheel map contour sensitivity" initialValue={contourWheelSensitivityFactor} externalValue={contourWheelSensitivityFactor} setExternalValue={(val: number) => dispatch(setContourWheelSensitivityFactor(val))}/>
                     </Form.Group>
-                    <Form.Group controlId="mapLineWidthSlider" style={{paddingTop:'0.5rem', paddingBottom:'0rem', paddingRight:'0.5rem', paddingLeft:'1rem', width: '25rem'}}>
-                        <MoorhenSlider minVal={0.1} maxVal={1.5} logScale={true} sliderTitle="Map lines thickness" initialValue={mapLineWidth} externalValue={mapLineWidth} setExternalValue={(val: number) => dispatch(setMapLineWidth(val))}/>
-                    </Form.Group>
                     <hr></hr>
                     <MoorhenBackupPreferencesMenuItem 
                         setPopoverIsShown={setPopoverIsShown}
@@ -149,7 +145,7 @@ export const MoorhenPreferencesMenu = (props: MoorhenNavBarExtendedControlsInter
                     <MoorhenDefaultBondSmoothnessPreferencesMenuItem
                         setPopoverIsShown={setPopoverIsShown}
                     />
-                    <MoorhenMapSamplingMenuItem
+                    <MapContourSettingsMenuItem
                         glRef={props.glRef}
                         commandCentre={props.commandCentre}
                         setPopoverIsShown={setPopoverIsShown}

--- a/baby-gru/src/components/validation-tools/MoorhenRamachandran.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenRamachandran.tsx
@@ -15,6 +15,7 @@ interface Props extends moorhen.CollectedProps {
     setAccordionDropdownId: React.Dispatch<React.SetStateAction<number>>;
     sideBarWidth: number;
     showSideBar: boolean;
+    resizeTrigger: boolean;
 }
 
 export const MoorhenRamachandran = (props: Props) => {
@@ -414,7 +415,7 @@ export const MoorhenRamachandran = (props: Props) => {
             }
         }, 50);
 
-    }, [width, height])
+    }, [width, height, props.resizeTrigger])
 
     useEffect(() => {
         async function fetchRamaData() {

--- a/baby-gru/src/components/validation-tools/MoorhenValidationChartWidgetBase.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenValidationChartWidgetBase.tsx
@@ -8,6 +8,7 @@ import { gemmi } from "../../types/gemmi";
 import annotationPlugin from 'chartjs-plugin-annotation'
 import { moorhen } from "../../types/moorhen";
 import { useSelector } from "react-redux";
+import { convertViewtoPx } from "../../utils/MoorhenUtils";
 
 Chart.register(...registerables);
 Chart.register(annotationPlugin);
@@ -36,6 +37,7 @@ export const MoorhenValidationChartWidgetBase = forwardRef<Chart, ValidationChar
     const [selectedChain, setSelectedChain] = useState<string | null>(null)
     const [cachedGemmiStructure, setCachedGemmiStructure] = useState<null | gemmi.Structure>(null)
 
+    const height = useSelector((state: moorhen.State) => state.canvasStates.height)
     const backgroundColor = useSelector((state: moorhen.State) => state.canvasStates.backgroundColor)
     const molecules = useSelector((state: moorhen.State) => state.molecules)
     const maps = useSelector((state: moorhen.State) => state.maps)
@@ -137,15 +139,14 @@ export const MoorhenValidationChartWidgetBase = forwardRef<Chart, ValidationChar
                         </Row>
                     </Form.Group>
                 </Form>
-                <div className="validation-plot-div" >
+                <div style={{display: 'flex'}} className="validation-plot-div" >
                     <div style={{height: '100%'}} className="chartBox" id="myChartBox">
                         <div className="validation-plot-container" style={{height: '100%', overflowX:'scroll'}}>
-                            <div style={{height: '100%'}} className="containerBody" id="myContainerBody">
+                            <div style={{height: '100%', minHeight: convertViewtoPx(45, height)}} className="containerBody" id="myContainerBody">
                                 <canvas id="myChart"></canvas>
                             </div>
                         </div>
                     </div>
-                <canvas id="myChartAxis"></canvas>
                 </div>
             </Fragment>
 


### PR DESCRIPTION
This update resolves #168 and includes some other small changes:
- Add waters menu is no under "Calculate" instead of "Ligand" and a map must be selected instead of using `activeMap`
- Map sampling grid and map lines width selectors are under the same menu "Map contour settings" in "Preferences"