### PR TITLE
Manage residue selection actions with a notification component

### DIFF
--- a/baby-gru/src/components/MoorhenContainer.tsx
+++ b/baby-gru/src/components/MoorhenContainer.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useCallback, useRef, useMemo } from 'react';
-import { Container, Col, Row, Spinner } from 'react-bootstrap';
+import { Container, Col, Row, Spinner, Stack } from 'react-bootstrap';
 import { MoorhenWebMG } from './webMG/MoorhenWebMG';
-import { getTooltipShortcutLabel, createLocalStorageInstance, cidToSpec } from '../utils/MoorhenUtils';
+import { getTooltipShortcutLabel, createLocalStorageInstance, cidToSpec, guid } from '../utils/MoorhenUtils';
 import { MoorhenCommandCentre } from "../utils/MoorhenCommandCentre"
 import { MoorhenTimeCapsule } from '../utils/MoorhenTimeCapsule';
-import { Backdrop } from "@mui/material";
+import { Backdrop, IconButton } from "@mui/material";
 import { babyGruKeyPress } from '../utils/MoorhenKeyboardAccelerators';
 import { isDarkBackground } from '../WebGLgComponents/mgWebGL'
 import { MoorhenNavBar } from "./navbar-menus/MoorhenNavBar"
@@ -17,6 +17,7 @@ import { setDefaultBackgroundColor } from '../store/sceneSettingsSlice';
 import { setBackgroundColor, setHeight, setIsDark, setWidth } from '../store/canvasStatesSlice';
 import { clearResidueSelection, setCootInitialized, setNotificationContent, setResidueSelection, setStopResidueSelection, setTheme } from '../store/generalStatesSlice';
 import { setEnableAtomHovering, setHoveredAtom } from '../store/hoveringStatesSlice';
