### PR TITLE
Expand residue selections to include neighboring residues

### DIFF
--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moorhen",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": false,
   "main": "moorhen.js",
   "types": "./types/main.d.ts",

--- a/baby-gru/src/components/button/MoorhenContextButtonBase.tsx
+++ b/baby-gru/src/components/button/MoorhenContextButtonBase.tsx
@@ -123,7 +123,9 @@ export const MoorhenContextButtonBase = (props: {
             }
         }
         
-        const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: props.selectedMolecule.molNo } })
+        const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { 
+            modifiedMolecule: props.selectedMolecule.molNo
+        }})
         document.dispatchEvent(scoresUpdateEvent)
         props.selectedMolecule.setAtomsDirty(true)
         props.selectedMolecule.clearBuffersOfStyle('hover')

--- a/baby-gru/src/components/button/MoorhenDragAtomsButton.tsx
+++ b/baby-gru/src/components/button/MoorhenDragAtomsButton.tsx
@@ -128,7 +128,7 @@ export const MoorhenDragAtomsButton = (props: moorhen.ContextButtonProps) => {
             }, true)
             chosenMolecule.current.atomsDirty = true
             await chosenMolecule.current.redraw()
-            const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: chosenMolecule.current.molNo } })
+            const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { modifiedMolecule: chosenMolecule.current.molNo } })
             document.dispatchEvent(scoresUpdateEvent)
         }
         moltenFragmentRef.current.delete()

--- a/baby-gru/src/components/button/MoorhenRotamerChangeButton.tsx
+++ b/baby-gru/src/components/button/MoorhenRotamerChangeButton.tsx
@@ -46,7 +46,7 @@ export const MoorhenRotamerChangeButton = (props: moorhen.ContextButtonProps) =>
         fragmentMolecule.current.delete()
         chosenMolecule.current.unhideAll()
 
-        const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: chosenMolecule.current.molNo } })
+        const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { modifiedMolecule: chosenMolecule.current.molNo } })
         document.dispatchEvent(scoresUpdateEvent)
         dispatch(setIsChangingRotamers(false))
 

--- a/baby-gru/src/components/button/MoorhenRotateTranslateZoneButton.tsx
+++ b/baby-gru/src/components/button/MoorhenRotateTranslateZoneButton.tsx
@@ -45,7 +45,7 @@ export const MoorhenRotateTranslateZoneButton = (props: moorhen.ContextButtonPro
         await chosenMolecule.current.updateWithMovedAtoms(transformedAtoms)
         fragmentMolecule.current.delete()
         chosenMolecule.current.unhideAll()
-        const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: chosenMolecule.current.molNo } })
+        const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { modifiedMolecule: chosenMolecule.current.molNo } })
         document.dispatchEvent(scoresUpdateEvent)
         dispatch(setIsRotatingAtoms(false))
     }, [props, chosenMolecule, fragmentMolecule])

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -398,7 +398,7 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
         await props.molecule.undo()
         props.setCurrentDropdownMolNo(-1)
         const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", {
-            detail: { origin: props.glRef.current.origin, modifiedMolecule: props.molecule.molNo } 
+            detail: { modifiedMolecule: props.molecule.molNo } 
         })
         document.dispatchEvent(scoresUpdateEvent)
     }
@@ -407,7 +407,7 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
         await props.molecule.redo()
         props.setCurrentDropdownMolNo(-1)
         const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", {
-            detail: { origin: props.glRef.current.origin, modifiedMolecule: props.molecule.molNo } 
+            detail: { modifiedMolecule: props.molecule.molNo } 
         })
         document.dispatchEvent(scoresUpdateEvent)
     }

--- a/baby-gru/src/components/menu-item/MoorhenAddSimpleMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenAddSimpleMenuItem.tsx
@@ -34,7 +34,7 @@ export const MoorhenAddSimpleMenuItem = (props: {
         const selectedMolecule = molecules.find(molecule => molecule.molNo === parseInt(moleculeSelectRef.current.value))
         if (selectedMolecule) {
             await selectedMolecule.addLigandOfType(molTypeSelectRef.current.value)
-            const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: selectedMolecule.molNo } })
+            const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { modifiedMolecule: selectedMolecule.molNo } })
             document.dispatchEvent(scoresUpdateEvent)    
         }
     }, [props.glRef, molecules])

--- a/baby-gru/src/components/menu-item/MoorhenAddWatersMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenAddWatersMenuItem.tsx
@@ -42,7 +42,7 @@ export const MoorhenAddWatersMenuItem = (props: {
         selectedMolecule.setAtomsDirty(true)
         await selectedMolecule.redraw()
         
-        const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: moleculeMolNo } })
+        const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { modifiedMolecule: moleculeMolNo } })
         document.dispatchEvent(scoresUpdateEvent)
 
     }, [molecules, maps, props.glRef, props.commandCentre])

