### PR TITLE
Fix bugs and move fit ligand using conformers out of dev mode

### DIFF
--- a/.github/workflows/js-documentation.yml
+++ b/.github/workflows/js-documentation.yml
@@ -17,6 +17,9 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
+      - name: Update mirrors
+        working-directory: /home/runner/work/MoorhenOrgBuild/MoorhenOrgBuild/
+        run: sudo apt-get update -y
       - name: Install dependencies 
         working-directory: /home/runner/work/Moorhen/
         run: |    

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -16,7 +16,8 @@ jobs:
            mv Moorhen ccp4_wasm
        - name: Install dependencies 
          working-directory: /home/runner/work/Moorhen/       
-         run: |    
+         run: |
+           sudo apt-get update -y
            sudo apt-get install -y bzr nodejs npm                  
            cd /home/runner/work/Moorhen/
            git clone https://github.com/emscripten-core/emsdk.git

--- a/.github/workflows/tsc-compilation.yml
+++ b/.github/workflows/tsc-compilation.yml
@@ -17,7 +17,8 @@ jobs:
         node-version: 16
     - name: Install dependencies 
       working-directory: /home/runner/work/Moorhen/
-      run: |    
+      run: | 
+        sudo apt-get update -y   
         sudo apt-get install -y npm
     - name: Create mock version file
       working-directory: /home/runner/work/Moorhen/       

--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -62,7 +62,7 @@
       ]
     }
   },
-"dependencies": { },
+  "dependencies": { },
   "scripts": {
     "create-version": "npx genversion -e -p ./package.json -d -s ./src/version.js",
     "transpile-ts-worker": "npx tsc --module es2015 --lib webworker --skipLibCheck public/baby-gru/CootWorker.ts && sed -i.bak '/export {}/d' public/baby-gru/CootWorker.js && rm public/baby-gru/CootWorker.js.bak",

--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -62,7 +62,7 @@
       ]
     }
   },
