### PR TITLE
Prevent draggable modals getting outside the window on resize events

### DIFF
--- a/baby-gru/src/components/modal/MoorhenMapsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenMapsModal.tsx
@@ -54,7 +54,7 @@ export const MoorhenMapsModal = (props: MoorhenMapsModalProps) => {
     displayData.sort((a, b) => (a.props.index > b.props.index) ? 1 : ((b.props.index > a.props.index) ? -1 : 0))
 
     return <MoorhenDraggableModalBase
-                left={width / 2}
+                left={width - (convertRemToPx(55) + 100)}
                 top={height / 2}
                 show={props.show}
                 setShow={props.setShow}

--- a/baby-gru/src/components/modal/MoorhenModelsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenModelsModal.tsx
@@ -50,7 +50,7 @@ export const MoorhenModelsModal = (props: MoorhenModelsModalProps) => {
     displayData.sort((a, b) => (a.props.index > b.props.index) ? 1 : ((b.props.index > a.props.index) ? -1 : 0))
 
     return <MoorhenDraggableModalBase
-                left={width / 2}
+                left={width - (convertRemToPx(55) + 100)}
                 top={height / 4}
                 show={props.show}
                 setShow={props.setShow}


### PR DESCRIPTION
This update makes the `Draggable` component inside `MoorhenDraggableModal` a controlled component for better management of the position while dragging the modals. This is a continuation of #173 as it prevents modals from getting outside the window on resize events.