### PR TITLE
Move `getMoleculeBFactors` into C++ and use as a method of `MoorhenMolecule` and fixes to `writeCIFASCII`

### DIFF
--- a/baby-gru/src/components/validation-tools/MoorhenIrisValidation.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenIrisValidation.tsx
@@ -4,7 +4,7 @@ import { Chart, TooltipItem } from 'chart.js'
 import { MoorhenChainSelect } from '../select/MoorhenChainSelect'
 import { MoorhenMapSelect } from '../select/MoorhenMapSelect'
 import { MoorhenMoleculeSelect } from '../select/MoorhenMoleculeSelect'
-import { residueCodesOneToThree, getResidueInfo, convertViewtoPx, convertRemToPx, getMoleculeBfactors } from '../../utils/MoorhenUtils'
+import { residueCodesOneToThree, getResidueInfo, convertViewtoPx, convertRemToPx } from '../../utils/MoorhenUtils'
 import { useDispatch, useSelector } from "react-redux"
 import { setHoveredAtom } from "../../store/hoveringStatesSlice"
 import { Iris, IrisData, IrisAesthetics, IrisProps, generate_random_data } from "iris-validation"

--- a/baby-gru/src/moorhen.ts
+++ b/baby-gru/src/moorhen.ts
@@ -12,7 +12,7 @@ import { MoorhenMoleculeSelect } from "./components/select/MoorhenMoleculeSelect
 import { MoorhenMapSelect } from "./components/select/MoorhenMapSelect";
 import { MoorhenSlider } from "./components/misc/MoorhenSlider";
 import { MoorhenFetchOnlineSourcesForm } from "./components/form/MoorhenFetchOnlineSourcesForm";
