### PR TITLE
Inject controls keyboard SVG as plain text into DOM and enable actions on speherical residue selections

### DIFF
--- a/baby-gru/public/baby-gru/pixmaps/keyboard-blank.svg
+++ b/baby-gru/public/baby-gru/pixmaps/keyboard-blank.svg
@@ -2,7 +2,7 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   id="svg5675"
+   id="moorhen-keyboard-blank-svg"
    sodipodi:docname="keyboard-blank.svg"
    viewBox="0 0 891.00003 612.88018"
    sodipodi:version="0.32"

--- a/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
+++ b/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
@@ -96,8 +96,8 @@ export const MoorhenResidueSelectionActions = (props) => {
     const handleSelectionCopy = useCallback(async () => {
         let cid: string
         
-        if (residueSelection.isMultiCid) {
-            // pass
+        if (residueSelection.isMultiCid && Array.isArray(residueSelection.cid)) {
+            cid = residueSelection.cid.join('||')
         } else if (residueSelection.molecule && residueSelection.cid) {
             cid = residueSelection.cid as string
         } else if (residueSelection.molecule && residueSelection.first) {
@@ -114,8 +114,8 @@ export const MoorhenResidueSelectionActions = (props) => {
     }, [residueSelection, clearSelection])
 
     const handleRefinement = useCallback(async () => {
-        if (residueSelection.isMultiCid) {
-            // pass
+        if (residueSelection.isMultiCid && Array.isArray(residueSelection.cid)) {
+            await residueSelection.molecule.refineResiduesUsingAtomCid(residueSelection.cid.join('||'), 'LITERAL')
         } else if (residueSelection.molecule && residueSelection.cid) {
             const startResSpec = cidToSpec(residueSelection.first)
             const stopResSpec = cidToSpec(residueSelection.second)
@@ -133,8 +133,8 @@ export const MoorhenResidueSelectionActions = (props) => {
     const handleDelete = useCallback(async () => {
         let cid: string
         
-        if (residueSelection.isMultiCid) {
-            // pass
+        if (residueSelection.isMultiCid && Array.isArray(residueSelection.cid)) {
+            cid = residueSelection.cid.join('||')
         } else if (residueSelection.molecule && residueSelection.cid) {
             cid = residueSelection.cid as string
         } else if (residueSelection.molecule && residueSelection.first) {
@@ -204,11 +204,9 @@ export const MoorhenResidueSelectionActions = (props) => {
                     <IconButton onClick={handleSelectionCopy} onMouseEnter={() => setTooltipContents('Copy fragment')}>
                         <CopyAllOutlined/>
                     </IconButton>
-                    {/**
                     <IconButton onClick={handleExpandSelection} onMouseEnter={() => setTooltipContents('Expand to neighbouring residues')}>
                         <AllOutOutlined/>
                     </IconButton>
-                     */}
                     <IconButton onClick={clearSelection} onMouseEnter={() => setTooltipContents('Clear selection')}>
                         <CloseOutlined/>
                     </IconButton>

--- a/baby-gru/src/components/navbar-menus/MoorhenHelpMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenHelpMenu.tsx
@@ -1,20 +1,20 @@
 import { useState } from "react";
 import { MoorhenAboutMenuItem } from "../menu-item/MoorhenAboutMenuItem";
 import { MoorhenContactMenuItem } from "../menu-item/MoorhenContactMenuItem";
-import { MoorhenControlsModal } from "../modal/MoorhenControlsModal";
 import { MenuItem } from "@mui/material";
 import { MoorhenNavBarExtendedControlsInterface } from "./MoorhenNavBar";
 
 export const MoorhenHelpMenu = (props: MoorhenNavBarExtendedControlsInterface) => {
     const [popoverIsShown, setPopoverIsShown] = useState<boolean>(false)
-    const [showControlsModal, setShowControlsModal] = useState<boolean>(false)
     const menuItemProps = {setPopoverIsShown, ...props}
     
     return <>
         <MenuItem onClick={() => window.open('https://moorhen-coot.github.io/wiki/')}>Go to Moorhen wiki...</MenuItem>
-        <MenuItem onClick={() => setShowControlsModal(true)}>Show controls...</MenuItem>
+        <MenuItem onClick={() => {
+            props.setShowControlsModal(true)
+            document.body.click()
+        }}>Show controls...</MenuItem>
         <MoorhenContactMenuItem {...menuItemProps} />
         <MoorhenAboutMenuItem {...menuItemProps} />
-        <MoorhenControlsModal {...props} showControlsModal={showControlsModal} setShowControlsModal={setShowControlsModal} />
     </>
 }

--- a/baby-gru/src/components/navbar-menus/MoorhenNavBar.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenNavBar.tsx
@@ -25,6 +25,7 @@ import { MoorhenQuerySequenceModal } from '../modal/MoorhenQuerySequenceModal';
 import { MoorhenScriptModal } from '../modal/MoorhenScriptModal';
 import { moorhen } from '../../types/moorhen';
 import { useSelector } from 'react-redux';
+import { MoorhenControlsModal } from '../modal/MoorhenControlsModal';
 
 export interface MoorhenNavBarExtendedControlsInterface extends moorhen.CollectedProps {
     dropdownId: string;
@@ -32,6 +33,7 @@ export interface MoorhenNavBarExtendedControlsInterface extends moorhen.Collecte
     setShowQuerySequence: React.Dispatch<React.SetStateAction<boolean>>;
     setShowScripting: React.Dispatch<React.SetStateAction<boolean>>;
     setShowCreateAcedrgLinkModal: React.Dispatch<React.SetStateAction<boolean>>;
+    setShowControlsModal: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const MoorhenNavBar = forwardRef<HTMLElement, moorhen.CollectedProps>((props, ref) => {
@@ -44,6 +46,7 @@ export const MoorhenNavBar = forwardRef<HTMLElement, moorhen.CollectedProps>((pr
     const [showValidation, setShowValidation] = useState<boolean>(false)
     const [showModels, setShowModels] = useState<boolean>(false)
     const [showMaps, setShowMaps] = useState<boolean>(false)
+    const [showControlsModal, setShowControlsModal] = useState<boolean>(false)
     const [showQuerySequence, setShowQuerySequence] = useState<boolean>(false)
     const [showScripting, setShowScripting] = useState<boolean>(false)
     const [popoverTargetRef, setPopoverTargetRef] = useState()
@@ -89,7 +92,8 @@ export const MoorhenNavBar = forwardRef<HTMLElement, moorhen.CollectedProps>((pr
     }, [props.timeCapsuleRef.current])
 
     const collectedProps = {
-        setShowQuerySequence, setShowScripting, setShowCreateAcedrgLinkModal, setBusy, ...props
+        setShowControlsModal, setShowQuerySequence, setShowScripting, 
+        setShowCreateAcedrgLinkModal, setBusy, ...props
     }
 
     const navBarMenus = {
@@ -284,6 +288,13 @@ export const MoorhenNavBar = forwardRef<HTMLElement, moorhen.CollectedProps>((pr
     
     {showScripting &&
         <MoorhenScriptModal show={showScripting} setShow={setShowScripting} {...props} />
+    }
+
+    {showControlsModal &&
+        <MoorhenControlsModal
+            show={showControlsModal}
+            setShow={setShowControlsModal}
+            {...props}/>
     }
     
     { props.extraNavBarModals && props.extraNavBarModals.filter(modal => modal.show).map(modal => modal.JSXElement) }


### PR DESCRIPTION
This update includes:
- Actions on residue selections that have been expanded to include the neighboring residues are now active.
- The blank keyboard svg used in the "Show Controls" modal is now fetched and the plain text injected into the DOM
- The "Show Controls" modal now uses `MoorhenDraggableModalBase`