### PR TITLE
Iris validation

### DIFF
--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -62,10 +62,7 @@
       ]
     }
   },
-  "dependencies": {
-    "iris-validation": "^0.1.10",
-    "iris-validation-backend": "^0.0.8"
-  },
+  "dependencies": {},
   "scripts": {
     "create-version": "npx genversion -e -p ./package.json -d -s ./src/version.js",
     "transpile-ts-worker": "npx tsc --module es2015 --lib webworker --skipLibCheck public/baby-gru/CootWorker.ts && sed -i.bak '/export {}/d' public/baby-gru/CootWorker.js && rm public/baby-gru/CootWorker.js.bak",
@@ -145,6 +142,8 @@
     "gl-matrix": "^3.4.3",
     "html-react-parser": "^1.4.14",
     "html-webpack-plugin": "^5.5.0",
+    "iris-validation": "^0.1.10",
+    "iris-validation-backend": "^0.0.8",
     "jest": "^27.5.1",
     "jsdoc": "^4.0.2",
     "localforage": "^1.10.0",

--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -62,7 +62,10 @@
       ]
     }
   },
-  "dependencies": { },
+  "dependencies": {
+    "iris-validation": "^0.1.10",
+    "iris-validation-backend": "^0.0.8"
+  },
   "scripts": {
     "create-version": "npx genversion -e -p ./package.json -d -s ./src/version.js",
     "transpile-ts-worker": "npx tsc --module es2015 --lib webworker --skipLibCheck public/baby-gru/CootWorker.ts && sed -i.bak '/export {}/d' public/baby-gru/CootWorker.js && rm public/baby-gru/CootWorker.js.bak",
@@ -142,7 +145,6 @@
     "gl-matrix": "^3.4.3",
     "html-react-parser": "^1.4.14",
     "html-webpack-plugin": "^5.5.0",
-    "iris-validation": "^0.1.8",
     "jest": "^27.5.1",
     "jsdoc": "^4.0.2",
     "localforage": "^1.10.0",

--- a/baby-gru/src/components/validation-tools/MoorhenIrisValidation.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenIrisValidation.tsx
@@ -4,12 +4,13 @@ import { Chart, TooltipItem } from 'chart.js'
 import { MoorhenChainSelect } from '../select/MoorhenChainSelect'
 import { MoorhenMapSelect } from '../select/MoorhenMapSelect'
 import { MoorhenMoleculeSelect } from '../select/MoorhenMoleculeSelect'
-import { residueCodesOneToThree, getResidueInfo, convertViewtoPx, convertRemToPx } from '../../utils/MoorhenUtils'
+import { residueCodesOneToThree, getResidueInfo, convertViewtoPx, convertRemToPx, getMoleculeBfactors } from '../../utils/MoorhenUtils'
 import { useDispatch, useSelector } from "react-redux"
 import { setHoveredAtom } from "../../store/hoveringStatesSlice"
-import {Iris, IrisData, IrisAesthetics, IrisProps, generate_random_data} from "iris-validation"
+import { Iris, IrisData, IrisAesthetics, IrisProps, generate_random_data } from "iris-validation"
 import { moorhen } from "../../types/moorhen"
 import { libcootApi } from "../../types/libcoot"
+import iris_module from "iris-validation-backend"
 
 export const MoorhenIrisValidation = (props: {
     sideBarWidth: number;
@@ -28,30 +29,70 @@ export const MoorhenIrisValidation = (props: {
     const width = useSelector((state: moorhen.State) => state.sceneSettings.width)
     const height = useSelector((state: moorhen.State) => state.sceneSettings.height)
     const molecules = useSelector((state: moorhen.State) => state.molecules)
+    const maps = useSelector((state: moorhen.State) => state.maps)
+
+    const [result, setResult] = useState();
 
     const random_data = generate_random_data(5) // get 5 metric rings
+    const [selectedModel, setSelectedModel] = useState<null | number>(null)
+    const [selectedMap, setSelectedMap] = useState<null | number>(null)
+    const mapSelectRef = useRef<undefined | HTMLSelectElement>();
+    const moleculeSelectRef = useRef<undefined | HTMLSelectElement>();
+
+    const handleModelChange = (evt: React.ChangeEvent<HTMLSelectElement>) => {
+        setSelectedModel(parseInt(evt.target.value))
+    }
+
+    const handleMapChange = (evt: React.ChangeEvent<HTMLSelectElement>) => {
+        setSelectedMap(parseInt(evt.target.value))
+    }
 
     const aes: IrisAesthetics = {
         dimensions: [plotDimensions, plotDimensions],
-        radius_change: 50, 
+        radius_change: 50,
         header: 40,
-        text_size: 50
+        text_size: 100
     }
 
     const results: IrisData = {
-        data: random_data,
-        chain_list: ["A", "B", "C"],
-        file_list: ["input1"], 
-    } 
-    
-    const iris_props: IrisProps = { 
+        data: result,
+        chain_list: null,
+        file_list: [`${molecules[0].name}.pdb`],
+    }
+
+    const iris_props: IrisProps = {
         results: results,
-        from_wasm: false,
-        aesthetics: aes, 
-        callback: (residue) => { 
-            console.log("RESIDUE CLICKED", residue)
+        from_wasm: true,
+        aesthetics: aes,
+        click_callback: (residue) => {
+            const split_res = residue.split("/")
+            const res = `${split_res[0]}/${split_res[2]}(${split_res[1]})`
+            molecules[0].centreOn(res)
+        },
+        hover_callback: (residue) => {
+            // const split_res = residue.split("/")
+            // const res = `${split_res[0]}/${split_res[2]}(${split_res[1]})`
+            // console.log(res)
+            // molecules[0].drawHover(res)
+
         }
     }
+
+    useEffect(() => {
+        iris_module().then(async (Module) => {
+            const map_response = await maps[0].getMap()
+            const moleculeData = await molecules[0].getAtoms()
+            let map_data = new Uint8Array(map_response.data.result.mapData)
+
+            const molecule_name = `${molecules[0].name}.pdb`
+            const map_name = `${maps[0].name}.map`
+            Module['FS_createDataFile']('/', map_name, map_data, true, true, true)
+            Module['FS_createDataFile']('/', molecule_name, moleculeData, true, true, true)
+
+            let backend_call = Module.calculate_single_pdb(molecule_name, map_name, false);
+            setResult(backend_call.results);
+        })
+    }, [])
 
     useEffect(() => {
         setTimeout(() => {
@@ -65,8 +106,19 @@ export const MoorhenIrisValidation = (props: {
     }, [width, height, props.resizeTrigger])
 
 
-    return  <Fragment>
-                <Iris {...iris_props} />
-            </Fragment>
+
+    return <Fragment>
+        <Form style={{ padding: '0', margin: '0' }}>
+            <Form.Group>
+                <Row style={{ padding: '0', margin: '0' }}>
+                    <Col>
+                        <MoorhenMoleculeSelect width="" onChange={handleModelChange} molecules={molecules} ref={moleculeSelectRef} />
+                    </Col>
+
+                </Row>
+            </Form.Group>
+        </Form>
+        {result ? <Iris {...iris_props} /> : <>Molecule not loaded</>}
+    </Fragment>
 
 }

--- a/baby-gru/vite.config.mts
+++ b/baby-gru/vite.config.mts
@@ -54,4 +54,7 @@ export default defineConfig({
         },
     },
     base: './',
+    optimizeDeps: {
+        exclude: ['iris-validation-backend']
+      }
 });


### PR DESCRIPTION
I have added a new node package to dev dependencies called iris-validation-backend. This package is essentially just the web assembly and js bindings for the iris metric calculations. 

I have added a call to this module in the MoorhenIrisValidation file.

The iris-validation-backend module contains two functions :
- `calculate_single_pdb(pdb_filename: string, density_filename: string, reflections: boolean)` 
- `calculate_multi_pdb(pdb_filename1: string, pdb_filename2: string, density_filename: string, reflections: boolean)` 

where `reflections=true` when working with an MTZ and `false` with a MAP.

Example usage:
```
let backend_call;
  if (filenames.length == 2) { 
      backend_call = Module.calculate_multi_pdb(...filenames, mtz_path, true)
  }
  else { 
      backend_call = Module.calculate_single_pdb(filenames[0], mtz_path, true)

  }
  setResults(backend_call.results)
```

Currently, this code breaks when no molecules are loaded and the drop-down for molecule selection does not work. I imagine there should be a drop-down for which molecule(s) to use and what map to use. There could also be a drop-down for what chain to look at. There are no props for selecting molecule or chain since it normally comes from within Iris but I will add that soon. 

Also added are the callback functions for a click event and hover event.