-import { loadSessionData, getMoleculeBfactors } from "./utils/MoorhenUtils";
+import { loadSessionData } from "./utils/MoorhenUtils";
 import { MoorhenReduxProvider } from "./components/misc/MoorhenReduxProvider";
 import { setDefaultBackgroundColor, setDrawCrosshairs, setDrawFPS, setDrawMissingLoops, setDefaultBondSmoothness,
     setDrawInteractions, setDoSSAO, setSsaoRadius, setSsaoBias, setResetClippingFogging, setClipCap,  
@@ -49,5 +49,5 @@ export {
     addMolecule, removeMolecule, emptyMolecules, addMoleculeList, setContourWheelSensitivityFactor, MoorhenFetchOnlineSourcesForm,
     setZoomWheelSensitivityFactor, setMouseSensitivity, setShowShortcutToast, setShortcutOnHoveredAtom, setShortCuts,
     setShowScoresToast, addMapUpdatingScore, removeMapUpdatingScore, overwriteMapUpdatingScores, MoorhenSlider,
-    addMap, addMapList, removeMap, emptyMaps, getMoleculeBfactors, MoorhenQuerySequenceModal, MoorhenPreferences
+    addMap, addMapList, removeMap, emptyMaps, MoorhenQuerySequenceModal, MoorhenPreferences
 };

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -12,6 +12,7 @@ declare global {
 
 export namespace libcootApi {
     type CCP4ModuleType = {
+        get_structure_bfactors(gemmiStructure: gemmi.Structure): emscriptem.vector<{ cid: string; bFactor: number }>;
         get_sequence_info(gemmiStructure: gemmi.Structure, molName: string): emscriptem.vector<SequenceEntry>;
         get_atom_info_for_selection(gemmiStructure: gemmi.Structure, arg1: string, arg2: string): emscriptem.vector<AtomInfo>;
         structure_is_ligand(gemmiStructure: gemmi.Structure): boolean;

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -82,6 +82,8 @@ declare module 'moorhen' {
         generateSelfRestraints(cid?: string, maxRadius?: number): Promise<void>;
         clearExtraRestraints(): Promise<_moorhen.WorkerResponse>;
         refineResiduesUsingAtomCid(cid: string, mode: string, ncyc?: number, redraw?: boolean): Promise<void>;
+        getNcsRelatedChains(): Promise<string[][]>;
+        getResidueBFactors(): { cid: string, bFactor: number }[];
         redo(): Promise<void>;
         undo(): Promise<void>;
         show(style: string, cid?: string): void;
@@ -209,9 +211,6 @@ declare module 'moorhen' {
         }
     }
     module.exports.MoorhenMap = MoorhenMap
-
-    function getMoleculeBfactors(gemmiStructure: gemmi.Structure): { cid: string, bFactor: number, chainId: string, resNum: number, modelName: string }[];
-    module.exports = getMoleculeBfactors;
 
     function loadSessionData(
         sessionDataString: string,

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -90,6 +90,8 @@ export namespace moorhen {
     }
     
     interface Molecule {
+        getResidueBFactors(): { cid: string, bFactor: number }[];
+        getNcsRelatedChains(): Promise<string[][]>;
         animateRefine(n_cyc: number, n_iteration: number, final_n_cyc?: number): Promise<void>;
         refineResidueRange(chainId: string, start: number, stop: number, ncyc?: number, redraw?: boolean): Promise<void>;
         SSMSuperpose(movChainId: string, refMolNo: number, refChainId: string): Promise<WorkerResponse>;

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1666,6 +1666,36 @@ export class MoorhenMolecule implements moorhen.Molecule {
     }
 
     /**
+     * Get information about the residue B-factors
+     * @returns {object[]} An array of objects indicating the residue CID and B-factor
+     */
+    getResidueBFactors() {
+        let result: { cid: string, bFactor: number }[] = []
+        const resBfactorInfoVec = window.CCP4Module.get_structure_bfactors(this.gemmiStructure)
+        const resBfactorInfoVecSize = resBfactorInfoVec.size()
+        for (let i = 0; i < resBfactorInfoVecSize; i++) {
+            const resInfo = resBfactorInfoVec.get(i)
+            result.push({...resInfo})
+        }
+        resBfactorInfoVec.delete()
+        
+        return result
+    }
+
+    /**
+     * Get chain IDs that are related by NCS or molecular symmetry 
+     * @returns {string[][]} An array of arrays where chain IDs are grouped together
+     */
+    async getNcsRelatedChains(): Promise<string[][]> {
+        const result = await this.commandCentre.current.cootCommand({
+            returnType: 'string_array_array',
+            command: 'get_ncs_related_chains',
+            commandArgs: [this.molNo]
+        }, false) as moorhen.WorkerResponse<string[][]>
+        return result.data.result.result
+    }
+
+    /**
      * A function to get the number of atoms in the current molecule
      * @returns {Promise<number>} The number of atoms in the molecule
      */

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -740,60 +740,6 @@ export const getTooltipShortcutLabel = (shortCut: moorhen.Shortcut): string => {
     return modifiers.length > 0 ? `<${modifiers.join(" ")} ${shortCut.keyPress.toUpperCase()}>` : `<${shortCut.keyPress.toUpperCase()}>`
 }
 
-// FIXME: Again looping thourhg atoms every where...
-export const getMoleculeBfactors = (gemmiStructure: gemmi.Structure): { cid: string, bFactor: number, chainId: string, resNum: number, modelName: string }[] => {
-    let bFactors: { cid: string, bFactor: number, chainId: string, resNum: number, modelName: string }[] = []
-    try {
-        const models = gemmiStructure.models
-        for (let modelIndex = 0; modelIndex < models.size(); modelIndex++) {
-            const model = models.get(modelIndex)
-            const modelName = model.name
-            const chains = model.chains
-            const chainsSize = chains.size()
-            for (let chainIndex = 0; chainIndex < chainsSize; chainIndex++) {
-                const chain = chains.get(chainIndex)
-                const chainName = chain.name
-                const residues = chain.residues
-                const residuesSize = residues.size()
-                for (let residueIndex = 0; residueIndex < residuesSize; residueIndex++) {
-                    let residueTemp = 0
-                    const residue = residues.get(residueIndex)
-                    const residueSeqId = residue.seqid
-                    const resNum = residueSeqId.str()
-                    const atoms = residue.atoms
-                    const atomsSize = atoms.size()
-                    for (let atomIndex = 0; atomIndex < atomsSize; atomIndex++) {
-                        const atom = atoms.get(atomIndex)
-                        const atomTemp = atom.b_iso
-                        residueTemp += atomTemp
-                        atom.delete()
-                    }
-                    bFactors.push({
-                        cid: `/${modelName}/${chainName}/${resNum}/*`,
-                        bFactor: residueTemp / atomsSize,
-                        chainId: chainName,
-                        modelName: modelName,
-                        resNum: parseInt(resNum)
-                    })
-                    residue.delete()
-                    residueSeqId.delete()
-                    atoms.delete()
-                }
-                chain.delete()
-                residues.delete()
-            }
-            model.delete()
-            chains.delete()
-        }
-        models.delete()
-    } finally {
-        if (gemmiStructure && !gemmiStructure.isDeleted()) {
-            gemmiStructure.delete()
-        }
-    }
-    return bFactors
-}
-
 export function componentToHex(c: number): string {
     const hex = c.toString(16)
     return hex.length === 1 ? "0" + hex : hex
@@ -865,11 +811,11 @@ export const getMultiColourRuleArgs = (molecule: moorhen.Molecule, ruleType: str
     let multiRulesArgs: string
     switch (ruleType) {
         case 'b-factor':
-            const bFactors = getMoleculeBfactors(molecule.gemmiStructure.clone())
+            const bFactors = molecule.getResidueBFactors()
             multiRulesArgs = getBfactorColourRules(bFactors)
             break;
         case 'af2-plddt':
-            const plddt = getMoleculeBfactors(molecule.gemmiStructure.clone())
+            const plddt = molecule.getResidueBFactors()
             multiRulesArgs = getPlddtColourRules(plddt)
             break;
         default:

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -517,6 +517,27 @@ describe("Testing MoorhenMolecule", () => {
         ])
     })
 
+    test("Test getResidueBFactors", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl, 'mol-test')
+
+        const bFactors = molecule.getResidueBFactors()
+
+        expect(bFactors).toHaveLength(650)
+        expect(bFactors[0].cid).toBe('/1/A/4(SER)/*')
+        expect(bFactors[0].bFactor).toBeCloseTo(27.18, 1)
+        expect(bFactors[bFactors.length - 1].cid).toBe('/1/A/1248(HOH)/*')
+        expect(bFactors[bFactors.length - 1].bFactor).toBeCloseTo(55.18, 1)
+    })
+
     test("Test checkIsLigand", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -706,6 +706,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     ;
     class_<molecules_container_t>("molecules_container_t")
     .constructor<bool>()
+    .function("get_ncs_related_chains", &molecules_container_t::get_ncs_related_chains)
     .function("is_EM_map",&molecules_container_t::is_EM_map)
     .function("set_map_sampling_rate",&molecules_container_t::set_map_sampling_rate)
     .function("get_mesh_for_ligand_validation_vs_dictionary",&molecules_container_t::get_mesh_for_ligand_validation_vs_dictionary)

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -430,8 +430,11 @@ class molecules_container_js : public molecules_container_t {
             return get_mol(imol)->WritePDBASCII(fname_cp);
         }
         int writeCIFASCII(int imol, const std::string &file_name) { 
-            const char *fname_cp = file_name.c_str();
-            return get_mol(imol)->WriteCIFASCII(fname_cp);
+            const auto mol = get_mol(imol);
+            mmdb::Manager *mol_copy  = new mmdb::Manager;
+            mol_copy->Copy(mol, mmdb::MMDBFCM_All);
+            int ierr = mol_copy->WriteCIFASCII(file_name.c_str());
+            return ierr;
         }
         int writeCCP4Map(int imol, const std::string &file_name) {
             auto xMap = (*this)[imol].xmap;


### PR DESCRIPTION
This update includes:
- Refactor the JS function `getMoleculeBFactors` into C++ and add a new method in `MoorhenMolecule` to make use of it.
-  Fix bug in `writeCIFASCII` where atoms are duplicated