+import { ClearOutlined } from '@mui/icons-material';
 
 /**
  * A container for the Moorhen app. Needs to be rendered within a MoorhenReduxprovider.
@@ -371,11 +372,11 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
     const handleAtomClicked = useCallback(async (evt: moorhen.AtomClickedEvent) => {
         const clearSelection = () => {
             dispatch( clearResidueSelection() )
+            dispatch( setNotificationContent(null) )
             molecules.forEach(molecule => molecule.clearBuffersOfStyle('residueSelection'))
         }
 
         if (!evt.detail.isResidueSelection || evt.detail.buffer.id == null) {
-            clearSelection()
             return
         } 
 
@@ -391,6 +392,22 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
             dispatch(
                 setResidueSelection({ molecule: selectedMolecule, first: evt.detail.atom.label, second: null, cid: null})
             )
+            dispatch(
+                setNotificationContent(
+                    <MoorhenNotification key={guid()} width={13}>
+                        <Stack gap={2} direction='horizontal' style={{width: '100%', display:'flex', justifyContent: 'space-between'}}>
+                            <div style={{alignItems: 'center', display: 'flex', justifyContent: 'center'}}>
+                                {`/${resSpec.mol_no}/${resSpec.chain_id}/${resSpec.res_no}`}
+                            </div>
+                            <IconButton onClick={() => {
+                                clearSelection()
+                            }}>
+                                <ClearOutlined/>
+                            </IconButton>
+                        </Stack>
+                    </MoorhenNotification>   
+                )
+            )
             return
         }
 
@@ -404,7 +421,23 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
             await selectedMolecule.drawResidueSelection(cid)
             dispatch(
                 setResidueSelection({ molecule: selectedMolecule, first: residueSelection.first, second: evt.detail.atom.label, cid: cid})
-            )    
+            )
+            dispatch(
+                setNotificationContent(
+                    <MoorhenNotification key={guid()} width={13}>
+                        <Stack gap={2} direction='horizontal' style={{width: '100%', display:'flex', justifyContent: 'space-between'}}>
+                            <div style={{alignItems: 'center', display: 'flex', justifyContent: 'center'}}>
+                                { `/${startResSpec.mol_no}/${startResSpec.chain_id}/${sortedResNums[0]}-${sortedResNums[1]}`}
+                            </div>
+                            <IconButton onClick={() => {
+                                clearSelection()
+                            }}>
+                                <ClearOutlined/>
+                            </IconButton>
+                        </Stack>
+                    </MoorhenNotification>   
+                )
+            )
         }
     }, [molecules, residueSelection])
 

--- a/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
+++ b/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
@@ -1,0 +1,150 @@
+import { IconButton } from "@mui/material"
+import { cidToSpec, guid } from "../../utils/MoorhenUtils"
+import { MoorhenNotification } from "./MoorhenNotification"
+import { CloseOutlined, CopyAllOutlined, CrisisAlertOutlined, DeleteOutlined } from "@mui/icons-material"
+import { useDispatch, useSelector } from "react-redux"
+import { moorhen } from "../../types/moorhen"
+import { Stack } from "react-bootstrap"
+import { clearResidueSelection, setNotificationContent, setResidueSelection } from '../../store/generalStatesSlice';
+import { useCallback, useEffect, useRef, useState } from "react"
+import { addMolecule, removeMolecule } from "../../moorhen"
+
+
+export const MoorhenResidueSelectionActions = (props) => {
+
+    const notificationKeyRef = useRef<string>(guid())
+
+    const [selectionLabel, setSelectionLabel] = useState<null | string>(null)
+
+    const molecules = useSelector((state: moorhen.State) => state.molecules)
+    const isDark = useSelector((state: moorhen.State) => state.canvasStates.isDark)
+    const residueSelection = useSelector((state: moorhen.State) => state.generalStates.residueSelection)
+    const dispatch = useDispatch()
+
+    const clearSelection = useCallback(() => {
+        dispatch( clearResidueSelection() )
+        dispatch( setNotificationContent(null) )
+        setSelectionLabel(null)
+        molecules.forEach(molecule => molecule.clearBuffersOfStyle('residueSelection'))
+    }, [molecules])
+
+    const handleAtomClicked = useCallback(async (evt: moorhen.AtomClickedEvent) => {
+        if (!evt.detail.isResidueSelection || evt.detail.buffer.id == null) {
+            return
+        } 
+
+        const selectedMolecule = molecules.find(molecule => molecule.buffersInclude(evt.detail.buffer))
+        if (!selectedMolecule) {
+            clearSelection()
+            return
+        }
+        
+        if (residueSelection.first === null || residueSelection.molecule === null || residueSelection.molecule.molNo !== selectedMolecule.molNo) {
+            const resSpec = cidToSpec(evt.detail.atom.label)
+            await selectedMolecule.drawResidueSelection(`/*/${resSpec.chain_id}/${resSpec.res_no}-${resSpec.res_no}/*`)
+            dispatch(
+                setResidueSelection({ molecule: selectedMolecule, first: evt.detail.atom.label, second: null, cid: null})
+            )
+            setSelectionLabel(`/${resSpec.mol_no}/${resSpec.chain_id}/${resSpec.res_no}`)
+            return
+        }
+
+        const startResSpec = cidToSpec(residueSelection.first)
+        const stopResSpec = cidToSpec(evt.detail.atom.label)
+        if (startResSpec.chain_id !== stopResSpec.chain_id) {
+            clearSelection()
+        } else {
+            const sortedResNums = [startResSpec.res_no, stopResSpec.res_no].sort(function(a, b){return a - b})
+            const cid = `/*/${startResSpec.chain_id}/${sortedResNums[0]}-${sortedResNums[1]}/*`
+            await selectedMolecule.drawResidueSelection(cid)
+            dispatch(
+                setResidueSelection({ molecule: selectedMolecule, first: residueSelection.first, second: evt.detail.atom.label, cid: cid})
+            )
+            setSelectionLabel(`/${startResSpec.mol_no}/${startResSpec.chain_id}/${sortedResNums[0]}-${sortedResNums[1]}`)
+        }
+    }, [clearSelection, residueSelection])
+
+    useEffect(() => {
+        document.addEventListener('atomClicked', handleAtomClicked)
+        return () => {
+            document.removeEventListener('atomClicked', handleAtomClicked)
+        }
+    }, [handleAtomClicked])
+
+    const handleSelectionCopy = useCallback(async () => {
+        let cid: string
+        
+        if (residueSelection.molecule && residueSelection.cid) {
+            cid = residueSelection.cid
+        } else if (residueSelection.molecule && residueSelection.first) {
+            const startResSpec = cidToSpec(residueSelection.first)
+            cid =`/${startResSpec.mol_no}/${startResSpec.chain_id}/${startResSpec.res_no}-${startResSpec.res_no}`
+        }
+
+        if (cid) {
+            const newMolecule = await residueSelection.molecule.copyFragmentUsingCid(cid, true)
+            dispatch( addMolecule(newMolecule) )
+        }
+        
+        clearSelection()
+    }, [residueSelection, clearSelection])
+
+    const handleRefinement = useCallback(async () => {
+        if (residueSelection.molecule && residueSelection.cid) {
+            const startResSpec = cidToSpec(residueSelection.first)
+            const stopResSpec = cidToSpec(residueSelection.second)
+            const sortedResNums = [startResSpec.res_no, stopResSpec.res_no].sort(function(a, b){return a - b})
+            await residueSelection.molecule.refineResidueRange(startResSpec.chain_id, sortedResNums[0], sortedResNums[1], 5000, true)
+        } else if (residueSelection.molecule && residueSelection.first) {
+            const startResSpec = cidToSpec(residueSelection.first)
+            await residueSelection.molecule.refineResidueRange(startResSpec.chain_id, startResSpec.res_no, startResSpec.res_no, 5000, true)
+        }
+        clearSelection()
+    }, [clearSelection, residueSelection])
+
+    const handleDelete = useCallback(async () => {
+        let cid: string
+        
+        if (residueSelection.molecule && residueSelection.cid) {
+            cid = residueSelection.cid
+        } else if (residueSelection.molecule && residueSelection.first) {
+            const startResSpec = cidToSpec(residueSelection.first)
+            cid = `/${startResSpec.mol_no}/${startResSpec.chain_id}/${startResSpec.res_no}-${startResSpec.res_no}`
+        }
+
+        if (cid) {
+            const result = await residueSelection.molecule.deleteCid(cid, true)
+            if (result.second < 1) {
+                console.log('Empty molecule detected, deleting it now...')
+                await residueSelection.molecule.delete()
+                dispatch(removeMolecule(residueSelection.molecule))
+            }
+        }
+
+        clearSelection()
+    }, [residueSelection, clearSelection])
+
+    return  selectionLabel ?
+        <MoorhenNotification key={notificationKeyRef.current} width={13}>
+            <Stack direction="vertical" gap={1}>
+                <div>
+                    <span>{selectionLabel}</span>
+                </div>
+                <Stack gap={2} direction='horizontal' style={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
+                    <IconButton onClick={handleDelete}>
+                        <DeleteOutlined/>
+                    </IconButton>
+                    <IconButton onClick={handleRefinement}>
+                        <CrisisAlertOutlined/>
+                    </IconButton>
+                    <IconButton onClick={handleSelectionCopy}>
+                        <CopyAllOutlined/>
+                    </IconButton>
+                    <IconButton onClick={clearSelection}>
+                        <CloseOutlined/>
+                    </IconButton>
+                </Stack>
+            </Stack>
+        </MoorhenNotification>
+        : null
+}

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -47,8 +47,9 @@ declare module 'moorhen' {
 
     class MoorhenMolecule implements _moorhen.Molecule {
         constructor(commandCentre: React.RefObject<_moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, monomerLibrary: string)
+        refineResidueRange(chainId: string, start: number, stop: number, ncyc?: number, redraw?: boolean): Promise<void>;
         SSMSuperpose(movChainId: string, refMolNo: number, refChainId: string): Promise<_moorhen.WorkerResponse>;
-        deleteCid(cid: string, redraw?: boolean): Promise<void>;
+        deleteCid(cid: string, redraw?: boolean): Promise<{first: number, second: number}>;
         getNumberOfAtoms(): Promise<number>;
         moveMoleculeHere(x: number, y: number, z: number): Promise<void>;
         checkHasGlycans(): Promise<boolean>;

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -92,7 +92,7 @@ declare module 'moorhen' {
         drawHover: (cid: string) => Promise<void>;
         drawResidueSelection: (cid: string) => Promise<void>;
         clearBuffersOfStyle: (style: string) => void;
-        loadToCootFromURL: (inputFile: string, molName: string) => Promise<_moorhen.Molecule>;
+        loadToCootFromURL: (inputFile: string, molName: string, options?: RequestInit) => Promise<_moorhen.Molecule>;
         applyTransform: () => Promise<void>;
         getAtoms(format?: string): Promise<string>;
         hide: (style: string, cid?: string) => void;
@@ -166,8 +166,8 @@ declare module 'moorhen' {
         doCootContour(x: number, y: number, z: number, radius: number, contourLevel: number): Promise<void>;
         fetchReflectionData(): Promise<_moorhen.WorkerResponse<Uint8Array>>;
         getMap(): Promise<_moorhen.WorkerResponse>;
-        loadToCootFromMtzURL(url: RequestInfo | URL, name: string, selectedColumns: _moorhen.selectedMtzColumns): Promise<_moorhen.Map>;
-        loadToCootFromMapURL(url: RequestInfo | URL, name: string, isDiffMap?: boolean): Promise<_moorhen.Map>;
+        loadToCootFromMtzURL(url: RequestInfo | URL, name: string, selectedColumns: _moorhen.selectedMtzColumns, options?: RequestInit): Promise<_moorhen.Map>;
+        loadToCootFromMapURL(url: RequestInfo | URL, name: string, isDiffMap?: boolean, options?: RequestInit): Promise<_moorhen.Map>;
         setActive(): Promise<void>;
         setupContourBuffers(objects: any[], keepCootColours?: boolean): void;
         setOtherMapForColouring(molNo: number, min?: number, max?: number): void;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -134,7 +134,7 @@ export namespace moorhen {
         drawHover: (cid: string) => Promise<void>;
         drawResidueSelection: (cid: string) => Promise<void>;
         clearBuffersOfStyle: (style: string) => void;
-        loadToCootFromURL: (inputFile: string, molName: string) => Promise<Molecule>;
+        loadToCootFromURL: (inputFile: string, molName: string, options?: RequestInit) => Promise<Molecule>;
         applyTransform: () => Promise<void>;
         getAtoms(format?: string): Promise<string>;
         hide: (style: string, cid?: string) => void;
@@ -368,8 +368,8 @@ export namespace moorhen {
         doCootContour(x: number, y: number, z: number, radius: number, contourLevel: number): Promise<void>;
         fetchReflectionData(): Promise<WorkerResponse<Uint8Array>>;
         getMap(): Promise<WorkerResponse>;
-        loadToCootFromMtzURL(url: RequestInfo | URL, name: string, selectedColumns: selectedMtzColumns): Promise<Map>;
-        loadToCootFromMapURL(url: RequestInfo | URL, name: string, isDiffMap?: boolean): Promise<Map>;
+        loadToCootFromMtzURL(url: RequestInfo | URL, name: string, selectedColumns: selectedMtzColumns, options?: RequestInit): Promise<Map>;
+        loadToCootFromMapURL(url: RequestInfo | URL, name: string, isDiffMap?: boolean, options?: RequestInit): Promise<Map>;
         setActive(): Promise<void>;
         setupContourBuffers(objects: any[], keepCootColours?: boolean): void;
         setOtherMapForColouring(molNo: number, min?: number, max?: number): void;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -89,9 +89,10 @@ export namespace moorhen {
     }
     
     interface Molecule {
+        refineResidueRange(chainId: string, start: number, stop: number, ncyc?: number, redraw?: boolean): Promise<void>;
         SSMSuperpose(movChainId: string, refMolNo: number, refChainId: string): Promise<WorkerResponse>;
         refineResiduesUsingAtomCid(cid: string, mode: string, ncyc?: number, redraw?: boolean): Promise<void>;
-        deleteCid(cid: string, redraw?: boolean): Promise<void>;
+        deleteCid(cid: string, redraw?: boolean): Promise<{first: number, second: number}>;
         getNumberOfAtoms(): Promise<number>;
         moveMoleculeHere(x: number, y: number, z: number): Promise<void>;
         checkHasGlycans(): Promise<boolean>;

--- a/baby-gru/src/utils/MoorhenMap.ts
+++ b/baby-gru/src/utils/MoorhenMap.ts
@@ -194,12 +194,13 @@ export class MoorhenMap implements moorhen.Map {
      * @param {string} url - The url to the MTZ file
      * @param {string} name - The name that will be assigned to the map
      * @param {moorhen.selectedMtzColumns} selectedColumns - Object indicating the selected MTZ columns
+     * @param {object} [options] - Options passed to fetch API
      * @returns {Pormise<moorhen.Map>} This moorhenMap instance
      */