--- a/baby-gru/src/components/menu-item/MoorhenImportLigandDictionary.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenImportLigandDictionary.tsx
@@ -97,7 +97,7 @@ const MoorhenImportLigandDictionary = (props: {
                     if (typeof toMolecule !== 'undefined') {
                         const otherMolecules = [newMolecule]
                         await toMolecule.mergeMolecules(otherMolecules, true)
-                        const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: glRef.current.origin, modifiedMolecule: toMolecule.molNo } })
+                        const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { modifiedMolecule: toMolecule.molNo } })
                         document.dispatchEvent(scoresUpdateEvent)
                         await toMolecule.redraw()
                     } else {

--- a/baby-gru/src/components/menu-item/MoorhenMergeMoleculesMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenMergeMoleculesMenuItem.tsx
@@ -32,7 +32,7 @@ export const MoorhenMergeMoleculesMenuItem = (props: {
         }
         await toMolecule.mergeMolecules(otherMolecules, true)
         props.setPopoverIsShown(false)
-        const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: toMolecule.molNo } })
+        const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { modifiedMolecule: toMolecule.molNo } })
         document.dispatchEvent(scoresUpdateEvent)
     }, [toRef.current, fromRef.current, molecules, props.fromMolNo, props.glRef])
 

--- a/baby-gru/src/components/menu-item/MoorhenMoveMoleculeHere.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenMoveMoleculeHere.tsx
@@ -26,7 +26,7 @@ export const MoorhenMoveMoleculeHere = (props: {
         if (selectedMolecule) {
             await selectedMolecule.moveMoleculeHere(...props.glRef.current.origin.map(coord => -coord) as [number, number, number])
             const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {
-                origin: props.glRef.current.origin, modifiedMolecule: selectedMolecule.molNo 
+                modifiedMolecule: selectedMolecule.molNo 
             } })
             document.dispatchEvent(scoresUpdateEvent)
         }

