### PR TITLE
Add residue selections part I

### DIFF
--- a/baby-gru/src/WebGLgComponents/mgWebGL.tsx
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.tsx
@@ -8859,10 +8859,11 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
                 }
                 this.props.messageChanged({ message: label + ", xyz:(" + atx + " " + aty + " " + atz + ")" + tempFactorLabel });
 
-                let atomClicked = new CustomEvent("atomClicked", {
+                let atomClicked: moorhen.AtomClickedEvent = new CustomEvent("atomClicked", {
                     "detail": {
                         atom: self.displayBuffers[minidx].atoms[minj],
-                        buffer: self.displayBuffers[minidx]
+                        buffer: self.displayBuffers[minidx],
+                        isResidueSelection: self.keysDown['residue_selection']
                     }
                 });
                 document.dispatchEvent(atomClicked);
@@ -8885,7 +8886,7 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
                     } else {
                         self.measuredAtoms[self.measuredAtoms.length - 1].push(theAtom);
                     }
-                }
+                } 
             }
             if(updateLabels) self.updateLabels()
         }

--- a/baby-gru/src/components/MoorhenContainer.tsx
+++ b/baby-gru/src/components/MoorhenContainer.tsx
@@ -358,7 +358,8 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
     }, [hoveredAtom])
 
     useEffect(() => {
-        glResize()
+        glRef.current.resize(width, height)
+        glRef.current.drawScene()
     }, [width, height])
 
     useEffect(() => {
@@ -367,10 +368,6 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
         }
     }, [activeMap])
 
-    const glResize = () => {
-        glRef.current.resize(width, height)
-        glRef.current.drawScene()
-    }
 
     return <> 
     <div>

