### PR TITLE
Move gemmiAtomsForCid to C++

### DIFF
--- a/baby-gru/src/types/gemmi.d.ts
+++ b/baby-gru/src/types/gemmi.d.ts
@@ -73,7 +73,7 @@ export namespace gemmi {
         altloc: number;
         charge: number;
         b_iso: number;
-        serial: string;
+        serial: number;
         has_altloc: () => boolean;
     }
     interface ResidueSeqId extends emscriptem.instance<ResidueSeqId> {

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -12,6 +12,7 @@ declare global {
 
 export namespace libcootApi {
     type CCP4ModuleType = {
+        get_sequence_info(gemmiStructure: gemmi.Structure, molName: string): emscriptem.vector<SequenceEntry>;
         get_atom_info_for_selection(gemmiStructure: gemmi.Structure, arg1: string, arg2: string): emscriptem.vector<AtomInfo>;
         structure_is_ligand(gemmiStructure: gemmi.Structure): boolean;
         count_residues_in_selection(gemmiStructure: gemmi.Structure, selection: gemmi.Selection): number;
@@ -33,6 +34,18 @@ export namespace libcootApi {
         Position: { new(x: number, y: number, z: number): gemmi.Position };
         Fractional: { new(x: number, y: number, z: number): gemmi.Fractional };
         cifDocument: { new(): gemmi.cifDocument }
+    }
+    type SequenceResInfo = {
+        resNum: number;
+        resCode: string;
+        cid: string;
+    }
+    type SequenceEntry = {
+        type: number;
+        name: string;
+        chain: string;
+        sequence: emscriptem.vector<SequenceResInfo>;
+    
     }
     // We need to define AtomInfo here because we cannot import moorhen namespace otherwise worker code breaks during transpilation
     type AtomInfo = {

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -2,6 +2,8 @@
 import { emscriptem } from "./emscriptem";
 import { gemmi } from "./gemmi"
 
+// Warning: do not import moorhen namespace otherwise worker code breaks during transpilation
+
 declare global {
     function print(arg0: string): void;
     function createRSRModule(arg0: any): Promise<any>;
@@ -10,6 +12,7 @@ declare global {
 
 export namespace libcootApi {
     type CCP4ModuleType = {
+        get_atom_info_for_selection(gemmiStructure: gemmi.Structure, arg1: string, arg2: string): emscriptem.vector<AtomInfo>;
         structure_is_ligand(gemmiStructure: gemmi.Structure): boolean;
         count_residues_in_selection(gemmiStructure: gemmi.Structure, selection: gemmi.Selection): number;
         remove_non_selected_residues(gemmiStructure: gemmi.Structure, selection: gemmi.Selection): gemmi.Structure;
@@ -31,8 +34,8 @@ export namespace libcootApi {
         Fractional: { new(x: number, y: number, z: number): gemmi.Fractional };
         cifDocument: { new(): gemmi.cifDocument }
     }
+    // We need to define AtomInfo here because we cannot import moorhen namespace otherwise worker code breaks during transpilation
     type AtomInfo = {
-        pos: [number, number, number];
         x: number;
         y: number;
         z: number;
@@ -40,7 +43,7 @@ export namespace libcootApi {
         element: emscriptem.instance<string>;
         symbol: string;
         tempFactor: number;
-        serial: string;
+        serial: number;
         name: string;
         has_altloc: boolean;
         alt_loc: string;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -58,7 +58,7 @@ export namespace moorhen {
         element: emscriptem.instance<string>;
         symbol: string;
         tempFactor: number;
-        serial: string;
+        serial: number;
         name: string;
         has_altloc: boolean;
         alt_loc: string;

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -321,63 +321,29 @@ export class MoorhenMolecule implements moorhen.Molecule {
             return
         }
 
-        let sequences: moorhen.Sequence[] = []
-        const structure = this.gemmiStructure.clone()
-        try {
-            const models = structure.models
-            const modelsSize = models.size()
-            for (let modelIndex = 0; modelIndex < modelsSize; modelIndex++) {
-                const model = models.get(modelIndex)
-                const chains = model.chains
-                const chainsSize = chains.size()
-                for (let chainIndex = 0; chainIndex < chainsSize; chainIndex++) {
-                    let currentSequence: moorhen.ResidueInfo[] = []
-                    const chain = chains.get(chainIndex)
-                    window.CCP4Module.remove_ligands_and_waters_chain(chain)
-                    const residues = chain.residues
-                    const chainName = chain.name
-                    const polymerConst = chain.get_polymer_const()
-                    const polymerType = window.CCP4Module.check_polymer_type(polymerConst)
-                    const polymerTypeValue: number = polymerType.value
-                    let threeToOne = [3, 4, 5].includes(polymerTypeValue) ? nucleotideCodesThreeToOne : residueCodesThreeToOne
-                    const residuesSize = residues.size()
-                    for (let residueIndex = 0; residueIndex < residuesSize; residueIndex++) {
-                        const residue = residues.get(residueIndex)
-                        const resName = residue.name
-                        const residueSeqId = residue.seqid
-                        const resNum = residueSeqId.str()
-                        currentSequence.push({
-                            resNum: Number(resNum),
-                            resCode: Object.keys(threeToOne).includes(resName) ? threeToOne[resName] : 'X',
-                            cid: `//${chainName}/${resNum}(${resName})/`
-                        })
-                        residue.delete()
-                        residueSeqId.delete()
-                    }
-                    if (currentSequence.length > 0) {
-                        sequences.push({
-                            name: `${this.name}_${chainName}`,
-                            chain: chainName,
-                            type: polymerTypeValue,
-                            sequence: currentSequence,
-                        })
-                    }
-                    chain.delete()
-                    residues.delete()
-                    polymerConst.delete()
-                }
-                model.delete()
-                chains.delete()
+        let result: moorhen.Sequence[] = []
+        const sequenceInfoVec = window.CCP4Module.get_sequence_info(this.gemmiStructure, this.name)
+        const sequenceInfoVecSize = sequenceInfoVec.size()
+        for (let i = 0; i < sequenceInfoVecSize; i++) {
+            const sequenceInfo = sequenceInfoVec.get(i)
+            const sequenceInfoSeq = sequenceInfo.sequence
+            let currentSequence: moorhen.ResidueInfo[] = []
+            const sequenceInfoSize = sequenceInfoSeq.size()
+            for (let i = 0; i < sequenceInfoSize; i++) {
+                currentSequence.push(sequenceInfoSeq.get(i))
             }
-            models.delete()
-        } finally {
-            if (structure && !structure.isDeleted()) {
-                structure.delete()
-            }
+            sequenceInfoSeq.delete()    
+            result.push({
+                name: sequenceInfo.name,
+                chain: sequenceInfo.chain,
+                type: sequenceInfo.type,
+                sequence: currentSequence
+            })
         }
+        sequenceInfoVec.delete()
 
-        this.sequences = sequences
-        this.hasDNA = sequences.some(sequence => [3, 4, 5].includes(sequence.type))
+        this.sequences = result
+        this.hasDNA = this.sequences.some(sequence => [3, 4, 5].includes(sequence.type))
     }
 
     /**

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -903,7 +903,7 @@ export const getDashedCylinder = (nsteps: number, cylinder_accu: number): [numbe
 }
 
 export const gemmiAtomPairsToCylindersInfo = (
-    atoms: [{ pos: [number, number, number], serial: string }, { pos: [number, number, number], serial: string }][],
+    atoms: [{ pos: [number, number, number], serial: (number | string) }, { pos: [number, number, number], serial: (number | string) }][],
     size: number,
     colourScheme: { [x: string]: number[]; },
     labelled: boolean = false,

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -279,6 +279,27 @@ describe("Testing MoorhenMolecule", () => {
         await molecule.hideCid("/*/A/29-30/*")
         const gemmiAtoms = await molecule.gemmiAtomsForCid('//A/30-31/CA', true)
         expect(f).toHaveBeenCalled()
+        expect(gemmiAtoms).toEqual([
+            {
+              res_name: 'GLY',
+              res_no: '31',
+              mol_name: '1',
+              chain_id: 'A',
+              pos: [ 70.995, 43.686, 22.449 ],
+              x: 70.995,
+              y: 43.686,
+              z: 22.449,
+              charge: 0,
+              element: 'C',
+              symbol: 'C',
+              tempFactor: 9.109999656677246,
+              serial: 213,
+              name: 'CA',
+              has_altloc: false,
+              alt_loc: "",
+              label: '/1/A/31(GLY)/CA'
+            }
+        ])
         expect(gemmiAtoms.map(atomInfo => atomInfo.label)).toEqual([ "/1/A/31(GLY)/CA" ])
     })
 

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -303,6 +303,37 @@ describe("Testing MoorhenMolecule", () => {
         expect(gemmiAtoms.map(atomInfo => atomInfo.label)).toEqual([ "/1/A/31(GLY)/CA" ])
     })
 
+    test("Test parseSequences", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl, 'mol-test')
+        expect(molecule.sequences).toHaveLength(1)
+        
+        const firstSequence = molecule.sequences[0]
+        expect(firstSequence.name).toBe("mol-test_A")
+        expect(firstSequence.chain).toBe("A")
+        expect(firstSequence.type).toBe(1)
+        expect(firstSequence.sequence).toHaveLength(300)
+        
+        const firstResidue = firstSequence.sequence[0]
+        expect(firstResidue.resNum).toBe(4)
+        expect(firstResidue.resCode).toBe("S")
+        expect(firstResidue.cid).toBe("//A/4(SER)/")
+        
+        const lastResidue = firstSequence.sequence[299]
+        expect(lastResidue.resNum).toBe(303)
+        expect(lastResidue.resCode).toBe("S")
+        expect(lastResidue.cid).toBe("//A/303(SER)/")
+    })
+
     test("Test updateAtoms", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')


### PR DESCRIPTION
This update moves most of the code in `MoorhenMolecule.gemmiAtomsForCid` to C++, making the code in MoorhenMolecule more simple. It also removes the need to call `delete()` for webassembly objects.