--- a/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
+++ b/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
@@ -194,9 +194,11 @@ export const MoorhenResidueSelectionActions = (props) => {
                     <IconButton onClick={handleSelectionCopy} onMouseEnter={() => setTooltipContents('Copy fragment')}>
                         <CopyAllOutlined/>
                     </IconButton>
+                    {/**
                     <IconButton onClick={handleExpandSelection} onMouseEnter={() => setTooltipContents('Expand to neighbouring residues')}>
                         <AllOutOutlined/>
                     </IconButton>
+                     */}
                     <IconButton onClick={clearSelection} onMouseEnter={() => setTooltipContents('Clear selection')}>
                         <CloseOutlined/>
                     </IconButton>

--- a/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
+++ b/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
@@ -1,7 +1,7 @@
 import { IconButton, Tooltip } from "@mui/material"
 import { cidToSpec, guid } from "../../utils/MoorhenUtils"
 import { MoorhenNotification } from "./MoorhenNotification"
-import { CloseOutlined, CopyAllOutlined, CrisisAlertOutlined, DeleteOutlined } from "@mui/icons-material"
+import { AllOutOutlined, CloseOutlined, CopyAllOutlined, CrisisAlertOutlined, DeleteOutlined } from "@mui/icons-material"
 import { useDispatch, useSelector } from "react-redux"
 import { moorhen } from "../../types/moorhen"
 import { Stack } from "react-bootstrap"
@@ -46,7 +46,13 @@ export const MoorhenResidueSelectionActions = (props) => {
             const resSpec = cidToSpec(evt.detail.atom.label)
             await selectedMolecule.drawResidueSelection(`/*/${resSpec.chain_id}/${resSpec.res_no}-${resSpec.res_no}/*`)
             dispatch(
-                setResidueSelection({ molecule: selectedMolecule, first: evt.detail.atom.label, second: null, cid: null})
+                setResidueSelection({
+                    molecule: selectedMolecule,
+                    first: evt.detail.atom.label,
+                    second: null,
+                    cid: null,
+                    isMultiCid: false
+                })
             )
             setSelectionLabel(`/${resSpec.mol_no}/${resSpec.chain_id}/${resSpec.res_no}`)
             return
@@ -61,7 +67,13 @@ export const MoorhenResidueSelectionActions = (props) => {
             const cid = `/*/${startResSpec.chain_id}/${sortedResNums[0]}-${sortedResNums[1]}/*`
             await selectedMolecule.drawResidueSelection(cid)
             dispatch(
-                setResidueSelection({ molecule: selectedMolecule, first: residueSelection.first, second: evt.detail.atom.label, cid: cid})
+                setResidueSelection({
+                    molecule: selectedMolecule,
+                    first: residueSelection.first,
+                    second: evt.detail.atom.label,
+                    cid: cid,
+                    isMultiCid: false
+                })
             )
             setSelectionLabel(`/${startResSpec.mol_no}/${startResSpec.chain_id}/${sortedResNums[0]}-${sortedResNums[1]}`)
         }
@@ -77,8 +89,10 @@ export const MoorhenResidueSelectionActions = (props) => {
     const handleSelectionCopy = useCallback(async () => {
         let cid: string
         
-        if (residueSelection.molecule && residueSelection.cid) {
-            cid = residueSelection.cid
+        if (residueSelection.isMultiCid) {
+            // pass
+        } else if (residueSelection.molecule && residueSelection.cid) {
+            cid = residueSelection.cid as string
         } else if (residueSelection.molecule && residueSelection.first) {
             const startResSpec = cidToSpec(residueSelection.first)
             cid =`/${startResSpec.mol_no}/${startResSpec.chain_id}/${startResSpec.res_no}-${startResSpec.res_no}`
@@ -93,7 +107,9 @@ export const MoorhenResidueSelectionActions = (props) => {
     }, [residueSelection, clearSelection])
 
     const handleRefinement = useCallback(async () => {
-        if (residueSelection.molecule && residueSelection.cid) {
+        if (residueSelection.isMultiCid) {
+            // pass
+        } else if (residueSelection.molecule && residueSelection.cid) {
             const startResSpec = cidToSpec(residueSelection.first)
             const stopResSpec = cidToSpec(residueSelection.second)
             const sortedResNums = [startResSpec.res_no, stopResSpec.res_no].sort(function(a, b){return a - b})
@@ -108,8 +124,10 @@ export const MoorhenResidueSelectionActions = (props) => {
     const handleDelete = useCallback(async () => {
         let cid: string
         
-        if (residueSelection.molecule && residueSelection.cid) {
-            cid = residueSelection.cid
+        if (residueSelection.isMultiCid) {
+            // pass
+        } else if (residueSelection.molecule && residueSelection.cid) {
+            cid = residueSelection.cid as string
         } else if (residueSelection.molecule && residueSelection.first) {
             const startResSpec = cidToSpec(residueSelection.first)
             cid = `/${startResSpec.mol_no}/${startResSpec.chain_id}/${startResSpec.res_no}-${startResSpec.res_no}`
@@ -127,22 +145,57 @@ export const MoorhenResidueSelectionActions = (props) => {
         clearSelection()
     }, [residueSelection, clearSelection])
 
+    const handleExpandSelection = useCallback(async () => {
+        let cid: string
+        
+        if (residueSelection.isMultiCid) {
+            // pass
+        } else if (residueSelection.molecule && residueSelection.cid) {
+            cid = residueSelection.cid as string
+            const startResSpec = cidToSpec(residueSelection.first)
+            const stopResSpec = cidToSpec(residueSelection.second)
+            const sortedResNums = [startResSpec.res_no, stopResSpec.res_no].sort(function(a, b){return a - b})
+            setSelectionLabel(`/${startResSpec.mol_no}/${startResSpec.chain_id}/${sortedResNums[0]}-${sortedResNums[1]} +7Å`)
+        } else if (residueSelection.molecule && residueSelection.first) {
+            const startResSpec = cidToSpec(residueSelection.first)
+            cid = `/${startResSpec.mol_no}/${startResSpec.chain_id}/${startResSpec.res_no}-${startResSpec.res_no}`
+            setSelectionLabel(`/${startResSpec.mol_no}/${startResSpec.chain_id}/${startResSpec.res_no} +7Å`)
+        }
+
+        if (cid) {
+            const result = await residueSelection.molecule.getNeighborResiduesCids(cid, 7)
+            await residueSelection.molecule.drawResidueSelection(result.join('||'))
+            dispatch(
+                setResidueSelection({
+                    molecule: residueSelection.molecule,
+                    first: residueSelection.first,
+                    second: residueSelection.second,
+                    cid: result,
+                    isMultiCid: true
+                })
+            )
+        }
+}, [residueSelection, clearSelection])
+
     return  selectionLabel ?
-        <MoorhenNotification key={notificationKeyRef.current} width={14}>
+        <MoorhenNotification key={notificationKeyRef.current} width={16}>
             <Tooltip className="moorhen-tooltip" title={tooltipContents}>
             <Stack ref={notificationComponentRef} direction="vertical" gap={1}>
                 <div>
                     <span>{selectionLabel}</span>
                 </div>
                 <Stack gap={2} direction='horizontal' style={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
-                    <IconButton onClick={handleDelete} onMouseEnter={() => setTooltipContents('Delete')}>
-                        <DeleteOutlined/>
-                    </IconButton>
                     <IconButton onClick={handleRefinement} onMouseEnter={() => setTooltipContents('Refine')}>
                         <CrisisAlertOutlined/>
                     </IconButton>
+                    <IconButton onClick={handleDelete} onMouseEnter={() => setTooltipContents('Delete')}>
+                        <DeleteOutlined/>
+                    </IconButton>
                     <IconButton onClick={handleSelectionCopy} onMouseEnter={() => setTooltipContents('Copy fragment')}>
                         <CopyAllOutlined/>
+                    </IconButton>
+                    <IconButton onClick={handleExpandSelection} onMouseEnter={() => setTooltipContents('Expand to neighbouring residues')}>
+                        <AllOutOutlined/>
                     </IconButton>
                     <IconButton onClick={clearSelection} onMouseEnter={() => setTooltipContents('Clear selection')}>
                         <CloseOutlined/>

--- a/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
+++ b/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
@@ -24,6 +24,13 @@ export const MoorhenResidueSelectionActions = (props) => {
     const isDraggingAtoms = useSelector((state: moorhen.State) => state.generalStates.isDraggingAtoms)
     const residueSelection = useSelector((state: moorhen.State) => state.generalStates.residueSelection)
 
+    const updateScores = (molecule: moorhen.Molecule) => {
+        const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {
+            modifiedMolecule: molecule.molNo
+        }})
+        document.dispatchEvent(scoresUpdateEvent)
+    }
+
     const clearSelection = useCallback(() => {
         dispatch( clearResidueSelection() )
         dispatch( setNotificationContent(null) )
@@ -114,9 +121,11 @@ export const MoorhenResidueSelectionActions = (props) => {
             const stopResSpec = cidToSpec(residueSelection.second)
             const sortedResNums = [startResSpec.res_no, stopResSpec.res_no].sort(function(a, b){return a - b})
             await residueSelection.molecule.refineResidueRange(startResSpec.chain_id, sortedResNums[0], sortedResNums[1], 5000, true)
+            updateScores(residueSelection.molecule)
         } else if (residueSelection.molecule && residueSelection.first) {
             const startResSpec = cidToSpec(residueSelection.first)
             await residueSelection.molecule.refineResidueRange(startResSpec.chain_id, startResSpec.res_no, startResSpec.res_no, 5000, true)
+            updateScores(residueSelection.molecule)
         }
         clearSelection()
     }, [clearSelection, residueSelection])
@@ -140,6 +149,7 @@ export const MoorhenResidueSelectionActions = (props) => {
                 await residueSelection.molecule.delete()
                 dispatch(removeMolecule(residueSelection.molecule))
             }
+            updateScores(residueSelection.molecule)
         }
 
         clearSelection()

--- a/baby-gru/src/components/navbar-menus/MoorhenDevMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenDevMenu.tsx
@@ -43,7 +43,7 @@ const doTest = async (props: any) => {
 
         molecule.setAtomsDirty(true)
         await molecule.redraw()
-        const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: props.glRef.current.origin, modifiedMolecule: molecule.molNo } })
+        const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { modifiedMolecule: molecule.molNo } })
         document.dispatchEvent(scoresUpdateEvent)
         
         if (TRIAL_COUNT <= 99) {

--- a/baby-gru/src/components/validation-tools/MoorhenFillMissingAtoms.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenFillMissingAtoms.tsx
@@ -34,7 +34,7 @@ export const MoorhenFillMissingAtoms = (props: Props) => {
         }
         selectedMolecule.setAtomsDirty(true)
         selectedMolecule.redraw()
-        const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {origin: props.glRef.current.origin,  modifiedMolecule: selectedMolecule.molNo} })
+        const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {modifiedMolecule: selectedMolecule.molNo} })
         document.dispatchEvent(scoresUpdateEvent);    
     }
 

--- a/baby-gru/src/components/validation-tools/MoorhenPepflipsDifferenceMap.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenPepflipsDifferenceMap.tsx
@@ -41,7 +41,7 @@ export const MoorhenPepflipsDifferenceMap = (props: Props) => {
         const selectedMolecule = molecules.find(molecule => molecule.molNo === selectedMolNo)
         selectedMolecule.setAtomsDirty(true)
         selectedMolecule.redraw()
-        const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {origin: props.glRef.current.origin,  modifiedMolecule: selectedMolecule.molNo} })
+        const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {modifiedMolecule: selectedMolecule.molNo} })
         document.dispatchEvent(scoresUpdateEvent)
     }
 

--- a/baby-gru/src/components/webMG/MoorhenWebMG.tsx
+++ b/baby-gru/src/components/webMG/MoorhenWebMG.tsx
@@ -275,7 +275,7 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
         }
     }, [useOffScreenBuffers])
 