--- a/baby-gru/src/components/context-menu/MoorhenContextMenu.tsx
+++ b/baby-gru/src/components/context-menu/MoorhenContextMenu.tsx
@@ -108,12 +108,14 @@ export const MoorhenContextMenu = (props: {
 
   const contextMenuRef = useRef(null)
   const quickActionsFormGroupRef = useRef<HTMLInputElement>(null)
+  
   const [showOverlay, setShowOverlay] = useState<boolean>(false)
   const [overlayContents, setOverlayContents] = useState<null | JSX.Element>(null)
   const [overrideMenuContents, setOverrideMenuContents] = useState<boolean>(false)
   const [opacity, setOpacity] = useState<number>(1.0)
   const [toolTip, setToolTip] = useState<string>('')
   
+  const residueSelection = useSelector((state: moorhen.State) => state.generalStates.residueSelection)
   const molecules = useSelector((state: moorhen.State) => state.molecules)
   const width = useSelector((state: moorhen.State) => state.canvasStates.width)
   const height = useSelector((state: moorhen.State) => state.canvasStates.height)
@@ -178,7 +180,22 @@ export const MoorhenContextMenu = (props: {
             <List>
               {props.viewOnly ? 
                 <MoorhenBackgroundColorMenuItem setPopoverIsShown={() => { }}/>
-              :              
+              :
+              residueSelection.cid !== null && residueSelection.molecule !== null ? 
+              <>
+              <div style={{ display:'flex', justifyContent: 'center' }}>
+              <Tooltip className="moorhen-tooltip" title={toolTip}>
+              <FormGroup ref={quickActionsFormGroupRef} style={{ justifyContent: 'center', margin: "0px", padding: "0px", width: '18rem' }} row>
+              <MoorhenRefineResiduesButton mode='context' {...collectedProps}/> 
+              <MoorhenDeleteButton mode='context' {...collectedProps} />
+              <MoorhenRigidBodyFitButton  mode='context' {...collectedProps}/>
+              <MoorhenRotateTranslateZoneButton mode='context' {...collectedProps} />
+              <MoorhenDragAtomsButton mode='context' {...collectedProps} />
+              </FormGroup>
+              </Tooltip>
+              </div>
+              </>
+              :
               selectedMolecule && chosenAtom &&
               <div style={{ display:'flex', justifyContent: 'center' }}>
               <Tooltip className="moorhen-tooltip" title={toolTip}>

--- a/baby-gru/src/components/modal/MoorhenDraggableModalBase.tsx
+++ b/baby-gru/src/components/modal/MoorhenDraggableModalBase.tsx
@@ -109,7 +109,7 @@ export const MoorhenDraggableModalBase = (props: {
         })
     }
 
-    const handleDragStart = useCallback(() => {
+    const handleStart = useCallback(() => {
         if (enableAtomHovering) {
             dispatch( setEnableAtomHovering(false) )
             cachedEnableAtomHovering.current = true
@@ -139,13 +139,20 @@ export const MoorhenDraggableModalBase = (props: {
         }
     }, [windowWidth, windowHeight])
 
+    const handleResizeStop = (evt: MouseEvent | TouchEvent, direction: 'top' | 'right' | 'bottom' | 'left' | 'topRight' | 'bottomRight' | 'bottomLeft' | 'topLeft', ref: HTMLDivElement, delta: {width: number, height: number}) => {
+        if (cachedEnableAtomHovering.current) {
+            dispatch( setEnableAtomHovering(true) )
+        }
+        props.onResizeStop(evt, direction, ref, delta)
+    }
+        
     return <Draggable
                 nodeRef={draggableNodeRef}
                 handle={`.${props.handleClassName}`}
                 position={position}
                 onDrag={handleDrag}
                 onStop={handleDragStop}
-                onStart={handleDragStart}
+                onStart={handleStart}
                 >
             <Card
                 className="moorhen-draggable-card"
@@ -181,7 +188,8 @@ export const MoorhenDraggableModalBase = (props: {
                     lockAspectRatio={props.lockAspectRatio}
                     enable={props.enableResize}
                     handleComponent={{bottomRight: props.enableResize ? <SquareFootOutlined style={{transform: 'rotate(270deg)'}}/> : <></>}}
-                    onResizeStop={props.onResizeStop}
+                    onResizeStop={handleResizeStop}
+                    onResizeStart={handleStart}
                     >
                     <div style={{
                             overflowY: props.overflowY,

--- a/baby-gru/src/store/generalStatesSlice.ts
+++ b/baby-gru/src/store/generalStatesSlice.ts
@@ -12,6 +12,7 @@ export const generalStatesSlice = createSlice({
     activeMap: null,
     theme: 'flatly',
     viewOnly: false,
+    residueSelection: { molecule: null, first: null, second: null, cid: null } as moorhen.ResidueSelection,
   },
   reducers: {
     setTheme: (state, action: {payload: string, type: string}) => {
@@ -37,12 +38,36 @@ export const generalStatesSlice = createSlice({
     },
     setDevMode: (state, action: {payload: boolean, type: string}) => {
         return {...state, devMode: action.payload}
+    },
+    clearResidueSelection: (state) => {
+      return {...state, residueSelection: { molecule: null, first: null, second: null, cid: null }}
+    },
+    setResidueSelection: (state, action: {payload: moorhen.ResidueSelection, type: string}) => {
+      return {...state, residueSelection: action.payload}
+    },
+    setMoleculeResidueSelection: (state, action: {payload: moorhen.Molecule, type: string}) => {
+      const newResidueSelection = {...state.residueSelection, molecule: action.payload}
+      return {...state, residueSelection: newResidueSelection}
+    },
+    setStopResidueSelection: (state, action: {payload: string, type: string}) => {
+      const newResidueSelection = {...state.residueSelection, stop: action.payload}
+      return {...state, residueSelection: newResidueSelection}
+    },
+    setStartResidueSelection: (state, action: {payload: string, type: string}) => {
+      const newResidueSelection = {...state.residueSelection, start: action.payload}
+      return {...state, residueSelection: newResidueSelection}
+    },
+    setCidResidueSelection: (state, action: {payload: string, type: string}) => {
+      const newResidueSelection = {...state.residueSelection, cid: action.payload}
+      return {...state, residueSelection: newResidueSelection}
     }
 }})
 
 export const {
-  setNotificationContent, setActiveMap, setCootInitialized,
-  setAppTittle, setUserPreferencesMounted, setDevMode, setTheme, setViewOnly
+  setNotificationContent, setActiveMap, setViewOnly, setTheme,
+  setAppTittle, setUserPreferencesMounted, setDevMode, setCootInitialized, 
+  setStopResidueSelection, setStartResidueSelection, clearResidueSelection,
+  setMoleculeResidueSelection, setResidueSelection, setCidResidueSelection
 } = generalStatesSlice.actions
 
 export default generalStatesSlice.reducer

--- a/baby-gru/src/store/hoveringStatesSlice.ts
+++ b/baby-gru/src/store/hoveringStatesSlice.ts
@@ -5,11 +5,11 @@ export const hoveringStatesSlice = createSlice({
   name: 'hoveringStates',
   initialState: {
     enableAtomHovering: true,
-    hoveredAtom: { molecule: null, cid: null } as { molecule: null | moorhen.Molecule, cid: null | string },
+    hoveredAtom: { molecule: null, cid: null } as moorhen.HoveredAtom,
     cursorStyle: 'default'
   },
   reducers: {
-    setHoveredAtom: (state, action: {payload: { molecule: null | moorhen.Molecule, cid: null | string }, type: string}) => {
+    setHoveredAtom: (state, action: {payload: moorhen.HoveredAtom, type: string}) => {
         return {...state, hoveredAtom: action.payload}
     },
     setEnableAtomHovering: (state, action: {payload: boolean, type: string}) => {

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -53,7 +53,7 @@ declare module 'moorhen' {
         moveMoleculeHere(x: number, y: number, z: number): Promise<void>;
         checkHasGlycans(): Promise<boolean>;
         fitLigandHere(mapMolNo: number, ligandMolNo: number, redraw?: boolean, useConformers?: boolean, conformerCount?: number): Promise<_moorhen.Molecule[]>;
-        isLigand(): boolean;
+        checkIsLigand(): boolean;
         removeRepresentation(representationId: string): void;
         addRepresentation(style: string, cid: string, isCustom?: boolean, colour?: _moorhen.ColourRule[], bondOptions?: _moorhen.cootBondOptions, applyColourToNonCarbonAtoms?: boolean): Promise<_moorhen.MoleculeRepresentation>;
         getNeighborResiduesCids(selectionCid: string, maxDist: number): Promise<string[]>;
@@ -101,6 +101,7 @@ declare module 'moorhen' {
         centreAndAlignViewOn(selectionCid: string, animate?: boolean): Promise<void>;
         buffersInclude: (bufferIn: { id: string; }) => boolean;
         redrawRepresentation: (id: string) => Promise<void>;
+        isLigand: boolean;
         type: string;
         excludedCids: string[];
         commandCentre: React.RefObject<_moorhen.CommandCentre>;

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -90,6 +90,7 @@ declare module 'moorhen' {
         drawEnvironment: (cid: string, labelled?: boolean) => Promise<void>;
         centreOn: (selectionCid?: string, animate?: boolean) => Promise<void>;
         drawHover: (cid: string) => Promise<void>;
+        drawResidueSelection: (cid: string) => Promise<void>;
         clearBuffersOfStyle: (style: string) => void;
         loadToCootFromURL: (inputFile: string, molName: string) => Promise<_moorhen.Molecule>;
         applyTransform: () => Promise<void>;
@@ -137,6 +138,7 @@ declare module 'moorhen' {
         hoverRepresentation: _moorhen.MoleculeRepresentation;
         unitCellRepresentation: _moorhen.MoleculeRepresentation;
         environmentRepresentation: _moorhen.MoleculeRepresentation;
+        selectionRepresentation: _moorhen.MoleculeRepresentation;
         hasDNA: boolean;
         hasGlycans: boolean;
     }

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -221,6 +221,13 @@ export namespace moorhen {
         isCustom: boolean;
         styleHasColourRules: boolean;
     }
+
+    type ResidueSelection = {
+        molecule: null | moorhen.Molecule;
+        first: null | string;
+        second: null | string;
+        cid: null | string;
+    }
     
     type HoveredAtom = {
         molecule: Molecule | null,

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -96,7 +96,7 @@ export namespace moorhen {
         moveMoleculeHere(x: number, y: number, z: number): Promise<void>;
         checkHasGlycans(): Promise<boolean>;
         fitLigandHere(mapMolNo: number, ligandMolNo: number, redraw?: boolean, useConformers?: boolean, conformerCount?: number): Promise<Molecule[]>;
-        isLigand(): boolean;
+        checkIsLigand(): boolean;
         removeRepresentation(representationId: string): void;
         addRepresentation(style: string, cid: string, isCustom?: boolean, colour?: ColourRule[], bondOptions?: cootBondOptions, applyColourToNonCarbonAtoms?: boolean): Promise<MoleculeRepresentation>;
         getNeighborResiduesCids(selectionCid: string, maxDist: number): Promise<string[]>;
@@ -144,6 +144,7 @@ export namespace moorhen {
         buffersInclude: (bufferIn: { id: string; }) => boolean;
         redrawRepresentation: (id: string) => Promise<void>;
         type: string;
+        isLigand: boolean;
         excludedCids: string[];
         commandCentre: React.RefObject<CommandCentre>;
         glRef: React.RefObject<webGL.MGWebGL>;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -132,6 +132,7 @@ export namespace moorhen {
         drawEnvironment: (cid: string, labelled?: boolean) => Promise<void>;
         centreOn: (selectionCid?: string, animate?: boolean) => Promise<void>;
         drawHover: (cid: string) => Promise<void>;
+        drawResidueSelection: (cid: string) => Promise<void>;
         clearBuffersOfStyle: (style: string) => void;
         loadToCootFromURL: (inputFile: string, molName: string) => Promise<Molecule>;
         applyTransform: () => Promise<void>;
@@ -179,13 +180,14 @@ export namespace moorhen {
         hoverRepresentation: MoleculeRepresentation;
         unitCellRepresentation: MoleculeRepresentation;
         environmentRepresentation: MoleculeRepresentation;
+        selectionRepresentation: MoleculeRepresentation;
         hasDNA: boolean;
         hasGlycans: boolean;
     }
 
     type RepresentationStyles = 'VdwSpheres' | 'ligands' | 'CAs' | 'CBs' | 'CDs' | 'gaussian' | 'allHBonds' | 'rama' | 
     'rotamer' | 'CRs' | 'MolecularSurface' | 'DishyBases' | 'VdWSurface' | 'Calpha' | 'unitCell' | 'hover' | 'environment' | 
-    'ligand_environment' | 'contact_dots' | 'chemical_features' | 'ligand_validation' | 'glycoBlocks' | 'restraints'
+    'ligand_environment' | 'contact_dots' | 'chemical_features' | 'ligand_validation' | 'glycoBlocks' | 'restraints' | 'residueSelection'
 
     interface MoleculeRepresentation {
         setApplyColourToNonCarbonAtoms(newVal: boolean): void;
@@ -529,6 +531,7 @@ export namespace moorhen {
     type AtomClickedEvent = CustomEvent<{
         buffer: { id: string };
         atom: { label: string };
+        isResidueSelection: boolean;
     }>
 
     type ConnectMapsEvent = CustomEvent<ConnectMapsInfo>
@@ -678,12 +681,6 @@ export namespace moorhen {
         defaultActionButtonSettings: actionButtonSettings;
         setDefaultActionButtonSettings: (arg0: {key: string; value: string}) => void;     
     }
-    
-    type MolChange<T extends Molecule | Map> = {
-        action: 'Add' | 'Remove' | 'AddList' | 'Empty';
-        item?: T;
-        items?: T[];
-    }    
 
     interface ContainerRefs {
         glRef: React.MutableRefObject<null | webGL.MGWebGL>;
@@ -795,6 +792,7 @@ export namespace moorhen {
             notificationContent: JSX.Element;
             activeMap: Map;
             theme: string;
+            residueSelection: ResidueSelection;
         };
         hoveringStates: {
             enableAtomHovering: boolean;

--- a/baby-gru/src/utils/MoorhenKeyboardAccelerators.tsx
+++ b/baby-gru/src/utils/MoorhenKeyboardAccelerators.tsx
@@ -8,11 +8,15 @@ import { moorhen } from "../types/moorhen";
 import { webGL } from "../types/mgWebGL";
 import { libcootApi } from "../types/libcoot";
 import { MoorhenNotification } from "../components/misc/MoorhenNotification";
+import { Dispatch } from "react";
+import { AnyAction } from "@reduxjs/toolkit";
+import { setNotificationContent, clearResidueSelection } from "../store/generalStatesSlice";
+import { setHoveredAtom } from "../store/hoveringStatesSlice";
 
-const apresEdit = (molecule: moorhen.Molecule, glRef: React.RefObject<webGL.MGWebGL>, timeCapsuleRef: React.RefObject<moorhen.TimeCapsule>, setHoveredAtom: (arg0: moorhen.HoveredAtom) => void) => {
+const apresEdit = (molecule: moorhen.Molecule, glRef: React.RefObject<webGL.MGWebGL>, dispatch: Dispatch<AnyAction>) => {
     molecule.setAtomsDirty(true)
     molecule.redraw()
-    setHoveredAtom({ molecule: null, cid: null })
+    dispatch( setHoveredAtom({ molecule: null, cid: null }) )
     const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: glRef.current.origin,  modifiedMolecule: molecule.molNo} })
     document.dispatchEvent(scoresUpdateEvent)
 }
@@ -21,9 +25,8 @@ export const babyGruKeyPress = (
     event: KeyboardEvent, 
     collectedProps: {
         isDark: boolean;
-        setNotificationContent: (arg: JSX.Element) => void;
+        dispatch: Dispatch<AnyAction>
         hoveredAtom: moorhen.HoveredAtom;
-        setHoveredAtom: (arg: moorhen.HoveredAtom) => void;
         commandCentre: React.RefObject<moorhen.CommandCentre>;
         activeMap: moorhen.Map;
         molecules: moorhen.Molecule[];
@@ -39,8 +42,8 @@ export const babyGruKeyPress = (
 ): boolean | Promise<boolean> => {
     
     const { 
-        setNotificationContent, hoveredAtom, setHoveredAtom, commandCentre, activeMap, 
-        glRef, molecules, timeCapsuleRef, viewOnly, videoRecorderRef, isDark, windowWidth
+        hoveredAtom, commandCentre, activeMap, glRef, molecules, dispatch,
+        timeCapsuleRef, viewOnly, videoRecorderRef, isDark, windowWidth
     } = collectedProps;
 
     const getCentreAtom = async (): Promise<[moorhen.Molecule, string]> => {
@@ -84,7 +87,7 @@ export const babyGruKeyPress = (
                 changesMolecules: [chosenMolecule.molNo]
             }, true)
             .then(_ => {
-                apresEdit(chosenMolecule, glRef, timeCapsuleRef, setHoveredAtom)
+                apresEdit(chosenMolecule, glRef, dispatch)
             })
             .then(_ => false)
             .catch(err => {
@@ -105,11 +108,11 @@ export const babyGruKeyPress = (
     if (event.key === " ") modifiers.push("<Space>")
 
     if (showShortcutToast && !viewOnly) {
-        setNotificationContent(
+        dispatch( setNotificationContent(
             <MoorhenNotification key={guid()} hideDelay={5000}>
                 <h5 style={{margin: 0}}>{`${modifiers.join("-")} ${event.key} pressed`}</h5>
             </MoorhenNotification>
-        )
+        ))
     }
     
     let action: null | string = null;
@@ -129,7 +132,7 @@ export const babyGruKeyPress = (
         const formatArgs = (chosenMolecule: moorhen.Molecule, chosenAtom: moorhen.ResidueSpec) => {
             return [chosenMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}`, "SPHERE", 4000]
         }
-        showShortcutToast && setNotificationContent(
+        showShortcutToast && dispatch( setNotificationContent(
             <MoorhenNotification key={guid()} hideDelay={5000}>
             <h5 style={{margin: 0}}>
                 <List>
@@ -138,7 +141,7 @@ export const babyGruKeyPress = (
                 </List>
             </h5>
             </MoorhenNotification>
-        )
+        ))
         return doShortCut('refine_residues_using_atom_cid', formatArgs)
     }
 
@@ -166,7 +169,7 @@ export const babyGruKeyPress = (
         const formatArgs = (chosenMolecule: moorhen.Molecule, chosenAtom: moorhen.ResidueSpec) => {
             return [chosenMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}/${chosenAtom.atom_name}`, '']
         }
-        showShortcutToast && setNotificationContent(
+        showShortcutToast && dispatch( setNotificationContent(
             <MoorhenNotification key={guid()} hideDelay={5000}>
             <h5 style={{margin: 0}}>
                 <List>
@@ -175,7 +178,7 @@ export const babyGruKeyPress = (
                 </List>
             </h5>
             </MoorhenNotification>
-        )
+        ))
         return doShortCut('flipPeptide_cid', formatArgs)
     }
 
@@ -183,7 +186,7 @@ export const babyGruKeyPress = (
         const formatArgs = (chosenMolecule: moorhen.Molecule, chosenAtom: moorhen.ResidueSpec) => {
             return [chosenMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}`, "TRIPLE", 4000]
         }
-        showShortcutToast && setNotificationContent(
+        showShortcutToast && dispatch( setNotificationContent(
             <MoorhenNotification key={guid()} hideDelay={5000}>
             <h5 style={{margin: 0}}>
                 <List>
@@ -192,7 +195,7 @@ export const babyGruKeyPress = (
                 </List>
             </h5>
             </MoorhenNotification>
-        )
+        ))
         return doShortCut('refine_residues_using_atom_cid', formatArgs)
     }
 
@@ -207,7 +210,7 @@ export const babyGruKeyPress = (
                 activeMap.molNo
             ]
         }
-        showShortcutToast && setNotificationContent(
+        showShortcutToast && dispatch( setNotificationContent(
             <MoorhenNotification key={guid()} hideDelay={5000}>
             <h5 style={{margin: 0}}>
                 <List>
@@ -216,7 +219,7 @@ export const babyGruKeyPress = (
                 </List>
             </h5>
             </MoorhenNotification>
-        )
+        ))
         return doShortCut('auto_fit_rotamer', formatArgs)
     }
 
@@ -224,14 +227,14 @@ export const babyGruKeyPress = (
         const formatArgs = (chosenMolecule: moorhen.Molecule, chosenAtom: moorhen.ResidueSpec) => {
             return [chosenMolecule.molNo,  `//${chosenAtom.chain_id}/${chosenAtom.res_no}`]
         }
-        showShortcutToast && setNotificationContent(
+        showShortcutToast && dispatch( setNotificationContent(
             <h5 style={{margin: 0}}>
                 <List>
                     <ListItem style={{justifyContent: 'center'}}>{`${modifiers.join("-")} ${event.key} pressed`}</ListItem>
                     <ListItem style={{justifyContent: 'center'}}>Add residue</ListItem>
                 </List>
             </h5>
-        )
+        ))
         return doShortCut('add_terminal_residue_directly_using_cid', formatArgs)
     }
 
@@ -243,7 +246,7 @@ export const babyGruKeyPress = (
                 'LITERAL'
             ]
         }
-        showShortcutToast && setNotificationContent(
+        showShortcutToast && dispatch( setNotificationContent(
             <MoorhenNotification key={guid()} hideDelay={5000}>
             <h5 style={{margin: 0}}>
                 <List>
@@ -252,7 +255,7 @@ export const babyGruKeyPress = (
                 </List>
             </h5>
             </MoorhenNotification>
-        )
+        ))
         return doShortCut('delete_using_cid', formatArgs)
     }
 
@@ -260,7 +263,7 @@ export const babyGruKeyPress = (
         const formatArgs = (chosenMolecule: moorhen.Molecule, chosenAtom: moorhen.ResidueSpec) => {
             return [chosenMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}`]
         }
-        showShortcutToast && setNotificationContent(
+        showShortcutToast && dispatch( setNotificationContent(
             <MoorhenNotification key={guid()} hideDelay={5000}>
             <h5 style={{margin: 0}}>
                 <List>
@@ -269,12 +272,12 @@ export const babyGruKeyPress = (
                 </List>
             </h5>
             </MoorhenNotification>
-        )
+        ))
         return doShortCut('eigen_flip_ligand', formatArgs)
     }
 
     else if (action === 'go_to_blob' && activeMap && !viewOnly) {
-        showShortcutToast && setNotificationContent(
+        showShortcutToast && dispatch( setNotificationContent(
             <MoorhenNotification key={guid()} hideDelay={5000}>
             <h5 style={{margin: 0}}>
                 <List>
@@ -283,7 +286,7 @@ export const babyGruKeyPress = (
                 </List>
             </h5>
             </MoorhenNotification>
-        )
+        ))
         const frontAndBack: [number[], number[], number, number] = glRef.current.getFrontAndBackPos(event);
         const goToBlobEvent = {
             back: [frontAndBack[0][0], frontAndBack[0][1], frontAndBack[0][2]],
@@ -310,7 +313,9 @@ export const babyGruKeyPress = (
         glRef.current.measuredAtoms = []
         glRef.current.clearMeasureCylinderBuffers()
         glRef.current.drawScene()
-        showShortcutToast && setNotificationContent(
+        dispatch( clearResidueSelection() )
+        molecules.forEach(molecule => molecule.clearBuffersOfStyle('residueSelection'))
+        showShortcutToast && dispatch( setNotificationContent(
             <MoorhenNotification key={guid()} hideDelay={5000}>
             <h5 style={{margin: 0}}>
                 <List>
@@ -319,7 +324,7 @@ export const babyGruKeyPress = (
                 </List>
             </h5>
             </MoorhenNotification>
-        )
+        ))
     }
 
     else if (action === 'move_up') {
@@ -414,7 +419,7 @@ export const babyGruKeyPress = (
             glRef.current.showShortCutHelp = null
             glRef.current.drawScene()
         }
-        showShortcutToast && setNotificationContent(
+        showShortcutToast && dispatch( setNotificationContent(
             <MoorhenNotification key={guid()} hideDelay={5000}>
             <h5 style={{margin: 0}}>
                 <List>
@@ -423,7 +428,7 @@ export const babyGruKeyPress = (
                 </List>
             </h5>
             </MoorhenNotification>
-        )
+        ))
         return false
     }
 
@@ -464,7 +469,7 @@ export const babyGruKeyPress = (
     else if (action === 'decrease_front_clip') {
         glRef.current.gl_clipPlane0[3] = glRef.current.gl_clipPlane0[3] - 0.5
         glRef.current.drawScene()
-        showShortcutToast && setNotificationContent(
+        showShortcutToast && dispatch( setNotificationContent(
             <MoorhenNotification key={guid()} hideDelay={5000}>
             <h5 style={{margin: 0}}>
                 <List>
@@ -473,14 +478,14 @@ export const babyGruKeyPress = (
                 </List>
             </h5>
             </MoorhenNotification>
-        )
+        ))
         return false
     }
 
     else if (action === 'increase_front_clip') {
         glRef.current.gl_clipPlane0[3] = glRef.current.gl_clipPlane0[3] + 0.5
         glRef.current.drawScene()
-        showShortcutToast && setNotificationContent(
+        showShortcutToast && dispatch( setNotificationContent(
             <MoorhenNotification key={guid()} hideDelay={5000}>
             <h5 style={{margin: 0}}>
                 <List>
@@ -489,14 +494,14 @@ export const babyGruKeyPress = (
                 </List>
             </h5>
             </MoorhenNotification>
-        )
+        ))
         return false
     }
 
     else if (action === 'decrease_back_clip') {
         glRef.current.gl_clipPlane1[3] = glRef.current.gl_clipPlane1[3] - 0.5
         glRef.current.drawScene()
-        showShortcutToast && setNotificationContent(
+        showShortcutToast && dispatch( setNotificationContent(
             <MoorhenNotification key={guid()} hideDelay={5000}>
             <h5 style={{margin: 0}}>
                 <List>
@@ -505,14 +510,14 @@ export const babyGruKeyPress = (
                 </List>
             </h5>
             </MoorhenNotification>
-        )
+        ))
         return false
     }
 
     else if (action === 'increase_back_clip') {
         glRef.current.gl_clipPlane1[3] = glRef.current.gl_clipPlane1[3] + 0.5
         glRef.current.drawScene()
-        showShortcutToast && setNotificationContent(
+        showShortcutToast && dispatch( setNotificationContent(
             <MoorhenNotification key={guid()} hideDelay={5000}>
             <h5 style={{margin: 0}}>
                 <List>
@@ -521,7 +526,7 @@ export const babyGruKeyPress = (
                 </List>
             </h5>
             </MoorhenNotification>
-        )
+        ))
         return false
     }
 

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -85,6 +85,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
     hoverRepresentation: moorhen.MoleculeRepresentation;
     unitCellRepresentation: moorhen.MoleculeRepresentation;
     environmentRepresentation: moorhen.MoleculeRepresentation;
+    selectionRepresentation: moorhen.MoleculeRepresentation;
     hasGlycans: boolean;
     hasDNA: boolean;
     restraints: {maxRadius: number, cid: string}[];
@@ -136,6 +137,8 @@ export class MoorhenMolecule implements moorhen.Molecule {
         this.environmentRepresentation.setParentMolecule(this)
         this.hoverRepresentation = new MoorhenMoleculeRepresentation('hover', null, this.commandCentre, this.glRef)
         this.hoverRepresentation.setParentMolecule(this)
+        this.selectionRepresentation = new MoorhenMoleculeRepresentation('residueSelection', null, this.commandCentre, this.glRef)
+        this.selectionRepresentation.setParentMolecule(this)
     }
 
     /**
@@ -414,6 +417,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         this.hoverRepresentation?.deleteBuffers()
         this.unitCellRepresentation?.deleteBuffers()
         this.environmentRepresentation?.deleteBuffers()
+        this.selectionRepresentation?.deleteBuffers()
         this.representations.forEach(representation => representation.deleteBuffers())
         this.glRef.current.drawScene()
         const response = await this.commandCentre.current.cootCommand({
@@ -914,6 +918,8 @@ export class MoorhenMolecule implements moorhen.Molecule {
             this.unitCellRepresentation?.deleteBuffers()
         } else if (style === 'environment') {
             this.environmentRepresentation?.deleteBuffers()
+        } else if (style === 'residueSelection') {
+            this.selectionRepresentation?.deleteBuffers()
         } else {
             this.representations.forEach(representation => representation.style === style ? representation.deleteBuffers() : null)
             this.representations = this.representations.filter(representation => representation.style !== style)
@@ -972,6 +978,17 @@ export class MoorhenMolecule implements moorhen.Molecule {
         if (typeof selectionString === 'string') {
             this.hoverRepresentation.cid = selectionString
             this.hoverRepresentation.redraw()
+        }
+    }
+
+    /**
+     * Highlight residues in a selected CID range
+     * @param {string} selectionString - The CID selection for the residues that will be highlighted
+     */
+    async drawResidueSelection(selectionString: string): Promise<void> {
+        if (typeof selectionString === 'string') {
+            this.selectionRepresentation.cid = selectionString
+            this.selectionRepresentation.redraw()
         }
     }
 

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -88,6 +88,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
     hasGlycans: boolean;
     hasDNA: boolean;
     restraints: {maxRadius: number, cid: string}[];
+    isLigand: boolean;
 
     constructor(commandCentre: React.RefObject<moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, monomerLibraryPath = "./baby-gru/monomers") {
         this.type = 'molecule'
@@ -124,6 +125,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         this.restraints = []
         this.hasDNA = false
         this.hasGlycans = false
+        this.isLigand = false
         this.displayObjectsTransformation = { origin: [0, 0, 0], quat: null, centre: [0, 0, 0] }
         this.uniqueId = guid()
         this.monomerLibraryPath = monomerLibraryPath
@@ -379,7 +381,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * Check if the molecule instance consists of a ligand
      * @returns {boolean} True if the molecule is a ligand
      */
-    isLigand(): boolean {
+    checkIsLigand(): boolean {
         let isLigand = true
         const structure = this.gemmiStructure.clone()
        
@@ -401,7 +403,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         }
         models.delete()    
         structure.delete()
-    
+        this.isLigand = isLigand
         return isLigand
     }
 
@@ -442,6 +444,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         }, true) as moorhen.WorkerResponse<number>
 
         newMolecule.molNo = response.data.result.result
+        newMolecule.isLigand = this.isLigand
         newMolecule.hasGlycans = this.hasGlycans
         newMolecule.hasDNA = this.hasDNA
 
@@ -542,6 +545,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
                 commandArgs: [coordData, this.name],
             }, true)
             this.molNo = response.data.result.result
+            this.checkIsLigand()
             await Promise.all([
                 this.getNumberOfAtoms(),
                 this.loadMissingMonomers(),
@@ -662,6 +666,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         if (this.gemmiStructure && !this.gemmiStructure.isDeleted()) {
             this.gemmiStructure.delete()
         }
+        this.checkIsLigand()
         const [_hasGlycans, pdbString] = await Promise.all([
             this.checkHasGlycans(),
             this.getAtoms()

--- a/baby-gru/src/utils/MoorhenPreferences.ts
+++ b/baby-gru/src/utils/MoorhenPreferences.ts
@@ -32,7 +32,7 @@ export class MoorhenPreferences implements moorhen.Preferences {
     }
 
     static defaultPreferencesValues: moorhen.PreferencesValues = {
-        version: 'v31',
+        version: 'v32',
         transparentModalsOnMouseOut: false,
         defaultBackgroundColor: [1, 1, 1, 1],
         atomLabelDepthMode: true,
@@ -231,6 +231,12 @@ export class MoorhenPreferences implements moorhen.Preferences {
                 keyPress: "l",
                 label: "Label an atom on click",
                 viewOnly: true
+            },
+            "residue_selection": {
+                modifiers: ["shiftKey"],
+                keyPress: "shift",
+                label: "Create a residue selection",
+                viewOnly: false
             },
             "center_atom": {
                 modifiers: ["altKey"],

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -325,7 +325,7 @@ describe("Testing MoorhenMolecule", () => {
         expect(result).toEqual(['//A/32-34/*'])
     })
 
-    test("Test isLigand", async () => {
+    test("Test checkIsLigand", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
@@ -336,13 +336,15 @@ describe("Testing MoorhenMolecule", () => {
         }
         const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
         await molecule.loadToCootFromURL(fileUrl, 'mol-test')
-        
+        expect(molecule.isLigand).toBeFalsy()
+
         const result_cid = molecules_container.delete_using_cid(molecule.molNo, "//A", "LITERAL")
         expect(result_cid.first).toBe(1)
 
         molecule.setAtomsDirty(true)
         await molecule.updateAtoms()
-        const isLigand = molecule.isLigand()
+        expect(molecule.isLigand).toBeTruthy()
+        const isLigand = molecule.checkIsLigand()
         expect(isLigand).toBeTruthy()
     })
 


### PR DESCRIPTION
This update adds new keyboard bindings to perform a residue selection (shift + atomClick). Selected residues are highlighted in red. A new context menu with residue range specific options appears when this is followed by right click. Related to #176.