### PR TITLE
Add iris validation (devMode) and fix bug where 0 frames are requested in recentering animation

### DIFF
--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -142,6 +142,7 @@
     "gl-matrix": "^3.4.3",
     "html-react-parser": "^1.4.14",
     "html-webpack-plugin": "^5.5.0",
+    "iris-validation": "^0.1.8",
     "jest": "^27.5.1",
     "jsdoc": "^4.0.2",
     "localforage": "^1.10.0",

--- a/baby-gru/src/WebGLgComponents/mgWebGL.tsx
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.tsx
@@ -3469,7 +3469,6 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
         // Optimal speed is 1A per frame, with upper limit of 10 frames
         const nFrames = Math.floor(distance / 1.5)
         this.nAnimationFrames = nFrames > 10 ? 10 : nFrames
-        console.log(this.nAnimationFrames)
         const dx = DX/this.nAnimationFrames
         const dy = DY/this.nAnimationFrames
         const dz = DZ/this.nAnimationFrames

--- a/baby-gru/src/WebGLgComponents/mgWebGL.tsx
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.tsx
@@ -3468,7 +3468,7 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
         const distance = Math.sqrt(DX**2 + DY**2 + DZ**2)
         // Optimal speed is 1A per frame, with upper limit of 10 frames
         const nFrames = Math.floor(distance / 1.5)
-        this.nAnimationFrames = nFrames > 10 ? 10 : nFrames
+        this.nAnimationFrames = nFrames > 10 ? 10 : nFrames <= 0 ? 1 : nFrames
         const dx = DX/this.nAnimationFrames
         const dy = DY/this.nAnimationFrames
         const dz = DZ/this.nAnimationFrames

--- a/baby-gru/src/WebGLgComponents/mgWebGL.tsx
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.tsx
@@ -3468,7 +3468,7 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
         const distance = Math.sqrt(DX**2 + DY**2 + DZ**2)
         // Optimal speed is 1A per frame, with upper limit of 10 frames
         const nFrames = Math.floor(distance / 1.5)
-        this.nAnimationFrames = nFrames > 10 ? 10 : nFrames <= 0 ? 1 : nFrames
+        this.nAnimationFrames = nFrames > 10 ? 10 : nFrames < 1 ? 1 : nFrames
         const dx = DX/this.nAnimationFrames
         const dy = DY/this.nAnimationFrames
         const dz = DZ/this.nAnimationFrames

--- a/baby-gru/src/components/modal/MoorhenValidationToolsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenValidationToolsModal.tsx
@@ -29,6 +29,7 @@ export const MoorhenValidationToolsModal = (props: MoorhenValidationModalProps) 
     
     const width = useSelector((state: moorhen.State) => state.sceneSettings.width)
     const height = useSelector((state: moorhen.State) => state.sceneSettings.height)
+    const devMode = useSelector((state: moorhen.State) => state.generalStates.devMode)
 
     const collectedProps = {
         sideBarWidth: convertViewtoPx(35, width), dropdownId: 1, busy: false, 
@@ -44,9 +45,14 @@ export const MoorhenValidationToolsModal = (props: MoorhenValidationModalProps) 
             {label: "Fill partial residues", toolWidget: <MoorhenFillMissingAtoms {...collectedProps}/>},
             {label: "Unmodelled blobs", toolWidget: <MoorhenUnmodelledBlobs {...collectedProps}/>},
             {label: "MMRRCC plot", toolWidget: <MoorhenMMRRCCPlot {...collectedProps}/>},
-            {label: "Water validation", toolWidget: <MoorhenWaterValidation {...collectedProps}/>},
-            // {label: "Iris validation", toolWidget: <MoorhenIrisValidation resizeNodeRef={resizeNodeRef} resizeTrigger={draggableResizeTrigger} {...collectedProps}/>}
+            {label: "Water validation", toolWidget: <MoorhenWaterValidation {...collectedProps}/>}
     ]