-    const handleScoreUpdates = useCallback(async (e) => {
+    const handleScoreUpdates = useCallback(async (e: moorhen.ScoresUpdateEvent) => {
         if (e.detail?.modifiedMolecule !== null && connectedMolNo && connectedMolNo.molecule === e.detail.modifiedMolecule && glRef !== null && typeof glRef !== 'function') {
             
             await Promise.all(

--- a/baby-gru/src/store/generalStatesSlice.ts
+++ b/baby-gru/src/store/generalStatesSlice.ts
@@ -12,7 +12,7 @@ export const generalStatesSlice = createSlice({
     activeMap: null,
     theme: 'flatly',
     viewOnly: false,
-    residueSelection: { molecule: null, first: null, second: null, cid: null } as moorhen.ResidueSelection,
+    residueSelection: { molecule: null, first: null, second: null, cid: null, isMultiCid: false } as moorhen.ResidueSelection,
     isChangingRotamers: false,
     isDraggingAtoms: false,
     isRotatingAtoms: false
@@ -52,7 +52,7 @@ export const generalStatesSlice = createSlice({
         return {...state, devMode: action.payload}
     },
     clearResidueSelection: (state) => {
-      return {...state, residueSelection: { molecule: null, first: null, second: null, cid: null }}
+      return {...state, residueSelection: { molecule: null, first: null, second: null, cid: null, isMultiCid: false }}
     },
     setResidueSelection: (state, action: {payload: moorhen.ResidueSelection, type: string}) => {
       return {...state, residueSelection: action.payload}

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -232,7 +232,8 @@ export namespace moorhen {
         molecule: null | moorhen.Molecule;
         first: null | string;
         second: null | string;
-        cid: null | string;
+        cid: null | string | string[];
+        isMultiCid: boolean;
     }
     
     type HoveredAtom = {

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -524,7 +524,6 @@ export namespace moorhen {
     type MapRadiusChangeEvent = CustomEvent<{ factor: number; }>
 
     type ScoresUpdateEvent = CustomEvent<{
-        origin: [number, number, number];
         modifiedMolecule: number;
     }>
     

--- a/baby-gru/src/utils/MoorhenKeyboardAccelerators.tsx
+++ b/baby-gru/src/utils/MoorhenKeyboardAccelerators.tsx
@@ -17,7 +17,7 @@ const apresEdit = (molecule: moorhen.Molecule, glRef: React.RefObject<webGL.MGWe
     molecule.setAtomsDirty(true)
     molecule.redraw()
     dispatch( setHoveredAtom({ molecule: null, cid: null }) )
-    const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { origin: glRef.current.origin,  modifiedMolecule: molecule.molNo} })
+    const scoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: {modifiedMolecule: molecule.molNo} })
     document.dispatchEvent(scoresUpdateEvent)
 }
 
@@ -158,7 +158,7 @@ export const babyGruKeyPress = (
         }
         promise.then(_ => {
             const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", {
-                detail: { origin: glRef.current.origin, modifiedMolecule: selectedMolecule.molNo } 
+                detail: { modifiedMolecule: selectedMolecule.molNo } 
             })
             document.dispatchEvent(scoresUpdateEvent)        
         })

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -296,20 +296,13 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @returns {Promise<string[]>} List of CIDs with the residues found within the radius of search
      */
     async getNeighborResiduesCids(selectionCid: string, maxDist: number): Promise<string[]> {
-        let multiCidRanges: string[] = []
-        
         const response = await this.commandCentre.current.cootCommand({
             returnType: "status",
             command: 'get_neighbours_cid',
             commandArgs: [this.molNo, selectionCid, maxDist]
         }, true) as moorhen.WorkerResponse<string>
 
-        response.data.result.result.split('|').forEach(chainResidueCid => {
-            let [chainId, resNums] = chainResidueCid.split('/')
-            const residueRanges = findConsecutiveRanges(resNums.split(',').map(n => parseInt(n)))
-            residueRanges.forEach(range => multiCidRanges.push(`//${chainId}/${range[0]}-${range[1]}/*`))
-        })
-        
+        const multiCidRanges: string[] = response.data.result.result.split('||')
         return multiCidRanges
     }
 

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -443,7 +443,7 @@ describe("Testing MoorhenMolecule", () => {
         expect(molecule.ligands).toHaveLength(0)
     })
 
-    test("Test getNeighborResiduesCids", async () => {
+    test("Test getNeighborResiduesCids 1", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
@@ -458,6 +458,63 @@ describe("Testing MoorhenMolecule", () => {
         
         const result = await molecule.getNeighborResiduesCids('//A/33/CA', 3)
         expect(result).toEqual(['//A/32-34/*'])
+    })
+
+    test("Test getNeighborResiduesCids 2", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl, 'mol-test')
+        
+        const result = await molecule.getNeighborResiduesCids('//A/188/CA', 7)
+        expect(result).toEqual([
+            "//A/147-147/*",
+            "//A/152-152/*",
+            "//A/183-190/*",
+            "//A/197-197/*",
+            "//A/939-939/*",
+            "//A/965-965/*",
+            "//A/971-971/*",
+            "//A/995-995/*",
+            "//A/1011-1011/*",
+            "//A/1037-1037/*",
+            "//A/1042-1042/*",
+            "//A/1132-1133/*",
+            "//A/1149-1149/*",
+            "//A/1163-1163/*",
+            "//A/1198-1198/*",
+            "//A/1208-1208/*"
+        ])
+    })
+    
+    test("Test getNeighborResiduesCids 3", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl, 'mol-test')
+        
+        const result = await molecule.getNeighborResiduesCids('//A/30-33/CA', 5)
+        expect(result).toEqual([
+            "//A/29-34/*",
+            "//A/58-62/*",
+            "//A/259-261/*",
+            "//A/300-300/*",
+            "//A/1044-1044/*"
+        ])
     })
 
     test("Test checkIsLigand", async () => {

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -300,7 +300,91 @@ describe("Testing MoorhenMolecule", () => {
               label: '/1/A/31(GLY)/CA'
             }
         ])
-        expect(gemmiAtoms.map(atomInfo => atomInfo.label)).toEqual([ "/1/A/31(GLY)/CA" ])
+    })
+
+    test("Test gemmiAtomsForCid 3", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        const f = jest.spyOn(molecule, 'updateAtoms')
+        await molecule.loadToCootFromURL(fileUrl_1, 'mol-test')
+        molecule.setAtomsDirty(true)
+        const gemmiAtoms = await molecule.gemmiAtomsForCid('//A/30-31/CA||//A/60-61/CA')
+        expect(f).toHaveBeenCalled()
+        expect(gemmiAtoms).toHaveLength(4)
+        expect(gemmiAtoms.map(atomInfo => atomInfo.label)).toEqual([ "/1/A/30(LYS)/CA", "/1/A/31(GLY)/CA", "/1/A/60(VAL)/CA", "/1/A/61(PHE)/CA" ])
+    })
+
+    test("Test gemmiAtomsForCid 4", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        const f = jest.spyOn(molecule, 'updateAtoms')
+        await molecule.loadToCootFromURL(fileUrl_1, 'mol-test')
+        molecule.setAtomsDirty(true)
+        await molecule.hideCid("/*/A/29-30/*")
+        await molecule.hideCid("/*/A/59-60/*")
+        const gemmiAtoms = await molecule.gemmiAtomsForCid('//A/30-31/CA||//A/60-61/CA', true)
+        expect(f).toHaveBeenCalled()
+        expect(gemmiAtoms).toHaveLength(2)
+        expect(gemmiAtoms).toEqual([
+            {
+              res_name: 'GLY',
+              res_no: '31',
+              mol_name: '1',
+              chain_id: 'A',
+              pos: [ 70.995, 43.686, 22.449 ],
+              x: 70.995,
+              y: 43.686,
+              z: 22.449,
+              charge: 0,
+              element: 'C',
+              symbol: 'C',
+              tempFactor: 9.109999656677246,
+              serial: 213,
+              name: 'CA',
+              has_altloc: false,
+              alt_loc: "",
+              label: '/1/A/31(GLY)/CA'
+            },
+            {
+                alt_loc: "",
+                chain_id: "A",
+                charge: 0,
+                element: "C",
+                has_altloc: false,
+                label: "/1/A/61(PHE)/CA",
+                mol_name: "1",
+                name: "CA",
+                pos: [
+                    66.013,
+                    44.486,
+                    20.155,
+                ],
+                res_name: "PHE",
+                res_no: "61",
+                serial: 475,
+                symbol: "C",
+                tempFactor: 8.699999809265137,
+                x: 66.013,
+                y: 44.486,
+                z: 20.155,
+            }
+        ])
     })
 
     test("Test parseSequences", async () => {

--- a/coot/gemmi-wrappers.cc
+++ b/coot/gemmi-wrappers.cc
@@ -350,7 +350,7 @@ bool selection_vector_matches_atom(const std::vector<gemmi::Selection> &selectio
 }
 
 std::vector<gemmi::Selection> parse_multi_cid_selections(const std::string &cids) {
-    std::vector<gemmi::Selection> selections_vec;    
+    std::vector<gemmi::Selection> selections_vec;
     if (!cids.empty()) {
         std::istringstream stream(cids);
         std::string token;
@@ -367,8 +367,8 @@ std::vector<gemmi::Selection> parse_multi_cid_selections(const std::string &cids
 // cids and excluded_cids are strings of CID selections separated with ||
 std::vector<AtomInfo> get_atom_info_for_selection(const gemmi::Structure &Structure, const std::string &cids, const std::string &excluded_cids) {
 
-    std::vector<gemmi::Selection> selections_vec = parse_multi_cid_selections(cids);    
-    std::vector<gemmi::Selection> excluded_selections_vec = parse_multi_cid_selections(excluded_cids);    
+    std::vector<gemmi::Selection> selections_vec = parse_multi_cid_selections(cids);
+    std::vector<gemmi::Selection> excluded_selections_vec = parse_multi_cid_selections(excluded_cids);
 
     std::vector<AtomInfo> atom_info_vec;
     auto structure_copy = Structure;

--- a/coot/gemmi-wrappers.cc
+++ b/coot/gemmi-wrappers.cc
@@ -301,52 +301,99 @@ struct AtomInfo {
     std::string label;
 };
 
-// excluded_cids is a string of CID selections separated with ||
-std::vector<AtomInfo> get_atom_info_for_selection(const gemmi::Structure &Structure, const std::string &cid, const std::string &excluded_cids) {
-
-    std::vector<gemmi::Selection> excluded_selections_vec;    
-    if (!excluded_cids.empty()) {
-        std::istringstream stream(excluded_cids);
-        std::string token;
-        while (std::getline(stream, token, '|')) {
-            gemmi::Selection sele(token);
-            excluded_selections_vec.push_back(sele);
+bool selection_vector_matches_model(const std::vector<gemmi::Selection> &selections_vec, const gemmi::Model &model) {
+    bool is_match = false;
+    for (int selectionIndex = 0; selectionIndex < selections_vec.size(); selectionIndex++) {
+        gemmi::Selection selection = selections_vec[selectionIndex];
+        if (selection.matches(model)) {
+            is_match = true;
+            break;
         }
     }
+    return is_match;
+}
 
-    const gemmi::Selection Selection(cid);
+bool selection_vector_matches_chain(const std::vector<gemmi::Selection> &selections_vec, const gemmi::Chain &chain) {
+    bool is_match = false;
+    for (int selectionIndex = 0; selectionIndex < selections_vec.size(); selectionIndex++) {
+        gemmi::Selection selection = selections_vec[selectionIndex];
+        if (selection.matches(chain)) {
+            is_match = true;
+            break;
+        }
+    }
+    return is_match;
+}
+
+bool selection_vector_matches_residue(const std::vector<gemmi::Selection> &selections_vec, const gemmi::Residue &residue) {
+    bool is_match = false;
+    for (int selectionIndex = 0; selectionIndex < selections_vec.size(); selectionIndex++) {
+        gemmi::Selection selection = selections_vec[selectionIndex];
+        if (selection.matches(residue)) {
+            is_match = true;
+            break;
+        }
+    }
+    return is_match;
+}
+
+bool selection_vector_matches_atom(const std::vector<gemmi::Selection> &selections_vec, const gemmi::Atom &atom) {
+    bool is_match = false;
+    for (int selectionIndex = 0; selectionIndex < selections_vec.size(); selectionIndex++) {
+        gemmi::Selection selection = selections_vec[selectionIndex];
+        if (selection.matches(atom)) {
+            is_match = true;
+            break;
+        }
+    }
+    return is_match;
+}
+
+std::vector<gemmi::Selection> parse_multi_cid_selections(const std::string &cids) {
+    std::vector<gemmi::Selection> selections_vec;    
+    if (!cids.empty()) {
+        std::istringstream stream(cids);
+        std::string token;
+        while (std::getline(stream, token, '|')) {
+            if (!token.empty()) {
+                gemmi::Selection sele(token);
+                selections_vec.push_back(sele);
+            }
+        }
+    }
+    return selections_vec;
+}
+
+// cids and excluded_cids are strings of CID selections separated with ||
+std::vector<AtomInfo> get_atom_info_for_selection(const gemmi::Structure &Structure, const std::string &cids, const std::string &excluded_cids) {
+
+    std::vector<gemmi::Selection> selections_vec = parse_multi_cid_selections(cids);    
+    std::vector<gemmi::Selection> excluded_selections_vec = parse_multi_cid_selections(excluded_cids);    
+
     std::vector<AtomInfo> atom_info_vec;
     auto structure_copy = Structure;
     auto models = structure_copy.models;
     for (int modelIndex = 0; modelIndex < models.size(); modelIndex++) {
         const auto model = models[modelIndex];
-        if (!Selection.matches(model)) {
+        if (!selection_vector_matches_model(selections_vec, model)) {
             continue;
         }
         const auto chains = model.chains;
         for (int chainIndex = 0; chainIndex < chains.size(); chainIndex++) {
             auto chain = chains[chainIndex];
-            if (!Selection.matches(chain)) {
+            if (!selection_vector_matches_chain(selections_vec, chain)) {
                 continue;
             }
             const auto residues = chain.residues;
             for (int residueIndex = 0; residueIndex < residues.size(); residueIndex++) {
                 const auto residue = residues[residueIndex];
-                bool omit = false;
-                for (int selectionIndex = 0; selectionIndex < excluded_selections_vec.size(); selectionIndex++) {
-                    auto exclude_selection = excluded_selections_vec[selectionIndex];
-                    if (exclude_selection.matches(residue)) {
-                        omit = true;
-                        break;
-                    }
-                }
-                if (!Selection.matches(residue) || omit) {
+                if (!selection_vector_matches_residue(selections_vec, residue) || selection_vector_matches_residue(excluded_selections_vec, residue)) {
                     continue;
                 }
                 const auto atoms = residue.atoms;
                 for (int atomIndex = 0; atomIndex < atoms.size(); atomIndex++) {
                     const auto atom = atoms[atomIndex];
-                    if (!Selection.matches(atom)) {
+                    if (!selection_vector_matches_atom(selections_vec, atom)) {
                         continue;
                     }
                     AtomInfo atom_info;

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -325,18 +325,13 @@ class molecules_container_js : public molecules_container_t {
                     resNum += std::string(".") + std::string(neighb_residues[i]->GetInsCode());
                 }
                 chainsResidues[chainId] += resNum;
-
-                //std::cout << resNum << std::endl;
-
             }
             for (auto const& [key, val] : chainsResidues){
                 neighb_cid += key + std::string("/") + val + std::string("|");
             }
             neighb_cid = neighb_cid.substr(0,neighb_cid.length()-1);
-            std::cout << neighb_cid << std::endl;
             return neighb_cid;
         }
-
 
         std::pair<coot::symmetry_info_t,std::vector<std::array<float, 16>>> get_symmetry_with_matrices(int imol, float symmetry_search_radius, float x, float y, float z) { 
             coot::symmetry_info_t si = get_symmetry(imol, symmetry_search_radius, x, y, z);

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -297,10 +297,36 @@ class molecules_container_js : public molecules_container_t {
             return molecules_container_t::make_exportable_environment_bond_box(imol,resSpec);
         }
 
+        std::vector<std::pair<int, int>> get_consecutive_ranges(const std::vector<int> &numbers) {
+            std::vector<int> numbers_vec = numbers;
+            std::sort(numbers_vec.begin(), numbers_vec.end());
+            
+            std::vector<std::pair<int, int>> ranges;
+            if (!numbers_vec.empty()) {
+                int start = numbers_vec[0];
+                int end = numbers_vec[0];
+                for (int i = 1; i < numbers_vec.size(); i++) {
+                    int i_number = numbers_vec[i];
+                    if (i_number == end + 1) {
+                        end = i_number;
+                    } else {
+                        std::pair<int, int> i_pair(start, end);
+                        ranges.push_back(i_pair);
+                        start = i_number;
+                        end = i_number;
+                    }
+                }
+                std::pair<int, int> i_pair(start, end);
+                ranges.push_back(i_pair);
+            }
+            
+            return ranges;
+        }
+
+        // Returns a "||" separated string of cids.
         std::string get_neighbours_cid(int imol, const std::string &central_Cid_str, double max_dist){
-            //Returns a "|" separated string of cids.
             std::string neighb_cid = "";
-            std::map<std::string, std::string> chainsResidues;
+            std::map<std::string, std::vector<int>> chainsResidues;
             mmdb::Manager *mol = get_mol(imol);
             const char * central_Cid = central_Cid_str.c_str();
             int central_SelHnd = mol->NewSelection();
@@ -315,21 +341,20 @@ class molecules_container_js : public molecules_container_t {
             mol->GetSelIndex(neighb_SelHnd, neighb_residues, n_neighb_residues);
             for(int i=0; i<n_neighb_residues; i++){
                 std::string chainId = std::string(neighb_residues[i]->GetChainID());
-                if(chainsResidues.count(chainId)==0){
-                    chainsResidues[chainId] = std::string();
-                } else {
-                    chainsResidues[chainId] += std::string(",");
+                if(!chainsResidues.count(chainId)){
+                    std::vector<int> int_vec;
+                    chainsResidues[chainId] = int_vec;
                 }
-                std::string resNum = std::to_string(neighb_residues[i]->GetSeqNum());
-                if(strlen(neighb_residues[i]->GetInsCode())>0){
-                    resNum += std::string(".") + std::string(neighb_residues[i]->GetInsCode());
-                }
-                chainsResidues[chainId] += resNum;
+                chainsResidues[chainId].push_back(neighb_residues[i]->GetSeqNum());
             }
             for (auto const& [key, val] : chainsResidues){
-                neighb_cid += key + std::string("/") + val + std::string("|");
+                auto residue_ranges = get_consecutive_ranges(val);
+                for (int i=0; i < residue_ranges.size(); i++) {
+                    auto i_residue_range = residue_ranges[i];
+                    neighb_cid += std::string("//") + key + std::string("/") + std::to_string(i_residue_range.first) + "-" + std::to_string(i_residue_range.second) + std::string("/*||");
+                }
             }
-            neighb_cid = neighb_cid.substr(0,neighb_cid.length()-1);
+            neighb_cid = neighb_cid.substr(0,neighb_cid.length()-2);
             return neighb_cid;
         }
 
@@ -1081,6 +1106,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     register_map<unsigned int, std::array<float, 3>>("MapIntFloat3");
     register_map<coot::residue_spec_t, coot::util::density_correlation_stats_info_t>("Map_residue_spec_t_density_correlation_stats_info_t");
     register_vector<std::array<float, 16>>("VectorArrayFloat16");
+    register_vector<std::pair<int, int>>("VectorInt_pair");
     register_vector<std::pair<std::string, unsigned int> >("VectorStringUInt_pair");
     register_vector<std::pair<symm_trans_t, Cell_Translation>>("Vectorsym_trans_t_Cell_Translation_pair");
     register_vector<std::pair<std::string, std::string>>("Vectorstring_string_pair");


### PR DESCRIPTION
This update includes:
- Function `get_neighbours_cid` in `moorhen-wrappers` now returns the residue ranges grouped into ranges separated by "||"
- `MoorhenMolecule.gemmiAtomsForCid` now accepts multi-CID selections separated by "||"
- Linear residue selections can now be expanded to include neighboring residues (currently disabled as action buttons won't do anything useful)
- Simplification of `moorhen.ScoresUpdateEvent` so that it doesn't need to include the origin coords.