### PR TITLE
Fix `structure already deleted` bug in `MoorhenMolecule.isLigand()`

### DIFF
--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -10,6 +10,7 @@ declare global {
 
 export namespace libcootApi {
     type CCP4ModuleType = {
+        structure_is_ligand(gemmiStructure: gemmi.Structure): boolean;
         count_residues_in_selection(gemmiStructure: gemmi.Structure, selection: gemmi.Selection): number;
         remove_non_selected_residues(gemmiStructure: gemmi.Structure, selection: gemmi.Selection): gemmi.Structure;
         check_polymer_type(polymerConst: emscriptem.instance<number>): {value: number};

--- a/baby-gru/tests/__tests__/integration.test.js
+++ b/baby-gru/tests/__tests__/integration.test.js
@@ -170,6 +170,18 @@ describe("Testing gemmi", () => {
         cleanUpVariables.push(st_1, st_2, model_1, chains_1, model_2, chains_2, chain_2, residues_2, residue_2_seqId, residue_2)
     })
 
+    test("Test structure_is_ligand", () => {
+        const st_1 = cootModule.read_structure_file('./5a3h.pdb', cootModule.CoorFormat.Pdb)
+        cootModule.gemmi_setup_entities(st_1)
+        
+        const is_ligand_1 = cootModule.structure_is_ligand(st_1)
+        expect(is_ligand_1).toBeFalsy()
+
+        const selection = new cootModule.Selection('//B')
+        const st_2 = cootModule.remove_non_selected_residues(st_1, selection)
+        const is_ligand_2 = cootModule.structure_is_ligand(st_2)
+        expect(is_ligand_2).toBeTruthy()
+    })
 })
 
 describe('Testing molecules_container_js', () => {

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -321,7 +321,6 @@ describe("Testing MoorhenMolecule", () => {
         await molecule.loadToCootFromURL(fileUrl, 'mol-test')
         
         const result = await molecule.getNeighborResiduesCids('//A/33/CA', 3)
-        console.log(result)
         expect(result).toEqual(['//A/32-34/*'])
     })
 

--- a/coot/gemmi-wrappers.cc
+++ b/coot/gemmi-wrappers.cc
@@ -42,6 +42,25 @@ using namespace emscripten;
 using GemmiSMat33double = gemmi::SMat33<double>;
 using GemmiSMat33float = gemmi::SMat33<float>;
 
+bool structure_is_ligand(const gemmi::Structure &Structure) {
+    bool isLigand = true;
+    auto structure_copy = Structure;
+    gemmi::remove_ligands_and_waters(structure_copy);
+    gemmi::remove_hydrogens(structure_copy);
+    structure_copy.remove_empty_chains();
+
+    auto models = structure_copy.models;
+    for (auto modelIndex = 0; (modelIndex < models.size()) && isLigand; modelIndex++) {
+        const auto model = models[modelIndex];
+        const auto chains = model.chains;
+        if (chains.size() > 0) {
+            isLigand = false;
+        }
+    }
+    
+    return isLigand;
+}
+
 std::string get_pdb_string_from_gemmi_struct(const gemmi::Structure &Structure){
     std::ostringstream oss;
     gemmi::write_pdb(Structure, oss);
@@ -2267,6 +2286,7 @@ GlobWalk
     function("remove_non_selected_residues",&remove_non_selected_residues);
     function("count_residues_in_selection",&count_residues_in_selection);
     function("get_pdb_string_from_gemmi_struct",&get_pdb_string_from_gemmi_struct);
+    function("structure_is_ligand",&structure_is_ligand);
     function("read_structure_from_string",&read_structure_from_string);
     function("read_structure_file",&gemmi::read_structure_file);
     function("read_mtz_file",&gemmi::read_mtz_file);


### PR DESCRIPTION
After #177 there was a bug where `MoorhenMolecule.checkIsLigand()` is called after `MoorhenMolecule.gemmiStructure` is deleted, throwing a `structure already deleted` error. This fixes the bug and adds two more tests.