### PR TITLE
Add serNo to time capsule backups

### DIFF
--- a/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
@@ -126,6 +126,7 @@ export const MoorhenFileMenu = (props: MoorhenNavBarExtendedControlsInterface) =
         const key: moorhen.backupKey = {
             dateTime: `${Date.now()}`,
             type: 'manual',
+            serNo: guid(),
             molNames: session.moleculeData.map(mol => mol.name),
             mapNames: session.mapData.map(map => map.uniqueId),
             mtzNames: session.mapData.filter(map => map.hasReflectionData).map(map => map.associatedReflectionFileName)

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -415,6 +415,7 @@ export namespace moorhen {
         label?: string;
         dateTime: string;
         type: string;
+        serNo: string | number;
         molNames: string[];
         mapNames?: string[];
         mtzNames?: string[];

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -1,5 +1,6 @@
 import { moorhen } from "../types/moorhen";
 import { webGL } from "../types/mgWebGL";
+import { guid } from "./MoorhenUtils";
 
 export const getBackupLabel = (key: moorhen.backupKey): string => {
     const dateOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' } as const
@@ -48,7 +49,7 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
         this.modificationCount = 0
         this.modificationCountBackupThreshold = 5
         this.maxBackupCount = 10
-        this.version = 'v15'
+        this.version = 'v16'
         this.disableBackups = false
         this.storageInstance = null
         this.onIsBusyChange = null
@@ -274,6 +275,7 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
             const key: moorhen.backupKey = {
                 dateTime: `${Date.now()}`, 
                 type: 'automatic', 
+                serNo: guid(),
                 molNames: this.moleculesRef.current.map(mol => mol.name),
                 mapNames: this.mapsRef.current.map(map => map.uniqueId),
                 mtzNames: this.mapsRef.current.filter(map => map.hasReflectionData).map(map => map.associatedReflectionFileName)


### PR DESCRIPTION
This update is related to a bug in CCP4 cloud preventing backup load within the history menu. Time capsule backups have now a unique identifier attribute `serNo`