-  "dependencies": { },
+"dependencies": { },
   "scripts": {
     "create-version": "npx genversion -e -p ./package.json -d -s ./src/version.js",
     "transpile-ts-worker": "npx tsc --module es2015 --lib webworker --skipLibCheck public/baby-gru/CootWorker.ts && sed -i.bak '/export {}/d' public/baby-gru/CootWorker.js && rm public/baby-gru/CootWorker.js.bak",
@@ -112,6 +112,7 @@
     "@mui/icons-material": "^5.10.9",
     "@mui/lab": "^5.0.0-alpha.140",
     "@mui/material": "^5.10.10",
+    "@mui/x-tree-view": "^6.17.0",
     "@reduxjs/toolkit": "^1.9.7",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",

--- a/baby-gru/src/components/card/MoorhenColourRuleCard.tsx
+++ b/baby-gru/src/components/card/MoorhenColourRuleCard.tsx
@@ -25,8 +25,11 @@ export const MoorhenColourRuleCard = (props: {
 
     const { index, molecule, rule, urlPrefix, setRuleList } = props
     
-    const [r, g, b]: number[] = hexToRgb(rule.color).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
-
+    let [r, g, b]: number[] = []
+    if (!rule.isMultiColourRule) {
+        [r, g, b] = hexToRgb(rule.color).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+    }
+    
     const redrawIfDirty = () => {
         if (isDirty.current) {
             busyRedrawing.current = true

--- a/baby-gru/src/components/card/MoorhenMapCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMapCard.tsx
@@ -268,7 +268,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
         props.map.contourLevel = mapContourLevel
         props.map.mapRadius = mapRadius
         isDirty.current = true
-        if (props.map.cootContour) {
+        if (props.map.isVisible) {
             if (!busyContouring.current) {
                 doContourIfDirty()
             }
@@ -277,7 +277,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
 
     const handleWheelContourLevelCallback = useCallback((evt: moorhen.WheelContourLevelEvent) => {
         let newMapContourLevel: number
-        if (props.map.cootContour && props.map.molNo === activeMap.molNo) {
+        if (props.map.isVisible && props.map.molNo === activeMap.molNo) {
             if (evt.detail.factor > 1) {
                 newMapContourLevel = mapContourLevel + contourWheelSensitivityFactor
             } else {
@@ -294,17 +294,17 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
                 </MoorhenNotification>
             ))
         }
-    }, [mapContourLevel, mapRadius, activeMap?.molNo, props.map.molNo, props.map.cootContour])
+    }, [mapContourLevel, mapRadius, activeMap?.molNo, props.map.molNo, props.map.isVisible])
 
     const handleRadiusChangeCallback = useCallback((evt: moorhen.MapRadiusChangeEvent) => {
-        if (props.map.cootContour && props.map.molNo === activeMap.molNo) {
+        if (props.map.isVisible && props.map.molNo === activeMap.molNo) {
             setMapRadius(mapRadius + evt.detail.factor)
         }
-    }, [mapRadius, activeMap?.molNo, props.map.molNo, props.map.cootContour])
+    }, [mapRadius, activeMap?.molNo, props.map.molNo, props.map.isVisible])
 
     const handleNewMapContour = useCallback((evt: moorhen.NewMapContourEvent) => {
         if (props.map.molNo === evt.detail.molNo) {
-            setCootContour(evt.detail.cootContour)
+            setCootContour(evt.detail.isVisible)
             setMapContourLevel(evt.detail.contourLevel)
             setMapLitLines(evt.detail.litLines)
             setMapRadius(evt.detail.mapRadius)
@@ -337,14 +337,14 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     }, [mapOpacity])
 
     useEffect(() => {
-        setCootContour(props.map.cootContour)
+        setCootContour(props.map.isVisible)
         nextOrigin.current = props.glRef.current.origin.map(coord => -coord)
         props.map.litLines = mapLitLines
         props.map.solid = mapSolid
         props.map.contourLevel = mapContourLevel
         props.map.mapRadius = mapRadius
         isDirty.current = true
-        if (props.map.cootContour && !busyContouring.current) {
+        if (props.map.isVisible && !busyContouring.current) {
             doContourIfDirty()
         }
 

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef, useReducer, useCallback, useImperativeHandle, forwardRef } from 'react';
 import { Card, Row, Col, Stack, Button, Spinner } from "react-bootstrap";
 import { Accordion, AccordionDetails, AccordionSummary } from '@mui/material';
-import { convertRemToPx, doDownload, representationLabelMapping } from '../../utils/MoorhenUtils';
+import { convertRemToPx, convertViewtoPx, doDownload, representationLabelMapping } from '../../utils/MoorhenUtils';
 import { isDarkBackground } from '../../WebGLgComponents/mgWebGL'
 import { MoorhenSequenceList } from "../list/MoorhenSequenceList";
 import { MoorhenMoleculeCardButtonBar } from "../button-bar/MoorhenMoleculeCardButtonBar"
@@ -70,7 +70,8 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
     const defaultExpandDisplayCards = useSelector((state: moorhen.State) => state.miscAppSettings.defaultExpandDisplayCards)
     const drawMissingLoops = useSelector((state: moorhen.State) => state.sceneSettings.drawMissingLoops)
     const userPreferencesMounted = useSelector((state: moorhen.State) => state.generalStates.userPreferencesMounted)
-    
+    const height = useSelector((state: moorhen.State) => state.canvasStates.height)
+
     const addColourRulesAnchorDivRef = useRef<HTMLDivElement | null>(null)
     const busyRedrawing = useRef<boolean>(false)
     const isDirty = useRef<boolean>(false)
@@ -517,7 +518,7 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
                         Ligands
                     </AccordionSummary>
                     <AccordionDetails style={{padding: '0.2rem', backgroundColor: isDark ? '#ced5d6' : 'white'}}>
-                        <MoorhenLigandList setBusy={setBusyLoadingLigands} commandCentre={props.commandCentre} molecule={props.molecule} glRef={props.glRef}/>
+                        <MoorhenLigandList setBusy={setBusyLoadingLigands} commandCentre={props.commandCentre} molecule={props.molecule} glRef={props.glRef} height={convertViewtoPx(30, height)}/>
                     </AccordionDetails>
                 </Accordion>
             </div>

--- a/baby-gru/src/components/list/MoorhenLigandList.tsx
+++ b/baby-gru/src/components/list/MoorhenLigandList.tsx
@@ -5,16 +5,15 @@ import { MenuItem } from "@mui/material";
 import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
 import { useSelector } from "react-redux";
-import { convertViewtoPx } from "../../utils/MoorhenUtils";
 
 export const MoorhenLigandList = (props: { 
     setBusy?: React.Dispatch<React.SetStateAction<boolean>>;
     commandCentre: React.RefObject<moorhen.CommandCentre>;
     molecule: moorhen.Molecule;
     glRef: React.RefObject<webGL.MGWebGL>; 
+    height?: number | string;
 }) => {
 
-    const height = useSelector((state: moorhen.State) => state.canvasStates.height)
     const isDark = useSelector((state: moorhen.State) => state.canvasStates.isDark)
 
     const [showState, setShowState] = useState<{ [key: string]: boolean }>({})
@@ -133,7 +132,7 @@ export const MoorhenLigandList = (props: {
             null
             : ligandList.length > 0 ? 
                 <>
-                    <Row style={{ maxHeight: convertViewtoPx(30, height), overflowY: 'auto' }}>
+                    <Row style={{ maxHeight: props.height, overflowY: 'auto' }}>
                         <Col style={{paddingLeft: '0.5rem', paddingRight: '0.5rem'}}>
                             {ligandList.map((ligand, index) => {
                                 const ligandCid = `/*/${ligand.chainName}/${ligand.resNum}(${ligand.resName})`
@@ -252,4 +251,4 @@ export const MoorhenLigandList = (props: {
         </>
 }
 
-MoorhenLigandList.defaultProps = { setBusy: () => {} }
+MoorhenLigandList.defaultProps = { setBusy: () => {}, height: '30vh'}

--- a/baby-gru/src/components/list/MoorhenLigandList.tsx
+++ b/baby-gru/src/components/list/MoorhenLigandList.tsx
@@ -216,7 +216,7 @@ export const MoorhenLigandList = (props: {
                                                                 }}/>
                                                                 <Form.Check
                                                                     key={keyval}
-                                                                    label={"Validation"}
+                                                                    label={"Geom. Validation"}
                                                                     type="checkbox"
                                                                     checked={showState[keyval]}
                                                                     style={{'margin': '0.5rem'}}

--- a/baby-gru/src/components/menu-item/MapContourSettingsMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MapContourSettingsMenuItem.tsx
@@ -65,7 +65,11 @@ export const MapContourSettingsMenuItem = (props: {
                                 command: 'shim_replace_map_by_mtz_from_file',
                                 commandArgs: [map.molNo, reflectionData.data.result.mtzData, map.selectedColumns]
                             }, true) as moorhen.WorkerResponse<number>
-                            return map.doCootContour(...props.glRef.current.origin.map(coord => -coord) as [number, number, number], map.mapRadius, map.contourLevel)
+                            if (map.isVisible) {
+                                return map.doCootContour(...props.glRef.current.origin.map(coord => -coord) as [number, number, number], map.mapRadius, map.contourLevel)
+                            } else {
+                                return Promise.resolve()
+                            }
                         })
                     )
                 }

--- a/baby-gru/src/components/menu-item/MoorhenCentreOnLigandMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenCentreOnLigandMenuItem.tsx
@@ -2,8 +2,7 @@ import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
 import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem";
 import { ChevronRightOutlined, ExpandMoreOutlined } from "@mui/icons-material";
-import TreeView from '@mui/lab/TreeView';
-import TreeItem from '@mui/lab/TreeItem';
+import { TreeView, TreeItem } from '@mui/x-tree-view';
 import { useSelector } from 'react-redux';
 
 export const MoorhenCentreOnLigandMenuItem = (props: { 

--- a/baby-gru/src/components/menu-item/MoorhenFitLigandRightHereMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenFitLigandRightHereMenuItem.tsx
@@ -19,7 +19,6 @@ export const MoorhenFitLigandRightHereMenuItem = (props: {
 }) => {
 
     const dispatch = useDispatch()
-    const devMode = useSelector((state: moorhen.State) => state.generalStates.devMode)
     const molecules = useSelector((state: moorhen.State) => state.molecules)
     const maps = useSelector((state: moorhen.State) => state.maps)
 
@@ -35,8 +34,7 @@ export const MoorhenFitLigandRightHereMenuItem = (props: {
         <MoorhenMapSelect maps={maps} label="Map" ref={mapSelectRef} />
         <MoorhenMoleculeSelect molecules={molecules} label="Protein molecule" allowAny={false} ref={intoMoleculeRef} />
         <MoorhenMoleculeSelect molecules={molecules} label="Ligand molecule" allowAny={false} ref={ligandMoleculeRef} filterFunction={(molecule: moorhen.Molecule) => molecule.isLigand} />
-        {devMode && 
-         <Form.Check
+        <Form.Check
             style={{margin: '0.5rem'}} 
             type="switch"
             checked={useConformers}
@@ -44,7 +42,7 @@ export const MoorhenFitLigandRightHereMenuItem = (props: {
                 useConformersRef.current = !useConformers
                 setUseConformers(!useConformers)
             }}
-            label="Use conformers"/>}
+            label="Use conformers"/>
         {useConformers && <MoorhenNumberForm ref={conformerCountRef} label="No. of conformers" defaultValue={10}/> }
     </>
 

--- a/baby-gru/src/components/menu-item/MoorhenFitLigandRightHereMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenFitLigandRightHereMenuItem.tsx
@@ -1,4 +1,3 @@
-import { TextField } from "@mui/material";
 import { useRef, useState } from "react";
 import { Form } from "react-bootstrap";
 import { MoorhenMoleculeSelect } from "../select/MoorhenMoleculeSelect";

--- a/baby-gru/src/components/menu-item/MoorhenImportFSigFMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenImportFSigFMenuItem.tsx
@@ -73,7 +73,7 @@ export const MoorhenImportFSigFMenuItem = (props:{
                         "detail": {
                             molNo: currentMap.molNo,
                             mapRadius: currentMap.mapRadius,
-                            cootContour: currentMap.cootContour,
+                            isVisible: currentMap.isVisible,
                             contourLevel: newContourLevel,
                             mapColour: currentMap.mapColour,
                             litLines: currentMap.litLines,

--- a/baby-gru/src/components/sequence-viewer/MoorhenSequenceViewer.tsx
+++ b/baby-gru/src/components/sequence-viewer/MoorhenSequenceViewer.tsx
@@ -164,7 +164,7 @@ export const MoorhenSequenceViewer = (props: MoorhenSequenceViewerPropsType) => 
 
         const [_, insCode, chainId, resInfo, atomName]   = hoveredAtom.cid.split('/')
 
-        if (chainId !== sequence.chain || !resInfo) {
+        if (chainId !== sequence.chain || !resInfo || hoveredAtom.molecule.molNo !== molecule.molNo) {
             return
         }
         

--- a/baby-gru/src/components/validation-tools/MoorhenLigandValidation.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenLigandValidation.tsx
@@ -32,7 +32,7 @@ export const MoorhenLigandValidation = (props: Props) => {
             const selectedMolecule = molecules.find(molecule => molecule.molNo === parseInt(moleculeSelectRef.current.value))
             if(selectedMolecule) {
                 setCardList(
-                    <MoorhenLigandList commandCentre={props.commandCentre} molecule={selectedMolecule} glRef={props.glRef}/>    
+                    <MoorhenLigandList commandCentre={props.commandCentre} molecule={selectedMolecule} glRef={props.glRef} height={'100%'}/>    
                 )
             } else {
                 setCardList(null)    
@@ -72,7 +72,7 @@ export const MoorhenLigandValidation = (props: Props) => {
                         </Row>
                     </Form.Group>
                 </Form>
-                <div style={{overflowY:'auto', overflowX: 'hidden', height:'100%', paddingTop:'0.5rem', paddingLeft:'1rem', paddingRight:'1rem'}} >
+                <div style={{overflowY: 'auto', overflowX: 'hidden', height: '100%', paddingTop: '0.5rem', paddingLeft: '1rem', paddingRight: '1rem'}} >
                     {cardList}
                 </div>
             </Fragment>

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -9,6 +9,9 @@ declare module 'moorhen' {
     let MoorhenContainer: any;
     module.exports = MoorhenContainer;
 
+    let ErrorBoundary: any;
+    module.exports = ErrorBoundary;
+
     let MoorhenDraggableModalBase: any;
     module.exports = MoorhenDraggableModalBase;
 

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -186,7 +186,7 @@ declare module 'moorhen' {
         mapRadius: number;
         mapColour: [number, number, number, number];
         webMGContour: boolean;
-        cootContour: boolean;
+        isVisible: boolean;
         displayObjects: any;
         litLines: boolean;
         solid: boolean;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -388,7 +388,7 @@ export namespace moorhen {
         mapRadius: number;
         mapColour: [number, number, number, number];
         webMGContour: boolean;
-        cootContour: boolean;
+        isVisible: boolean;
         displayObjects: any;
         litLines: boolean;
         solid: boolean;
@@ -435,7 +435,7 @@ export namespace moorhen {
         uniqueId: string;
         mapData: Uint8Array;
         reflectionData: Uint8Array;
-        cootContour: boolean;
+        isVisible: boolean;
         contourLevel: number;
         radius: number;
         colour: [number, number, number, number];
@@ -541,7 +541,7 @@ export namespace moorhen {
     type NewMapContourEvent = CustomEvent<{
         molNo: number;
         mapRadius: number;
-        cootContour: boolean;
+        isVisible: boolean;
         contourLevel: number;
         mapColour: [number, number, number, number],
         litLines: boolean;

--- a/baby-gru/src/utils/MoorhenMap.ts
+++ b/baby-gru/src/utils/MoorhenMap.ts
@@ -51,7 +51,7 @@ export class MoorhenMap implements moorhen.Map {
     mapRadius: number
     mapColour: [number, number, number, number]
     webMGContour: boolean
-    cootContour: boolean
+    isVisible: boolean
     displayObjects: any
     litLines: boolean
     solid: boolean
@@ -82,7 +82,7 @@ export class MoorhenMap implements moorhen.Map {
         this.mapRadius = 13
         this.mapColour = [0.3, 0.3, 1.0, 1.0]
         this.webMGContour = false
-        this.cootContour = true
+        this.isVisible = true
         this.displayObjects = { Coot: [] }
         this.litLines = false
         this.solid = false
@@ -371,7 +371,7 @@ export class MoorhenMap implements moorhen.Map {
      * Contour the map and make it live
      */
     makeCootLive(): void {
-        this.cootContour = true
+        this.isVisible = true
         this.doCootContour(...this.glRef.current.origin.map(coord => -coord) as [number, number, number], this.mapRadius, this.contourLevel)
         this.glRef.current.drawScene()
     }
@@ -380,9 +380,8 @@ export class MoorhenMap implements moorhen.Map {
      * Hide the map
      */
     makeCootUnlive(): void {
-        const $this = this
-        $this.cootContour = false
-        $this.clearBuffersOfStyle('Coot')
+        this.isVisible = false
+        this.clearBuffersOfStyle('Coot')
         this.glRef.current.buildBuffers();
         this.glRef.current.drawScene();
     }

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -48,7 +48,7 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
         this.modificationCount = 0
         this.modificationCountBackupThreshold = 5
         this.maxBackupCount = 10
-        this.version = 'v14'
+        this.version = 'v15'
         this.disableBackups = false
         this.storageInstance = null
         this.onIsBusyChange = null
@@ -216,7 +216,7 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
                 uniqueId: map.uniqueId,
                 mapData: mapDataPromises[index],
                 reflectionData: reflectionDataPromises[index],
-                cootContour: map.cootContour,
+                isVisible: map.isVisible,
                 contourLevel: map.contourLevel,
                 radius: map.mapRadius,
                 colour: map.mapColour,

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -285,7 +285,7 @@ export async function loadSessionData(
                 "detail": {
                     molNo: map.molNo,
                     mapRadius: storedMapData.radius,
-                    cootContour: storedMapData.cootContour,
+                    isVisible: storedMapData.isVisible,
                     contourLevel: storedMapData.contourLevel,
                     mapColour: storedMapData.colour,
                     litLines: storedMapData.litLines,

--- a/baby-gru/tests/__tests__/integration.test.js
+++ b/baby-gru/tests/__tests__/integration.test.js
@@ -34,7 +34,7 @@ describe("Testing gemmi", () => {
         cleanUpVariables = []
     })
 
-    test("Test metaballs", () => {
+    test.skip("Test metaballs", () => {
         console.log("Testing metaballs")
         const molecules_container = new cootModule.molecules_container_js(false)
         const coordMol = molecules_container.read_pdb('./5a3h.pdb')

--- a/baby-gru/tests/__tests__/integration.test.js
+++ b/baby-gru/tests/__tests__/integration.test.js
@@ -252,7 +252,7 @@ describe('Testing molecules_container_js', () => {
         expect(atomCount).toBe(14)
     })
 
-    test('Test ligand methods', () => {
+    test('Test fit_ligand_right_here 1', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         
         const result_import_dict = molecules_container.import_cif_dictionary('./LZA.cif', -999999)
@@ -267,6 +267,29 @@ describe('Testing molecules_container_js', () => {
 
         const useConformers = false
         const conformerCount = 10
+        const coordMolNo = molecules_container.read_pdb('./5a3h_no_ligand.pdb')
+        const mapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'FWT', 'PHWT', "", false, false)
+        const result = molecules_container.fit_ligand_right_here(
+            coordMolNo, mapMolNo, ligandMolNo, ...coords, 1., useConformers, conformerCount
+        )
+        expect(result.size()).toBeGreaterThan(0)
+    })
+
+    test('Test fit_ligand_right_here 2', () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        
+        const result_import_dict = molecules_container.import_cif_dictionary('./LZA.cif', -999999)
+        expect(result_import_dict).toBe(1)
+
+        const coords = [0, 0, 0]
+        const tlc = 'LZA'
+        const ligandMolNo = molecules_container.get_monomer_and_position_at(
+            tlc, -999999, ...coords
+        )
+        expect(ligandMolNo).toBe(0)
+
+        const useConformers = true
+        const conformerCount = 50
         const coordMolNo = molecules_container.read_pdb('./5a3h_no_ligand.pdb')
         const mapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'FWT', 'PHWT', "", false, false)
         const result = molecules_container.fit_ligand_right_here(


### PR DESCRIPTION
This update includes:
- `Fit ligand right here` now allows to try multiple conformers out of dev mode
- Bug where sequence viewer hovering would be triggered regardless of the molecule being hovered is now fixed.
- Fixes #188 
- Fix bug where "Centre on ligand" menu item shows nothing
- Add `ErroBoundary` to `main.d.ts`