+
+    if (devMode) {
+        toolOptions.push(
+            {label: "Iris validation", toolWidget: <MoorhenIrisValidation resizeNodeRef={resizeNodeRef} resizeTrigger={draggableResizeTrigger} {...collectedProps}/>}
+        )
+    }
 
     const handleChange = (evt: React.ChangeEvent<HTMLSelectElement>) => {
         if (evt.target.value) {

--- a/baby-gru/src/components/modal/MoorhenValidationToolsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenValidationToolsModal.tsx
@@ -11,6 +11,7 @@ import { MoorhenMMRRCCPlot } from "../validation-tools/MoorhenMMRRCCPlot"
 import { MoorhenWaterValidation } from "../validation-tools/MoorhenWaterValidation"
 import { MoorhenLigandValidation } from "../validation-tools/MoorhenLigandValidation"
 import { MoorhenUnmodelledBlobs } from "../validation-tools/MoorhenUnmodelledBlobs"
+import { MoorhenIrisValidation } from "../validation-tools/MoorhenIrisValidation"
 import { convertRemToPx, convertViewtoPx} from '../../utils/MoorhenUtils';
 import { useSelector } from "react-redux";
 
@@ -43,7 +44,8 @@ export const MoorhenValidationToolsModal = (props: MoorhenValidationModalProps) 
             {label: "Fill partial residues", toolWidget: <MoorhenFillMissingAtoms {...collectedProps}/>},
             {label: "Unmodelled blobs", toolWidget: <MoorhenUnmodelledBlobs {...collectedProps}/>},
             {label: "MMRRCC plot", toolWidget: <MoorhenMMRRCCPlot {...collectedProps}/>},
-            {label: "Water validation", toolWidget: <MoorhenWaterValidation {...collectedProps}/>}
+            {label: "Water validation", toolWidget: <MoorhenWaterValidation {...collectedProps}/>},
+            // {label: "Iris validation", toolWidget: <MoorhenIrisValidation resizeNodeRef={resizeNodeRef} resizeTrigger={draggableResizeTrigger} {...collectedProps}/>}
     ]
 
     const handleChange = (evt: React.ChangeEvent<HTMLSelectElement>) => {

--- a/baby-gru/src/components/validation-tools/MoorhenIrisValidation.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenIrisValidation.tsx
@@ -1,0 +1,72 @@
+import { Fragment, useEffect, useRef, useState } from "react"
+import { Col, Row, Form, Button } from 'react-bootstrap'
+import { Chart, TooltipItem } from 'chart.js'
+import { MoorhenChainSelect } from '../select/MoorhenChainSelect'
+import { MoorhenMapSelect } from '../select/MoorhenMapSelect'
+import { MoorhenMoleculeSelect } from '../select/MoorhenMoleculeSelect'
+import { residueCodesOneToThree, getResidueInfo, convertViewtoPx, convertRemToPx } from '../../utils/MoorhenUtils'
+import { useDispatch, useSelector } from "react-redux"
+import { setHoveredAtom } from "../../store/hoveringStatesSlice"
+import {Iris, IrisData, IrisAesthetics, IrisProps, generate_random_data} from "iris-validation"
+import { moorhen } from "../../types/moorhen"
+import { libcootApi } from "../../types/libcoot"
+
+export const MoorhenIrisValidation = (props: {
+    sideBarWidth: number;
+    showSideBar: boolean;
+    dropdownId: number;
+    accordionDropdownId: number;
+    commandCentre: React.RefObject<moorhen.CommandCentre>;
+    resizeTrigger: boolean;
+    resizeNodeRef: React.RefObject<HTMLDivElement>;
+}) => {
+
+    const [plotDimensions, setPlotDimensions] = useState<number>(230)
+
+    const dispatch = useDispatch()
+    const hoveredAtom = useSelector((state: moorhen.State) => state.hoveringStates.hoveredAtom)
+    const width = useSelector((state: moorhen.State) => state.sceneSettings.width)
+    const height = useSelector((state: moorhen.State) => state.sceneSettings.height)
+    const molecules = useSelector((state: moorhen.State) => state.molecules)
+
+    const random_data = generate_random_data(5) // get 5 metric rings
+
+    const aes: IrisAesthetics = {
+        dimensions: [plotDimensions, plotDimensions],
+        radius_change: 50, 
+        header: 40,
+        text_size: 50
+    }
+
+    const results: IrisData = {
+        data: random_data,
+        chain_list: ["A", "B", "C"],
+        file_list: ["input1"], 
+    } 
+    
+    const iris_props: IrisProps = { 
+        results: results,
+        from_wasm: false,
+        aesthetics: aes, 
+        callback: (residue) => { 
+            console.log("RESIDUE CLICKED", residue)
+        }
+    }
+
+    useEffect(() => {
+        setTimeout(() => {
+            let plotHeigth = (props.resizeNodeRef.current.clientHeight) - convertRemToPx(10)
+            let plotWidth = (props.resizeNodeRef.current.clientWidth) - convertRemToPx(3)
+            if (plotHeigth > 0 && plotWidth > 0) {
+                plotHeigth > plotWidth ? setPlotDimensions(plotWidth) : setPlotDimensions(plotHeigth)
+            }
+        }, 50);
+
+    }, [width, height, props.resizeTrigger])
+
+
+    return  <Fragment>
+                <Iris {...iris_props} />
+            </Fragment>
+
+}

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -764,6 +764,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("delete_colour_rules",&molecules_container_t::delete_colour_rules)
     .function("add_colour_rules_multi",&molecules_container_t::add_colour_rules_multi)
     .function("fit_ligand_right_here",&molecules_container_t::fit_ligand_right_here)
+    .function("fit_ligand",&molecules_container_t::fit_ligand)
     .function("fit_to_map_by_random_jiggle",&molecules_container_t::fit_to_map_by_random_jiggle)
     .function("fit_to_map_by_random_jiggle_using_cid",&molecules_container_t::fit_to_map_by_random_jiggle_using_cid)
     .function("get_svg_for_residue_type",&molecules_container_t::get_svg_for_residue_type)


### PR DESCRIPTION
This update includes:
- Fix a bug where 0 frames are requested when setting a new origin if the distance is small
- Add iris validation, currently only under `devMode`