-    async loadToCootFromMtzURL(url: RequestInfo | URL, name: string, selectedColumns: moorhen.selectedMtzColumns): Promise<moorhen.Map> {
+    async loadToCootFromMtzURL(url: RequestInfo | URL, name: string, selectedColumns: moorhen.selectedMtzColumns, options?: RequestInit): Promise<moorhen.Map> {
 
         try {
-            const response = await fetch(url)
+            const response = await fetch(url, options)
             if (!response.ok) {
                 return Promise.reject(`Error fetching data from url ${url}`)
             }
@@ -269,12 +270,13 @@ export class MoorhenMap implements moorhen.Map {
      * @param {string} url - The url to the MTZ file
      * @param {string} name - The name that will be assigned to the map
      * @param {boolean} [isDiffMap=false] - Indicates whether the new map is a difference map
+     * @param {object} [options] - Options passed to fetch API
      * @returns {Promise<moorhen.Map>} This moorhenMap instance
      */
-    async loadToCootFromMapURL(url: RequestInfo | URL, name: string, isDiffMap: boolean= false): Promise<moorhen.Map>  {
+    async loadToCootFromMapURL(url: RequestInfo | URL, name: string, isDiffMap: boolean= false, options?: RequestInit): Promise<moorhen.Map>  {
 
         try {
-            const response = await fetch(url);
+            const response = await fetch(url, options);
             const mapData = await response.blob();
             const arrayBuffer = await mapData.arrayBuffer();
             return await this.loadToCootFromMapData(new Uint8Array(arrayBuffer), name, isDiffMap);

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -437,10 +437,11 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * Load a new molecule from a file URL
      * @param {string} url - The url to the path with the data for the new molecule
      * @param {string} molName - The new molecule name
+     * @param {object} [options] - Options passed to fetch API
      * @returns {Promise<moorhen.Molecule>} The new molecule
      */
-    async loadToCootFromURL(url: RequestInfo | URL, molName: string): Promise<moorhen.Molecule> {
-        const response = await fetch(url)
+    async loadToCootFromURL(url: RequestInfo | URL, molName: string, options?: RequestInit): Promise<moorhen.Molecule> {
+        const response = await fetch(url, options)
         try {
             if (response.ok) {
                 const coordData = await response.text()


### PR DESCRIPTION
After this update, residue range selections are managed using a notification component that lets:
- Clear the selection
- Do residue range refinement
- Delete the residue range
- Copy the residues into a fragment
This update also includes changes to the `MoorhenMolecule` and `MoorhenMap` fetch API to include `RequestInit` options.