### PR TITLE
Support of  mmcif format when comunicating with libcoot api

### DIFF
--- a/baby-gru/src/ErrorBoundary.tsx
+++ b/baby-gru/src/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import React, { ErrorInfo } from 'react';
 import { Modal, Button } from "react-bootstrap"
 import { doDownload, createLocalStorageInstance } from "./utils/MoorhenUtils"
 import { MoorhenTimeCapsule } from "./utils/MoorhenTimeCapsule"
+import { MoorhenMolecule } from './utils/MoorhenMolecule';
 import { moorhen } from './types/moorhen';
 
 type ErrorBoundaryPropsType = {
@@ -46,7 +47,8 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryPropsType, Error
         const backup = await timeCapsule.retrieveLastBackup() as string
         const sessionData: moorhen.backupSession = JSON.parse(backup)
         const promises = sessionData.moleculeData.map(molData => {
-            return this.doAsyncDownload([molData.pdbData], `${molData.name}.pdb`)
+            const format = MoorhenMolecule.guessCoordFormat(molData.coordString)
+            return this.doAsyncDownload([molData.coordString], `${molData.name}.${format}`)
         })
         await Promise.all(promises)
     }

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -375,8 +375,7 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
     }
 
     const handleDownload = async () => {
-        let pdbString = await props.molecule.getAtoms()
-        doDownload([pdbString], `${props.molecule.name}`)
+        await props.molecule.downloadAtoms()
         props.setCurrentDropdownMolNo(-1)
     }
 

--- a/baby-gru/src/components/menu-item/MoorhenGetMonomerMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenGetMonomerMenuItem.tsx
@@ -63,6 +63,7 @@ export const MoorhenGetMonomerMenuItem = (props: {
             newMolecule.name = newTlc
             newMolecule.setBackgroundColour(props.glRef.current.background_colour)
             newMolecule.defaultBondOptions.smoothness = defaultBondSmoothness
+            newMolecule.coordsFormat = 'mmcif'
             const fromMolecule = molecules.find(molecule => molecule.molNo === fromMolNo)
             if (typeof fromMolecule !== 'undefined') {
                 const ligandDict = fromMolecule.getDict(newTlc)

--- a/baby-gru/src/components/menu-item/MoorhenImportLigandDictionary.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenImportLigandDictionary.tsx
@@ -86,6 +86,7 @@ const MoorhenImportLigandDictionary = (props: {
                 newMolecule.name = instanceName
                 newMolecule.setBackgroundColour(backgroundColor)
                 newMolecule.defaultBondOptions.smoothness = defaultBondSmoothness
+                newMolecule.coordsFormat = 'mmcif'
                 await Promise.all([
                     newMolecule.fetchDefaultColourRules(),
                     newMolecule.addDict(fileContent)

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -12,6 +12,13 @@ declare global {
 
 export namespace libcootApi {
     type CCP4ModuleType = {
+        get_ligand_info_for_structure(gemmiStructure: gemmi.Structure): emscriptem.vector<{
+            resName: string;
+            chainName: string;
+            resNum: string;
+            modelName: string;
+            cid: string;
+        }>;
         guess_coord_data_format(coordDataString: string): number;
         get_structure_bfactors(gemmiStructure: gemmi.Structure): emscriptem.vector<{ cid: string; bFactor: number }>;
         get_sequence_info(gemmiStructure: gemmi.Structure, molName: string): emscriptem.vector<SequenceEntry>;

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -12,6 +12,7 @@ declare global {
 
 export namespace libcootApi {
     type CCP4ModuleType = {
+        guess_coord_data_format(coordDataString: string): number;
         get_structure_bfactors(gemmiStructure: gemmi.Structure): emscriptem.vector<{ cid: string; bFactor: number }>;
         get_sequence_info(gemmiStructure: gemmi.Structure, molName: string): emscriptem.vector<SequenceEntry>;
         get_atom_info_for_selection(gemmiStructure: gemmi.Structure, arg1: string, arg2: string): emscriptem.vector<AtomInfo>;
@@ -21,9 +22,10 @@ export namespace libcootApi {
         check_polymer_type(polymerConst: emscriptem.instance<number>): {value: number};
         remove_ligands_and_waters_chain(chain: gemmi.Chain): void;
         gemmi_setup_entities(gemmiStructure: gemmi.Structure): void;
+        gemmi_add_entity_types(gemmiStructure: gemmi.Structure, overWrite: boolean): void;
         remove_ligands_and_waters_structure(gemmiStructure: gemmi.Structure): void;
         remove_hydrogens_structure(gemmiStructure: gemmi.Structure): void;
-        read_structure_from_string(pdbData: string | ArrayBuffer, molName: string): gemmi.Structure;
+        read_structure_from_string(coordData: string | ArrayBuffer, molName: string): gemmi.Structure;
         get_mtz_columns(fileName: string): emscriptem.vector<string>;
         FS_createDataFile(arg0: string, fileName: string, byteArray: Uint8Array, arg3: boolean, arg4: boolean): void;
         getElementNameAsString: (arg0: emscriptem.instance<string>) => string;

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -149,7 +149,7 @@ declare module 'moorhen' {
         selectionRepresentation: _moorhen.MoleculeRepresentation;
         hasDNA: boolean;
         hasGlycans: boolean;
-        originalFileFormat: _moorhen.coorFormats;
+        coordsFormat: _moorhen.coorFormats;
     }
     module.exports.MoorhenMolecule = MoorhenMolecule
     

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -90,7 +90,7 @@ declare module 'moorhen' {
         setSymmetryRadius(radius: number): Promise<void>;
         drawSymmetry: (fetchSymMatrix?: boolean) => Promise<void>;
         getUnitCellParams():  { a: number; b: number; c: number; alpha: number; beta: number; gamma: number; };
-        replaceModelWithFile(fileUrl: string, molName: string): Promise<void>
+        replaceModelWithFile(fileUrl: string): Promise<void>
         delete(): Promise<_moorhen.WorkerResponse> 
         fetchDefaultColourRules(): Promise<void>;
         fetchIfDirtyAndDraw(arg0: string): Promise<void>;
@@ -109,6 +109,7 @@ declare module 'moorhen' {
         centreAndAlignViewOn(selectionCid: string, animate?: boolean): Promise<void>;
         buffersInclude: (bufferIn: { id: string; }) => boolean;
         redrawRepresentation: (id: string) => Promise<void>;
+        downloadAtoms(format?: 'mmcif' | 'pdb'): Promise<void>;
         isLigand: boolean;
         type: string;
         excludedCids: string[];
@@ -148,6 +149,7 @@ declare module 'moorhen' {
         selectionRepresentation: _moorhen.MoleculeRepresentation;
         hasDNA: boolean;
         hasGlycans: boolean;
+        originalFileFormat: _moorhen.coorFormats;
     }
     module.exports.MoorhenMolecule = MoorhenMolecule
     

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -190,7 +190,7 @@ export namespace moorhen {
         selectionRepresentation: MoleculeRepresentation;
         hasDNA: boolean;
         hasGlycans: boolean;
-        originalFileFormat: coorFormats
+        coordsFormat: coorFormats
     }
 
     type RepresentationStyles = 'VdwSpheres' | 'ligands' | 'CAs' | 'CBs' | 'CDs' | 'gaussian' | 'allHBonds' | 'rama' | 

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -87,8 +87,11 @@ export namespace moorhen {
         ruleType: string;
         label: string;
     }
+
+    type coorFormats = 'pdb' | 'mmcif';
     
     interface Molecule {
+        downloadAtoms(format?: 'mmcif' | 'pdb'): Promise<void>;
         getResidueBFactors(): { cid: string, bFactor: number }[];
         getNcsRelatedChains(): Promise<string[][]>;
         animateRefine(n_cyc: number, n_iteration: number, final_n_cyc?: number): Promise<void>;
@@ -129,7 +132,7 @@ export namespace moorhen {
         setSymmetryRadius(radius: number): Promise<void>;
         drawSymmetry: (fetchSymMatrix?: boolean) => Promise<void>;
         getUnitCellParams():  { a: number; b: number; c: number; alpha: number; beta: number; gamma: number; };
-        replaceModelWithFile(fileUrl: string, molName: string): Promise<void>
+        replaceModelWithFile(fileUrl: string): Promise<void>
         delete(): Promise<WorkerResponse> 
         fetchDefaultColourRules(): Promise<void>;
         fetchIfDirtyAndDraw(arg0: string): Promise<void>;
@@ -187,6 +190,7 @@ export namespace moorhen {
         selectionRepresentation: MoleculeRepresentation;
         hasDNA: boolean;
         hasGlycans: boolean;
+        originalFileFormat: coorFormats
     }
 
     type RepresentationStyles = 'VdwSpheres' | 'ligands' | 'CAs' | 'CBs' | 'CDs' | 'gaussian' | 'allHBonds' | 'rama' | 
@@ -427,7 +431,7 @@ export namespace moorhen {
     type moleculeSessionData = {
         name: string;
         molNo: number;
-        pdbData: string;
+        coordString: string;
         representations: { cid: string, style: string, isCustom: boolean, colourRules: ColourRule[], bondOptions: cootBondOptions }[];
         defaultBondOptions: cootBondOptions;
         defaultColourRules: ColourRule[];

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -253,7 +253,8 @@ export class MoorhenMolecule implements moorhen.Molecule {
         }
         this.gemmiStructure = readGemmiStructure(coordString, this.name)
         window.CCP4Module.gemmi_setup_entities(this.gemmiStructure)
-        window.CCP4Module.gemmi_add_entity_types(this.gemmiStructure, true)
+        // Only override if this is mmcif
+        window.CCP4Module.gemmi_add_entity_types(this.gemmiStructure, this.coordsFormat === 'mmcif')
         this.parseSequences()
         this.updateLigands()
     }

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1,5 +1,5 @@
 import 'pako';
-import { guid, readTextFile, readGemmiStructure, centreOnGemmiAtoms, getRandomMoleculeColour } from './MoorhenUtils'
+import { guid, readTextFile, readGemmiStructure, centreOnGemmiAtoms, getRandomMoleculeColour, doDownload } from './MoorhenUtils'
 import { MoorhenMoleculeRepresentation } from "./MoorhenMoleculeRepresentation"
 import { quatToMat4 } from '../WebGLgComponents/quatToMat4.js';
 import { isDarkBackground } from '../WebGLgComponents/mgWebGL'
@@ -87,6 +87,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
     hasDNA: boolean;
     restraints: {maxRadius: number, cid: string}[];
     isLigand: boolean;
+    originalFileFormat: moorhen.coorFormats
 
     constructor(commandCentre: React.RefObject<moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, monomerLibraryPath = "./baby-gru/monomers") {
         this.type = 'molecule'
@@ -96,6 +97,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         this.isVisible = true
         this.name = "unnamed"
         this.molNo = null
+        this.originalFileFormat = null
         this.gemmiStructure = null
         this.sequences = []
         this.ligands = null
@@ -157,10 +159,8 @@ export class MoorhenMolecule implements moorhen.Molecule {
     /**
      * Replace the current molecule with the model in a file
      * @param {string} fileUrl - The uri to the file with the new model
-     * @param {string} molName - The molecule name
-     * @param {string} format - The format of the file
      */
-    async replaceModelWithFile(fileUrl: string, molName: string, format: string = "pdb"): Promise<void> {
+    async replaceModelWithFile(fileUrl: string): Promise<void> {
         let coordData: string
         let fetchResponse: Response
 
@@ -179,7 +179,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         const cootResponse = await this.commandCentre.current.cootCommand({
             returnType: "status",
             command: 'replace_molecule_by_model_from_string',
-            commandArgs: [this.molNo, format, coordData],
+            commandArgs: [this.molNo, coordData],
             changesMolecules: [this.molNo]
         }, true)
 
@@ -247,12 +247,13 @@ export class MoorhenMolecule implements moorhen.Molecule {
     /**
      * Update the cached gemmi structure for this molecule
      */
-    async updateGemmiStructure(pdbString: string): Promise<void> {
+    async updateGemmiStructure(coordString: string): Promise<void> {
         if (this.gemmiStructure && !this.gemmiStructure.isDeleted()) {
             this.gemmiStructure.delete()
         }
-        this.gemmiStructure = readGemmiStructure(pdbString, this.name)
+        this.gemmiStructure = readGemmiStructure(coordString, this.name)
         window.CCP4Module.gemmi_setup_entities(this.gemmiStructure)
+        window.CCP4Module.gemmi_add_entity_types(this.gemmiStructure, true)
         this.parseSequences()
         this.updateLigands()
     }
@@ -372,15 +373,16 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @returns {moorhen.Molecule} New molecule instance
      */
     async copyMolecule(): Promise<moorhen.Molecule> {
-        let pdbString = await this.getAtoms()
+        let coordString = await this.getAtoms()
         let newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath)
         newMolecule.name = `${this.name}-placeholder`
         newMolecule.defaultBondOptions = this.defaultBondOptions
+        newMolecule.originalFileFormat = this.originalFileFormat
 
         let response = await this.commandCentre.current.cootCommand({
             returnType: "status",
             command: 'read_pdb_string',
-            commandArgs: [pdbString, newMolecule.name]
+            commandArgs: [coordString, newMolecule.name]
         }, true) as moorhen.WorkerResponse<number>
 
         newMolecule.molNo = response.data.result.result
@@ -413,6 +415,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         newMolecule.molNo = response.data.result.result
         newMolecule.isDarkBackground = this.isDarkBackground
         newMolecule.defaultBondOptions = this.defaultBondOptions
+        newMolecule.originalFileFormat = this.originalFileFormat
         await Promise.all(Object.keys(this.ligandDicts).map(key => newMolecule.addDict(this.ligandDicts[key])))
         await newMolecule.fetchDefaultColourRules()
         if (doRecentre) {
@@ -460,6 +463,35 @@ export class MoorhenMolecule implements moorhen.Molecule {
     }
 
     /**
+     * Guess the coordinate format from the file contents
+     * @param {string} coordDataString - The file contents
+     * @returns {string} - The file format
+     */
+    static guessCoordFormat(coordDataString: string): moorhen.coorFormats {
+        let result: moorhen.coorFormats = 'pdb'
+        try {
+            const format = window.CCP4Module.guess_coord_data_format(coordDataString)
+            if (format === 0) {
+                // result = 'unknown'
+            } else if (format === 1) {
+                // result = 'detect'
+            } else if (format === 2) {
+                result = 'pdb'
+            } else if (format === 3) {
+                result = 'mmcif'
+            } else if (format === 4) {
+                // result = 'mmjson'
+            } else if (format === 5) {
+                // result = 'chemComp'
+            }    
+        } catch (err) {
+            console.warn(err)
+            console.log('Unable to guess format of coords using gemmi... Defaulting to PDB format')
+        }
+        return result
+    }
+
+    /**
      * Load a new molecule from a string
      * @param {string} coordData - The molecule data
      * @param {string} name - The new molecule name
@@ -475,6 +507,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
             this.gemmiStructure.delete()
         }
 
+        this.originalFileFormat = MoorhenMolecule.guessCoordFormat(coordData as string)
         this.name = name.replace(pdbRegex, "").replace(entRegex, "").replace(cifRegex, "").replace(mmcifRegex, "");
 
         try {
@@ -574,16 +607,25 @@ export class MoorhenMolecule implements moorhen.Molecule {
 
     /**
      * Get a string with the PDB file contents of the molecule in its current state
-     * @param {string} [format='pdb'] - Indicate the file format
+     * @param {string} [format='pdb'] - File format will match the one of the original file unless specified here
      * @returns {string}  A string representation file contents
      */
-    async getAtoms(format: string = 'pdb'): Promise<string> {
+    async getAtoms(format?: 'mmcif' | 'pdb'): Promise<string> {
         const response = await this.commandCentre.current.cootCommand({
             returnType: "string",
             command: 'get_molecule_atoms',
-            commandArgs: [this.molNo, format],
+            commandArgs: [this.molNo, format ? format : this.originalFileFormat ? this.originalFileFormat : 'pdb'],
         }, false) as moorhen.WorkerResponse<string>
         return response.data.result.result
+    }
+
+    /**
+     * Download the PDB file contents of the molecule in its current state
+     * @param {string} [format='pdb'] - File format will match the one of the original file unless specified here
+     */
+    async downloadAtoms(format?: 'mmcif' | 'pdb') {
+        const coordsString = await this.getAtoms(format)
+        doDownload([coordsString], `${this.name}.${format ? format : this.originalFileFormat ? this.originalFileFormat : 'pdb'}`)
     }
 
     /**
@@ -607,16 +649,16 @@ export class MoorhenMolecule implements moorhen.Molecule {
         if (this.gemmiStructure && !this.gemmiStructure.isDeleted()) {
             this.gemmiStructure.delete()
         }
-        const [_hasGlycans, pdbString] = await Promise.all([
+        const [_hasGlycans, coordString] = await Promise.all([
             this.checkHasGlycans(),
             this.getAtoms()
         ])
         try {
-            this.updateGemmiStructure(pdbString)
+            this.updateGemmiStructure(coordString)
         }
         catch (err) {
             console.log(err)
-            console.warn('Issue parsing coordinates into Gemmi structure', pdbString)
+            console.warn('Issue parsing coordinates into Gemmi structure', coordString)
         }
         this.atomsDirty = false
 }

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1337,34 +1337,13 @@ export class MoorhenMolecule implements moorhen.Molecule {
      */
     async updateLigands(): Promise<void> {
         let ligandList: moorhen.LigandInfo[] = []
-        const model = this.gemmiStructure.first_model()
-        const modelName = model.name
-
-        try {
-            const chains = model.chains
-            const chainsSize = chains.size()
-            for (let i = 0; i < chainsSize; i++) {
-                const chain = chains.get(i)
-                const chainName = chain.name
-                const ligands = chain.get_ligands_const()
-                const ligandsSize = ligands.size()
-                for (let j = 0; j < ligandsSize; j++) {
-                    let ligand = ligands.at(j)
-                    const resName = ligand.name
-                    const ligandSeqId = ligand.seqid
-                    const resNum = ligandSeqId.str()
-                    const cid = `/${model.name}/${chain.name}/${ligandSeqId.num?.value}(${ligand.name})`
-                    ligandList.push({ resName, chainName, resNum, modelName, cid })
-                    ligand.delete()
-                    ligandSeqId.delete()
-                }
-                chain.delete()
-                ligands.delete()
-            }
-            chains.delete()
-        } finally {
-            model.delete()
+        const ligandInfoVec = window.CCP4Module.get_ligand_info_for_structure(this.gemmiStructure)
+        const ligandInfoVecSize = ligandInfoVec.size()
+        for (let i = 0; i < ligandInfoVecSize; i++) {
+            const ligandInfo = ligandInfoVec.get(i)
+            ligandList.push({...ligandInfo})
         }
+        ligandInfoVec.delete()
 
         this.ligands = ligandList
         this.checkIsLigand()

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -87,7 +87,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
     hasDNA: boolean;
     restraints: {maxRadius: number, cid: string}[];
     isLigand: boolean;
-    originalFileFormat: moorhen.coorFormats
+    coordsFormat: moorhen.coorFormats
 
     constructor(commandCentre: React.RefObject<moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, monomerLibraryPath = "./baby-gru/monomers") {
         this.type = 'molecule'
@@ -97,7 +97,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         this.isVisible = true
         this.name = "unnamed"
         this.molNo = null
-        this.originalFileFormat = null
+        this.coordsFormat = null
         this.gemmiStructure = null
         this.sequences = []
         this.ligands = null
@@ -377,7 +377,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         let newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath)
         newMolecule.name = `${this.name}-placeholder`
         newMolecule.defaultBondOptions = this.defaultBondOptions
-        newMolecule.originalFileFormat = this.originalFileFormat
+        newMolecule.coordsFormat = this.coordsFormat
 
         let response = await this.commandCentre.current.cootCommand({
             returnType: "status",
@@ -415,7 +415,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         newMolecule.molNo = response.data.result.result
         newMolecule.isDarkBackground = this.isDarkBackground
         newMolecule.defaultBondOptions = this.defaultBondOptions
-        newMolecule.originalFileFormat = this.originalFileFormat
+        newMolecule.coordsFormat = this.coordsFormat
         await Promise.all(Object.keys(this.ligandDicts).map(key => newMolecule.addDict(this.ligandDicts[key])))
         await newMolecule.fetchDefaultColourRules()
         if (doRecentre) {
@@ -507,7 +507,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
             this.gemmiStructure.delete()
         }
 
-        this.originalFileFormat = MoorhenMolecule.guessCoordFormat(coordData as string)
+        this.coordsFormat = MoorhenMolecule.guessCoordFormat(coordData as string)
         this.name = name.replace(pdbRegex, "").replace(entRegex, "").replace(cifRegex, "").replace(mmcifRegex, "");
 
         try {
@@ -614,7 +614,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         const response = await this.commandCentre.current.cootCommand({
             returnType: "string",
             command: 'get_molecule_atoms',
-            commandArgs: [this.molNo, format ? format : this.originalFileFormat ? this.originalFileFormat : 'pdb'],
+            commandArgs: [this.molNo, format ? format : this.coordsFormat ? this.coordsFormat : 'pdb'],
         }, false) as moorhen.WorkerResponse<string>
         return response.data.result.result
     }
@@ -625,7 +625,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
      */
     async downloadAtoms(format?: 'mmcif' | 'pdb') {
         const coordsString = await this.getAtoms(format)
-        doDownload([coordsString], `${this.name}.${format ? format : this.originalFileFormat ? this.originalFileFormat : 'pdb'}`)
+        doDownload([coordsString], `${this.name}.${format ? format : this.coordsFormat ? this.coordsFormat : 'pdb'}`)
     }
 
     /**

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -49,7 +49,7 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
         this.modificationCount = 0
         this.modificationCountBackupThreshold = 5
         this.maxBackupCount = 10
-        this.version = 'v16'
+        this.version = 'v17'
         this.disableBackups = false
         this.storageInstance = null
         this.onIsBusyChange = null
@@ -195,7 +195,7 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
             return {
                 name: molecule.name,
                 molNo: molecule.molNo,
-                pdbData: moleculeDataPromises[index],
+                coordString: moleculeDataPromises[index],
                 representations: molecule.representations.filter(item => item.visible).map(item => { return {
                     cid: item.cid,
                     style: item.style,

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -214,10 +214,10 @@ export async function loadSessionData(
         dispatch( emptyMaps() )    
     })
 
-    // Load molecules stored in session from pdb string
+    // Load molecules stored in session from coords string
     const newMoleculePromises = sessionData.moleculeData.map(storedMoleculeData => {
         const newMolecule = new MoorhenMolecule(commandCentre, glRef, monomerLibraryPath)
-        return newMolecule.loadToCootFromString(storedMoleculeData.pdbData, storedMoleculeData.name)
+        return newMolecule.loadToCootFromString(storedMoleculeData.coordString, storedMoleculeData.name)
     })
     
     // Load maps stored in session
@@ -580,8 +580,8 @@ export const doDownloadText = (text: string, filename: string) => {
     document.body.removeChild(element);
 }
 
-export const readGemmiStructure = (pdbData: ArrayBuffer | string, molName: string): gemmi.Structure => {
-    const structure: gemmi.Structure = window.CCP4Module.read_structure_from_string(pdbData, molName)
+export const readGemmiStructure = (coordData: ArrayBuffer | string, molName: string): gemmi.Structure => {
+    const structure: gemmi.Structure = window.CCP4Module.read_structure_from_string(coordData, molName)
     return structure
 }
 

--- a/baby-gru/tests/__tests__/integration.test.js
+++ b/baby-gru/tests/__tests__/integration.test.js
@@ -739,13 +739,13 @@ describe('Testing molecules_container_js', () => {
         const pdbString_1  = molecules_container.get_molecule_atoms(coordMolNo_1, "pdb")
         expect(pdbString_1).toHaveLength(258719)
         const coordMolNo_2 = molecules_container.read_pdb('./5fjj.pdb')
-        molecules_container.replace_molecule_by_model_from_string(coordMolNo_2, "pdb", pdbString_1)
+        molecules_container.replace_molecule_by_model_from_string(coordMolNo_2, pdbString_1)
         const pdbString_2  = molecules_container.get_molecule_atoms(coordMolNo_2, "pdb")
         expect(pdbString_2).toBe(pdbString_1)
     })
 })
 
-const testDataFiles = ['5fjj.pdb', '5a3h.pdb', '5a3h_no_ligand.pdb', 'LZA.cif', 'nitrobenzene.cif', 'benzene.cif', '5a3h_sigmaa.mtz', 'rnasa-1.8-all_refmac1.mtz', 'tm-A.pdb']
+const testDataFiles = ['5fjj.pdb', '5a3h.pdb', '5a3h.mmcif', '5a3h_no_ligand.pdb', 'LZA.cif', 'nitrobenzene.cif', 'benzene.cif', '5a3h_sigmaa.mtz', 'rnasa-1.8-all_refmac1.mtz', 'tm-A.pdb']
 
 const setupFunctions = {
     removeTestDataFromFauxFS: () => {

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -67,9 +67,9 @@ describe("Testing MoorhenMolecule", () => {
             current: new MockMoorhenCommandCentre(molecules_container, cootModule)
         }
         const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
-        expect(molecule.originalFileFormat).toBe(null)
+        expect(molecule.coordsFormat).toBe(null)
         await molecule.loadToCootFromURL(fileUrl, 'mol-test')
-        expect(molecule.originalFileFormat).toBe('pdb')
+        expect(molecule.coordsFormat).toBe('pdb')
     })
 
     test("Test guessCoordFormat mmcif", async () => {
@@ -82,9 +82,9 @@ describe("Testing MoorhenMolecule", () => {
             current: new MockMoorhenCommandCentre(molecules_container, cootModule)
         }
         const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
-        expect(molecule.originalFileFormat).toBe(null)
+        expect(molecule.coordsFormat).toBe(null)
         await molecule.loadToCootFromURL(fileUrl, 'mol-test')
-        expect(molecule.originalFileFormat).toBe('mmcif')
+        expect(molecule.coordsFormat).toBe('mmcif')
     })
 
     test("Test guessCoordFormat ligandCif", async () => {
@@ -97,9 +97,9 @@ describe("Testing MoorhenMolecule", () => {
             current: new MockMoorhenCommandCentre(molecules_container, cootModule)
         }
         const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
-        expect(molecule.originalFileFormat).toBe(null)
+        expect(molecule.coordsFormat).toBe(null)
         await molecule.loadToCootFromURL(fileUrl, 'mol-test')
-        expect(molecule.originalFileFormat).toBe('mmcif')
+        expect(molecule.coordsFormat).toBe('mmcif')
     })
 
     test("Test delete", async () => {
@@ -211,7 +211,7 @@ describe("Testing MoorhenMolecule", () => {
         const coordData_2 = await molecule_2.getAtoms()
 
         expect(coordData_1).toBe(coordData_2)
-        expect(molecule_2.originalFileFormat).toBe(molecule_1.originalFileFormat)
+        expect(molecule_2.coordsFormat).toBe(molecule_1.coordsFormat)
     })
 
     test("Test copyFragmentUsingCid", async () => {
@@ -230,7 +230,7 @@ describe("Testing MoorhenMolecule", () => {
         const atomCount = molecules_container.get_number_of_atoms(molecule_2.molNo)
         expect(molecule_2.molNo).not.toBe(-1)
         expect(atomCount).toBe(14)
-        expect(molecule_2.originalFileFormat).toBe(molecule_1.originalFileFormat)
+        expect(molecule_2.coordsFormat).toBe(molecule_1.coordsFormat)
     })
 
     test("Test mergeMolecules", async () => {

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -41,7 +41,6 @@ beforeAll(() => {
         return Promise.resolve()
     })
 })
-
 describe("Testing MoorhenMolecule", () => {
 
     test("Test loadToCootFromURL", async () => {
@@ -56,6 +55,51 @@ describe("Testing MoorhenMolecule", () => {
         const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
         await molecule.loadToCootFromURL(fileUrl, 'mol-test')
         expect(molecule.molNo).toBe(0)
+    })
+
+    test("Test guessCoordFormat pdb", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        expect(molecule.originalFileFormat).toBe(null)
+        await molecule.loadToCootFromURL(fileUrl, 'mol-test')
+        expect(molecule.originalFileFormat).toBe('pdb')
+    })
+
+    test("Test guessCoordFormat mmcif", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.mmcif')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        expect(molecule.originalFileFormat).toBe(null)
+        await molecule.loadToCootFromURL(fileUrl, 'mol-test')
+        expect(molecule.originalFileFormat).toBe('mmcif')
+    })
+
+    test("Test guessCoordFormat ligandCif", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', 'LZA.cif')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        expect(molecule.originalFileFormat).toBe(null)
+        await molecule.loadToCootFromURL(fileUrl, 'mol-test')
+        expect(molecule.originalFileFormat).toBe('mmcif')
     })
 
     test("Test delete", async () => {
@@ -74,7 +118,7 @@ describe("Testing MoorhenMolecule", () => {
         expect(isValid).toBeFalsy()
     })
 
-    test("Test get_atoms", async () => {
+    test("Test get_atoms pdb", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
@@ -85,24 +129,45 @@ describe("Testing MoorhenMolecule", () => {
         }
         const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
         await molecule.loadToCootFromURL(fileUrl, 'mol-test')
-        const coordData = await molecule.getAtoms('pdb')
+        const coordData = await molecule.getAtoms()
         expect(coordData).toHaveLength(258719)
+    }) 
+
+    test("Test get_atoms mmcif", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.mmcif')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl, 'mol-test')
+        const coordData = await molecule.getAtoms()
+        expect(coordData).toHaveLength(278728)
     }) 
 
     test("Test get_number_of_atoms", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
-        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
         }
         const commandCentre = {
             current: new MockMoorhenCommandCentre(molecules_container, cootModule)
         }
-        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
-        await molecule.loadToCootFromURL(fileUrl, 'mol-test')
-        expect(molecule.atomCount).toBe(2765)
-        const atomCount = await molecule.getNumberOfAtoms()
-        expect(atomCount).toBe(2765)
+        // pdb
+        const molecule_pdb = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule_pdb.loadToCootFromURL(path.join(__dirname, '..', 'test_data', '5a3h.pdb'), 'mol-test')
+        expect(molecule_pdb.atomCount).toBe(2765)
+        const atomCount_pdb = await molecule_pdb.getNumberOfAtoms()
+        expect(atomCount_pdb).toBe(2765)
+        // mmcif
+        const molecule_mmcif = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule_mmcif.loadToCootFromURL(path.join(__dirname, '..', 'test_data', '5a3h.mmcif'), 'mol-test')
+        expect(molecule_mmcif.atomCount).toBe(atomCount_pdb)
+        const atomCount_mmcif = await molecule_mmcif.getNumberOfAtoms()
+        expect(atomCount_mmcif).toBe(atomCount_pdb)
     }) 
 
     test("Test replaceModelWithFile", async () => {
@@ -119,11 +184,11 @@ describe("Testing MoorhenMolecule", () => {
         const molecule_1 = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
         await molecule_1.loadToCootFromURL(fileUrl_1, 'mol-test')
         await molecule_1.replaceModelWithFile(fileUrl_2, 'mol-test')
-        const coordData_1 = await molecule_1.getAtoms('pdb')
+        const coordData_1 = await molecule_1.getAtoms()
 
         const molecule_2 = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
         await molecule_2.loadToCootFromURL(fileUrl_2, 'mol-test')
-        const coordData_2 = await molecule_2.getAtoms('pdb')
+        const coordData_2 = await molecule_2.getAtoms()
 
         expect(coordData_1).toBe(coordData_2)
     })
@@ -140,12 +205,13 @@ describe("Testing MoorhenMolecule", () => {
 
         const molecule_1 = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
         await molecule_1.loadToCootFromURL(fileUrl, 'mol-test')
-        const coordData_1 = await molecule_1.getAtoms('pdb')
+        const coordData_1 = await molecule_1.getAtoms()
 
         const molecule_2 = await molecule_1.copyMolecule()
-        const coordData_2 = await molecule_2.getAtoms('pdb')
+        const coordData_2 = await molecule_2.getAtoms()
 
         expect(coordData_1).toBe(coordData_2)
+        expect(molecule_2.originalFileFormat).toBe(molecule_1.originalFileFormat)
     })
 
     test("Test copyFragmentUsingCid", async () => {
@@ -164,6 +230,7 @@ describe("Testing MoorhenMolecule", () => {
         const atomCount = molecules_container.get_number_of_atoms(molecule_2.molNo)
         expect(molecule_2.molNo).not.toBe(-1)
         expect(atomCount).toBe(14)
+        expect(molecule_2.originalFileFormat).toBe(molecule_1.originalFileFormat)
     })
 
     test("Test mergeMolecules", async () => {
@@ -242,7 +309,7 @@ describe("Testing MoorhenMolecule", () => {
         expect(Object.keys(molecule.ligandDicts).sort()).toEqual([ 'BGC', 'G2F' ])
     })
 
-    test("Test gemmiAtomsForCid 1", async () => {
+    test("Test gemmiAtomsForCid 1 -pdb", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
@@ -262,9 +329,69 @@ describe("Testing MoorhenMolecule", () => {
         expect(gemmiAtoms.map(atomInfo => atomInfo.label)).toEqual([ "/1/A/30(LYS)/CA", "/1/A/31(GLY)/CA" ])
     })
 
-    test("Test gemmiAtomsForCid 2", async () => {
+    test("Test gemmiAtomsForCid 1 -mmcif", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.mmcif')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        const f = jest.spyOn(molecule, 'updateAtoms')
+        await molecule.loadToCootFromURL(fileUrl_1, 'mol-test')
+        molecule.setAtomsDirty(true)
+        const gemmiAtoms = await molecule.gemmiAtomsForCid('//A/30-31/CA')
+        expect(f).toHaveBeenCalled()
+        expect(gemmiAtoms).toHaveLength(2)
+        expect(gemmiAtoms.map(atomInfo => atomInfo.label)).toEqual([ "/1/A/30(LYS)/CA", "/1/A/31(GLY)/CA" ])
+    })
+
+    test("Test gemmiAtomsForCid 2 -pdb", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        const f = jest.spyOn(molecule, 'updateAtoms')
+        await molecule.loadToCootFromURL(fileUrl_1, 'mol-test')
+        molecule.setAtomsDirty(true)
+        await molecule.hideCid("/*/A/29-30/*")
+        const gemmiAtoms = await molecule.gemmiAtomsForCid('//A/30-31/CA', true)
+        expect(f).toHaveBeenCalled()
+        expect(gemmiAtoms).toEqual([
+            {
+              res_name: 'GLY',
+              res_no: '31',
+              mol_name: '1',
+              chain_id: 'A',
+              pos: [ 70.995, 43.686, 22.449 ],
+              x: 70.995,
+              y: 43.686,
+              z: 22.449,
+              charge: 0,
+              element: 'C',
+              symbol: 'C',
+              tempFactor: 9.109999656677246,
+              serial: 213,
+              name: 'CA',
+              has_altloc: false,
+              alt_loc: "",
+              label: '/1/A/31(GLY)/CA'
+            }
+        ])
+    })
+
+    test("Test gemmiAtomsForCid 2 -mmcif", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.mmcif')
         const glRef = {
             current: new MockWebGL()
         }
@@ -387,7 +514,7 @@ describe("Testing MoorhenMolecule", () => {
         ])
     })
 
-    test("Test parseSequences", async () => {
+    test("Test parseSequences pdb", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
@@ -418,7 +545,38 @@ describe("Testing MoorhenMolecule", () => {
         expect(lastResidue.cid).toBe("//A/303(SER)/")
     })
 
-    test("Test updateAtoms", async () => {
+    test("Test parseSequences mmcif", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.mmcif')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl, 'mol-test')
+        expect(molecule.sequences).toHaveLength(1)
+        
+        const firstSequence = molecule.sequences[0]
+        expect(firstSequence.name).toBe("mol-test_A")
+        expect(firstSequence.chain).toBe("A")
+        expect(firstSequence.type).toBe(1)
+        expect(firstSequence.sequence).toHaveLength(300)
+        
+        const firstResidue = firstSequence.sequence[0]
+        expect(firstResidue.resNum).toBe(4)
+        expect(firstResidue.resCode).toBe("S")
+        expect(firstResidue.cid).toBe("//A/4(SER)/")
+        
+        const lastResidue = firstSequence.sequence[299]
+        expect(lastResidue.resNum).toBe(303)
+        expect(lastResidue.resCode).toBe("S")
+        expect(lastResidue.cid).toBe("//A/303(SER)/")
+    })
+
+    test("Test updateAtoms pdb", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
@@ -433,12 +591,37 @@ describe("Testing MoorhenMolecule", () => {
         
         const sequence_1 = molecule.sequences.find(seq => seq.chain === 'A')
         const length_1 = sequence_1.sequence.length
-        molecules_container.delete_using_cid(molecule.molNo, "A/32-33/*", "LITERAL")
+        await molecule.deleteCid("A/32-33/*", false)
         await molecule.updateAtoms()
         const sequence_2 = molecule.sequences.find(seq => seq.chain === 'A')
         expect(sequence_2.sequence).toHaveLength(length_1 - 2)
        
-        molecules_container.delete_using_cid(molecule.molNo, "//B", "LITERAL")
+        await molecule.deleteCid("//B", false)
+        await molecule.updateAtoms()
+        expect(molecule.ligands).toHaveLength(0)
+    })
+
+    test("Test updateAtoms mmcif", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.mmcif')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl, 'mol-test')
+        
+        const sequence_1 = molecule.sequences.find(seq => seq.chain === 'A')
+        const length_1 = sequence_1.sequence.length
+        await molecule.deleteCid("A/32-33/*", false)
+        await molecule.updateAtoms()
+        const sequence_2 = molecule.sequences.find(seq => seq.chain === 'A')
+        expect(sequence_2.sequence).toHaveLength(length_1 - 2)
+       
+        await molecule.deleteCid("//B", false)
         await molecule.updateAtoms()
         expect(molecule.ligands).toHaveLength(0)
     })
@@ -538,9 +721,32 @@ describe("Testing MoorhenMolecule", () => {
         expect(bFactors[bFactors.length - 1].bFactor).toBeCloseTo(55.18, 1)
     })
 
-    test("Test checkIsLigand", async () => {
+    test("Test checkIsLigand pdb", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl, 'mol-test')
+        expect(molecule.isLigand).toBeFalsy()
+
+        const result_cid = molecules_container.delete_using_cid(molecule.molNo, "//A", "LITERAL")
+        expect(result_cid.first).toBe(1)
+
+        molecule.setAtomsDirty(true)
+        await molecule.updateAtoms()
+        expect(molecule.isLigand).toBeTruthy()
+        const isLigand = molecule.checkIsLigand()
+        expect(isLigand).toBeTruthy()
+    })
+
+    test("Test checkIsLigand mmcif", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.mmcif')
         const glRef = {
             current: new MockWebGL()
         }
@@ -714,9 +920,25 @@ describe("Testing MoorhenMolecule", () => {
         expect(instancedMesh_2.data.result.result.instance_sizes).toEqual(instancedMesh_4.data.result.result.instance_sizes)
     })
 
-    test("Test hasDNA", async () => {
+    test("Test hasDNA pdb", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         const fileUrl = path.join('https://files.rcsb.org/download/3L1P.pdb')
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+        const glRef = {
+            current: new MockWebGL()
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl, 'mol-test-1')
+        expect(molecule.molNo).toBe(0)
+        expect(molecule.hasDNA).toBeTruthy()
+    })
+
+    test("Test hasDNA mmcif", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join('https://files.rcsb.org/download/3L1P.cif')
         const commandCentre = {
             current: new MockMoorhenCommandCentre(molecules_container, cootModule)
         }
@@ -748,7 +970,7 @@ describe("Testing MoorhenMolecule", () => {
     })
 })
 
-const testDataFiles = ['5fjj.pdb', '5a3h.pdb', '5a3h_no_ligand.pdb', 'LZA.cif', 'nitrobenzene.cif', 'benzene.cif', '5a3h_sigmaa.mtz', 'rnasa-1.8-all_refmac1.mtz', 'tm-A.pdb']
+const testDataFiles = ['5fjj.pdb', '5a3h.pdb', '5a3h.mmcif', '5a3h_no_ligand.pdb', 'LZA.cif', 'nitrobenzene.cif', 'benzene.cif', '5a3h_sigmaa.mtz', 'rnasa-1.8-all_refmac1.mtz', 'tm-A.pdb']
 
 const setupFunctions = {
     removeTestDataFromFauxFS: () => {

--- a/baby-gru/tests/test_data/5a3h.mmcif
+++ b/baby-gru/tests/test_data/5a3h.mmcif
@@ -1,0 +1,4792 @@
+data_5A3H
+# 
+_entry.id   5A3H 
+# 
+_audit_conform.dict_name       mmcif_pdbx.dic 
+_audit_conform.dict_version    5.375 
+_audit_conform.dict_location   http://mmcif.pdb.org/dictionaries/ascii/mmcif_pdbx.dic 
+# 
+loop_
+_database_2.database_id 
+_database_2.database_code 
+_database_2.pdbx_database_accession 
+_database_2.pdbx_DOI 
+PDB   5A3H         pdb_00005a3h 10.2210/pdb5a3h/pdb 
+WWPDB D_1000179663 ?            ?                   
+# 
+_pdbx_database_status.status_code                     REL 
+_pdbx_database_status.entry_id                        5A3H 
+_pdbx_database_status.recvd_initial_deposition_date   1998-07-23 
+_pdbx_database_status.deposit_site                    ? 
+_pdbx_database_status.process_site                    BNL 
+_pdbx_database_status.status_code_sf                  REL 
+_pdbx_database_status.status_code_mr                  ? 
+_pdbx_database_status.SG_entry                        ? 
+_pdbx_database_status.pdb_format_compatible           Y 
+_pdbx_database_status.status_code_cs                  ? 
+_pdbx_database_status.status_code_nmr_data            ? 
+_pdbx_database_status.methods_development_category    ? 
+# 
+loop_
+_audit_author.name 
+_audit_author.pdbx_ordinal 
+'Davies, G.J.'     1 
+'Varrot, A.'       2 
+'Dauter, M.'       3 
+'Brzozowski, A.M.' 4 
+'Schulein, M.'     5 
+'Mackenzie, L.'    6 
+'Withers, S.G.'    7 
+# 
+loop_
+_citation.id 
+_citation.title 
+_citation.journal_abbrev 
+_citation.journal_volume 
+_citation.page_first 
+_citation.page_last 
+_citation.year 
+_citation.journal_id_ASTM 
+_citation.country 
+_citation.journal_id_ISSN 
+_citation.journal_id_CSD 
+_citation.book_publisher 
+_citation.pdbx_database_id_PubMed 
+_citation.pdbx_database_id_DOI 
+primary 'Snapshots along an enzymatic reaction coordinate: analysis of a retaining beta-glycoside hydrolase.'                   
+Biochemistry 37 11707 11713 1998 BICHAW US 0006-2960 0033 ? 9718293 10.1021/bi981315i 
+1       'Structure of the Bacillus Agaradherans Family 5 Endoglucanase at 1.6 A and its Cellobiose Complex at 2.0 A Resolution' 
+Biochemistry 37 1926  ?     1998 BICHAW US 0006-2960 0033 ? ?       ?                 
+# 
+loop_
+_citation_author.citation_id 
+_citation_author.name 
+_citation_author.ordinal 
+_citation_author.identifier_ORCID 
+primary 'Davies, G.J.'     1  ? 
+primary 'Mackenzie, L.'    2  ? 
+primary 'Varrot, A.'       3  ? 
+primary 'Dauter, M.'       4  ? 
+primary 'Brzozowski, A.M.' 5  ? 
+primary 'Schulein, M.'     6  ? 
+primary 'Withers, S.G.'    7  ? 
+1       'Davies, G.J.'     8  ? 
+1       'Dauter, M.'       9  ? 
+1       'Brzozowski, A.M.' 10 ? 
+1       'Bjornvad, M.E.'   11 ? 
+1       'Andersen, K.V.'   12 ? 
+1       'Schulein, M.'     13 ? 
+# 
+_cell.entry_id           5A3H 
+_cell.length_a           54.710 
+_cell.length_b           69.570 
+_cell.length_c           77.040 
+_cell.angle_alpha        90.00 
+_cell.angle_beta         90.00 
+_cell.angle_gamma        90.00 
+_cell.Z_PDB              4 
+_cell.pdbx_unique_axis   ? 
+# 
+_symmetry.entry_id                         5A3H 
+_symmetry.space_group_name_H-M             'P 21 21 21' 
+_symmetry.pdbx_full_space_group_name_H-M   ? 
+_symmetry.cell_setting                     ? 
+_symmetry.Int_Tables_number                19 
+# 
+loop_
+_entity.id 
+_entity.type 
+_entity.src_method 
+_entity.pdbx_description 
+_entity.formula_weight 
+_entity.pdbx_number_of_molecules 
+_entity.pdbx_ec 
+_entity.pdbx_mutation 
+_entity.pdbx_fragment 
+_entity.details 
+1 polymer  man ENDOGLUCANASE                                                       33998.023 1   3.2.1.4 ? 
+'CATALYTIC CORE DOMAIN ONLY' 
+'THIS IS A COMPLEX WITH 2-DEOXY-2-FLUOROCELLOBIOSE COVALENTLY LINKED TO THE ENZYMATIC NUCLEOPHILE, GLU 228' 
+2 branched man 'beta-D-glucopyranose-(1-4)-2-deoxy-2-fluoro-alpha-D-glucopyranose' 344.288   1   ?       ? ? ? 
+3 water    nat water                                                               18.015    348 ?       ? ? ? 
+# 
+loop_
+_entity_name_com.entity_id 
+_entity_name_com.name 
+1 CELLULASE                        
+2 2-deoxy-2-fluoro-beta-cellobiose 
+# 
+_entity_poly.entity_id                      1 
+_entity_poly.type                           'polypeptide(L)' 
+_entity_poly.nstd_linkage                   no 
+_entity_poly.nstd_monomer                   no 
+_entity_poly.pdbx_seq_one_letter_code       
+;DNDSVVEEHGQLSISNGELVNERGEQVQLKGMSSHGLQWYGQFVNYESMKWLRDDWGINVFRAAMYTSSGGYIDDPSVKE
+KVKEAVEAAIDLDIYVIIDWHILSDNDPNIYKEEAKDFFDEMSELYGDYPNVIYEIANEPNGSDVTWGNQIKPYAEEVIP
+IIRNNDPNNIIIVGTGTWSQDVHHAADNQLADPNVMYAFHFYAGTHGQNLRDQVDYALDQGAAIFVSEWGTSAATGDGGV
+FLDEAQVWIDFMDERNLSWANWSLTHKDESSAALMPGANPTGGWTEAELSPSGTFVREKIRES
+;
+_entity_poly.pdbx_seq_one_letter_code_can   
+;DNDSVVEEHGQLSISNGELVNERGEQVQLKGMSSHGLQWYGQFVNYESMKWLRDDWGINVFRAAMYTSSGGYIDDPSVKE
+KVKEAVEAAIDLDIYVIIDWHILSDNDPNIYKEEAKDFFDEMSELYGDYPNVIYEIANEPNGSDVTWGNQIKPYAEEVIP
+IIRNNDPNNIIIVGTGTWSQDVHHAADNQLADPNVMYAFHFYAGTHGQNLRDQVDYALDQGAAIFVSEWGTSAATGDGGV
+FLDEAQVWIDFMDERNLSWANWSLTHKDESSAALMPGANPTGGWTEAELSPSGTFVREKIRES
+;
+_entity_poly.pdbx_strand_id                 A 
+_entity_poly.pdbx_target_identifier         ? 
+# 
+loop_
+_entity_poly_seq.entity_id 
+_entity_poly_seq.num 
+_entity_poly_seq.mon_id 
+_entity_poly_seq.hetero 
+1 1   ASP n 
+1 2   ASN n 
+1 3   ASP n 
+1 4   SER n 
+1 5   VAL n 
+1 6   VAL n 
+1 7   GLU n 
+1 8   GLU n 
+1 9   HIS n 
+1 10  GLY n 
+1 11  GLN n 
+1 12  LEU n 
+1 13  SER n 
+1 14  ILE n 
+1 15  SER n 
+1 16  ASN n 
+1 17  GLY n 
+1 18  GLU n 
+1 19  LEU n 
+1 20  VAL n 
+1 21  ASN n 
+1 22  GLU n 
+1 23  ARG n 
+1 24  GLY n 
+1 25  GLU n 
+1 26  GLN n 
+1 27  VAL n 
+1 28  GLN n 
+1 29  LEU n 
+1 30  LYS n 
+1 31  GLY n 
+1 32  MET n 
+1 33  SER n 
+1 34  SER n 
+1 35  HIS n 
+1 36  GLY n 
+1 37  LEU n 
+1 38  GLN n 
+1 39  TRP n 
+1 40  TYR n 
+1 41  GLY n 
+1 42  GLN n 
+1 43  PHE n 
+1 44  VAL n 
+1 45  ASN n 
+1 46  TYR n 
+1 47  GLU n 
+1 48  SER n 
+1 49  MET n 
+1 50  LYS n 
+1 51  TRP n 
+1 52  LEU n 
+1 53  ARG n 
+1 54  ASP n 
+1 55  ASP n 
+1 56  TRP n 
+1 57  GLY n 
+1 58  ILE n 
+1 59  ASN n 
+1 60  VAL n 
+1 61  PHE n 
+1 62  ARG n 
+1 63  ALA n 
+1 64  ALA n 
+1 65  MET n 
+1 66  TYR n 
+1 67  THR n 
+1 68  SER n 
+1 69  SER n 
+1 70  GLY n 
+1 71  GLY n 
+1 72  TYR n 
+1 73  ILE n 
+1 74  ASP n 
+1 75  ASP n 
+1 76  PRO n 
+1 77  SER n 
+1 78  VAL n 
+1 79  LYS n 
+1 80  GLU n 
+1 81  LYS n 
+1 82  VAL n 
+1 83  LYS n 
+1 84  GLU n 
+1 85  ALA n 
+1 86  VAL n 
+1 87  GLU n 
+1 88  ALA n 
+1 89  ALA n 
+1 90  ILE n 
+1 91  ASP n 
+1 92  LEU n 
+1 93  ASP n 
+1 94  ILE n 
+1 95  TYR n 
+1 96  VAL n 
+1 97  ILE n 
+1 98  ILE n 
+1 99  ASP n 
+1 100 TRP n 
+1 101 HIS n 
+1 102 ILE n 
+1 103 LEU n 
+1 104 SER n 
+1 105 ASP n 
+1 106 ASN n 
+1 107 ASP n 
+1 108 PRO n 
+1 109 ASN n 
+1 110 ILE n 
+1 111 TYR n 
+1 112 LYS n 
+1 113 GLU n 
+1 114 GLU n 
+1 115 ALA n 
+1 116 LYS n 
+1 117 ASP n 
+1 118 PHE n 
+1 119 PHE n 
+1 120 ASP n 
+1 121 GLU n 
+1 122 MET n 
+1 123 SER n 
+1 124 GLU n 
+1 125 LEU n 
+1 126 TYR n 
+1 127 GLY n 
+1 128 ASP n 
+1 129 TYR n 
+1 130 PRO n 
+1 131 ASN n 
+1 132 VAL n 
+1 133 ILE n 
+1 134 TYR n 
+1 135 GLU n 
+1 136 ILE n 
+1 137 ALA n 
+1 138 ASN n 
+1 139 GLU n 
+1 140 PRO n 
+1 141 ASN n 
+1 142 GLY n 
+1 143 SER n 
+1 144 ASP n 
+1 145 VAL n 
+1 146 THR n 
+1 147 TRP n 
+1 148 GLY n 
+1 149 ASN n 
+1 150 GLN n 
+1 151 ILE n 
+1 152 LYS n 
+1 153 PRO n 
+1 154 TYR n 
+1 155 ALA n 
+1 156 GLU n 
+1 157 GLU n 
+1 158 VAL n 
+1 159 ILE n 
+1 160 PRO n 
+1 161 ILE n 
+1 162 ILE n 
+1 163 ARG n 
+1 164 ASN n 
+1 165 ASN n 
+1 166 ASP n 
+1 167 PRO n 
+1 168 ASN n 
+1 169 ASN n 
+1 170 ILE n 
+1 171 ILE n 
+1 172 ILE n 
+1 173 VAL n 
+1 174 GLY n 
+1 175 THR n 
+1 176 GLY n 
+1 177 THR n 
+1 178 TRP n 
+1 179 SER n 
+1 180 GLN n 
+1 181 ASP n 
+1 182 VAL n 
+1 183 HIS n 
+1 184 HIS n 
+1 185 ALA n 
+1 186 ALA n 
+1 187 ASP n 
+1 188 ASN n 
+1 189 GLN n 
+1 190 LEU n 
+1 191 ALA n 
+1 192 ASP n 
+1 193 PRO n 
+1 194 ASN n 
+1 195 VAL n 
+1 196 MET n 
+1 197 TYR n 
+1 198 ALA n 
+1 199 PHE n 
+1 200 HIS n 
+1 201 PHE n 
+1 202 TYR n 
+1 203 ALA n 
+1 204 GLY n 
+1 205 THR n 
+1 206 HIS n 
+1 207 GLY n 
+1 208 GLN n 
+1 209 ASN n 
+1 210 LEU n 
+1 211 ARG n 
+1 212 ASP n 
+1 213 GLN n 
+1 214 VAL n 
+1 215 ASP n 
+1 216 TYR n 
+1 217 ALA n 
+1 218 LEU n 
+1 219 ASP n 
+1 220 GLN n 
+1 221 GLY n 
+1 222 ALA n 
+1 223 ALA n 
+1 224 ILE n 
+1 225 PHE n 
+1 226 VAL n 
+1 227 SER n 
+1 228 GLU n 
+1 229 TRP n 
+1 230 GLY n 
+1 231 THR n 
+1 232 SER n 
+1 233 ALA n 
+1 234 ALA n 
+1 235 THR n 
+1 236 GLY n 
+1 237 ASP n 
+1 238 GLY n 
+1 239 GLY n 
+1 240 VAL n 
+1 241 PHE n 
+1 242 LEU n 
+1 243 ASP n 
+1 244 GLU n 
+1 245 ALA n 
+1 246 GLN n 
+1 247 VAL n 
+1 248 TRP n 
+1 249 ILE n 
+1 250 ASP n 
+1 251 PHE n 
+1 252 MET n 
+1 253 ASP n 
+1 254 GLU n 
+1 255 ARG n 
+1 256 ASN n 
+1 257 LEU n 
+1 258 SER n 
+1 259 TRP n 
+1 260 ALA n 
+1 261 ASN n 
+1 262 TRP n 
+1 263 SER n 
+1 264 LEU n 
+1 265 THR n 
+1 266 HIS n 
+1 267 LYS n 
+1 268 ASP n 
+1 269 GLU n 
+1 270 SER n 
+1 271 SER n 
+1 272 ALA n 
+1 273 ALA n 
+1 274 LEU n 
+1 275 MET n 
+1 276 PRO n 
+1 277 GLY n 
+1 278 ALA n 
+1 279 ASN n 
+1 280 PRO n 
+1 281 THR n 
+1 282 GLY n 
+1 283 GLY n 
+1 284 TRP n 
+1 285 THR n 
+1 286 GLU n 
+1 287 ALA n 
+1 288 GLU n 
+1 289 LEU n 
+1 290 SER n 
+1 291 PRO n 
+1 292 SER n 
+1 293 GLY n 
+1 294 THR n 
+1 295 PHE n 
+1 296 VAL n 
+1 297 ARG n 
+1 298 GLU n 
+1 299 LYS n 
+1 300 ILE n 
+1 301 ARG n 
+1 302 GLU n 
+1 303 SER n 
+# 
+_entity_src_gen.entity_id                          1 
+_entity_src_gen.pdbx_src_id                        1 
+_entity_src_gen.pdbx_alt_source_flag               sample 
+_entity_src_gen.pdbx_seq_type                      ? 
+_entity_src_gen.pdbx_beg_seq_num                   ? 
+_entity_src_gen.pdbx_end_seq_num                   ? 
+_entity_src_gen.gene_src_common_name               ? 
+_entity_src_gen.gene_src_genus                     Bacillus 
+_entity_src_gen.pdbx_gene_src_gene                 ? 
+_entity_src_gen.gene_src_species                   ? 
+_entity_src_gen.gene_src_strain                    'AC13 (NCIMB 40482)' 
+_entity_src_gen.gene_src_tissue                    ? 
+_entity_src_gen.gene_src_tissue_fraction           ? 
+_entity_src_gen.gene_src_details                   ? 
+_entity_src_gen.pdbx_gene_src_fragment             ? 
+_entity_src_gen.pdbx_gene_src_scientific_name      'Bacillus agaradhaerens' 
+_entity_src_gen.pdbx_gene_src_ncbi_taxonomy_id     76935 
+_entity_src_gen.pdbx_gene_src_variant              ? 
+_entity_src_gen.pdbx_gene_src_cell_line            ? 
+_entity_src_gen.pdbx_gene_src_atcc                 ? 
+_entity_src_gen.pdbx_gene_src_organ                ? 
+_entity_src_gen.pdbx_gene_src_organelle            ? 
+_entity_src_gen.pdbx_gene_src_cell                 ? 
+_entity_src_gen.pdbx_gene_src_cellular_location    ? 
+_entity_src_gen.host_org_common_name               ? 
+_entity_src_gen.pdbx_host_org_scientific_name      'Bacillus subtilis' 
+_entity_src_gen.pdbx_host_org_ncbi_taxonomy_id     1423 
+_entity_src_gen.host_org_genus                     Bacillus 
+_entity_src_gen.pdbx_host_org_gene                 ? 
+_entity_src_gen.pdbx_host_org_organ                ? 
+_entity_src_gen.host_org_species                   ? 
+_entity_src_gen.pdbx_host_org_tissue               ? 
+_entity_src_gen.pdbx_host_org_tissue_fraction      ? 
+_entity_src_gen.pdbx_host_org_strain               PL2306 
+_entity_src_gen.pdbx_host_org_variant              ? 
+_entity_src_gen.pdbx_host_org_cell_line            ? 
+_entity_src_gen.pdbx_host_org_atcc                 ? 
+_entity_src_gen.pdbx_host_org_culture_collection   ? 
+_entity_src_gen.pdbx_host_org_cell                 ? 
+_entity_src_gen.pdbx_host_org_organelle            ? 
+_entity_src_gen.pdbx_host_org_cellular_location    ? 
+_entity_src_gen.pdbx_host_org_vector_type          'BACILLUS, CELLULASE NEGATIVE STRAIN' 
+_entity_src_gen.pdbx_host_org_vector               PMOL995 
+_entity_src_gen.host_org_details                   ? 
+_entity_src_gen.expression_system_id               ? 
+_entity_src_gen.plasmid_name                       'THERMAMYL-AMYLASE PROMOTER SYSTEM' 
+_entity_src_gen.plasmid_details                    ? 
+_entity_src_gen.pdbx_description                   ? 
+# 
+_struct_ref.id                         1 
+_struct_ref.db_name                    UNP 
+_struct_ref.db_code                    GUN5_BACAG 
+_struct_ref.entity_id                  1 
+_struct_ref.pdbx_db_accession          O85465 
+_struct_ref.pdbx_align_begin           1 
+_struct_ref.pdbx_seq_one_letter_code   
+;MKKITTIFVVLLMTVALFSIGNTTAADNDSVVEEHGQLSISNGELVNERGEQVQLKGMSSHGLQWYGQFVNYESMKWLRD
+DWGINVFRAAMYTSSGGYIDDPSVKEKVKEAVEAAIDLDIYVIIDWHILSDNDPNIYKEEAKDFFDEMSELYGDYPNVIY
+EIANEPNGSDVTWGNQIKPYAEEVIPIIRNNDPNNIIIVGTGTWSQDVHHAADNQLADPNVMYAFHFYAGTHGQNLRDQV
+DYALDQGAAIFVSEWGTSAATGDGGVFLDEAQVWIDFMDERNLSWANWSLTHKDESSAALMPGANPTGGWTEAELSPSGT
+FVREKIRESASIPPSDPTPPSDPGEPDPTPPSDPGEYPAWDPNQIYTNEIVYHNGQLWQAKWWTQNQEPGDPYGPWEPLN
+
+;
+_struct_ref.pdbx_db_isoform            ? 
+# 
+_struct_ref_seq.align_id                      1 
+_struct_ref_seq.ref_id                        1 
+_struct_ref_seq.pdbx_PDB_id_code              5A3H 
+_struct_ref_seq.pdbx_strand_id                A 
+_struct_ref_seq.seq_align_beg                 1 
+_struct_ref_seq.pdbx_seq_align_beg_ins_code   ? 
+_struct_ref_seq.seq_align_end                 303 
+_struct_ref_seq.pdbx_seq_align_end_ins_code   ? 
+_struct_ref_seq.pdbx_db_accession             O85465 
+_struct_ref_seq.db_align_beg                  27 
+_struct_ref_seq.pdbx_db_align_beg_ins_code    ? 
+_struct_ref_seq.db_align_end                  329 
+_struct_ref_seq.pdbx_db_align_end_ins_code    ? 
+_struct_ref_seq.pdbx_auth_seq_align_beg       1 
+_struct_ref_seq.pdbx_auth_seq_align_end       303 
+# 
+loop_
+_chem_comp.id 
+_chem_comp.type 
+_chem_comp.mon_nstd_flag 
+_chem_comp.name 
+_chem_comp.pdbx_synonyms 
+_chem_comp.formula 
+_chem_comp.formula_weight 
+ALA 'L-peptide linking'           y ALANINE                                ? 'C3 H7 N O2'     89.093  
+ARG 'L-peptide linking'           y ARGININE                               ? 'C6 H15 N4 O2 1' 175.209 
+ASN 'L-peptide linking'           y ASPARAGINE                             ? 'C4 H8 N2 O3'    132.118 
+ASP 'L-peptide linking'           y 'ASPARTIC ACID'                        ? 'C4 H7 N O4'     133.103 
+BGC 'D-saccharide, beta linking'  . beta-D-glucopyranose                   'beta-D-glucose; D-glucose; glucose' 'C6 H12 O6'      
+180.156 
+G2F 'D-saccharide, alpha linking' . 2-deoxy-2-fluoro-alpha-D-glucopyranose 
+'2-deoxy-2-fluoro-alpha-D-glucose; 2-deoxy-2-fluoro-D-glucose; 2-deoxy-2-fluoro-glucose' 'C6 H11 F O5'    182.147 
+GLN 'L-peptide linking'           y GLUTAMINE                              ? 'C5 H10 N2 O3'   146.144 
+GLU 'L-peptide linking'           y 'GLUTAMIC ACID'                        ? 'C5 H9 N O4'     147.129 
+GLY 'peptide linking'             y GLYCINE                                ? 'C2 H5 N O2'     75.067  
+HIS 'L-peptide linking'           y HISTIDINE                              ? 'C6 H10 N3 O2 1' 156.162 
+HOH non-polymer                   . WATER                                  ? 'H2 O'           18.015  
+ILE 'L-peptide linking'           y ISOLEUCINE                             ? 'C6 H13 N O2'    131.173 
+LEU 'L-peptide linking'           y LEUCINE                                ? 'C6 H13 N O2'    131.173 
+LYS 'L-peptide linking'           y LYSINE                                 ? 'C6 H15 N2 O2 1' 147.195 
+MET 'L-peptide linking'           y METHIONINE                             ? 'C5 H11 N O2 S'  149.211 
+PHE 'L-peptide linking'           y PHENYLALANINE                          ? 'C9 H11 N O2'    165.189 
+PRO 'L-peptide linking'           y PROLINE                                ? 'C5 H9 N O2'     115.130 
+SER 'L-peptide linking'           y SERINE                                 ? 'C3 H7 N O3'     105.093 
+THR 'L-peptide linking'           y THREONINE                              ? 'C4 H9 N O3'     119.119 
+TRP 'L-peptide linking'           y TRYPTOPHAN                             ? 'C11 H12 N2 O2'  204.225 
+TYR 'L-peptide linking'           y TYROSINE                               ? 'C9 H11 N O3'    181.189 
+VAL 'L-peptide linking'           y VALINE                                 ? 'C5 H11 N O2'    117.146 
+# 
+_exptl.entry_id          5A3H 
+_exptl.method            'X-RAY DIFFRACTION' 
+_exptl.crystals_number   1 
+# 
+_exptl_crystal.id                    1 
+_exptl_crystal.density_meas          ? 
+_exptl_crystal.density_Matthews      1.95 
+_exptl_crystal.density_percent_sol   36.4 
+_exptl_crystal.description           ? 
+# 
+_exptl_crystal_grow.crystal_id      1 
+_exptl_crystal_grow.method          ? 
+_exptl_crystal_grow.temp            ? 
+_exptl_crystal_grow.temp_details    ? 
+_exptl_crystal_grow.pH              5.5 
+_exptl_crystal_grow.pdbx_pH_range   ? 
+_exptl_crystal_grow.pdbx_details    'pH 5.5' 
+# 
+_diffrn.id                     1 
+_diffrn.ambient_temp           100 
+_diffrn.ambient_temp_details   ? 
+_diffrn.crystal_id             1 
+# 
+_diffrn_detector.diffrn_id              1 
+_diffrn_detector.detector               'IMAGE PLATE' 
+_diffrn_detector.type                   MARRESEARCH 
+_diffrn_detector.pdbx_collection_date   1997-05 
+_diffrn_detector.details                'YALE/MSC MIRRORS' 
+# 
+_diffrn_radiation.diffrn_id                        1 
+_diffrn_radiation.wavelength_id                    1 
+_diffrn_radiation.pdbx_monochromatic_or_laue_m_l   M 
+_diffrn_radiation.monochromator                    ? 
+_diffrn_radiation.pdbx_diffrn_protocol             ? 
+_diffrn_radiation.pdbx_scattering_type             x-ray 
+# 
+_diffrn_radiation_wavelength.id           1 
+_diffrn_radiation_wavelength.wavelength   1.5418 
+_diffrn_radiation_wavelength.wt           1.0 
+# 
+_diffrn_source.diffrn_id                   1 
+_diffrn_source.source                      'ROTATING ANODE' 
+_diffrn_source.type                        'RIGAKU RUH2R' 
+_diffrn_source.pdbx_synchrotron_site       ? 
+_diffrn_source.pdbx_synchrotron_beamline   ? 
+_diffrn_source.pdbx_wavelength             1.5418 
+_diffrn_source.pdbx_wavelength_list        ? 
+# 
+_reflns.entry_id                     5A3H 
+_reflns.observed_criterion_sigma_I   0 
+_reflns.observed_criterion_sigma_F   ? 
+_reflns.d_resolution_low             15 
+_reflns.d_resolution_high            1.82 
+_reflns.number_obs                   27156 
+_reflns.number_all                   ? 
+_reflns.percent_possible_obs         99.7 
+_reflns.pdbx_Rmerge_I_obs            0.0610000 
+_reflns.pdbx_Rsym_value              0.0610000 
+_reflns.pdbx_netI_over_sigmaI        16.5 
+_reflns.B_iso_Wilson_estimate        14.24 
+_reflns.pdbx_redundancy              4.2 
+_reflns.pdbx_diffrn_id               1 
+_reflns.pdbx_ordinal                 1 
+# 
+_reflns_shell.d_res_high             1.82 
+_reflns_shell.d_res_low              1.88 
+_reflns_shell.percent_possible_all   99.2 
+_reflns_shell.Rmerge_I_obs           0.2600000 
+_reflns_shell.pdbx_Rsym_value        0.2600000 
+_reflns_shell.meanI_over_sigI_obs    4.6 
+_reflns_shell.pdbx_redundancy        4.3 
+_reflns_shell.pdbx_diffrn_id         ? 
+_reflns_shell.pdbx_ordinal           1 
+# 
+_refine.entry_id                                 5A3H 
+_refine.ls_number_reflns_obs                     27131 
+_refine.ls_number_reflns_all                     ? 
+_refine.pdbx_ls_sigma_I                          ? 
+_refine.pdbx_ls_sigma_F                          0.0 
+_refine.pdbx_data_cutoff_high_absF               ? 
+_refine.pdbx_data_cutoff_low_absF                ? 
+_refine.pdbx_data_cutoff_high_rms_absF           ? 
+_refine.ls_d_res_low                             15 
+_refine.ls_d_res_high                            1.82 
+_refine.ls_percent_reflns_obs                    99.6 
+_refine.ls_R_factor_obs                          ? 
+_refine.ls_R_factor_all                          ? 
+_refine.ls_R_factor_R_work                       0.1440000 
+_refine.ls_R_factor_R_free                       0.1860000 
+_refine.ls_R_factor_R_free_error                 ? 
+_refine.ls_R_factor_R_free_error_details         ? 
+_refine.ls_percent_reflns_R_free                 5 
+_refine.ls_number_reflns_R_free                  1407 
+_refine.ls_number_parameters                     ? 
+_refine.ls_number_restraints                     ? 
+_refine.occupancy_min                            ? 
+_refine.occupancy_max                            ? 
+_refine.B_iso_mean                               13.5 
+_refine.aniso_B[1][1]                            ? 
+_refine.aniso_B[2][2]                            ? 
+_refine.aniso_B[3][3]                            ? 
+_refine.aniso_B[1][2]                            ? 
+_refine.aniso_B[1][3]                            ? 
+_refine.aniso_B[2][3]                            ? 
+_refine.solvent_model_details                    ? 
+_refine.solvent_model_param_ksol                 ? 
+_refine.solvent_model_param_bsol                 ? 
+_refine.pdbx_ls_cross_valid_method               THROUGHOUT 
+_refine.details                                  ? 
+_refine.pdbx_starting_model                      'PDB ENTRY 1A3H' 
+_refine.pdbx_method_to_determine_struct          'MOLECULAR REPLACEMENT' 
+_refine.pdbx_isotropic_thermal_model             ? 
+_refine.pdbx_stereochemistry_target_values       ? 
+_refine.pdbx_stereochem_target_val_spec_case     ? 
+_refine.pdbx_R_Free_selection_details            RANDOM 
+_refine.pdbx_overall_ESU_R                       ? 
+_refine.pdbx_overall_ESU_R_Free                  ? 
+_refine.overall_SU_ML                            ? 
+_refine.overall_SU_B                             ? 
+_refine.pdbx_refine_id                           'X-RAY DIFFRACTION' 
+_refine.pdbx_diffrn_id                           1 
+_refine.pdbx_TLS_residual_ADP_flag               ? 
+_refine.correlation_coeff_Fo_to_Fc               ? 
+_refine.correlation_coeff_Fo_to_Fc_free          ? 
+_refine.pdbx_solvent_vdw_probe_radii             ? 
+_refine.pdbx_solvent_ion_probe_radii             ? 
+_refine.pdbx_solvent_shrinkage_radii             ? 
+_refine.pdbx_overall_phase_error                 ? 
+_refine.overall_SU_R_Cruickshank_DPI             ? 
+_refine.pdbx_overall_SU_R_free_Cruickshank_DPI   ? 
+_refine.pdbx_overall_SU_R_Blow_DPI               ? 
+_refine.pdbx_overall_SU_R_free_Blow_DPI          ? 
+# 
+_refine_hist.pdbx_refine_id                   'X-RAY DIFFRACTION' 
+_refine_hist.cycle_id                         LAST 
+_refine_hist.pdbx_number_atoms_protein        2394 
+_refine_hist.pdbx_number_atoms_nucleic_acid   0 
+_refine_hist.pdbx_number_atoms_ligand         23 
+_refine_hist.number_atoms_solvent             348 
+_refine_hist.number_atoms_total               2765 
+_refine_hist.d_res_high                       1.82 
+_refine_hist.d_res_low                        15 
+# 
+loop_
+_refine_ls_restr.type 
+_refine_ls_restr.dev_ideal 
+_refine_ls_restr.dev_ideal_target 
+_refine_ls_restr.weight 
+_refine_ls_restr.number 
+_refine_ls_restr.pdbx_refine_id 
+_refine_ls_restr.pdbx_restraint_function 
+p_bond_d            0.012 0.020  ? ? 'X-RAY DIFFRACTION' ? 
+p_angle_d           0.026 0.040  ? ? 'X-RAY DIFFRACTION' ? 
+p_angle_deg         ?     ?      ? ? 'X-RAY DIFFRACTION' ? 
+p_planar_d          0.030 0.050  ? ? 'X-RAY DIFFRACTION' ? 
+p_hb_or_metal_coord ?     ?      ? ? 'X-RAY DIFFRACTION' ? 
+p_mcbond_it         2.0   3.0    ? ? 'X-RAY DIFFRACTION' ? 
+p_mcangle_it        2.5   5.0    ? ? 'X-RAY DIFFRACTION' ? 
+p_scbond_it         3.7   4.0    ? ? 'X-RAY DIFFRACTION' ? 
+p_scangle_it        5.1   6.0    ? ? 'X-RAY DIFFRACTION' ? 
+p_plane_restr       0.02  0.0125 ? ? 'X-RAY DIFFRACTION' ? 
+p_chiral_restr      0.115 0.150  ? ? 'X-RAY DIFFRACTION' ? 
+p_singtor_nbd       0.174 0.30   ? ? 'X-RAY DIFFRACTION' ? 
+p_multtor_nbd       0.243 0.3    ? ? 'X-RAY DIFFRACTION' ? 
+p_xhyhbond_nbd      ?     ?      ? ? 'X-RAY DIFFRACTION' ? 
+p_xyhbond_nbd       0.166 0.3    ? ? 'X-RAY DIFFRACTION' ? 
+p_planar_tor        4.3   7.0    ? ? 'X-RAY DIFFRACTION' ? 
+p_staggered_tor     12.4  15.0   ? ? 'X-RAY DIFFRACTION' ? 
+p_orthonormal_tor   ?     ?      ? ? 'X-RAY DIFFRACTION' ? 
+p_transverse_tor    28.4  20.0   ? ? 'X-RAY DIFFRACTION' ? 
+p_special_tor       ?     ?      ? ? 'X-RAY DIFFRACTION' ? 
+# 
+_struct.entry_id                  5A3H 
+_struct.title                     
+;2-DEOXY-2-FLURO-B-D-CELLOBIOSYL/ENZYME INTERMEDIATE COMPLEX OF THE ENDOGLUCANASE CEL5A FROM BACILLUS AGARADHEARANS AT 1.8 ANGSTROMS RESOLUTION
+;
+_struct.pdbx_model_details        ? 
+_struct.pdbx_CASP_flag            ? 
+_struct.pdbx_model_type_details   ? 
+# 
+_struct_keywords.entry_id        5A3H 
+_struct_keywords.pdbx_keywords   HYDROLASE 
+_struct_keywords.text            
+'HYDROLASE, CELLULOSE DEGRADATION, ENDOGLUCANASE, GLYCOSIDE HYDROLASE FAMILY 5, MICHAELIS COMPLEX, SKEW-BOAT, DISTORTION' 
+# 
+loop_
+_struct_asym.id 
+_struct_asym.pdbx_blank_PDB_chainid_flag 
+_struct_asym.pdbx_modified 
+_struct_asym.entity_id 
+_struct_asym.details 
+A N N 1 ? 
+B N N 2 ? 
+C N N 3 ? 
+# 
+_struct_biol.id   1 
+# 
+loop_
+_struct_conf.conf_type_id 
+_struct_conf.id 
+_struct_conf.pdbx_PDB_helix_id 
+_struct_conf.beg_label_comp_id 
+_struct_conf.beg_label_asym_id 
+_struct_conf.beg_label_seq_id 
+_struct_conf.pdbx_beg_PDB_ins_code 
+_struct_conf.end_label_comp_id 
+_struct_conf.end_label_asym_id 
+_struct_conf.end_label_seq_id 
+_struct_conf.pdbx_end_PDB_ins_code 
+_struct_conf.beg_auth_comp_id 
+_struct_conf.beg_auth_asym_id 
+_struct_conf.beg_auth_seq_id 
+_struct_conf.end_auth_comp_id 
+_struct_conf.end_auth_asym_id 
+_struct_conf.end_auth_seq_id 
+_struct_conf.pdbx_PDB_helix_class 
+_struct_conf.details 
+_struct_conf.pdbx_PDB_helix_length 
+HELX_P HELX_P1  1  VAL A 5   ? HIS A 9   ? VAL A 5   HIS A 9   1 ? 5  
+HELX_P HELX_P2  2  LEU A 37  ? PHE A 43  ? LEU A 37  PHE A 43  1 ? 7  
+HELX_P HELX_P3  3  TYR A 46  ? ASP A 55  ? TYR A 46  ASP A 55  1 ? 10 
+HELX_P HELX_P4  4  PRO A 76  ? LEU A 92  ? PRO A 76  LEU A 92  5 ? 17 
+HELX_P HELX_P5  5  LYS A 112 ? TYR A 126 ? LYS A 112 TYR A 126 1 ? 15 
+HELX_P HELX_P6  6  ILE A 151 ? ARG A 163 ? ILE A 151 ARG A 163 1 ? 13 
+HELX_P HELX_P7  7  GLY A 176 ? SER A 179 ? GLY A 176 SER A 179 1 ? 4  
+HELX_P HELX_P8  8  VAL A 182 ? ALA A 186 ? VAL A 182 ALA A 186 1 ? 5  
+HELX_P HELX_P9  9  GLN A 208 ? GLN A 220 ? GLN A 208 GLN A 220 1 ? 13 
+HELX_P HELX_P10 10 LEU A 242 ? GLU A 254 ? LEU A 242 GLU A 254 1 ? 13 
+HELX_P HELX_P11 11 GLU A 286 ? GLU A 288 ? GLU A 286 GLU A 288 5 ? 3  
+HELX_P HELX_P12 12 PRO A 291 ? ARG A 301 ? PRO A 291 ARG A 301 1 ? 11 
+# 
+_struct_conf_type.id          HELX_P 
+_struct_conf_type.criteria    ? 
+_struct_conf_type.reference   ? 
+# 
+loop_
+_struct_conn.id 
+_struct_conn.conn_type_id 
+_struct_conn.pdbx_leaving_atom_flag 
+_struct_conn.pdbx_PDB_id 
+_struct_conn.ptnr1_label_asym_id 
+_struct_conn.ptnr1_label_comp_id 
+_struct_conn.ptnr1_label_seq_id 
+_struct_conn.ptnr1_label_atom_id 
+_struct_conn.pdbx_ptnr1_label_alt_id 
+_struct_conn.pdbx_ptnr1_PDB_ins_code 
+_struct_conn.pdbx_ptnr1_standard_comp_id 
+_struct_conn.ptnr1_symmetry 
+_struct_conn.ptnr2_label_asym_id 
+_struct_conn.ptnr2_label_comp_id 
+_struct_conn.ptnr2_label_seq_id 
+_struct_conn.ptnr2_label_atom_id 
+_struct_conn.pdbx_ptnr2_label_alt_id 
+_struct_conn.pdbx_ptnr2_PDB_ins_code 
+_struct_conn.ptnr1_auth_asym_id 
+_struct_conn.ptnr1_auth_comp_id 
+_struct_conn.ptnr1_auth_seq_id 
+_struct_conn.ptnr2_auth_asym_id 
+_struct_conn.ptnr2_auth_comp_id 
+_struct_conn.ptnr2_auth_seq_id 
+_struct_conn.ptnr2_symmetry 
+_struct_conn.pdbx_ptnr3_label_atom_id 
+_struct_conn.pdbx_ptnr3_label_seq_id 
+_struct_conn.pdbx_ptnr3_label_comp_id 
+_struct_conn.pdbx_ptnr3_label_asym_id 
+_struct_conn.pdbx_ptnr3_label_alt_id 
+_struct_conn.pdbx_ptnr3_PDB_ins_code 
+_struct_conn.details 
+_struct_conn.pdbx_dist_value 
+_struct_conn.pdbx_value_order 
+_struct_conn.pdbx_role 
+covale1 covale one  ? A GLU 228 OE2 ? ? ? 1_555 B G2F . C1 ? ? A GLU 228 B G2F 1 1_555 ? ? ? ? ? ? ? 1.452 ?    ? 
+covale2 covale both ? B G2F .   O4  ? ? ? 1_555 B BGC . C1 ? ? B G2F 1   B BGC 2 1_555 ? ? ? ? ? ? ? 1.441 sing ? 
+# 
+_struct_conn_type.id          covale 
+_struct_conn_type.criteria    ? 
+_struct_conn_type.reference   ? 
+# 
+_struct_mon_prot_cis.pdbx_id                1 
+_struct_mon_prot_cis.label_comp_id          TRP 
+_struct_mon_prot_cis.label_seq_id           262 
+_struct_mon_prot_cis.label_asym_id          A 
+_struct_mon_prot_cis.label_alt_id           . 
+_struct_mon_prot_cis.pdbx_PDB_ins_code      ? 
+_struct_mon_prot_cis.auth_comp_id           TRP 
+_struct_mon_prot_cis.auth_seq_id            262 
+_struct_mon_prot_cis.auth_asym_id           A 
+_struct_mon_prot_cis.pdbx_label_comp_id_2   SER 
+_struct_mon_prot_cis.pdbx_label_seq_id_2    263 
+_struct_mon_prot_cis.pdbx_label_asym_id_2   A 
+_struct_mon_prot_cis.pdbx_PDB_ins_code_2    ? 
+_struct_mon_prot_cis.pdbx_auth_comp_id_2    SER 
+_struct_mon_prot_cis.pdbx_auth_seq_id_2     263 
+_struct_mon_prot_cis.pdbx_auth_asym_id_2    A 
+_struct_mon_prot_cis.pdbx_PDB_model_num     1 
+_struct_mon_prot_cis.pdbx_omega_angle       0.70 
+# 
+loop_
+_struct_sheet.id 
+_struct_sheet.type 
+_struct_sheet.number_strands 
+_struct_sheet.details 
+A ? 2 ? 
+B ? 5 ? 
+C ? 2 ? 
+D ? 2 ? 
+# 
+loop_
+_struct_sheet_order.sheet_id 
+_struct_sheet_order.range_id_1 
+_struct_sheet_order.range_id_2 
+_struct_sheet_order.offset 
+_struct_sheet_order.sense 
+A 1 2 ? anti-parallel 
+B 1 2 ? parallel      
+B 2 3 ? parallel      
+B 3 4 ? parallel      
+B 4 5 ? parallel      
+C 1 2 ? parallel      
+D 1 2 ? parallel      
+# 
+loop_
+_struct_sheet_range.sheet_id 
+_struct_sheet_range.id 
+_struct_sheet_range.beg_label_comp_id 
+_struct_sheet_range.beg_label_asym_id 
+_struct_sheet_range.beg_label_seq_id 
+_struct_sheet_range.pdbx_beg_PDB_ins_code 
+_struct_sheet_range.end_label_comp_id 
+_struct_sheet_range.end_label_asym_id 
+_struct_sheet_range.end_label_seq_id 
+_struct_sheet_range.pdbx_end_PDB_ins_code 
+_struct_sheet_range.beg_auth_comp_id 
+_struct_sheet_range.beg_auth_asym_id 
+_struct_sheet_range.beg_auth_seq_id 
+_struct_sheet_range.end_auth_comp_id 
+_struct_sheet_range.end_auth_asym_id 
+_struct_sheet_range.end_auth_seq_id 
+A 1 SER A 13  ? SER A 15  ? SER A 13  SER A 15  
+A 2 GLU A 18  ? VAL A 20  ? GLU A 18  VAL A 20  
+B 1 TRP A 259 ? ASN A 261 ? TRP A 259 ASN A 261 
+B 2 LYS A 30  ? SER A 33  ? LYS A 30  SER A 33  
+B 3 VAL A 60  ? TYR A 66  ? VAL A 60  TYR A 66  
+B 4 TYR A 95  ? HIS A 101 ? TYR A 95  HIS A 101 
+B 5 VAL A 132 ? GLU A 135 ? VAL A 132 GLU A 135 
+C 1 ILE A 171 ? VAL A 173 ? ILE A 171 VAL A 173 
+C 2 VAL A 195 ? TYR A 197 ? VAL A 195 TYR A 197 
+D 1 HIS A 200 ? TYR A 202 ? HIS A 200 TYR A 202 
+D 2 GLU A 228 ? GLY A 230 ? GLU A 228 GLY A 230 
+# 
+loop_
+_pdbx_struct_sheet_hbond.sheet_id 
+_pdbx_struct_sheet_hbond.range_id_1 
+_pdbx_struct_sheet_hbond.range_id_2 
+_pdbx_struct_sheet_hbond.range_1_label_atom_id 
+_pdbx_struct_sheet_hbond.range_1_label_comp_id 
+_pdbx_struct_sheet_hbond.range_1_label_asym_id 
+_pdbx_struct_sheet_hbond.range_1_label_seq_id 
+_pdbx_struct_sheet_hbond.range_1_PDB_ins_code 
+_pdbx_struct_sheet_hbond.range_1_auth_atom_id 
+_pdbx_struct_sheet_hbond.range_1_auth_comp_id 
+_pdbx_struct_sheet_hbond.range_1_auth_asym_id 
+_pdbx_struct_sheet_hbond.range_1_auth_seq_id 
+_pdbx_struct_sheet_hbond.range_2_label_atom_id 
+_pdbx_struct_sheet_hbond.range_2_label_comp_id 
+_pdbx_struct_sheet_hbond.range_2_label_asym_id 
+_pdbx_struct_sheet_hbond.range_2_label_seq_id 
+_pdbx_struct_sheet_hbond.range_2_PDB_ins_code 
+_pdbx_struct_sheet_hbond.range_2_auth_atom_id 
+_pdbx_struct_sheet_hbond.range_2_auth_comp_id 
+_pdbx_struct_sheet_hbond.range_2_auth_asym_id 
+_pdbx_struct_sheet_hbond.range_2_auth_seq_id 
+A 1 2 O SER A 13  ? O SER A 13  N VAL A 20  ? N VAL A 20  
+B 1 2 O TRP A 259 ? O TRP A 259 N GLY A 31  ? N GLY A 31  
+B 2 3 O MET A 32  ? O MET A 32  N VAL A 60  ? N VAL A 60  
+B 3 4 O PHE A 61  ? O PHE A 61  N TYR A 95  ? N TYR A 95  
+B 4 5 O VAL A 96  ? O VAL A 96  N ILE A 133 ? N ILE A 133 
+C 1 2 O ILE A 171 ? O ILE A 171 N MET A 196 ? N MET A 196 
+D 1 2 O PHE A 201 ? O PHE A 201 N GLU A 228 ? N GLU A 228 
+# 
+loop_
+_struct_site.id 
+_struct_site.pdbx_evidence_code 
+_struct_site.pdbx_auth_asym_id 
+_struct_site.pdbx_auth_comp_id 
+_struct_site.pdbx_auth_seq_id 
+_struct_site.pdbx_auth_ins_code 
+_struct_site.pdbx_num_residues 
+_struct_site.details 
+ACI Unknown ? ? ? ? 1 'CATALYTIC ACID/BASE'   
+NUC Unknown ? ? ? ? 1 'CATALYTIC NUCLEOPHILE' 
+# 
+loop_
+_struct_site_gen.id 
+_struct_site_gen.site_id 
+_struct_site_gen.pdbx_num_res 
+_struct_site_gen.label_comp_id 
+_struct_site_gen.label_asym_id 
+_struct_site_gen.label_seq_id 
+_struct_site_gen.pdbx_auth_ins_code 
+_struct_site_gen.auth_comp_id 
+_struct_site_gen.auth_asym_id 
+_struct_site_gen.auth_seq_id 
+_struct_site_gen.label_atom_id 
+_struct_site_gen.label_alt_id 
+_struct_site_gen.symmetry 
+_struct_site_gen.details 
+1 ACI 1 GLU A 139 ? GLU A 139 . ? 1_555 ? 
+2 NUC 1 GLU A 228 ? GLU A 228 . ? 1_555 ? 
+# 
+_database_PDB_matrix.entry_id          5A3H 
+_database_PDB_matrix.origx[1][1]       1.000000 
+_database_PDB_matrix.origx[1][2]       0.000000 
+_database_PDB_matrix.origx[1][3]       0.000000 
+_database_PDB_matrix.origx[2][1]       0.000000 
+_database_PDB_matrix.origx[2][2]       1.000000 
+_database_PDB_matrix.origx[2][3]       0.000000 
+_database_PDB_matrix.origx[3][1]       0.000000 
+_database_PDB_matrix.origx[3][2]       0.000000 
+_database_PDB_matrix.origx[3][3]       1.000000 
+_database_PDB_matrix.origx_vector[1]   0.00000 
+_database_PDB_matrix.origx_vector[2]   0.00000 
+_database_PDB_matrix.origx_vector[3]   0.00000 
+# 
+_atom_sites.entry_id                    5A3H 
+_atom_sites.fract_transf_matrix[1][1]   0.018278 
+_atom_sites.fract_transf_matrix[1][2]   0.000000 
+_atom_sites.fract_transf_matrix[1][3]   0.000000 
+_atom_sites.fract_transf_matrix[2][1]   0.000000 
+_atom_sites.fract_transf_matrix[2][2]   0.014374 
+_atom_sites.fract_transf_matrix[2][3]   0.000000 
+_atom_sites.fract_transf_matrix[3][1]   0.000000 
+_atom_sites.fract_transf_matrix[3][2]   0.000000 
+_atom_sites.fract_transf_matrix[3][3]   0.012980 
+_atom_sites.fract_transf_vector[1]      0.00000 
+_atom_sites.fract_transf_vector[2]      0.00000 
+_atom_sites.fract_transf_vector[3]      0.00000 
+# 
+loop_
+_atom_type.symbol 
+C 
+F 
+N 
+O 
+S 
+# 
+loop_
+_atom_site.group_PDB 
+_atom_site.id 
+_atom_site.type_symbol 
+_atom_site.label_atom_id 
+_atom_site.label_alt_id 
+_atom_site.label_comp_id 
+_atom_site.label_asym_id 
+_atom_site.label_entity_id 
+_atom_site.label_seq_id 
+_atom_site.pdbx_PDB_ins_code 
+_atom_site.Cartn_x 
+_atom_site.Cartn_y 
+_atom_site.Cartn_z 
+_atom_site.occupancy 
+_atom_site.B_iso_or_equiv 
+_atom_site.pdbx_formal_charge 
+_atom_site.auth_seq_id 
+_atom_site.auth_comp_id 
+_atom_site.auth_asym_id 
+_atom_site.auth_atom_id 
+_atom_site.pdbx_PDB_model_num 
+ATOM   1    N N   . SER A 1 4   ? 72.614 44.008 7.292  1.00 22.33 ? 4    SER A N   1 
+ATOM   2    C CA  . SER A 1 4   ? 73.773 43.117 7.334  1.00 26.14 ? 4    SER A CA  1 
+ATOM   3    C C   . SER A 1 4   ? 73.532 41.883 8.198  1.00 21.03 ? 4    SER A C   1 
+ATOM   4    O O   . SER A 1 4   ? 73.688 40.753 7.733  1.00 17.99 ? 4    SER A O   1 
+ATOM   5    C CB  . SER A 1 4   ? 74.996 43.892 7.812  1.00 31.65 ? 4    SER A CB  1 
+ATOM   6    O OG  . SER A 1 4   ? 74.691 44.910 8.745  1.00 43.97 ? 4    SER A OG  1 
+ATOM   7    N N   . VAL A 1 5   ? 73.159 42.071 9.466  1.00 20.13 ? 5    VAL A N   1 
+ATOM   8    C CA  . VAL A 1 5   ? 72.956 40.923 10.362 1.00 17.11 ? 5    VAL A CA  1 
+ATOM   9    C C   . VAL A 1 5   ? 71.990 39.883 9.868  1.00 13.73 ? 5    VAL A C   1 
+ATOM   10   O O   . VAL A 1 5   ? 72.289 38.675 9.749  1.00 15.30 ? 5    VAL A O   1 
+ATOM   11   C CB  . VAL A 1 5   ? 72.528 41.440 11.766 1.00 17.67 ? 5    VAL A CB  1 
+ATOM   12   C CG1 . VAL A 1 5   ? 71.998 40.329 12.647 1.00 18.24 ? 5    VAL A CG1 1 
+ATOM   13   C CG2 . VAL A 1 5   ? 73.724 42.184 12.380 1.00 22.93 ? 5    VAL A CG2 1 
+ATOM   14   N N   . VAL A 1 6   ? 70.752 40.294 9.587  1.00 13.09 ? 6    VAL A N   1 
+ATOM   15   C CA  . VAL A 1 6   ? 69.680 39.386 9.192  1.00 11.90 ? 6    VAL A CA  1 
+ATOM   16   C C   . VAL A 1 6   ? 69.889 38.867 7.771  1.00 10.07 ? 6    VAL A C   1 
+ATOM   17   O O   . VAL A 1 6   ? 69.646 37.684 7.456  1.00 12.72 ? 6    VAL A O   1 
+ATOM   18   C CB  . VAL A 1 6   ? 68.288 40.010 9.395  1.00 14.33 ? 6    VAL A CB  1 
+ATOM   19   C CG1 . VAL A 1 6   ? 67.209 39.089 8.831  1.00 12.17 ? 6    VAL A CG1 1 
+ATOM   20   C CG2 . VAL A 1 6   ? 68.072 40.184 10.907 1.00 13.32 ? 6    VAL A CG2 1 
+ATOM   21   N N   . GLU A 1 7   ? 70.498 39.712 6.938  1.00 12.53 ? 7    GLU A N   1 
+ATOM   22   C CA  . GLU A 1 7   ? 70.801 39.198 5.591  1.00 13.14 ? 7    GLU A CA  1 
+ATOM   23   C C   . GLU A 1 7   ? 71.835 38.084 5.653  1.00 14.57 ? 7    GLU A C   1 
+ATOM   24   O O   . GLU A 1 7   ? 71.742 37.076 4.944  1.00 14.77 ? 7    GLU A O   1 
+ATOM   25   C CB  . GLU A 1 7   ? 71.299 40.374 4.744  1.00 20.88 ? 7    GLU A CB  1 
+ATOM   26   C CG  . GLU A 1 7   ? 71.458 39.925 3.291  1.00 28.50 ? 7    GLU A CG  1 
+ATOM   27   C CD  . GLU A 1 7   ? 71.754 41.152 2.448  1.00 37.01 ? 7    GLU A CD  1 
+ATOM   28   O OE1 . GLU A 1 7   ? 72.542 42.016 2.895  1.00 45.98 ? 7    GLU A OE1 1 
+ATOM   29   O OE2 . GLU A 1 7   ? 71.163 41.204 1.368  1.00 35.50 ? 7    GLU A OE2 1 
+ATOM   30   N N   . GLU A 1 8   ? 72.832 38.216 6.509  1.00 12.76 ? 8    GLU A N   1 
+ATOM   31   C CA  . GLU A 1 8   ? 73.893 37.239 6.660  1.00 13.78 ? 8    GLU A CA  1 
+ATOM   32   C C   . GLU A 1 8   ? 73.493 35.969 7.368  1.00 12.35 ? 8    GLU A C   1 
+ATOM   33   O O   . GLU A 1 8   ? 73.733 34.857 6.874  1.00 16.63 ? 8    GLU A O   1 
+ATOM   34   C CB  . GLU A 1 8   ? 75.059 37.854 7.465  1.00 19.08 ? 8    GLU A CB  1 
+ATOM   35   C CG  . GLU A 1 8   ? 76.225 36.906 7.672  1.00 32.18 ? 8    GLU A CG  1 
+ATOM   36   C CD  . GLU A 1 8   ? 77.412 37.469 8.423  1.00 41.77 ? 8    GLU A CD  1 
+ATOM   37   O OE1 . GLU A 1 8   ? 77.545 38.715 8.504  1.00 43.06 ? 8    GLU A OE1 1 
+ATOM   38   O OE2 . GLU A 1 8   ? 78.225 36.655 8.927  1.00 44.32 ? 8    GLU A OE2 1 
+ATOM   39   N N   . HIS A 1 9   ? 72.809 36.105 8.502  1.00 11.47 ? 9    HIS A N   1 
+ATOM   40   C CA  . HIS A 1 9   ? 72.439 34.937 9.325  1.00 9.89  ? 9    HIS A CA  1 
+ATOM   41   C C   . HIS A 1 9   ? 71.084 34.368 8.980  1.00 14.15 ? 9    HIS A C   1 
+ATOM   42   O O   . HIS A 1 9   ? 70.856 33.161 9.073  1.00 13.09 ? 9    HIS A O   1 
+ATOM   43   C CB  . HIS A 1 9   ? 72.503 35.338 10.814 1.00 12.99 ? 9    HIS A CB  1 
+ATOM   44   C CG  . HIS A 1 9   ? 73.909 35.648 11.217 1.00 17.52 ? 9    HIS A CG  1 
+ATOM   45   N ND1 . HIS A 1 9   ? 74.908 34.717 11.116 1.00 16.67 ? 9    HIS A ND1 1 
+ATOM   46   C CD2 . HIS A 1 9   ? 74.483 36.781 11.681 1.00 20.03 ? 9    HIS A CD2 1 
+ATOM   47   C CE1 . HIS A 1 9   ? 76.063 35.257 11.519 1.00 21.87 ? 9    HIS A CE1 1 
+ATOM   48   N NE2 . HIS A 1 9   ? 75.825 36.522 11.847 1.00 18.43 ? 9    HIS A NE2 1 
+ATOM   49   N N   . GLY A 1 10  ? 70.186 35.219 8.506  1.00 12.46 ? 10   GLY A N   1 
+ATOM   50   C CA  . GLY A 1 10  ? 68.881 34.820 8.021  1.00 12.32 ? 10   GLY A CA  1 
+ATOM   51   C C   . GLY A 1 10  ? 68.015 34.077 9.005  1.00 11.04 ? 10   GLY A C   1 
+ATOM   52   O O   . GLY A 1 10  ? 67.819 34.483 10.160 1.00 11.94 ? 10   GLY A O   1 
+ATOM   53   N N   . GLN A 1 11  ? 67.518 32.930 8.555  1.00 9.91  ? 11   GLN A N   1 
+ATOM   54   C CA  . GLN A 1 11  ? 66.638 32.082 9.353  1.00 10.51 ? 11   GLN A CA  1 
+ATOM   55   C C   . GLN A 1 11  ? 67.400 31.432 10.498 1.00 12.94 ? 11   GLN A C   1 
+ATOM   56   O O   . GLN A 1 11  ? 68.412 30.744 10.369 1.00 13.76 ? 11   GLN A O   1 
+ATOM   57   C CB  . GLN A 1 11  ? 65.981 31.063 8.392  1.00 13.74 ? 11   GLN A CB  1 
+ATOM   58   C CG  . GLN A 1 11  ? 64.752 30.371 8.930  1.00 13.28 ? 11   GLN A CG  1 
+ATOM   59   C CD  . GLN A 1 11  ? 63.576 31.315 9.112  1.00 10.51 ? 11   GLN A CD  1 
+ATOM   60   O OE1 . GLN A 1 11  ? 63.404 32.219 8.299  1.00 13.52 ? 11   GLN A OE1 1 
+ATOM   61   N NE2 . GLN A 1 11  ? 62.872 31.156 10.216 1.00 15.16 ? 11   GLN A NE2 1 
+ATOM   62   N N   . LEU A 1 12  ? 66.923 31.696 11.714 1.00 7.28  ? 12   LEU A N   1 
+ATOM   63   C CA  . LEU A 1 12  ? 67.527 31.124 12.907 1.00 9.07  ? 12   LEU A CA  1 
+ATOM   64   C C   . LEU A 1 12  ? 66.772 29.839 13.248 1.00 9.26  ? 12   LEU A C   1 
+ATOM   65   O O   . LEU A 1 12  ? 65.602 29.705 12.902 1.00 13.84 ? 12   LEU A O   1 
+ATOM   66   C CB  . LEU A 1 12  ? 67.491 32.062 14.104 1.00 11.77 ? 12   LEU A CB  1 
+ATOM   67   C CG  . LEU A 1 12  ? 68.111 33.432 13.947 1.00 12.33 ? 12   LEU A CG  1 
+ATOM   68   C CD1 . LEU A 1 12  ? 67.848 34.293 15.190 1.00 14.81 ? 12   LEU A CD1 1 
+ATOM   69   C CD2 . LEU A 1 12  ? 69.587 33.371 13.603 1.00 13.72 ? 12   LEU A CD2 1 
+ATOM   70   N N   . SER A 1 13  ? 67.441 28.951 13.922 1.00 12.57 ? 13   SER A N   1 
+ATOM   71   C CA  . SER A 1 13  ? 66.806 27.708 14.379 1.00 9.79  ? 13   SER A CA  1 
+ATOM   72   C C   . SER A 1 13  ? 67.657 27.173 15.520 1.00 10.75 ? 13   SER A C   1 
+ATOM   73   O O   . SER A 1 13  ? 68.751 27.670 15.780 1.00 9.12  ? 13   SER A O   1 
+ATOM   74   C CB  . SER A 1 13  ? 66.698 26.624 13.289 1.00 15.44 ? 13   SER A CB  1 
+ATOM   75   O OG  . SER A 1 13  ? 68.023 26.342 12.854 1.00 17.25 ? 13   SER A OG  1 
+ATOM   76   N N   . ILE A 1 14  ? 67.137 26.085 16.107 1.00 12.29 ? 14   ILE A N   1 
+ATOM   77   C CA  . ILE A 1 14  ? 67.852 25.405 17.196 1.00 10.37 ? 14   ILE A CA  1 
+ATOM   78   C C   . ILE A 1 14  ? 68.373 24.059 16.681 1.00 12.60 ? 14   ILE A C   1 
+ATOM   79   O O   . ILE A 1 14  ? 67.584 23.300 16.079 1.00 11.29 ? 14   ILE A O   1 
+ATOM   80   C CB  . ILE A 1 14  ? 66.975 25.185 18.433 1.00 11.94 ? 14   ILE A CB  1 
+ATOM   81   C CG1 . ILE A 1 14  ? 66.476 26.510 19.009 1.00 11.37 ? 14   ILE A CG1 1 
+ATOM   82   C CG2 . ILE A 1 14  ? 67.686 24.371 19.504 1.00 13.60 ? 14   ILE A CG2 1 
+ATOM   83   C CD1 . ILE A 1 14  ? 67.474 27.570 19.403 1.00 12.85 ? 14   ILE A CD1 1 
+ATOM   84   N N   . SER A 1 15  ? 69.662 23.880 16.882 1.00 12.46 ? 15   SER A N   1 
+ATOM   85   C CA  . SER A 1 15  ? 70.350 22.645 16.493 1.00 13.73 ? 15   SER A CA  1 
+ATOM   86   C C   . SER A 1 15  ? 71.185 22.124 17.663 1.00 14.34 ? 15   SER A C   1 
+ATOM   87   O O   . SER A 1 15  ? 72.106 22.783 18.163 1.00 16.19 ? 15   SER A O   1 
+ATOM   88   C CB  . SER A 1 15  ? 71.276 22.840 15.285 1.00 17.47 ? 15   SER A CB  1 
+ATOM   89   O OG  . SER A 1 15  ? 71.954 21.602 15.030 1.00 25.01 ? 15   SER A OG  1 
+ATOM   90   N N   . ASN A 1 16  ? 70.800 20.960 18.182 1.00 16.54 ? 16   ASN A N   1 
+ATOM   91   C CA  . ASN A 1 16  ? 71.456 20.359 19.331 1.00 16.10 ? 16   ASN A CA  1 
+ATOM   92   C C   . ASN A 1 16  ? 71.560 21.316 20.515 1.00 16.09 ? 16   ASN A C   1 
+ATOM   93   O O   . ASN A 1 16  ? 72.616 21.506 21.094 1.00 15.44 ? 16   ASN A O   1 
+ATOM   94   C CB  . ASN A 1 16  ? 72.855 19.869 18.917 1.00 24.08 ? 16   ASN A CB  1 
+ATOM   95   C CG  . ASN A 1 16  ? 72.708 18.757 17.883 1.00 37.56 ? 16   ASN A CG  1 
+ATOM   96   O OD1 . ASN A 1 16  ? 73.476 18.702 16.915 1.00 51.17 ? 16   ASN A OD1 1 
+ATOM   97   N ND2 . ASN A 1 16  ? 71.723 17.876 18.016 1.00 40.35 ? 16   ASN A ND2 1 
+ATOM   98   N N   . GLY A 1 17  ? 70.476 22.020 20.840 1.00 15.81 ? 17   GLY A N   1 
+ATOM   99   C CA  . GLY A 1 17  ? 70.373 22.928 21.946 1.00 13.31 ? 17   GLY A CA  1 
+ATOM   100  C C   . GLY A 1 17  ? 71.068 24.266 21.780 1.00 14.17 ? 17   GLY A C   1 
+ATOM   101  O O   . GLY A 1 17  ? 71.140 25.022 22.755 1.00 15.60 ? 17   GLY A O   1 
+ATOM   102  N N   . GLU A 1 18  ? 71.532 24.557 20.570 1.00 11.62 ? 18   GLU A N   1 
+ATOM   103  C CA  . GLU A 1 18  ? 72.185 25.822 20.304 1.00 14.34 ? 18   GLU A CA  1 
+ATOM   104  C C   . GLU A 1 18  ? 71.466 26.650 19.245 1.00 13.98 ? 18   GLU A C   1 
+ATOM   105  O O   . GLU A 1 18  ? 70.942 26.104 18.273 1.00 11.81 ? 18   GLU A O   1 
+ATOM   106  C CB  . GLU A 1 18  ? 73.587 25.566 19.711 1.00 18.84 ? 18   GLU A CB  1 
+ATOM   107  C CG  . GLU A 1 18  ? 74.469 24.706 20.614 1.00 22.51 ? 18   GLU A CG  1 
+ATOM   108  C CD  . GLU A 1 18  ? 74.853 25.438 21.893 1.00 31.45 ? 18   GLU A CD  1 
+ATOM   109  O OE1 . GLU A 1 18  ? 74.877 26.699 21.912 1.00 27.91 ? 18   GLU A OE1 1 
+ATOM   110  O OE2 . GLU A 1 18  ? 75.137 24.744 22.902 1.00 36.04 ? 18   GLU A OE2 1 
+ATOM   111  N N   . LEU A 1 19  ? 71.549 27.963 19.400 1.00 11.84 ? 19   LEU A N   1 
+ATOM   112  C CA  . LEU A 1 19  ? 71.039 28.876 18.389 1.00 7.69  ? 19   LEU A CA  1 
+ATOM   113  C C   . LEU A 1 19  ? 72.008 28.959 17.207 1.00 10.21 ? 19   LEU A C   1 
+ATOM   114  O O   . LEU A 1 19  ? 73.185 29.244 17.421 1.00 12.71 ? 19   LEU A O   1 
+ATOM   115  C CB  . LEU A 1 19  ? 70.880 30.279 18.948 1.00 9.12  ? 19   LEU A CB  1 
+ATOM   116  C CG  . LEU A 1 19  ? 70.223 31.299 18.036 1.00 12.03 ? 19   LEU A CG  1 
+ATOM   117  C CD1 . LEU A 1 19  ? 68.792 30.928 17.690 1.00 14.14 ? 19   LEU A CD1 1 
+ATOM   118  C CD2 . LEU A 1 19  ? 70.227 32.661 18.728 1.00 14.96 ? 19   LEU A CD2 1 
+ATOM   119  N N   . VAL A 1 20  ? 71.505 28.604 16.032 1.00 12.02 ? 20   VAL A N   1 
+ATOM   120  C CA  . VAL A 1 20  ? 72.285 28.637 14.810 1.00 10.19 ? 20   VAL A CA  1 
+ATOM   121  C C   . VAL A 1 20  ? 71.594 29.455 13.696 1.00 13.67 ? 20   VAL A C   1 
+ATOM   122  O O   . VAL A 1 20  ? 70.372 29.622 13.648 1.00 10.54 ? 20   VAL A O   1 
+ATOM   123  C CB  . VAL A 1 20  ? 72.618 27.264 14.234 1.00 11.64 ? 20   VAL A CB  1 
+ATOM   124  C CG1 . VAL A 1 20  ? 73.421 26.413 15.195 1.00 13.08 ? 20   VAL A CG1 1 
+ATOM   125  C CG2 . VAL A 1 20  ? 71.381 26.492 13.807 1.00 13.61 ? 20   VAL A CG2 1 
+ATOM   126  N N   . ASN A 1 21  ? 72.418 29.844 12.715 1.00 11.14 ? 21   ASN A N   1 
+ATOM   127  C CA  . ASN A 1 21  ? 71.918 30.562 11.542 1.00 10.67 ? 21   ASN A CA  1 
+ATOM   128  C C   . ASN A 1 21  ? 71.505 29.550 10.450 1.00 13.03 ? 21   ASN A C   1 
+ATOM   129  O O   . ASN A 1 21  ? 71.565 28.318 10.610 1.00 12.63 ? 21   ASN A O   1 
+ATOM   130  C CB  . ASN A 1 21  ? 72.930 31.574 11.059 1.00 12.48 ? 21   ASN A CB  1 
+ATOM   131  C CG  . ASN A 1 21  ? 74.212 31.044 10.438 1.00 10.86 ? 21   ASN A CG  1 
+ATOM   132  O OD1 . ASN A 1 21  ? 74.302 29.849 10.149 1.00 11.78 ? 21   ASN A OD1 1 
+ATOM   133  N ND2 . ASN A 1 21  ? 75.211 31.899 10.296 1.00 17.09 ? 21   ASN A ND2 1 
+ATOM   134  N N   . GLU A 1 22  ? 71.112 30.038 9.288  1.00 10.76 ? 22   GLU A N   1 
+ATOM   135  C CA  . GLU A 1 22  ? 70.606 29.213 8.191  1.00 11.38 ? 22   GLU A CA  1 
+ATOM   136  C C   . GLU A 1 22  ? 71.668 28.358 7.500  1.00 15.65 ? 22   GLU A C   1 
+ATOM   137  O O   . GLU A 1 22  ? 71.296 27.463 6.721  1.00 12.82 ? 22   GLU A O   1 
+ATOM   138  C CB  . GLU A 1 22  ? 69.857 30.067 7.191  1.00 12.59 ? 22   GLU A CB  1 
+ATOM   139  C CG  . GLU A 1 22  ? 70.669 31.078 6.422  1.00 12.54 ? 22   GLU A CG  1 
+ATOM   140  C CD  . GLU A 1 22  ? 69.780 32.022 5.614  1.00 17.67 ? 22   GLU A CD  1 
+ATOM   141  O OE1 . GLU A 1 22  ? 68.565 32.169 5.814  1.00 16.84 ? 22   GLU A OE1 1 
+ATOM   142  O OE2 . GLU A 1 22  ? 70.376 32.697 4.740  1.00 22.86 ? 22   GLU A OE2 1 
+ATOM   143  N N   . ARG A 1 23  ? 72.914 28.623 7.773  1.00 11.67 ? 23   ARG A N   1 
+ATOM   144  C CA  . ARG A 1 23  ? 74.038 27.818 7.317  1.00 16.02 ? 23   ARG A CA  1 
+ATOM   145  C C   . ARG A 1 23  ? 74.549 26.929 8.434  1.00 19.55 ? 23   ARG A C   1 
+ATOM   146  O O   . ARG A 1 23  ? 75.624 26.355 8.297  1.00 20.77 ? 23   ARG A O   1 
+ATOM   147  C CB  . ARG A 1 23  ? 75.151 28.708 6.753  1.00 16.23 ? 23   ARG A CB  1 
+ATOM   148  C CG  . ARG A 1 23  ? 74.690 29.356 5.463  1.00 23.88 ? 23   ARG A CG  1 
+ATOM   149  C CD  . ARG A 1 23  ? 75.491 30.549 4.991  1.00 26.02 ? 23   ARG A CD  1 
+ATOM   150  N NE  . ARG A 1 23  ? 74.543 31.348 4.123  1.00 26.32 ? 23   ARG A NE  1 
+ATOM   151  C CZ  . ARG A 1 23  ? 74.468 30.975 2.853  1.00 25.84 ? 23   ARG A CZ  1 
+ATOM   152  N NH1 . ARG A 1 23  ? 75.250 29.993 2.450  1.00 29.29 ? 23   ARG A NH1 1 
+ATOM   153  N NH2 . ARG A 1 23  ? 73.665 31.580 1.996  1.00 30.18 ? 23   ARG A NH2 1 
+ATOM   154  N N   . GLY A 1 24  ? 73.814 26.815 9.552  1.00 14.49 ? 24   GLY A N   1 
+ATOM   155  C CA  . GLY A 1 24  ? 74.214 25.972 10.647 1.00 16.31 ? 24   GLY A CA  1 
+ATOM   156  C C   . GLY A 1 24  ? 75.297 26.432 11.588 1.00 19.39 ? 24   GLY A C   1 
+ATOM   157  O O   . GLY A 1 24  ? 75.694 25.649 12.474 1.00 18.14 ? 24   GLY A O   1 
+ATOM   158  N N   . GLU A 1 25  ? 75.764 27.663 11.499 1.00 12.66 ? 25   GLU A N   1 
+ATOM   159  C CA  . GLU A 1 25  ? 76.804 28.158 12.386 1.00 13.42 ? 25   GLU A CA  1 
+ATOM   160  C C   . GLU A 1 25  ? 76.178 28.805 13.636 1.00 12.91 ? 25   GLU A C   1 
+ATOM   161  O O   . GLU A 1 25  ? 75.106 29.395 13.525 1.00 12.99 ? 25   GLU A O   1 
+ATOM   162  C CB  . GLU A 1 25  ? 77.661 29.249 11.746 1.00 22.30 ? 25   GLU A CB  1 
+ATOM   163  C CG  . GLU A 1 25  ? 77.960 28.827 10.299 1.00 34.52 ? 25   GLU A CG  1 
+ATOM   164  C CD  . GLU A 1 25  ? 79.121 29.619 9.760  1.00 47.81 ? 25   GLU A CD  1 
+ATOM   165  O OE1 . GLU A 1 25  ? 79.303 30.814 10.089 1.00 53.17 ? 25   GLU A OE1 1 
+ATOM   166  O OE2 . GLU A 1 25  ? 79.842 28.950 8.988  1.00 55.99 ? 25   GLU A OE2 1 
+ATOM   167  N N   . GLN A 1 26  ? 76.847 28.574 14.747 1.00 15.69 ? 26   GLN A N   1 
+ATOM   168  C CA  . GLN A 1 26  ? 76.357 29.173 16.001 1.00 11.23 ? 26   GLN A CA  1 
+ATOM   169  C C   . GLN A 1 26  ? 76.359 30.672 15.832 1.00 12.94 ? 26   GLN A C   1 
+ATOM   170  O O   . GLN A 1 26  ? 77.274 31.287 15.284 1.00 16.32 ? 26   GLN A O   1 
+ATOM   171  C CB  . GLN A 1 26  ? 77.219 28.774 17.192 1.00 14.93 ? 26   GLN A CB  1 
+ATOM   172  C CG  . GLN A 1 26  ? 77.188 27.283 17.491 1.00 21.35 ? 26   GLN A CG  1 
+ATOM   173  C CD  . GLN A 1 26  ? 77.944 26.963 18.782 1.00 29.51 ? 26   GLN A CD  1 
+ATOM   174  O OE1 . GLN A 1 26  ? 78.627 27.798 19.361 1.00 35.86 ? 26   GLN A OE1 1 
+ATOM   175  N NE2 . GLN A 1 26  ? 77.783 25.738 19.226 1.00 33.29 ? 26   GLN A NE2 1 
+ATOM   176  N N   . VAL A 1 27  ? 75.328 31.307 16.377 1.00 12.29 ? 27   VAL A N   1 
+ATOM   177  C CA  . VAL A 1 27  ? 75.209 32.750 16.375 1.00 11.26 ? 27   VAL A CA  1 
+ATOM   178  C C   . VAL A 1 27  ? 74.784 33.190 17.783 1.00 10.71 ? 27   VAL A C   1 
+ATOM   179  O O   . VAL A 1 27  ? 74.105 32.473 18.514 1.00 14.50 ? 27   VAL A O   1 
+ATOM   180  C CB  A VAL A 1 27  ? 74.248 33.234 15.281 0.66 15.41 ? 27   VAL A CB  1 
+ATOM   181  C CB  B VAL A 1 27  ? 74.176 33.295 15.373 0.34 10.71 ? 27   VAL A CB  1 
+ATOM   182  C CG1 A VAL A 1 27  ? 72.943 32.463 15.355 0.66 18.20 ? 27   VAL A CG1 1 
+ATOM   183  C CG1 B VAL A 1 27  ? 74.520 33.020 13.922 0.34 8.05  ? 27   VAL A CG1 1 
+ATOM   184  C CG2 A VAL A 1 27  ? 73.952 34.727 15.388 0.66 21.95 ? 27   VAL A CG2 1 
+ATOM   185  C CG2 B VAL A 1 27  ? 72.780 32.778 15.704 0.34 8.97  ? 27   VAL A CG2 1 
+ATOM   186  N N   . GLN A 1 28  ? 75.282 34.349 18.184 1.00 9.43  ? 28   GLN A N   1 
+ATOM   187  C CA  . GLN A 1 28  ? 74.960 34.908 19.501 1.00 8.61  ? 28   GLN A CA  1 
+ATOM   188  C C   . GLN A 1 28  ? 74.407 36.312 19.300 1.00 10.72 ? 28   GLN A C   1 
+ATOM   189  O O   . GLN A 1 28  ? 75.070 37.183 18.707 1.00 11.06 ? 28   GLN A O   1 
+ATOM   190  C CB  . GLN A 1 28  ? 76.218 34.925 20.372 1.00 14.06 ? 28   GLN A CB  1 
+ATOM   191  C CG  . GLN A 1 28  ? 76.009 35.356 21.802 1.00 17.30 ? 28   GLN A CG  1 
+ATOM   192  C CD  . GLN A 1 28  ? 77.328 35.395 22.579 1.00 20.56 ? 28   GLN A CD  1 
+ATOM   193  O OE1 . GLN A 1 28  ? 78.409 35.530 22.006 1.00 20.36 ? 28   GLN A OE1 1 
+ATOM   194  N NE2 . GLN A 1 28  ? 77.207 35.342 23.891 1.00 13.04 ? 28   GLN A NE2 1 
+ATOM   195  N N   . LEU A 1 29  ? 73.204 36.521 19.836 1.00 10.97 ? 29   LEU A N   1 
+ATOM   196  C CA  . LEU A 1 29  ? 72.570 37.818 19.747 1.00 10.52 ? 29   LEU A CA  1 
+ATOM   197  C C   . LEU A 1 29  ? 72.788 38.550 21.070 1.00 10.13 ? 29   LEU A C   1 
+ATOM   198  O O   . LEU A 1 29  ? 72.854 37.964 22.141 1.00 10.65 ? 29   LEU A O   1 
+ATOM   199  C CB  . LEU A 1 29  ? 71.085 37.743 19.421 1.00 9.81  ? 29   LEU A CB  1 
+ATOM   200  C CG  . LEU A 1 29  ? 70.677 36.856 18.236 1.00 10.13 ? 29   LEU A CG  1 
+ATOM   201  C CD1 . LEU A 1 29  ? 69.153 36.764 18.165 1.00 11.35 ? 29   LEU A CD1 1 
+ATOM   202  C CD2 . LEU A 1 29  ? 71.312 37.344 16.952 1.00 15.10 ? 29   LEU A CD2 1 
+ATOM   203  N N   . LYS A 1 30  ? 73.078 39.822 20.972 1.00 8.66  ? 30   LYS A N   1 
+ATOM   204  C CA  . LYS A 1 30  ? 73.288 40.715 22.084 1.00 10.20 ? 30   LYS A CA  1 
+ATOM   205  C C   . LYS A 1 30  ? 72.578 42.027 21.751 1.00 12.26 ? 30   LYS A C   1 
+ATOM   206  O O   . LYS A 1 30  ? 72.876 42.696 20.743 1.00 11.06 ? 30   LYS A O   1 
+ATOM   207  C CB  . LYS A 1 30  ? 74.768 40.985 22.416 1.00 11.13 ? 30   LYS A CB  1 
+ATOM   208  C CG  . LYS A 1 30  ? 75.639 39.767 22.602 1.00 12.73 ? 30   LYS A CG  1 
+ATOM   209  C CD  . LYS A 1 30  ? 77.099 40.027 22.936 1.00 11.86 ? 30   LYS A CD  1 
+ATOM   210  C CE  . LYS A 1 30  ? 77.812 38.733 23.242 1.00 20.03 ? 30   LYS A CE  1 
+ATOM   211  N NZ  . LYS A 1 30  ? 79.310 38.871 23.386 1.00 16.43 ? 30   LYS A NZ  1 
+ATOM   212  N N   . GLY A 1 31  ? 71.692 42.429 22.690 1.00 9.99  ? 31   GLY A N   1 
+ATOM   213  C CA  . GLY A 1 31  ? 70.995 43.686 22.449 1.00 9.11  ? 31   GLY A CA  1 
+ATOM   214  C C   . GLY A 1 31  ? 70.390 44.227 23.725 1.00 12.40 ? 31   GLY A C   1 
+ATOM   215  O O   . GLY A 1 31  ? 70.775 43.896 24.849 1.00 10.46 ? 31   GLY A O   1 
+ATOM   216  N N   . MET A 1 32  ? 69.447 45.118 23.489 1.00 9.51  ? 32   MET A N   1 
+ATOM   217  C CA  . MET A 1 32  ? 68.757 45.791 24.583 1.00 8.67  ? 32   MET A CA  1 
+ATOM   218  C C   . MET A 1 32  ? 67.271 45.492 24.559 1.00 7.71  ? 32   MET A C   1 
+ATOM   219  O O   . MET A 1 32  ? 66.685 45.257 23.502 1.00 8.77  ? 32   MET A O   1 
+ATOM   220  C CB  . MET A 1 32  ? 68.863 47.306 24.386 1.00 9.73  ? 32   MET A CB  1 
+ATOM   221  C CG  . MET A 1 32  ? 70.200 47.931 24.787 1.00 13.27 ? 32   MET A CG  1 
+ATOM   222  S SD  . MET A 1 32  ? 70.699 47.576 26.465 1.00 8.57  ? 32   MET A SD  1 
+ATOM   223  C CE  . MET A 1 32  ? 69.505 48.396 27.456 1.00 10.07 ? 32   MET A CE  1 
+ATOM   224  N N   . SER A 1 33  ? 66.673 45.500 25.742 1.00 7.76  ? 33   SER A N   1 
+ATOM   225  C CA  . SER A 1 33  ? 65.250 45.453 25.896 1.00 7.27  ? 33   SER A CA  1 
+ATOM   226  C C   . SER A 1 33  ? 64.754 46.881 26.229 1.00 8.45  ? 33   SER A C   1 
+ATOM   227  O O   . SER A 1 33  ? 65.430 47.621 26.962 1.00 8.65  ? 33   SER A O   1 
+ATOM   228  C CB  . SER A 1 33  ? 64.829 44.525 27.052 1.00 8.59  ? 33   SER A CB  1 
+ATOM   229  O OG  . SER A 1 33  ? 63.444 44.522 27.250 1.00 10.53 ? 33   SER A OG  1 
+ATOM   230  N N   . SER A 1 34  ? 63.575 47.210 25.725 1.00 10.29 ? 34   SER A N   1 
+ATOM   231  C CA  . SER A 1 34  ? 62.882 48.401 26.172 1.00 8.48  ? 34   SER A CA  1 
+ATOM   232  C C   . SER A 1 34  ? 62.465 48.128 27.612 1.00 11.75 ? 34   SER A C   1 
+ATOM   233  O O   . SER A 1 34  ? 62.521 46.996 28.120 1.00 8.41  ? 34   SER A O   1 
+ATOM   234  C CB  . SER A 1 34  ? 61.611 48.672 25.326 1.00 9.41  ? 34   SER A CB  1 
+ATOM   235  O OG  . SER A 1 34  ? 60.657 47.652 25.652 1.00 7.98  ? 34   SER A OG  1 
+ATOM   236  N N   . HIS A 1 35  ? 62.026 49.177 28.294 1.00 10.13 ? 35   HIS A N   1 
+ATOM   237  C CA  . HIS A 1 35  ? 61.365 49.054 29.592 1.00 7.38  ? 35   HIS A CA  1 
+ATOM   238  C C   . HIS A 1 35  ? 59.899 48.894 29.175 1.00 7.94  ? 35   HIS A C   1 
+ATOM   239  O O   . HIS A 1 35  ? 59.667 48.555 27.997 1.00 8.64  ? 35   HIS A O   1 
+ATOM   240  C CB  . HIS A 1 35  ? 61.710 50.264 30.454 1.00 9.29  ? 35   HIS A CB  1 
+ATOM   241  C CG  . HIS A 1 35  ? 61.307 50.296 31.893 1.00 7.11  ? 35   HIS A CG  1 
+ATOM   242  N ND1 . HIS A 1 35  ? 60.029 50.357 32.357 1.00 11.16 ? 35   HIS A ND1 1 
+ATOM   243  C CD2 . HIS A 1 35  ? 62.124 50.229 32.994 1.00 8.35  ? 35   HIS A CD2 1 
+ATOM   244  C CE1 . HIS A 1 35  ? 60.043 50.347 33.684 1.00 11.43 ? 35   HIS A CE1 1 
+ATOM   245  N NE2 . HIS A 1 35  ? 61.307 50.294 34.097 1.00 11.15 ? 35   HIS A NE2 1 
+ATOM   246  N N   . GLY A 1 36  ? 58.915 49.045 30.039 1.00 7.77  ? 36   GLY A N   1 
+ATOM   247  C CA  . GLY A 1 36  ? 57.537 48.855 29.658 1.00 8.65  ? 36   GLY A CA  1 
+ATOM   248  C C   . GLY A 1 36  ? 57.153 49.834 28.546 1.00 9.70  ? 36   GLY A C   1 
+ATOM   249  O O   . GLY A 1 36  ? 57.341 51.041 28.719 1.00 9.80  ? 36   GLY A O   1 
+ATOM   250  N N   . LEU A 1 37  ? 56.573 49.306 27.475 1.00 10.43 ? 37   LEU A N   1 
+ATOM   251  C CA  . LEU A 1 37  ? 56.160 50.220 26.383 1.00 11.06 ? 37   LEU A CA  1 
+ATOM   252  C C   . LEU A 1 37  ? 55.048 51.187 26.761 1.00 13.78 ? 37   LEU A C   1 
+ATOM   253  O O   . LEU A 1 37  ? 54.883 52.189 26.026 1.00 13.10 ? 37   LEU A O   1 
+ATOM   254  C CB  . LEU A 1 37  ? 55.692 49.387 25.188 1.00 9.35  ? 37   LEU A CB  1 
+ATOM   255  C CG  . LEU A 1 37  ? 56.759 48.492 24.561 1.00 9.89  ? 37   LEU A CG  1 
+ATOM   256  C CD1 . LEU A 1 37  ? 56.166 47.589 23.484 1.00 12.46 ? 37   LEU A CD1 1 
+ATOM   257  C CD2 . LEU A 1 37  ? 57.912 49.306 24.008 1.00 10.92 ? 37   LEU A CD2 1 
+ATOM   258  N N   . GLN A 1 38  ? 54.246 50.892 27.775 1.00 11.76 ? 38   GLN A N   1 
+ATOM   259  C CA  . GLN A 1 38  ? 53.199 51.825 28.221 1.00 12.10 ? 38   GLN A CA  1 
+ATOM   260  C C   . GLN A 1 38  ? 53.742 53.020 29.000 1.00 15.35 ? 38   GLN A C   1 
+ATOM   261  O O   . GLN A 1 38  ? 53.010 53.992 29.256 1.00 14.76 ? 38   GLN A O   1 
+ATOM   262  C CB  . GLN A 1 38  ? 52.193 51.089 29.127 1.00 11.66 ? 38   GLN A CB  1 
+ATOM   263  C CG  . GLN A 1 38  ? 52.633 50.698 30.492 1.00 11.72 ? 38   GLN A CG  1 
+ATOM   264  C CD  . GLN A 1 38  ? 53.433 49.434 30.672 1.00 11.82 ? 38   GLN A CD  1 
+ATOM   265  O OE1 . GLN A 1 38  ? 54.181 49.028 29.779 1.00 11.50 ? 38   GLN A OE1 1 
+ATOM   266  N NE2 . GLN A 1 38  ? 53.303 48.860 31.845 1.00 9.85  ? 38   GLN A NE2 1 
+ATOM   267  N N   . TRP A 1 39  ? 54.998 53.004 29.400 1.00 12.50 ? 39   TRP A N   1 
+ATOM   268  C CA  . TRP A 1 39  ? 55.645 54.026 30.180 1.00 12.61 ? 39   TRP A CA  1 
+ATOM   269  C C   . TRP A 1 39  ? 56.785 54.707 29.451 1.00 11.71 ? 39   TRP A C   1 
+ATOM   270  O O   . TRP A 1 39  ? 56.999 55.922 29.616 1.00 12.53 ? 39   TRP A O   1 
+ATOM   271  C CB  . TRP A 1 39  ? 56.254 53.403 31.444 1.00 12.78 ? 39   TRP A CB  1 
+ATOM   272  C CG  . TRP A 1 39  ? 55.333 52.800 32.436 1.00 9.28  ? 39   TRP A CG  1 
+ATOM   273  C CD1 . TRP A 1 39  ? 54.169 53.333 32.913 1.00 12.17 ? 39   TRP A CD1 1 
+ATOM   274  C CD2 . TRP A 1 39  ? 55.521 51.546 33.108 1.00 11.90 ? 39   TRP A CD2 1 
+ATOM   275  N NE1 . TRP A 1 39  ? 53.636 52.473 33.863 1.00 13.13 ? 39   TRP A NE1 1 
+ATOM   276  C CE2 . TRP A 1 39  ? 54.427 51.360 33.979 1.00 14.78 ? 39   TRP A CE2 1 
+ATOM   277  C CE3 . TRP A 1 39  ? 56.512 50.557 33.046 1.00 11.79 ? 39   TRP A CE3 1 
+ATOM   278  C CZ2 . TRP A 1 39  ? 54.300 50.240 34.788 1.00 15.11 ? 39   TRP A CZ2 1 
+ATOM   279  C CZ3 . TRP A 1 39  ? 56.368 49.441 33.847 1.00 9.20  ? 39   TRP A CZ3 1 
+ATOM   280  C CH2 . TRP A 1 39  ? 55.294 49.283 34.714 1.00 11.94 ? 39   TRP A CH2 1 
+ATOM   281  N N   . TYR A 1 40  ? 57.648 53.949 28.758 1.00 11.32 ? 40   TYR A N   1 
+ATOM   282  C CA  . TYR A 1 40  ? 58.839 54.490 28.127 1.00 9.77  ? 40   TYR A CA  1 
+ATOM   283  C C   . TYR A 1 40  ? 59.008 54.185 26.654 1.00 10.95 ? 40   TYR A C   1 
+ATOM   284  O O   . TYR A 1 40  ? 60.063 53.981 26.038 1.00 11.25 ? 40   TYR A O   1 
+ATOM   285  C CB  . TYR A 1 40  ? 60.080 53.993 28.891 1.00 9.27  ? 40   TYR A CB  1 
+ATOM   286  C CG  . TYR A 1 40  ? 60.095 54.448 30.321 1.00 12.00 ? 40   TYR A CG  1 
+ATOM   287  C CD1 . TYR A 1 40  ? 60.281 55.791 30.659 1.00 15.60 ? 40   TYR A CD1 1 
+ATOM   288  C CD2 . TYR A 1 40  ? 59.847 53.547 31.335 1.00 11.81 ? 40   TYR A CD2 1 
+ATOM   289  C CE1 . TYR A 1 40  ? 60.248 56.200 31.988 1.00 17.35 ? 40   TYR A CE1 1 
+ATOM   290  C CE2 . TYR A 1 40  ? 59.856 53.940 32.660 1.00 11.00 ? 40   TYR A CE2 1 
+ATOM   291  C CZ  . TYR A 1 40  ? 60.045 55.266 32.975 1.00 16.79 ? 40   TYR A CZ  1 
+ATOM   292  O OH  . TYR A 1 40  ? 60.016 55.627 34.294 1.00 16.06 ? 40   TYR A OH  1 
+ATOM   293  N N   . GLY A 1 41  ? 57.869 54.164 25.956 1.00 9.75  ? 41   GLY A N   1 
+ATOM   294  C CA  . GLY A 1 41  ? 57.710 53.916 24.548 1.00 11.86 ? 41   GLY A CA  1 
+ATOM   295  C C   . GLY A 1 41  ? 58.360 54.931 23.638 1.00 14.41 ? 41   GLY A C   1 
+ATOM   296  O O   . GLY A 1 41  ? 58.724 54.602 22.505 1.00 12.09 ? 41   GLY A O   1 
+ATOM   297  N N   . GLN A 1 42  ? 58.617 56.156 24.141 1.00 13.01 ? 42   GLN A N   1 
+ATOM   298  C CA  . GLN A 1 42  ? 59.333 57.132 23.350 1.00 11.81 ? 42   GLN A CA  1 
+ATOM   299  C C   . GLN A 1 42  ? 60.743 56.706 22.984 1.00 12.53 ? 42   GLN A C   1 
+ATOM   300  O O   . GLN A 1 42  ? 61.264 57.225 21.965 1.00 11.58 ? 42   GLN A O   1 
+ATOM   301  C CB  . GLN A 1 42  ? 59.411 58.536 23.986 1.00 12.52 ? 42   GLN A CB  1 
+ATOM   302  C CG  . GLN A 1 42  ? 60.281 58.640 25.218 1.00 13.39 ? 42   GLN A CG  1 
+ATOM   303  C CD  . GLN A 1 42  ? 59.531 58.304 26.502 1.00 13.91 ? 42   GLN A CD  1 
+ATOM   304  O OE1 . GLN A 1 42  ? 58.621 57.476 26.596 1.00 12.29 ? 42   GLN A OE1 1 
+ATOM   305  N NE2 . GLN A 1 42  ? 59.951 58.971 27.570 1.00 11.39 ? 42   GLN A NE2 1 
+ATOM   306  N N   . PHE A 1 43  ? 61.385 55.790 23.730 1.00 13.29 ? 43   PHE A N   1 
+ATOM   307  C CA  . PHE A 1 43  ? 62.713 55.319 23.439 1.00 11.49 ? 43   PHE A CA  1 
+ATOM   308  C C   . PHE A 1 43  ? 62.759 54.211 22.391 1.00 11.02 ? 43   PHE A C   1 
+ATOM   309  O O   . PHE A 1 43  ? 63.835 53.764 22.014 1.00 10.21 ? 43   PHE A O   1 
+ATOM   310  C CB  . PHE A 1 43  ? 63.456 54.848 24.716 1.00 9.81  ? 43   PHE A CB  1 
+ATOM   311  C CG  . PHE A 1 43  ? 63.773 56.043 25.589 1.00 12.62 ? 43   PHE A CG  1 
+ATOM   312  C CD1 . PHE A 1 43  ? 64.864 56.860 25.305 1.00 13.68 ? 43   PHE A CD1 1 
+ATOM   313  C CD2 . PHE A 1 43  ? 62.978 56.354 26.664 1.00 10.38 ? 43   PHE A CD2 1 
+ATOM   314  C CE1 . PHE A 1 43  ? 65.105 57.966 26.108 1.00 10.46 ? 43   PHE A CE1 1 
+ATOM   315  C CE2 . PHE A 1 43  ? 63.229 57.444 27.480 1.00 14.10 ? 43   PHE A CE2 1 
+ATOM   316  C CZ  . PHE A 1 43  ? 64.309 58.251 27.174 1.00 13.01 ? 43   PHE A CZ  1 
+ATOM   317  N N   . VAL A 1 44  ? 61.590 53.794 21.917 1.00 10.01 ? 44   VAL A N   1 
+ATOM   318  C CA  . VAL A 1 44  ? 61.516 52.727 20.922 1.00 11.64 ? 44   VAL A CA  1 
+ATOM   319  C C   . VAL A 1 44  ? 61.040 53.323 19.602 1.00 9.12  ? 44   VAL A C   1 
+ATOM   320  O O   . VAL A 1 44  ? 59.880 53.678 19.407 1.00 9.37  ? 44   VAL A O   1 
+ATOM   321  C CB  . VAL A 1 44  ? 60.532 51.660 21.430 1.00 14.08 ? 44   VAL A CB  1 
+ATOM   322  C CG1 . VAL A 1 44  ? 60.434 50.506 20.423 1.00 12.25 ? 44   VAL A CG1 1 
+ATOM   323  C CG2 . VAL A 1 44  ? 61.006 51.101 22.765 1.00 13.06 ? 44   VAL A CG2 1 
+ATOM   324  N N   . ASN A 1 45  ? 61.985 53.492 18.671 1.00 7.60  ? 45   ASN A N   1 
+ATOM   325  C CA  . ASN A 1 45  ? 61.713 54.092 17.390 1.00 11.85 ? 45   ASN A CA  1 
+ATOM   326  C C   . ASN A 1 45  ? 62.860 53.742 16.450 1.00 11.21 ? 45   ASN A C   1 
+ATOM   327  O O   . ASN A 1 45  ? 63.929 53.356 16.911 1.00 10.39 ? 45   ASN A O   1 
+ATOM   328  C CB  . ASN A 1 45  ? 61.497 55.625 17.445 1.00 10.35 ? 45   ASN A CB  1 
+ATOM   329  C CG  . ASN A 1 45  ? 62.642 56.317 18.155 1.00 12.10 ? 45   ASN A CG  1 
+ATOM   330  O OD1 . ASN A 1 45  ? 63.726 56.524 17.596 1.00 8.80  ? 45   ASN A OD1 1 
+ATOM   331  N ND2 . ASN A 1 45  ? 62.414 56.668 19.403 1.00 11.13 ? 45   ASN A ND2 1 
+ATOM   332  N N   . TYR A 1 46  ? 62.643 53.897 15.152 1.00 10.07 ? 46   TYR A N   1 
+ATOM   333  C CA  . TYR A 1 46  ? 63.690 53.621 14.175 1.00 9.90  ? 46   TYR A CA  1 
+ATOM   334  C C   . TYR A 1 46  ? 65.020 54.302 14.478 1.00 13.20 ? 46   TYR A C   1 
+ATOM   335  O O   . TYR A 1 46  ? 66.095 53.679 14.373 1.00 8.68  ? 46   TYR A O   1 
+ATOM   336  C CB  . TYR A 1 46  ? 63.197 54.016 12.786 1.00 10.60 ? 46   TYR A CB  1 
+ATOM   337  C CG  . TYR A 1 46  ? 64.246 53.841 11.705 1.00 9.36  ? 46   TYR A CG  1 
+ATOM   338  C CD1 . TYR A 1 46  ? 64.417 52.630 11.057 1.00 8.79  ? 46   TYR A CD1 1 
+ATOM   339  C CD2 . TYR A 1 46  ? 65.044 54.942 11.356 1.00 11.97 ? 46   TYR A CD2 1 
+ATOM   340  C CE1 . TYR A 1 46  ? 65.389 52.497 10.068 1.00 13.30 ? 46   TYR A CE1 1 
+ATOM   341  C CE2 . TYR A 1 46  ? 66.013 54.789 10.367 1.00 13.80 ? 46   TYR A CE2 1 
+ATOM   342  C CZ  . TYR A 1 46  ? 66.160 53.591 9.717  1.00 14.23 ? 46   TYR A CZ  1 
+ATOM   343  O OH  . TYR A 1 46  ? 67.111 53.491 8.727  1.00 17.25 ? 46   TYR A OH  1 
+ATOM   344  N N   . GLU A 1 47  ? 65.003 55.575 14.814 1.00 10.12 ? 47   GLU A N   1 
+ATOM   345  C CA  . GLU A 1 47  ? 66.243 56.322 15.029 1.00 13.02 ? 47   GLU A CA  1 
+ATOM   346  C C   . GLU A 1 47  ? 67.076 55.870 16.218 1.00 10.70 ? 47   GLU A C   1 
+ATOM   347  O O   . GLU A 1 47  ? 68.296 55.695 16.133 1.00 10.56 ? 47   GLU A O   1 
+ATOM   348  C CB  . GLU A 1 47  ? 65.900 57.824 15.131 1.00 13.78 ? 47   GLU A CB  1 
+ATOM   349  C CG  A GLU A 1 47  ? 65.650 58.493 13.783 0.52 10.20 ? 47   GLU A CG  1 
+ATOM   350  C CG  B GLU A 1 47  ? 67.073 58.655 14.659 0.48 11.35 ? 47   GLU A CG  1 
+ATOM   351  C CD  A GLU A 1 47  ? 66.761 58.298 12.774 0.52 12.71 ? 47   GLU A CD  1 
+ATOM   352  C CD  B GLU A 1 47  ? 66.699 60.100 14.392 0.48 20.56 ? 47   GLU A CD  1 
+ATOM   353  O OE1 A GLU A 1 47  ? 67.947 58.363 13.138 0.52 12.18 ? 47   GLU A OE1 1 
+ATOM   354  O OE1 B GLU A 1 47  ? 65.676 60.566 14.918 0.48 17.00 ? 47   GLU A OE1 1 
+ATOM   355  O OE2 A GLU A 1 47  ? 66.489 58.073 11.574 0.52 17.54 ? 47   GLU A OE2 1 
+ATOM   356  O OE2 B GLU A 1 47  ? 67.469 60.729 13.632 0.48 22.93 ? 47   GLU A OE2 1 
+ATOM   357  N N   . SER A 1 48  ? 66.428 55.598 17.341 1.00 7.73  ? 48   SER A N   1 
+ATOM   358  C CA  . SER A 1 48  ? 67.138 55.102 18.534 1.00 10.14 ? 48   SER A CA  1 
+ATOM   359  C C   . SER A 1 48  ? 67.630 53.687 18.261 1.00 9.81  ? 48   SER A C   1 
+ATOM   360  O O   . SER A 1 48  ? 68.720 53.334 18.750 1.00 8.06  ? 48   SER A O   1 
+ATOM   361  C CB  . SER A 1 48  ? 66.314 55.137 19.805 1.00 12.06 ? 48   SER A CB  1 
+ATOM   362  O OG  . SER A 1 48  ? 65.280 54.185 19.808 1.00 16.75 ? 48   SER A OG  1 
+ATOM   363  N N   . MET A 1 49  ? 66.849 52.846 17.581 1.00 8.28  ? 49   MET A N   1 
+ATOM   364  C CA  . MET A 1 49  ? 67.250 51.484 17.296 1.00 9.04  ? 49   MET A CA  1 
+ATOM   365  C C   . MET A 1 49  ? 68.430 51.488 16.329 1.00 11.63 ? 49   MET A C   1 
+ATOM   366  O O   . MET A 1 49  ? 69.371 50.703 16.476 1.00 9.69  ? 49   MET A O   1 
+ATOM   367  C CB  A MET A 1 49  ? 66.066 50.638 16.781 0.68 10.87 ? 49   MET A CB  1 
+ATOM   368  C CB  B MET A 1 49  ? 66.114 50.684 16.634 0.32 9.41  ? 49   MET A CB  1 
+ATOM   369  C CG  A MET A 1 49  ? 65.102 50.289 17.931 0.68 7.26  ? 49   MET A CG  1 
+ATOM   370  C CG  B MET A 1 49  ? 66.361 49.188 16.731 0.32 8.91  ? 49   MET A CG  1 
+ATOM   371  S SD  A MET A 1 49  ? 63.485 49.687 17.367 0.68 6.24  ? 49   MET A SD  1 
+ATOM   372  S SD  B MET A 1 49  ? 64.940 48.202 16.207 0.32 9.35  ? 49   MET A SD  1 
+ATOM   373  C CE  A MET A 1 49  ? 63.915 48.115 16.640 0.68 6.85  ? 49   MET A CE  1 
+ATOM   374  C CE  B MET A 1 49  ? 63.716 48.800 17.382 0.32 4.28  ? 49   MET A CE  1 
+ATOM   375  N N   . LYS A 1 50  ? 68.410 52.431 15.382 1.00 9.42  ? 50   LYS A N   1 
+ATOM   376  C CA  . LYS A 1 50  ? 69.509 52.568 14.434 1.00 9.26  ? 50   LYS A CA  1 
+ATOM   377  C C   . LYS A 1 50  ? 70.790 53.043 15.128 1.00 10.38 ? 50   LYS A C   1 
+ATOM   378  O O   . LYS A 1 50  ? 71.870 52.538 14.844 1.00 10.68 ? 50   LYS A O   1 
+ATOM   379  C CB  . LYS A 1 50  ? 69.185 53.551 13.321 1.00 9.88  ? 50   LYS A CB  1 
+ATOM   380  C CG  . LYS A 1 50  ? 70.330 53.640 12.291 1.00 11.01 ? 50   LYS A CG  1 
+ATOM   381  C CD  . LYS A 1 50  ? 69.924 54.575 11.153 1.00 19.31 ? 50   LYS A CD  1 
+ATOM   382  C CE  . LYS A 1 50  ? 71.076 54.649 10.132 1.00 26.25 ? 50   LYS A CE  1 
+ATOM   383  N NZ  . LYS A 1 50  ? 70.789 55.708 9.122  1.00 35.30 ? 50   LYS A NZ  1 
+ATOM   384  N N   . TRP A 1 51  ? 70.638 53.927 16.118 1.00 11.51 ? 51   TRP A N   1 
+ATOM   385  C CA  . TRP A 1 51  ? 71.785 54.348 16.911 1.00 9.23  ? 51   TRP A CA  1 
+ATOM   386  C C   . TRP A 1 51  ? 72.329 53.176 17.729 1.00 10.50 ? 51   TRP A C   1 
+ATOM   387  O O   . TRP A 1 51  ? 73.539 52.988 17.817 1.00 9.73  ? 51   TRP A O   1 
+ATOM   388  C CB  . TRP A 1 51  ? 71.359 55.501 17.833 1.00 11.26 ? 51   TRP A CB  1 
+ATOM   389  C CG  . TRP A 1 51  ? 72.448 55.950 18.750 1.00 12.07 ? 51   TRP A CG  1 
+ATOM   390  C CD1 . TRP A 1 51  ? 72.539 55.683 20.088 1.00 11.01 ? 51   TRP A CD1 1 
+ATOM   391  C CD2 . TRP A 1 51  ? 73.606 56.710 18.398 1.00 11.17 ? 51   TRP A CD2 1 
+ATOM   392  N NE1 . TRP A 1 51  ? 73.688 56.252 20.594 1.00 13.12 ? 51   TRP A NE1 1 
+ATOM   393  C CE2 . TRP A 1 51  ? 74.375 56.877 19.589 1.00 11.71 ? 51   TRP A CE2 1 
+ATOM   394  C CE3 . TRP A 1 51  ? 74.111 57.251 17.213 1.00 16.97 ? 51   TRP A CE3 1 
+ATOM   395  C CZ2 . TRP A 1 51  ? 75.586 57.552 19.598 1.00 11.58 ? 51   TRP A CZ2 1 
+ATOM   396  C CZ3 . TRP A 1 51  ? 75.316 57.942 17.231 1.00 19.66 ? 51   TRP A CZ3 1 
+ATOM   397  C CH2 . TRP A 1 51  ? 76.033 58.097 18.415 1.00 19.51 ? 51   TRP A CH2 1 
+ATOM   398  N N   . LEU A 1 52  ? 71.464 52.378 18.355 1.00 9.42  ? 52   LEU A N   1 
+ATOM   399  C CA  . LEU A 1 52  ? 71.934 51.206 19.090 1.00 7.57  ? 52   LEU A CA  1 
+ATOM   400  C C   . LEU A 1 52  ? 72.698 50.259 18.164 1.00 12.00 ? 52   LEU A C   1 
+ATOM   401  O O   . LEU A 1 52  ? 73.750 49.718 18.538 1.00 10.43 ? 52   LEU A O   1 
+ATOM   402  C CB  . LEU A 1 52  ? 70.824 50.429 19.781 1.00 10.21 ? 52   LEU A CB  1 
+ATOM   403  C CG  . LEU A 1 52  ? 70.168 51.168 20.943 1.00 8.39  ? 52   LEU A CG  1 
+ATOM   404  C CD1 . LEU A 1 52  ? 68.854 50.492 21.333 1.00 11.07 ? 52   LEU A CD1 1 
+ATOM   405  C CD2 . LEU A 1 52  ? 71.129 51.172 22.126 1.00 12.42 ? 52   LEU A CD2 1 
+ATOM   406  N N   . ARG A 1 53  ? 72.155 50.029 16.965 1.00 9.59  ? 53   ARG A N   1 
+ATOM   407  C CA  . ARG A 1 53  ? 72.802 49.147 16.024 1.00 9.99  ? 53   ARG A CA  1 
+ATOM   408  C C   . ARG A 1 53  ? 74.190 49.658 15.624 1.00 13.24 ? 53   ARG A C   1 
+ATOM   409  O O   . ARG A 1 53  ? 75.170 48.913 15.587 1.00 11.57 ? 53   ARG A O   1 
+ATOM   410  C CB  . ARG A 1 53  ? 71.932 48.914 14.780 1.00 7.67  ? 53   ARG A CB  1 
+ATOM   411  C CG  . ARG A 1 53  ? 72.514 47.977 13.727 1.00 11.65 ? 53   ARG A CG  1 
+ATOM   412  C CD  . ARG A 1 53  ? 71.801 48.122 12.398 1.00 10.97 ? 53   ARG A CD  1 
+ATOM   413  N NE  . ARG A 1 53  ? 72.092 49.374 11.723 1.00 12.56 ? 53   ARG A NE  1 
+ATOM   414  C CZ  . ARG A 1 53  ? 71.703 49.740 10.504 1.00 14.55 ? 53   ARG A CZ  1 
+ATOM   415  N NH1 . ARG A 1 53  ? 70.971 48.935 9.757  1.00 13.20 ? 53   ARG A NH1 1 
+ATOM   416  N NH2 . ARG A 1 53  ? 72.065 50.930 10.036 1.00 14.22 ? 53   ARG A NH2 1 
+ATOM   417  N N   . ASP A 1 54  ? 74.263 50.931 15.243 1.00 12.89 ? 54   ASP A N   1 
+ATOM   418  C CA  . ASP A 1 54  ? 75.494 51.479 14.711 1.00 12.40 ? 54   ASP A CA  1 
+ATOM   419  C C   . ASP A 1 54  ? 76.535 51.842 15.769 1.00 12.89 ? 54   ASP A C   1 
+ATOM   420  O O   . ASP A 1 54  ? 77.715 51.665 15.474 1.00 13.15 ? 54   ASP A O   1 
+ATOM   421  C CB  . ASP A 1 54  ? 75.156 52.731 13.889 1.00 13.47 ? 54   ASP A CB  1 
+ATOM   422  C CG  . ASP A 1 54  ? 74.319 52.520 12.643 1.00 18.94 ? 54   ASP A CG  1 
+ATOM   423  O OD1 . ASP A 1 54  ? 74.132 51.378 12.217 1.00 20.57 ? 54   ASP A OD1 1 
+ATOM   424  O OD2 . ASP A 1 54  ? 73.843 53.556 12.126 1.00 22.41 ? 54   ASP A OD2 1 
+ATOM   425  N N   . ASP A 1 55  ? 76.125 52.377 16.901 1.00 11.49 ? 55   ASP A N   1 
+ATOM   426  C CA  . ASP A 1 55  ? 77.086 52.842 17.912 1.00 11.26 ? 55   ASP A CA  1 
+ATOM   427  C C   . ASP A 1 55  ? 77.354 51.779 18.966 1.00 12.01 ? 55   ASP A C   1 
+ATOM   428  O O   . ASP A 1 55  ? 78.478 51.656 19.434 1.00 13.61 ? 55   ASP A O   1 
+ATOM   429  C CB  . ASP A 1 55  ? 76.544 54.110 18.561 1.00 11.77 ? 55   ASP A CB  1 
+ATOM   430  C CG  . ASP A 1 55  ? 77.458 54.624 19.661 1.00 16.13 ? 55   ASP A CG  1 
+ATOM   431  O OD1 . ASP A 1 55  ? 78.550 55.096 19.254 1.00 11.50 ? 55   ASP A OD1 1 
+ATOM   432  O OD2 . ASP A 1 55  ? 77.127 54.579 20.843 1.00 15.08 ? 55   ASP A OD2 1 
+ATOM   433  N N   . TRP A 1 56  ? 76.316 51.019 19.339 1.00 11.46 ? 56   TRP A N   1 
+ATOM   434  C CA  . TRP A 1 56  ? 76.529 49.964 20.320 1.00 8.76  ? 56   TRP A CA  1 
+ATOM   435  C C   . TRP A 1 56  ? 76.835 48.635 19.657 1.00 12.11 ? 56   TRP A C   1 
+ATOM   436  O O   . TRP A 1 56  ? 77.478 47.847 20.331 1.00 13.09 ? 56   TRP A O   1 
+ATOM   437  C CB  . TRP A 1 56  ? 75.348 49.782 21.274 1.00 11.88 ? 56   TRP A CB  1 
+ATOM   438  C CG  . TRP A 1 56  ? 74.980 50.911 22.173 1.00 12.65 ? 56   TRP A CG  1 
+ATOM   439  C CD1 . TRP A 1 56  ? 75.050 52.254 21.952 1.00 9.89  ? 56   TRP A CD1 1 
+ATOM   440  C CD2 . TRP A 1 56  ? 74.374 50.770 23.485 1.00 12.08 ? 56   TRP A CD2 1 
+ATOM   441  N NE1 . TRP A 1 56  ? 74.613 52.943 23.052 1.00 10.35 ? 56   TRP A NE1 1 
+ATOM   442  C CE2 . TRP A 1 56  ? 74.182 52.054 24.001 1.00 13.55 ? 56   TRP A CE2 1 
+ATOM   443  C CE3 . TRP A 1 56  ? 74.046 49.673 24.276 1.00 14.83 ? 56   TRP A CE3 1 
+ATOM   444  C CZ2 . TRP A 1 56  ? 73.600 52.302 25.250 1.00 11.84 ? 56   TRP A CZ2 1 
+ATOM   445  C CZ3 . TRP A 1 56  ? 73.465 49.907 25.507 1.00 17.27 ? 56   TRP A CZ3 1 
+ATOM   446  C CH2 . TRP A 1 56  ? 73.271 51.202 25.994 1.00 12.37 ? 56   TRP A CH2 1 
+ATOM   447  N N   . GLY A 1 57  ? 76.394 48.382 18.433 1.00 7.73  ? 57   GLY A N   1 
+ATOM   448  C CA  . GLY A 1 57  ? 76.597 47.090 17.803 1.00 10.21 ? 57   GLY A CA  1 
+ATOM   449  C C   . GLY A 1 57  ? 75.515 46.066 18.107 1.00 10.83 ? 57   GLY A C   1 
+ATOM   450  O O   . GLY A 1 57  ? 75.684 44.843 17.924 1.00 12.03 ? 57   GLY A O   1 
+ATOM   451  N N   . ILE A 1 58  ? 74.334 46.495 18.554 1.00 11.16 ? 58   ILE A N   1 
+ATOM   452  C CA  . ILE A 1 58  ? 73.279 45.522 18.870 1.00 7.96  ? 58   ILE A CA  1 
+ATOM   453  C C   . ILE A 1 58  ? 72.859 44.778 17.597 1.00 11.66 ? 58   ILE A C   1 
+ATOM   454  O O   . ILE A 1 58  ? 72.886 45.321 16.496 1.00 9.60  ? 58   ILE A O   1 
+ATOM   455  C CB  . ILE A 1 58  ? 72.047 46.113 19.534 1.00 7.96  ? 58   ILE A CB  1 
+ATOM   456  C CG1 . ILE A 1 58  ? 71.122 46.872 18.558 1.00 8.81  ? 58   ILE A CG1 1 
+ATOM   457  C CG2 . ILE A 1 58  ? 72.371 47.030 20.696 1.00 11.41 ? 58   ILE A CG2 1 
+ATOM   458  C CD1 . ILE A 1 58  ? 69.769 47.221 19.151 1.00 11.61 ? 58   ILE A CD1 1 
+ATOM   459  N N   . ASN A 1 59  ? 72.406 43.548 17.772 1.00 7.50  ? 59   ASN A N   1 
+ATOM   460  C CA  . ASN A 1 59  ? 71.900 42.730 16.689 1.00 9.04  ? 59   ASN A CA  1 
+ATOM   461  C C   . ASN A 1 59  ? 70.514 42.173 17.043 1.00 8.45  ? 59   ASN A C   1 
+ATOM   462  O O   . ASN A 1 59  ? 69.964 41.384 16.258 1.00 9.25  ? 59   ASN A O   1 
+ATOM   463  C CB  . ASN A 1 59  ? 72.873 41.662 16.198 1.00 10.92 ? 59   ASN A CB  1 
+ATOM   464  C CG  . ASN A 1 59  ? 73.273 40.653 17.259 1.00 13.28 ? 59   ASN A CG  1 
+ATOM   465  O OD1 . ASN A 1 59  ? 72.664 40.641 18.314 1.00 11.38 ? 59   ASN A OD1 1 
+ATOM   466  N ND2 . ASN A 1 59  ? 74.304 39.857 17.020 1.00 16.02 ? 59   ASN A ND2 1 
+ATOM   467  N N   . VAL A 1 60  ? 69.947 42.614 18.148 1.00 9.77  ? 60   VAL A N   1 
+ATOM   468  C CA  . VAL A 1 60  ? 68.587 42.224 18.534 1.00 10.42 ? 60   VAL A CA  1 
+ATOM   469  C C   . VAL A 1 60  ? 67.998 43.302 19.426 1.00 9.79  ? 60   VAL A C   1 
+ATOM   470  O O   . VAL A 1 60  ? 68.750 43.974 20.161 1.00 8.76  ? 60   VAL A O   1 
+ATOM   471  C CB  . VAL A 1 60  ? 68.565 40.858 19.232 1.00 9.68  ? 60   VAL A CB  1 
+ATOM   472  C CG1 . VAL A 1 60  ? 69.314 40.853 20.553 1.00 9.53  ? 60   VAL A CG1 1 
+ATOM   473  C CG2 . VAL A 1 60  ? 67.146 40.357 19.464 1.00 8.11  ? 60   VAL A CG2 1 
+ATOM   474  N N   . PHE A 1 61  ? 66.684 43.503 19.296 1.00 9.15  ? 61   PHE A N   1 
+ATOM   475  C CA  . PHE A 1 61  ? 66.013 44.486 20.155 1.00 8.70  ? 61   PHE A CA  1 
+ATOM   476  C C   . PHE A 1 61  ? 64.774 43.823 20.725 1.00 10.66 ? 61   PHE A C   1 
+ATOM   477  O O   . PHE A 1 61  ? 64.045 43.131 19.993 1.00 9.68  ? 61   PHE A O   1 
+ATOM   478  C CB  . PHE A 1 61  ? 65.617 45.766 19.389 1.00 5.92  ? 61   PHE A CB  1 
+ATOM   479  C CG  . PHE A 1 61  ? 65.122 46.859 20.291 1.00 8.20  ? 61   PHE A CG  1 
+ATOM   480  C CD1 . PHE A 1 61  ? 66.027 47.707 20.912 1.00 10.07 ? 61   PHE A CD1 1 
+ATOM   481  C CD2 . PHE A 1 61  ? 63.780 46.986 20.603 1.00 10.47 ? 61   PHE A CD2 1 
+ATOM   482  C CE1 . PHE A 1 61  ? 65.621 48.672 21.790 1.00 12.77 ? 61   PHE A CE1 1 
+ATOM   483  C CE2 . PHE A 1 61  ? 63.364 47.973 21.475 1.00 9.67  ? 61   PHE A CE2 1 
+ATOM   484  C CZ  . PHE A 1 61  ? 64.273 48.821 22.084 1.00 10.98 ? 61   PHE A CZ  1 
+ATOM   485  N N   . ARG A 1 62  ? 64.515 43.994 22.000 1.00 9.19  ? 62   ARG A N   1 
+ATOM   486  C CA  . ARG A 1 62  ? 63.378 43.366 22.666 1.00 9.53  ? 62   ARG A CA  1 
+ATOM   487  C C   . ARG A 1 62  ? 62.314 44.377 23.055 1.00 8.40  ? 62   ARG A C   1 
+ATOM   488  O O   . ARG A 1 62  ? 62.583 45.353 23.753 1.00 8.66  ? 62   ARG A O   1 
+ATOM   489  C CB  . ARG A 1 62  ? 63.844 42.638 23.944 1.00 7.67  ? 62   ARG A CB  1 
+ATOM   490  C CG  . ARG A 1 62  ? 62.705 42.006 24.761 1.00 8.40  ? 62   ARG A CG  1 
+ATOM   491  C CD  . ARG A 1 62  ? 63.321 41.103 25.783 1.00 7.72  ? 62   ARG A CD  1 
+ATOM   492  N NE  . ARG A 1 62  ? 62.561 40.333 26.730 1.00 7.85  ? 62   ARG A NE  1 
+ATOM   493  C CZ  . ARG A 1 62  ? 62.266 40.617 27.985 1.00 9.29  ? 62   ARG A CZ  1 
+ATOM   494  N NH1 . ARG A 1 62  ? 62.535 41.798 28.533 1.00 8.19  ? 62   ARG A NH1 1 
+ATOM   495  N NH2 . ARG A 1 62  ? 61.664 39.669 28.698 1.00 9.06  ? 62   ARG A NH2 1 
+ATOM   496  N N   . ALA A 1 63  ? 61.095 44.216 22.533 1.00 8.43  ? 63   ALA A N   1 
+ATOM   497  C CA  . ALA A 1 63  ? 59.983 45.091 22.816 1.00 8.31  ? 63   ALA A CA  1 
+ATOM   498  C C   . ALA A 1 63  ? 59.188 44.499 23.992 1.00 8.22  ? 63   ALA A C   1 
+ATOM   499  O O   . ALA A 1 63  ? 58.466 43.524 23.810 1.00 8.88  ? 63   ALA A O   1 
+ATOM   500  C CB  . ALA A 1 63  ? 59.108 45.263 21.570 1.00 10.43 ? 63   ALA A CB  1 
+ATOM   501  N N   . ALA A 1 64  ? 59.320 45.098 25.170 1.00 7.80  ? 64   ALA A N   1 
+ATOM   502  C CA  . ALA A 1 64  ? 58.669 44.615 26.380 1.00 9.63  ? 64   ALA A CA  1 
+ATOM   503  C C   . ALA A 1 64  ? 57.271 45.163 26.571 1.00 7.52  ? 64   ALA A C   1 
+ATOM   504  O O   . ALA A 1 64  ? 57.066 46.233 27.159 1.00 8.79  ? 64   ALA A O   1 
+ATOM   505  C CB  . ALA A 1 64  ? 59.598 44.853 27.577 1.00 8.54  ? 64   ALA A CB  1 
+ATOM   506  N N   . MET A 1 65  ? 56.298 44.416 26.042 1.00 8.94  ? 65   MET A N   1 
+ATOM   507  C CA  . MET A 1 65  ? 54.899 44.795 26.111 1.00 8.67  ? 65   MET A CA  1 
+ATOM   508  C C   . MET A 1 65  ? 54.238 44.231 27.369 1.00 10.03 ? 65   MET A C   1 
+ATOM   509  O O   . MET A 1 65  ? 53.711 43.111 27.399 1.00 8.93  ? 65   MET A O   1 
+ATOM   510  C CB  . MET A 1 65  ? 54.114 44.400 24.870 1.00 8.11  ? 65   MET A CB  1 
+ATOM   511  C CG  . MET A 1 65  ? 52.722 44.978 24.778 1.00 8.43  ? 65   MET A CG  1 
+ATOM   512  S SD  . MET A 1 65  ? 51.628 44.340 23.526 1.00 6.73  ? 65   MET A SD  1 
+ATOM   513  C CE  . MET A 1 65  ? 51.314 42.705 24.175 1.00 8.41  ? 65   MET A CE  1 
+ATOM   514  N N   . TYR A 1 66  ? 54.290 45.003 28.455 1.00 9.01  ? 66   TYR A N   1 
+ATOM   515  C CA  . TYR A 1 66  ? 53.631 44.593 29.683 1.00 10.11 ? 66   TYR A CA  1 
+ATOM   516  C C   . TYR A 1 66  ? 52.156 44.321 29.319 1.00 9.66  ? 66   TYR A C   1 
+ATOM   517  O O   . TYR A 1 66  ? 51.556 45.021 28.488 1.00 9.92  ? 66   TYR A O   1 
+ATOM   518  C CB  . TYR A 1 66  ? 53.635 45.640 30.774 1.00 10.43 ? 66   TYR A CB  1 
+ATOM   519  C CG  . TYR A 1 66  ? 54.792 45.731 31.714 1.00 8.93  ? 66   TYR A CG  1 
+ATOM   520  C CD1 . TYR A 1 66  ? 56.026 46.182 31.252 1.00 9.95  ? 66   TYR A CD1 1 
+ATOM   521  C CD2 . TYR A 1 66  ? 54.684 45.419 33.061 1.00 7.92  ? 66   TYR A CD2 1 
+ATOM   522  C CE1 . TYR A 1 66  ? 57.111 46.306 32.103 1.00 11.38 ? 66   TYR A CE1 1 
+ATOM   523  C CE2 . TYR A 1 66  ? 55.759 45.529 33.918 1.00 8.52  ? 66   TYR A CE2 1 
+ATOM   524  C CZ  . TYR A 1 66  ? 56.966 45.990 33.429 1.00 9.60  ? 66   TYR A CZ  1 
+ATOM   525  O OH  . TYR A 1 66  ? 58.054 46.151 34.258 1.00 9.18  ? 66   TYR A OH  1 
+ATOM   526  N N   . THR A 1 67  ? 51.606 43.325 29.973 1.00 11.67 ? 67   THR A N   1 
+ATOM   527  C CA  . THR A 1 67  ? 50.217 42.947 29.808 1.00 10.10 ? 67   THR A CA  1 
+ATOM   528  C C   . THR A 1 67  ? 49.388 43.676 30.882 1.00 13.20 ? 67   THR A C   1 
+ATOM   529  O O   . THR A 1 67  ? 48.379 44.288 30.575 1.00 11.54 ? 67   THR A O   1 
+ATOM   530  C CB  . THR A 1 67  ? 50.099 41.420 29.995 1.00 8.78  ? 67   THR A CB  1 
+ATOM   531  O OG1 . THR A 1 67  ? 50.932 41.058 31.086 1.00 8.16  ? 67   THR A OG1 1 
+ATOM   532  C CG2 . THR A 1 67  ? 50.474 40.738 28.696 1.00 9.51  ? 67   THR A CG2 1 
+ATOM   533  N N   . SER A 1 68  ? 49.827 43.577 32.115 1.00 10.70 ? 68   SER A N   1 
+ATOM   534  C CA  . SER A 1 68  ? 49.193 44.267 33.220 1.00 13.63 ? 68   SER A CA  1 
+ATOM   535  C C   . SER A 1 68  ? 49.907 45.593 33.491 1.00 12.86 ? 68   SER A C   1 
+ATOM   536  O O   . SER A 1 68  ? 50.650 46.094 32.634 1.00 12.73 ? 68   SER A O   1 
+ATOM   537  C CB  . SER A 1 68  ? 49.176 43.380 34.465 1.00 16.74 ? 68   SER A CB  1 
+ATOM   538  O OG  . SER A 1 68  ? 48.341 44.022 35.431 1.00 19.13 ? 68   SER A OG  1 
+ATOM   539  N N   . SER A 1 69  ? 49.720 46.181 34.664 1.00 14.24 ? 69   SER A N   1 
+ATOM   540  C CA  . SER A 1 69  ? 50.380 47.414 35.067 1.00 14.28 ? 69   SER A CA  1 
+ATOM   541  C C   . SER A 1 69  ? 50.235 48.523 34.038 1.00 14.83 ? 69   SER A C   1 
+ATOM   542  O O   . SER A 1 69  ? 51.157 49.247 33.671 1.00 13.89 ? 69   SER A O   1 
+ATOM   543  C CB  . SER A 1 69  ? 51.863 47.183 35.353 1.00 12.82 ? 69   SER A CB  1 
+ATOM   544  O OG  . SER A 1 69  ? 52.073 46.127 36.262 1.00 14.96 ? 69   SER A OG  1 
+ATOM   545  N N   . GLY A 1 70  ? 49.016 48.710 33.546 1.00 13.36 ? 70   GLY A N   1 
+ATOM   546  C CA  . GLY A 1 70  ? 48.721 49.708 32.544 1.00 14.91 ? 70   GLY A CA  1 
+ATOM   547  C C   . GLY A 1 70  ? 49.104 49.347 31.119 1.00 14.93 ? 70   GLY A C   1 
+ATOM   548  O O   . GLY A 1 70  ? 49.036 50.180 30.225 1.00 12.38 ? 70   GLY A O   1 
+ATOM   549  N N   . GLY A 1 71  ? 49.509 48.112 30.876 1.00 12.37 ? 71   GLY A N   1 
+ATOM   550  C CA  . GLY A 1 71  ? 49.922 47.538 29.634 1.00 12.07 ? 71   GLY A CA  1 
+ATOM   551  C C   . GLY A 1 71  ? 48.750 47.163 28.742 1.00 14.36 ? 71   GLY A C   1 
+ATOM   552  O O   . GLY A 1 71  ? 47.635 47.699 28.817 1.00 14.25 ? 71   GLY A O   1 
+ATOM   553  N N   . TYR A 1 72  ? 49.006 46.152 27.911 1.00 9.83  ? 72   TYR A N   1 
+ATOM   554  C CA  . TYR A 1 72  ? 48.104 45.725 26.871 1.00 11.39 ? 72   TYR A CA  1 
+ATOM   555  C C   . TYR A 1 72  ? 46.682 45.398 27.277 1.00 12.54 ? 72   TYR A C   1 
+ATOM   556  O O   . TYR A 1 72  ? 45.764 45.764 26.506 1.00 13.84 ? 72   TYR A O   1 
+ATOM   557  C CB  . TYR A 1 72  ? 48.758 44.558 26.101 1.00 13.86 ? 72   TYR A CB  1 
+ATOM   558  C CG  . TYR A 1 72  ? 47.940 43.979 24.958 1.00 12.78 ? 72   TYR A CG  1 
+ATOM   559  C CD1 . TYR A 1 72  ? 47.859 44.602 23.719 1.00 12.00 ? 72   TYR A CD1 1 
+ATOM   560  C CD2 . TYR A 1 72  ? 47.230 42.797 25.131 1.00 12.45 ? 72   TYR A CD2 1 
+ATOM   561  C CE1 . TYR A 1 72  ? 47.108 44.071 22.696 1.00 13.58 ? 72   TYR A CE1 1 
+ATOM   562  C CE2 . TYR A 1 72  ? 46.512 42.224 24.105 1.00 11.45 ? 72   TYR A CE2 1 
+ATOM   563  C CZ  . TYR A 1 72  ? 46.433 42.873 22.883 1.00 11.99 ? 72   TYR A CZ  1 
+ATOM   564  O OH  . TYR A 1 72  ? 45.701 42.349 21.851 1.00 12.72 ? 72   TYR A OH  1 
+ATOM   565  N N   . ILE A 1 73  ? 46.457 44.736 28.400 1.00 12.55 ? 73   ILE A N   1 
+ATOM   566  C CA  . ILE A 1 73  ? 45.072 44.376 28.776 1.00 11.38 ? 73   ILE A CA  1 
+ATOM   567  C C   . ILE A 1 73  ? 44.273 45.620 29.147 1.00 17.83 ? 73   ILE A C   1 
+ATOM   568  O O   . ILE A 1 73  ? 43.097 45.657 28.839 1.00 15.83 ? 73   ILE A O   1 
+ATOM   569  C CB  . ILE A 1 73  ? 45.133 43.422 29.984 1.00 10.87 ? 73   ILE A CB  1 
+ATOM   570  C CG1 . ILE A 1 73  ? 45.865 42.148 29.566 1.00 13.76 ? 73   ILE A CG1 1 
+ATOM   571  C CG2 . ILE A 1 73  ? 43.767 43.097 30.576 1.00 16.45 ? 73   ILE A CG2 1 
+ATOM   572  C CD1 . ILE A 1 73  ? 45.243 41.299 28.498 1.00 13.89 ? 73   ILE A CD1 1 
+ATOM   573  N N   . ASP A 1 74  ? 44.928 46.625 29.716 1.00 15.81 ? 74   ASP A N   1 
+ATOM   574  C CA  . ASP A 1 74  ? 44.229 47.846 30.108 1.00 20.93 ? 74   ASP A CA  1 
+ATOM   575  C C   . ASP A 1 74  ? 44.090 48.803 28.946 1.00 17.78 ? 74   ASP A C   1 
+ATOM   576  O O   . ASP A 1 74  ? 43.073 49.489 28.846 1.00 20.59 ? 74   ASP A O   1 
+ATOM   577  C CB  . ASP A 1 74  ? 44.965 48.554 31.255 1.00 23.89 ? 74   ASP A CB  1 
+ATOM   578  C CG  . ASP A 1 74  ? 44.802 47.706 32.519 1.00 40.47 ? 74   ASP A CG  1 
+ATOM   579  O OD1 . ASP A 1 74  ? 43.730 47.099 32.734 1.00 40.72 ? 74   ASP A OD1 1 
+ATOM   580  O OD2 . ASP A 1 74  ? 45.826 47.622 33.237 1.00 44.15 ? 74   ASP A OD2 1 
+ATOM   581  N N   . ASP A 1 75  ? 45.110 48.849 28.113 1.00 15.26 ? 75   ASP A N   1 
+ATOM   582  C CA  . ASP A 1 75  ? 45.109 49.701 26.933 1.00 14.79 ? 75   ASP A CA  1 
+ATOM   583  C C   . ASP A 1 75  ? 45.905 49.037 25.813 1.00 13.50 ? 75   ASP A C   1 
+ATOM   584  O O   . ASP A 1 75  ? 47.126 49.112 25.780 1.00 14.78 ? 75   ASP A O   1 
+ATOM   585  C CB  . ASP A 1 75  ? 45.820 51.024 27.245 1.00 18.18 ? 75   ASP A CB  1 
+ATOM   586  C CG  . ASP A 1 75  ? 45.799 51.977 26.058 1.00 23.28 ? 75   ASP A CG  1 
+ATOM   587  O OD1 . ASP A 1 75  ? 45.309 51.619 24.965 1.00 22.60 ? 75   ASP A OD1 1 
+ATOM   588  O OD2 . ASP A 1 75  ? 46.280 53.110 26.266 1.00 28.50 ? 75   ASP A OD2 1 
+ATOM   589  N N   . PRO A 1 76  ? 45.213 48.402 24.904 1.00 14.37 ? 76   PRO A N   1 
+ATOM   590  C CA  . PRO A 1 76  ? 45.793 47.590 23.844 1.00 18.58 ? 76   PRO A CA  1 
+ATOM   591  C C   . PRO A 1 76  ? 46.481 48.348 22.743 1.00 15.65 ? 76   PRO A C   1 
+ATOM   592  O O   . PRO A 1 76  ? 47.225 47.789 21.918 1.00 17.08 ? 76   PRO A O   1 
+ATOM   593  C CB  . PRO A 1 76  ? 44.642 46.716 23.283 1.00 20.88 ? 76   PRO A CB  1 
+ATOM   594  C CG  . PRO A 1 76  ? 43.487 47.664 23.572 1.00 24.40 ? 76   PRO A CG  1 
+ATOM   595  C CD  . PRO A 1 76  ? 43.747 48.244 24.945 1.00 22.79 ? 76   PRO A CD  1 
+ATOM   596  N N   . SER A 1 77  ? 46.393 49.679 22.769 1.00 16.47 ? 77   SER A N   1 
+ATOM   597  C CA  . SER A 1 77  ? 47.042 50.539 21.796 1.00 18.71 ? 77   SER A CA  1 
+ATOM   598  C C   . SER A 1 77  ? 48.541 50.335 21.799 1.00 13.47 ? 77   SER A C   1 
+ATOM   599  O O   . SER A 1 77  ? 49.210 50.514 20.775 1.00 14.44 ? 77   SER A O   1 
+ATOM   600  C CB  . SER A 1 77  ? 46.621 52.000 22.043 1.00 16.71 ? 77   SER A CB  1 
+ATOM   601  O OG  . SER A 1 77  ? 47.308 52.498 23.164 1.00 21.25 ? 77   SER A OG  1 
+ATOM   602  N N   . VAL A 1 78  ? 49.158 49.870 22.895 1.00 12.99 ? 78   VAL A N   1 
+ATOM   603  C CA  . VAL A 1 78  ? 50.555 49.573 22.988 1.00 14.47 ? 78   VAL A CA  1 
+ATOM   604  C C   . VAL A 1 78  ? 51.018 48.498 22.013 1.00 14.06 ? 78   VAL A C   1 
+ATOM   605  O O   . VAL A 1 78  ? 52.193 48.417 21.637 1.00 12.65 ? 78   VAL A O   1 
+ATOM   606  C CB  . VAL A 1 78  ? 50.912 49.222 24.447 1.00 18.27 ? 78   VAL A CB  1 
+ATOM   607  C CG1 . VAL A 1 78  ? 50.366 47.862 24.897 1.00 15.15 ? 78   VAL A CG1 1 
+ATOM   608  C CG2 . VAL A 1 78  ? 52.394 49.329 24.627 1.00 21.56 ? 78   VAL A CG2 1 
+ATOM   609  N N   . LYS A 1 79  ? 50.105 47.647 21.488 1.00 10.65 ? 79   LYS A N   1 
+ATOM   610  C CA  . LYS A 1 79  ? 50.496 46.672 20.486 1.00 10.97 ? 79   LYS A CA  1 
+ATOM   611  C C   . LYS A 1 79  ? 51.059 47.371 19.248 1.00 11.16 ? 79   LYS A C   1 
+ATOM   612  O O   . LYS A 1 79  ? 51.881 46.839 18.492 1.00 10.18 ? 79   LYS A O   1 
+ATOM   613  C CB  . LYS A 1 79  ? 49.353 45.749 20.069 1.00 15.96 ? 79   LYS A CB  1 
+ATOM   614  C CG  . LYS A 1 79  ? 48.324 46.242 19.092 1.00 20.29 ? 79   LYS A CG  1 
+ATOM   615  C CD  . LYS A 1 79  ? 47.380 45.118 18.647 1.00 19.13 ? 79   LYS A CD  1 
+ATOM   616  C CE  . LYS A 1 79  ? 46.247 45.649 17.803 1.00 24.23 ? 79   LYS A CE  1 
+ATOM   617  N NZ  . LYS A 1 79  ? 45.111 44.697 17.663 1.00 20.43 ? 79   LYS A NZ  1 
+ATOM   618  N N   . GLU A 1 80  ? 50.560 48.580 18.949 1.00 11.62 ? 80   GLU A N   1 
+ATOM   619  C CA  . GLU A 1 80  ? 51.043 49.358 17.816 1.00 11.17 ? 80   GLU A CA  1 
+ATOM   620  C C   . GLU A 1 80  ? 52.496 49.742 17.953 1.00 11.10 ? 80   GLU A C   1 
+ATOM   621  O O   . GLU A 1 80  ? 53.211 49.848 16.920 1.00 9.97  ? 80   GLU A O   1 
+ATOM   622  C CB  . GLU A 1 80  ? 50.147 50.575 17.585 1.00 14.12 ? 80   GLU A CB  1 
+ATOM   623  C CG  . GLU A 1 80  ? 48.728 50.201 17.198 1.00 19.52 ? 80   GLU A CG  1 
+ATOM   624  C CD  . GLU A 1 80  ? 48.591 49.297 16.003 1.00 21.22 ? 80   GLU A CD  1 
+ATOM   625  O OE1 . GLU A 1 80  ? 49.149 49.541 14.895 1.00 22.77 ? 80   GLU A OE1 1 
+ATOM   626  O OE2 . GLU A 1 80  ? 47.931 48.269 16.144 1.00 23.36 ? 80   GLU A OE2 1 
+ATOM   627  N N   . LYS A 1 81  ? 52.980 49.981 19.180 1.00 8.41  ? 81   LYS A N   1 
+ATOM   628  C CA  . LYS A 1 81  ? 54.383 50.289 19.437 1.00 10.47 ? 81   LYS A CA  1 
+ATOM   629  C C   . LYS A 1 81  ? 55.222 49.038 19.190 1.00 9.70  ? 81   LYS A C   1 
+ATOM   630  O O   . LYS A 1 81  ? 56.335 49.134 18.670 1.00 11.00 ? 81   LYS A O   1 
+ATOM   631  C CB  . LYS A 1 81  ? 54.613 50.880 20.831 1.00 10.79 ? 81   LYS A CB  1 
+ATOM   632  C CG  . LYS A 1 81  ? 56.014 51.228 21.241 1.00 13.60 ? 81   LYS A CG  1 
+ATOM   633  C CD  . LYS A 1 81  ? 56.762 52.132 20.260 1.00 18.67 ? 81   LYS A CD  1 
+ATOM   634  C CE  . LYS A 1 81  ? 56.374 53.567 20.383 1.00 21.81 ? 81   LYS A CE  1 
+ATOM   635  N NZ  . LYS A 1 81  ? 57.190 54.434 19.468 1.00 22.52 ? 81   LYS A NZ  1 
+ATOM   636  N N   . VAL A 1 82  ? 54.712 47.860 19.556 1.00 9.73  ? 82   VAL A N   1 
+ATOM   637  C CA  . VAL A 1 82  ? 55.368 46.605 19.196 1.00 9.91  ? 82   VAL A CA  1 
+ATOM   638  C C   . VAL A 1 82  ? 55.544 46.529 17.689 1.00 9.92  ? 82   VAL A C   1 
+ATOM   639  O O   . VAL A 1 82  ? 56.643 46.255 17.201 1.00 8.00  ? 82   VAL A O   1 
+ATOM   640  C CB  . VAL A 1 82  ? 54.546 45.394 19.694 1.00 11.17 ? 82   VAL A CB  1 
+ATOM   641  C CG1 . VAL A 1 82  ? 55.172 44.094 19.197 1.00 14.00 ? 82   VAL A CG1 1 
+ATOM   642  C CG2 . VAL A 1 82  ? 54.503 45.405 21.232 1.00 12.28 ? 82   VAL A CG2 1 
+ATOM   643  N N   . LYS A 1 83  ? 54.495 46.811 16.923 1.00 8.59  ? 83   LYS A N   1 
+ATOM   644  C CA  . LYS A 1 83  ? 54.592 46.798 15.450 1.00 7.52  ? 83   LYS A CA  1 
+ATOM   645  C C   . LYS A 1 83  ? 55.650 47.771 14.958 1.00 7.64  ? 83   LYS A C   1 
+ATOM   646  O O   . LYS A 1 83  ? 56.465 47.408 14.087 1.00 8.48  ? 83   LYS A O   1 
+ATOM   647  C CB  . LYS A 1 83  ? 53.230 47.080 14.784 1.00 11.34 ? 83   LYS A CB  1 
+ATOM   648  C CG  . LYS A 1 83  ? 52.177 46.028 15.107 1.00 9.51  ? 83   LYS A CG  1 
+ATOM   649  C CD  . LYS A 1 83  ? 50.863 46.402 14.416 1.00 18.68 ? 83   LYS A CD  1 
+ATOM   650  C CE  . LYS A 1 83  ? 49.760 45.510 14.962 1.00 18.18 ? 83   LYS A CE  1 
+ATOM   651  N NZ  . LYS A 1 83  ? 48.423 45.763 14.330 1.00 19.58 ? 83   LYS A NZ  1 
+ATOM   652  N N   . GLU A 1 84  ? 55.715 48.972 15.537 1.00 8.01  ? 84   GLU A N   1 
+ATOM   653  C CA  . GLU A 1 84  ? 56.741 49.944 15.149 1.00 8.43  ? 84   GLU A CA  1 
+ATOM   654  C C   . GLU A 1 84  ? 58.137 49.403 15.405 1.00 8.66  ? 84   GLU A C   1 
+ATOM   655  O O   . GLU A 1 84  ? 59.006 49.481 14.513 1.00 10.49 ? 84   GLU A O   1 
+ATOM   656  C CB  . GLU A 1 84  ? 56.523 51.257 15.927 1.00 9.89  ? 84   GLU A CB  1 
+ATOM   657  C CG  . GLU A 1 84  ? 57.471 52.330 15.413 1.00 8.63  ? 84   GLU A CG  1 
+ATOM   658  C CD  . GLU A 1 84  ? 57.326 53.675 16.101 1.00 10.58 ? 84   GLU A CD  1 
+ATOM   659  O OE1 . GLU A 1 84  ? 56.384 53.849 16.880 1.00 9.63  ? 84   GLU A OE1 1 
+ATOM   660  O OE2 . GLU A 1 84  ? 58.197 54.516 15.817 1.00 13.44 ? 84   GLU A OE2 1 
+ATOM   661  N N   . ALA A 1 85  ? 58.362 48.723 16.550 1.00 8.34  ? 85   ALA A N   1 
+ATOM   662  C CA  . ALA A 1 85  ? 59.666 48.152 16.844 1.00 7.24  ? 85   ALA A CA  1 
+ATOM   663  C C   . ALA A 1 85  ? 60.015 47.029 15.852 1.00 9.64  ? 85   ALA A C   1 
+ATOM   664  O O   . ALA A 1 85  ? 61.133 46.982 15.346 1.00 8.33  ? 85   ALA A O   1 
+ATOM   665  C CB  . ALA A 1 85  ? 59.693 47.583 18.260 1.00 8.95  ? 85   ALA A CB  1 
+ATOM   666  N N   . VAL A 1 86  ? 59.027 46.200 15.522 1.00 8.18  ? 86   VAL A N   1 
+ATOM   667  C CA  . VAL A 1 86  ? 59.243 45.080 14.610 1.00 7.60  ? 86   VAL A CA  1 
+ATOM   668  C C   . VAL A 1 86  ? 59.643 45.607 13.224 1.00 10.17 ? 86   VAL A C   1 
+ATOM   669  O O   . VAL A 1 86  ? 60.619 45.119 12.641 1.00 9.93  ? 86   VAL A O   1 
+ATOM   670  C CB  . VAL A 1 86  ? 58.065 44.109 14.502 1.00 10.99 ? 86   VAL A CB  1 
+ATOM   671  C CG1 . VAL A 1 86  ? 58.281 43.097 13.382 1.00 10.78 ? 86   VAL A CG1 1 
+ATOM   672  C CG2 . VAL A 1 86  ? 57.872 43.382 15.837 1.00 8.26  ? 86   VAL A CG2 1 
+ATOM   673  N N   . GLU A 1 87  ? 58.911 46.627 12.785 1.00 11.29 ? 87   GLU A N   1 
+ATOM   674  C CA  . GLU A 1 87  ? 59.123 47.224 11.465 1.00 9.11  ? 87   GLU A CA  1 
+ATOM   675  C C   . GLU A 1 87  ? 60.474 47.895 11.373 1.00 10.08 ? 87   GLU A C   1 
+ATOM   676  O O   . GLU A 1 87  ? 61.235 47.764 10.385 1.00 9.83  ? 87   GLU A O   1 
+ATOM   677  C CB  . GLU A 1 87  ? 57.937 48.109 11.077 1.00 13.89 ? 87   GLU A CB  1 
+ATOM   678  C CG  . GLU A 1 87  ? 56.686 47.272 10.843 1.00 17.02 ? 87   GLU A CG  1 
+ATOM   679  C CD  . GLU A 1 87  ? 55.333 47.930 10.776 1.00 26.93 ? 87   GLU A CD  1 
+ATOM   680  O OE1 . GLU A 1 87  ? 55.252 49.169 10.874 1.00 27.71 ? 87   GLU A OE1 1 
+ATOM   681  O OE2 . GLU A 1 87  ? 54.315 47.170 10.657 1.00 19.76 ? 87   GLU A OE2 1 
+ATOM   682  N N   . ALA A 1 88  ? 60.855 48.541 12.478 1.00 9.73  ? 88   ALA A N   1 
+ATOM   683  C CA  . ALA A 1 88  ? 62.167 49.169 12.551 1.00 10.04 ? 88   ALA A CA  1 
+ATOM   684  C C   . ALA A 1 88  ? 63.252 48.111 12.436 1.00 10.00 ? 88   ALA A C   1 
+ATOM   685  O O   . ALA A 1 88  ? 64.245 48.310 11.726 1.00 10.54 ? 88   ALA A O   1 
+ATOM   686  C CB  . ALA A 1 88  ? 62.258 49.950 13.858 1.00 10.19 ? 88   ALA A CB  1 
+ATOM   687  N N   . ALA A 1 89  ? 63.084 46.987 13.139 1.00 7.90  ? 89   ALA A N   1 
+ATOM   688  C CA  . ALA A 1 89  ? 64.060 45.902 13.146 1.00 8.82  ? 89   ALA A CA  1 
+ATOM   689  C C   . ALA A 1 89  ? 64.209 45.322 11.736 1.00 8.26  ? 89   ALA A C   1 
+ATOM   690  O O   . ALA A 1 89  ? 65.321 45.029 11.286 1.00 10.09 ? 89   ALA A O   1 
+ATOM   691  C CB  . ALA A 1 89  ? 63.675 44.799 14.128 1.00 8.11  ? 89   ALA A CB  1 
+ATOM   692  N N   . ILE A 1 90  ? 63.095 45.202 11.019 1.00 8.65  ? 90   ILE A N   1 
+ATOM   693  C CA  . ILE A 1 90  ? 63.106 44.706 9.640  1.00 7.71  ? 90   ILE A CA  1 
+ATOM   694  C C   . ILE A 1 90  ? 63.862 45.697 8.757  1.00 10.03 ? 90   ILE A C   1 
+ATOM   695  O O   . ILE A 1 90  ? 64.790 45.318 8.003  1.00 10.24 ? 90   ILE A O   1 
+ATOM   696  C CB  . ILE A 1 90  ? 61.651 44.452 9.159  1.00 7.88  ? 90   ILE A CB  1 
+ATOM   697  C CG1 . ILE A 1 90  ? 61.002 43.268 9.887  1.00 9.51  ? 90   ILE A CG1 1 
+ATOM   698  C CG2 . ILE A 1 90  ? 61.671 44.190 7.655  1.00 10.07 ? 90   ILE A CG2 1 
+ATOM   699  C CD1 . ILE A 1 90  ? 59.506 43.256 9.673  1.00 9.52  ? 90   ILE A CD1 1 
+ATOM   700  N N   . ASP A 1 91  ? 63.583 46.990 8.944  1.00 9.03  ? 91   ASP A N   1 
+ATOM   701  C CA  . ASP A 1 91  ? 64.268 48.036 8.198  1.00 12.13 ? 91   ASP A CA  1 
+ATOM   702  C C   . ASP A 1 91  ? 65.770 48.128 8.474  1.00 14.38 ? 91   ASP A C   1 
+ATOM   703  O O   . ASP A 1 91  ? 66.551 48.435 7.562  1.00 12.93 ? 91   ASP A O   1 
+ATOM   704  C CB  . ASP A 1 91  ? 63.608 49.385 8.405  1.00 10.98 ? 91   ASP A CB  1 
+ATOM   705  C CG  . ASP A 1 91  ? 62.246 49.463 7.752  1.00 16.32 ? 91   ASP A CG  1 
+ATOM   706  O OD1 . ASP A 1 91  ? 61.989 48.702 6.788  1.00 18.98 ? 91   ASP A OD1 1 
+ATOM   707  O OD2 . ASP A 1 91  ? 61.412 50.245 8.188  1.00 13.88 ? 91   ASP A OD2 1 
+ATOM   708  N N   . LEU A 1 92  ? 66.212 47.845 9.670  1.00 7.90  ? 92   LEU A N   1 
+ATOM   709  C CA  . LEU A 1 92  ? 67.585 47.909 10.146 1.00 6.60  ? 92   LEU A CA  1 
+ATOM   710  C C   . LEU A 1 92  ? 68.315 46.579 10.042 1.00 8.70  ? 92   LEU A C   1 
+ATOM   711  O O   . LEU A 1 92  ? 69.507 46.464 10.305 1.00 9.96  ? 92   LEU A O   1 
+ATOM   712  C CB  . LEU A 1 92  ? 67.577 48.381 11.601 1.00 10.65 ? 92   LEU A CB  1 
+ATOM   713  C CG  . LEU A 1 92  ? 67.152 49.830 11.826 1.00 10.37 ? 92   LEU A CG  1 
+ATOM   714  C CD1 . LEU A 1 92  ? 66.905 50.087 13.303 1.00 11.41 ? 92   LEU A CD1 1 
+ATOM   715  C CD2 . LEU A 1 92  ? 68.182 50.781 11.233 1.00 12.32 ? 92   LEU A CD2 1 
+ATOM   716  N N   . ASP A 1 93  ? 67.591 45.556 9.587  1.00 9.38  ? 93   ASP A N   1 
+ATOM   717  C CA  . ASP A 1 93  ? 68.145 44.237 9.371  1.00 11.78 ? 93   ASP A CA  1 
+ATOM   718  C C   . ASP A 1 93  ? 68.747 43.668 10.648 1.00 12.38 ? 93   ASP A C   1 
+ATOM   719  O O   . ASP A 1 93  ? 69.857 43.123 10.652 1.00 11.29 ? 93   ASP A O   1 
+ATOM   720  C CB  . ASP A 1 93  ? 69.209 44.310 8.259  1.00 13.06 ? 93   ASP A CB  1 
+ATOM   721  C CG  . ASP A 1 93  ? 69.214 43.016 7.455  1.00 21.85 ? 93   ASP A CG  1 
+ATOM   722  O OD1 . ASP A 1 93  ? 68.122 42.533 7.082  1.00 19.36 ? 93   ASP A OD1 1 
+ATOM   723  O OD2 . ASP A 1 93  ? 70.343 42.505 7.244  1.00 21.81 ? 93   ASP A OD2 1 
+ATOM   724  N N   . ILE A 1 94  ? 68.011 43.770 11.756 1.00 10.76 ? 94   ILE A N   1 
+ATOM   725  C CA  . ILE A 1 94  ? 68.384 43.127 13.011 1.00 10.11 ? 94   ILE A CA  1 
+ATOM   726  C C   . ILE A 1 94  ? 67.218 42.271 13.509 1.00 7.47  ? 94   ILE A C   1 
+ATOM   727  O O   . ILE A 1 94  ? 66.085 42.319 12.966 1.00 7.81  ? 94   ILE A O   1 
+ATOM   728  C CB  . ILE A 1 94  ? 68.786 44.111 14.123 1.00 9.64  ? 94   ILE A CB  1 
+ATOM   729  C CG1 . ILE A 1 94  ? 67.666 45.070 14.521 1.00 8.21  ? 94   ILE A CG1 1 
+ATOM   730  C CG2 . ILE A 1 94  ? 70.032 44.894 13.701 1.00 8.84  ? 94   ILE A CG2 1 
+ATOM   731  C CD1 . ILE A 1 94  ? 68.014 45.861 15.784 1.00 10.55 ? 94   ILE A CD1 1 
+ATOM   732  N N   . TYR A 1 95  ? 67.451 41.421 14.495 1.00 9.08  ? 95   TYR A N   1 
+ATOM   733  C CA  . TYR A 1 95  ? 66.415 40.600 15.082 1.00 9.04  ? 95   TYR A CA  1 
+ATOM   734  C C   . TYR A 1 95  ? 65.580 41.397 16.087 1.00 8.17  ? 95   TYR A C   1 
+ATOM   735  O O   . TYR A 1 95  ? 66.038 42.391 16.647 1.00 6.73  ? 95   TYR A O   1 
+ATOM   736  C CB  . TYR A 1 95  ? 67.002 39.299 15.696 1.00 8.66  ? 95   TYR A CB  1 
+ATOM   737  C CG  . TYR A 1 95  ? 67.605 38.445 14.576 1.00 10.33 ? 95   TYR A CG  1 
+ATOM   738  C CD1 . TYR A 1 95  ? 66.821 37.602 13.801 1.00 11.05 ? 95   TYR A CD1 1 
+ATOM   739  C CD2 . TYR A 1 95  ? 68.964 38.500 14.327 1.00 10.53 ? 95   TYR A CD2 1 
+ATOM   740  C CE1 . TYR A 1 95  ? 67.405 36.845 12.791 1.00 8.40  ? 95   TYR A CE1 1 
+ATOM   741  C CE2 . TYR A 1 95  ? 69.563 37.761 13.334 1.00 10.90 ? 95   TYR A CE2 1 
+ATOM   742  C CZ  . TYR A 1 95  ? 68.756 36.943 12.557 1.00 10.72 ? 95   TYR A CZ  1 
+ATOM   743  O OH  . TYR A 1 95  ? 69.334 36.192 11.538 1.00 12.04 ? 95   TYR A OH  1 
+ATOM   744  N N   . VAL A 1 96  ? 64.360 40.903 16.309 1.00 9.39  ? 96   VAL A N   1 
+ATOM   745  C CA  . VAL A 1 96  ? 63.438 41.536 17.254 1.00 9.60  ? 96   VAL A CA  1 
+ATOM   746  C C   . VAL A 1 96  ? 62.647 40.516 18.050 1.00 8.20  ? 96   VAL A C   1 
+ATOM   747  O O   . VAL A 1 96  ? 62.178 39.527 17.476 1.00 10.73 ? 96   VAL A O   1 
+ATOM   748  C CB  . VAL A 1 96  ? 62.498 42.497 16.516 1.00 9.12  ? 96   VAL A CB  1 
+ATOM   749  C CG1 . VAL A 1 96  ? 61.568 41.805 15.515 1.00 6.57  ? 96   VAL A CG1 1 
+ATOM   750  C CG2 . VAL A 1 96  ? 61.690 43.288 17.531 1.00 9.07  ? 96   VAL A CG2 1 
+ATOM   751  N N   . ILE A 1 97  ? 62.553 40.743 19.348 1.00 6.91  ? 97   ILE A N   1 
+ATOM   752  C CA  . ILE A 1 97  ? 61.809 39.864 20.227 1.00 6.05  ? 97   ILE A CA  1 
+ATOM   753  C C   . ILE A 1 97  ? 60.492 40.537 20.629 1.00 7.11  ? 97   ILE A C   1 
+ATOM   754  O O   . ILE A 1 97  ? 60.482 41.693 21.115 1.00 8.76  ? 97   ILE A O   1 
+ATOM   755  C CB  . ILE A 1 97  ? 62.575 39.538 21.531 1.00 11.24 ? 97   ILE A CB  1 
+ATOM   756  C CG1 . ILE A 1 97  ? 63.905 38.878 21.231 1.00 10.07 ? 97   ILE A CG1 1 
+ATOM   757  C CG2 . ILE A 1 97  ? 61.674 38.697 22.432 1.00 10.44 ? 97   ILE A CG2 1 
+ATOM   758  C CD1 . ILE A 1 97  ? 64.869 38.799 22.418 1.00 10.98 ? 97   ILE A CD1 1 
+ATOM   759  N N   . ILE A 1 98  ? 59.383 39.873 20.360 1.00 7.86  ? 98   ILE A N   1 
+ATOM   760  C CA  . ILE A 1 98  ? 58.057 40.356 20.717 1.00 8.71  ? 98   ILE A CA  1 
+ATOM   761  C C   . ILE A 1 98  ? 57.744 39.738 22.080 1.00 10.07 ? 98   ILE A C   1 
+ATOM   762  O O   . ILE A 1 98  ? 57.529 38.539 22.153 1.00 9.30  ? 98   ILE A O   1 
+ATOM   763  C CB  . ILE A 1 98  ? 57.006 39.954 19.664 1.00 7.42  ? 98   ILE A CB  1 
+ATOM   764  C CG1 . ILE A 1 98  ? 57.287 40.562 18.314 1.00 8.07  ? 98   ILE A CG1 1 
+ATOM   765  C CG2 . ILE A 1 98  ? 55.617 40.287 20.181 1.00 9.29  ? 98   ILE A CG2 1 
+ATOM   766  C CD1 . ILE A 1 98  ? 56.332 40.067 17.199 1.00 10.63 ? 98   ILE A CD1 1 
+ATOM   767  N N   . ASP A 1 99  ? 57.795 40.544 23.155 1.00 9.40  ? 99   ASP A N   1 
+ATOM   768  C CA  . ASP A 1 99  ? 57.641 40.002 24.508 1.00 8.84  ? 99   ASP A CA  1 
+ATOM   769  C C   . ASP A 1 99  ? 56.298 40.331 25.144 1.00 10.54 ? 99   ASP A C   1 
+ATOM   770  O O   . ASP A 1 99  ? 55.954 41.488 25.436 1.00 10.28 ? 99   ASP A O   1 
+ATOM   771  C CB  . ASP A 1 99  ? 58.802 40.525 25.359 1.00 9.55  ? 99   ASP A CB  1 
+ATOM   772  C CG  . ASP A 1 99  ? 58.691 40.559 26.841 1.00 11.36 ? 99   ASP A CG  1 
+ATOM   773  O OD1 . ASP A 1 99  ? 58.000 39.675 27.421 1.00 8.43  ? 99   ASP A OD1 1 
+ATOM   774  O OD2 . ASP A 1 99  ? 59.304 41.471 27.475 1.00 10.90 ? 99   ASP A OD2 1 
+ATOM   775  N N   . TRP A 1 100 ? 55.541 39.292 25.397 1.00 6.42  ? 100  TRP A N   1 
+ATOM   776  C CA  . TRP A 1 100 ? 54.242 39.303 26.109 1.00 8.03  ? 100  TRP A CA  1 
+ATOM   777  C C   . TRP A 1 100 ? 54.675 39.312 27.569 1.00 7.48  ? 100  TRP A C   1 
+ATOM   778  O O   . TRP A 1 100 ? 55.001 38.302 28.172 1.00 7.06  ? 100  TRP A O   1 
+ATOM   779  C CB  . TRP A 1 100 ? 53.464 38.061 25.765 1.00 10.92 ? 100  TRP A CB  1 
+ATOM   780  C CG  . TRP A 1 100 ? 52.120 37.889 26.395 1.00 8.57  ? 100  TRP A CG  1 
+ATOM   781  C CD1 . TRP A 1 100 ? 51.791 37.089 27.443 1.00 10.80 ? 100  TRP A CD1 1 
+ATOM   782  C CD2 . TRP A 1 100 ? 50.900 38.529 25.976 1.00 9.51  ? 100  TRP A CD2 1 
+ATOM   783  N NE1 . TRP A 1 100 ? 50.444 37.192 27.712 1.00 9.33  ? 100  TRP A NE1 1 
+ATOM   784  C CE2 . TRP A 1 100 ? 49.875 38.071 26.838 1.00 10.51 ? 100  TRP A CE2 1 
+ATOM   785  C CE3 . TRP A 1 100 ? 50.569 39.436 24.974 1.00 9.06  ? 100  TRP A CE3 1 
+ATOM   786  C CZ2 . TRP A 1 100 ? 48.544 38.492 26.718 1.00 11.07 ? 100  TRP A CZ2 1 
+ATOM   787  C CZ3 . TRP A 1 100 ? 49.259 39.839 24.849 1.00 8.88  ? 100  TRP A CZ3 1 
+ATOM   788  C CH2 . TRP A 1 100 ? 48.266 39.386 25.721 1.00 11.04 ? 100  TRP A CH2 1 
+ATOM   789  N N   . HIS A 1 101 ? 54.812 40.531 28.096 1.00 8.21  ? 101  HIS A N   1 
+ATOM   790  C CA  . HIS A 1 101 ? 55.525 40.760 29.322 1.00 8.18  ? 101  HIS A CA  1 
+ATOM   791  C C   . HIS A 1 101 ? 54.664 40.645 30.573 1.00 8.65  ? 101  HIS A C   1 
+ATOM   792  O O   . HIS A 1 101 ? 54.274 41.613 31.182 1.00 10.10 ? 101  HIS A O   1 
+ATOM   793  C CB  . HIS A 1 101 ? 56.268 42.081 29.222 1.00 7.33  ? 101  HIS A CB  1 
+ATOM   794  C CG  . HIS A 1 101 ? 57.304 42.345 30.245 1.00 7.07  ? 101  HIS A CG  1 
+ATOM   795  N ND1 . HIS A 1 101 ? 58.628 42.041 29.957 1.00 8.41  ? 101  HIS A ND1 1 
+ATOM   796  C CD2 . HIS A 1 101 ? 57.289 42.868 31.495 1.00 7.44  ? 101  HIS A CD2 1 
+ATOM   797  C CE1 . HIS A 1 101 ? 59.376 42.390 30.997 1.00 10.21 ? 101  HIS A CE1 1 
+ATOM   798  N NE2 . HIS A 1 101 ? 58.584 42.860 31.957 1.00 9.69  ? 101  HIS A NE2 1 
+ATOM   799  N N   . ILE A 1 102 ? 54.420 39.366 30.946 1.00 8.21  ? 102  ILE A N   1 
+ATOM   800  C CA  . ILE A 1 102 ? 53.676 39.080 32.184 1.00 8.52  ? 102  ILE A CA  1 
+ATOM   801  C C   . ILE A 1 102 ? 54.595 39.348 33.381 1.00 9.87  ? 102  ILE A C   1 
+ATOM   802  O O   . ILE A 1 102 ? 55.817 39.242 33.286 1.00 9.86  ? 102  ILE A O   1 
+ATOM   803  C CB  . ILE A 1 102 ? 53.099 37.671 32.273 1.00 10.06 ? 102  ILE A CB  1 
+ATOM   804  C CG1 . ILE A 1 102 ? 54.152 36.605 32.547 1.00 12.73 ? 102  ILE A CG1 1 
+ATOM   805  C CG2 . ILE A 1 102 ? 52.324 37.343 30.991 1.00 9.16  ? 102  ILE A CG2 1 
+ATOM   806  C CD1 . ILE A 1 102 ? 53.536 35.211 32.799 1.00 10.57 ? 102  ILE A CD1 1 
+ATOM   807  N N   . LEU A 1 103 ? 54.006 39.757 34.496 1.00 9.16  ? 103  LEU A N   1 
+ATOM   808  C CA  . LEU A 1 103 ? 54.803 39.972 35.726 1.00 8.61  ? 103  LEU A CA  1 
+ATOM   809  C C   . LEU A 1 103 ? 53.857 39.902 36.927 1.00 10.71 ? 103  LEU A C   1 
+ATOM   810  O O   . LEU A 1 103 ? 53.770 38.836 37.542 1.00 11.55 ? 103  LEU A O   1 
+ATOM   811  C CB  . LEU A 1 103 ? 55.548 41.283 35.732 1.00 10.79 ? 103  LEU A CB  1 
+ATOM   812  C CG  . LEU A 1 103 ? 56.599 41.470 36.833 1.00 11.87 ? 103  LEU A CG  1 
+ATOM   813  C CD1 . LEU A 1 103 ? 57.777 40.513 36.707 1.00 16.70 ? 103  LEU A CD1 1 
+ATOM   814  C CD2 . LEU A 1 103 ? 57.067 42.920 36.860 1.00 14.09 ? 103  LEU A CD2 1 
+ATOM   815  N N   . SER A 1 104 ? 53.134 40.970 37.262 1.00 11.04 ? 104  SER A N   1 
+ATOM   816  C CA  . SER A 1 104 ? 52.167 40.889 38.374 1.00 12.04 ? 104  SER A CA  1 
+ATOM   817  C C   . SER A 1 104 ? 51.050 39.893 38.113 1.00 10.14 ? 104  SER A C   1 
+ATOM   818  O O   . SER A 1 104 ? 50.519 39.242 39.034 1.00 13.66 ? 104  SER A O   1 
+ATOM   819  C CB  A SER A 1 104 ? 51.603 42.278 38.678 0.19 12.84 ? 104  SER A CB  1 
+ATOM   820  C CB  B SER A 1 104 ? 51.616 42.285 38.712 0.81 11.10 ? 104  SER A CB  1 
+ATOM   821  O OG  A SER A 1 104 ? 52.657 43.227 38.668 0.19 16.39 ? 104  SER A OG  1 
+ATOM   822  O OG  B SER A 1 104 ? 50.918 42.830 37.584 0.81 13.75 ? 104  SER A OG  1 
+ATOM   823  N N   . ASP A 1 105 ? 50.656 39.644 36.883 1.00 11.73 ? 105  ASP A N   1 
+ATOM   824  C CA  . ASP A 1 105 ? 49.787 38.652 36.300 1.00 10.84 ? 105  ASP A CA  1 
+ATOM   825  C C   . ASP A 1 105 ? 50.732 37.472 36.118 1.00 13.14 ? 105  ASP A C   1 
+ATOM   826  O O   . ASP A 1 105 ? 51.278 37.149 35.069 1.00 14.41 ? 105  ASP A O   1 
+ATOM   827  C CB  . ASP A 1 105 ? 49.155 39.147 35.011 1.00 12.13 ? 105  ASP A CB  1 
+ATOM   828  C CG  . ASP A 1 105 ? 50.156 39.565 33.925 1.00 11.95 ? 105  ASP A CG  1 
+ATOM   829  O OD1 . ASP A 1 105 ? 51.158 40.258 34.248 1.00 11.54 ? 105  ASP A OD1 1 
+ATOM   830  O OD2 . ASP A 1 105 ? 49.919 39.180 32.772 1.00 12.00 ? 105  ASP A OD2 1 
+ATOM   831  N N   . ASN A 1 106 ? 50.957 36.829 37.286 1.00 14.09 ? 106  ASN A N   1 
+ATOM   832  C CA  . ASN A 1 106 ? 52.079 35.933 37.498 1.00 12.79 ? 106  ASN A CA  1 
+ATOM   833  C C   . ASN A 1 106 ? 51.952 34.566 36.856 1.00 11.11 ? 106  ASN A C   1 
+ATOM   834  O O   . ASN A 1 106 ? 52.963 33.895 36.696 1.00 11.70 ? 106  ASN A O   1 
+ATOM   835  C CB  . ASN A 1 106 ? 52.367 35.815 38.990 1.00 14.67 ? 106  ASN A CB  1 
+ATOM   836  C CG  . ASN A 1 106 ? 51.187 35.264 39.770 1.00 14.61 ? 106  ASN A CG  1 
+ATOM   837  O OD1 . ASN A 1 106 ? 50.167 35.949 39.871 1.00 14.87 ? 106  ASN A OD1 1 
+ATOM   838  N ND2 . ASN A 1 106 ? 51.335 34.035 40.241 1.00 13.47 ? 106  ASN A ND2 1 
+ATOM   839  N N   . ASP A 1 107 ? 50.727 34.206 36.545 1.00 10.77 ? 107  ASP A N   1 
+ATOM   840  C CA  . ASP A 1 107 ? 50.482 32.951 35.837 1.00 10.75 ? 107  ASP A CA  1 
+ATOM   841  C C   . ASP A 1 107 ? 50.129 33.337 34.420 1.00 15.24 ? 107  ASP A C   1 
+ATOM   842  O O   . ASP A 1 107 ? 49.186 34.124 34.207 1.00 12.63 ? 107  ASP A O   1 
+ATOM   843  C CB  . ASP A 1 107 ? 49.294 32.279 36.536 1.00 12.17 ? 107  ASP A CB  1 
+ATOM   844  C CG  . ASP A 1 107 ? 48.909 30.938 35.968 1.00 17.04 ? 107  ASP A CG  1 
+ATOM   845  O OD1 . ASP A 1 107 ? 49.308 30.548 34.864 1.00 12.24 ? 107  ASP A OD1 1 
+ATOM   846  O OD2 . ASP A 1 107 ? 48.146 30.259 36.686 1.00 19.77 ? 107  ASP A OD2 1 
+ATOM   847  N N   . PRO A 1 108 ? 50.811 32.790 33.412 1.00 11.01 ? 108  PRO A N   1 
+ATOM   848  C CA  . PRO A 1 108 ? 50.519 33.086 32.004 1.00 7.43  ? 108  PRO A CA  1 
+ATOM   849  C C   . PRO A 1 108 ? 49.125 32.706 31.587 1.00 10.10 ? 108  PRO A C   1 
+ATOM   850  O O   . PRO A 1 108 ? 48.546 33.231 30.605 1.00 9.45  ? 108  PRO A O   1 
+ATOM   851  C CB  . PRO A 1 108 ? 51.597 32.314 31.198 1.00 9.75  ? 108  PRO A CB  1 
+ATOM   852  C CG  . PRO A 1 108 ? 51.957 31.214 32.170 1.00 10.64 ? 108  PRO A CG  1 
+ATOM   853  C CD  . PRO A 1 108 ? 51.892 31.836 33.576 1.00 10.50 ? 108  PRO A CD  1 
+ATOM   854  N N   . ASN A 1 109 ? 48.469 31.791 32.343 1.00 8.60  ? 109  ASN A N   1 
+ATOM   855  C CA  . ASN A 1 109 ? 47.103 31.429 31.997 1.00 9.44  ? 109  ASN A CA  1 
+ATOM   856  C C   . ASN A 1 109 ? 46.091 32.516 32.261 1.00 12.11 ? 109  ASN A C   1 
+ATOM   857  O O   . ASN A 1 109 ? 44.982 32.436 31.713 1.00 9.50  ? 109  ASN A O   1 
+ATOM   858  C CB  . ASN A 1 109 ? 46.709 30.116 32.711 1.00 11.27 ? 109  ASN A CB  1 
+ATOM   859  C CG  . ASN A 1 109 ? 47.554 28.976 32.159 1.00 11.38 ? 109  ASN A CG  1 
+ATOM   860  O OD1 . ASN A 1 109 ? 47.358 28.534 31.032 1.00 13.95 ? 109  ASN A OD1 1 
+ATOM   861  N ND2 . ASN A 1 109 ? 48.515 28.475 32.923 1.00 11.14 ? 109  ASN A ND2 1 
+ATOM   862  N N   . ILE A 1 110 ? 46.389 33.487 33.137 1.00 11.18 ? 110  ILE A N   1 
+ATOM   863  C CA  . ILE A 1 110 ? 45.439 34.528 33.454 1.00 12.26 ? 110  ILE A CA  1 
+ATOM   864  C C   . ILE A 1 110 ? 44.910 35.195 32.182 1.00 14.51 ? 110  ILE A C   1 
+ATOM   865  O O   . ILE A 1 110 ? 43.684 35.319 31.988 1.00 14.09 ? 110  ILE A O   1 
+ATOM   866  C CB  . ILE A 1 110 ? 46.022 35.618 34.360 1.00 12.36 ? 110  ILE A CB  1 
+ATOM   867  C CG1 . ILE A 1 110 ? 46.415 35.025 35.706 1.00 14.28 ? 110  ILE A CG1 1 
+ATOM   868  C CG2 . ILE A 1 110 ? 45.019 36.764 34.539 1.00 15.75 ? 110  ILE A CG2 1 
+ATOM   869  C CD1 . ILE A 1 110 ? 47.415 35.832 36.497 1.00 14.19 ? 110  ILE A CD1 1 
+ATOM   870  N N   . TYR A 1 111 ? 45.837 35.643 31.320 1.00 11.30 ? 111  TYR A N   1 
+ATOM   871  C CA  . TYR A 1 111 ? 45.429 36.247 30.058 1.00 11.15 ? 111  TYR A CA  1 
+ATOM   872  C C   . TYR A 1 111 ? 45.709 35.399 28.821 1.00 12.48 ? 111  TYR A C   1 
+ATOM   873  O O   . TYR A 1 111 ? 46.061 35.917 27.745 1.00 12.83 ? 111  TYR A O   1 
+ATOM   874  C CB  . TYR A 1 111 ? 46.074 37.633 29.937 1.00 11.60 ? 111  TYR A CB  1 
+ATOM   875  C CG  . TYR A 1 111 ? 45.609 38.570 31.037 1.00 11.05 ? 111  TYR A CG  1 
+ATOM   876  C CD1 . TYR A 1 111 ? 44.280 38.924 31.172 1.00 12.96 ? 111  TYR A CD1 1 
+ATOM   877  C CD2 . TYR A 1 111 ? 46.529 39.092 31.922 1.00 13.98 ? 111  TYR A CD2 1 
+ATOM   878  C CE1 . TYR A 1 111 ? 43.864 39.776 32.190 1.00 13.44 ? 111  TYR A CE1 1 
+ATOM   879  C CE2 . TYR A 1 111 ? 46.142 39.956 32.918 1.00 13.23 ? 111  TYR A CE2 1 
+ATOM   880  C CZ  . TYR A 1 111 ? 44.803 40.273 33.052 1.00 15.76 ? 111  TYR A CZ  1 
+ATOM   881  O OH  . TYR A 1 111 ? 44.435 41.151 34.053 1.00 18.55 ? 111  TYR A OH  1 
+ATOM   882  N N   . LYS A 1 112 ? 45.522 34.073 28.900 1.00 10.86 ? 112  LYS A N   1 
+ATOM   883  C CA  . LYS A 1 112 ? 45.862 33.218 27.764 1.00 9.86  ? 112  LYS A CA  1 
+ATOM   884  C C   . LYS A 1 112 ? 45.043 33.418 26.513 1.00 10.66 ? 112  LYS A C   1 
+ATOM   885  O O   . LYS A 1 112 ? 45.566 33.358 25.386 1.00 10.30 ? 112  LYS A O   1 
+ATOM   886  C CB  . LYS A 1 112 ? 45.823 31.742 28.198 1.00 11.20 ? 112  LYS A CB  1 
+ATOM   887  C CG  . LYS A 1 112 ? 44.486 31.104 28.459 1.00 20.85 ? 112  LYS A CG  1 
+ATOM   888  C CD  . LYS A 1 112 ? 44.796 29.606 28.753 1.00 23.15 ? 112  LYS A CD  1 
+ATOM   889  C CE  . LYS A 1 112 ? 43.507 28.810 28.781 1.00 27.78 ? 112  LYS A CE  1 
+ATOM   890  N NZ  . LYS A 1 112 ? 43.771 27.462 29.386 1.00 30.76 ? 112  LYS A NZ  1 
+ATOM   891  N N   . GLU A 1 113 ? 43.755 33.741 26.651 1.00 10.83 ? 113  GLU A N   1 
+ATOM   892  C CA  . GLU A 1 113 ? 42.920 33.957 25.482 1.00 12.36 ? 113  GLU A CA  1 
+ATOM   893  C C   . GLU A 1 113 ? 43.404 35.214 24.753 1.00 13.36 ? 113  GLU A C   1 
+ATOM   894  O O   . GLU A 1 113 ? 43.505 35.180 23.516 1.00 13.95 ? 113  GLU A O   1 
+ATOM   895  C CB  . GLU A 1 113 ? 41.462 34.115 25.843 1.00 15.45 ? 113  GLU A CB  1 
+ATOM   896  C CG  . GLU A 1 113 ? 40.784 32.870 26.370 1.00 25.48 ? 113  GLU A CG  1 
+ATOM   897  C CD  . GLU A 1 113 ? 40.958 31.645 25.486 1.00 26.89 ? 113  GLU A CD  1 
+ATOM   898  O OE1 . GLU A 1 113 ? 40.808 31.737 24.260 1.00 29.11 ? 113  GLU A OE1 1 
+ATOM   899  O OE2 . GLU A 1 113 ? 41.277 30.589 26.091 1.00 30.68 ? 113  GLU A OE2 1 
+ATOM   900  N N   . GLU A 1 114 ? 43.696 36.273 25.511 1.00 9.22  ? 114  GLU A N   1 
+ATOM   901  C CA  . GLU A 1 114 ? 44.216 37.485 24.881 1.00 8.33  ? 114  GLU A CA  1 
+ATOM   902  C C   . GLU A 1 114 ? 45.582 37.226 24.256 1.00 11.14 ? 114  GLU A C   1 
+ATOM   903  O O   . GLU A 1 114 ? 45.951 37.749 23.188 1.00 10.75 ? 114  GLU A O   1 
+ATOM   904  C CB  . GLU A 1 114 ? 44.289 38.611 25.914 1.00 10.69 ? 114  GLU A CB  1 
+ATOM   905  C CG  . GLU A 1 114 ? 42.921 39.021 26.444 1.00 15.89 ? 114  GLU A CG  1 
+ATOM   906  C CD  . GLU A 1 114 ? 42.437 38.272 27.652 1.00 18.51 ? 114  GLU A CD  1 
+ATOM   907  O OE1 . GLU A 1 114 ? 42.985 37.218 27.981 1.00 14.38 ? 114  GLU A OE1 1 
+ATOM   908  O OE2 . GLU A 1 114 ? 41.495 38.732 28.345 1.00 21.76 ? 114  GLU A OE2 1 
+ATOM   909  N N   . ALA A 1 115 ? 46.414 36.407 24.881 1.00 10.46 ? 115  ALA A N   1 
+ATOM   910  C CA  . ALA A 1 115 ? 47.733 36.045 24.341 1.00 10.67 ? 115  ALA A CA  1 
+ATOM   911  C C   . ALA A 1 115 ? 47.625 35.289 23.026 1.00 9.46  ? 115  ALA A C   1 
+ATOM   912  O O   . ALA A 1 115 ? 48.379 35.552 22.066 1.00 10.63 ? 115  ALA A O   1 
+ATOM   913  C CB  . ALA A 1 115 ? 48.511 35.162 25.316 1.00 13.28 ? 115  ALA A CB  1 
+ATOM   914  N N   . LYS A 1 116 ? 46.680 34.360 22.953 1.00 11.22 ? 116  LYS A N   1 
+ATOM   915  C CA  . LYS A 1 116 ? 46.520 33.618 21.678 1.00 10.79 ? 116  LYS A CA  1 
+ATOM   916  C C   . LYS A 1 116 ? 46.106 34.556 20.552 1.00 12.43 ? 116  LYS A C   1 
+ATOM   917  O O   . LYS A 1 116 ? 46.622 34.484 19.436 1.00 8.84  ? 116  LYS A O   1 
+ATOM   918  C CB  . LYS A 1 116 ? 45.493 32.505 21.877 1.00 9.25  ? 116  LYS A CB  1 
+ATOM   919  C CG  . LYS A 1 116 ? 45.979 31.437 22.844 1.00 13.87 ? 116  LYS A CG  1 
+ATOM   920  C CD  . LYS A 1 116 ? 44.885 30.442 23.167 1.00 17.55 ? 116  LYS A CD  1 
+ATOM   921  C CE  . LYS A 1 116 ? 44.615 29.500 22.004 1.00 17.51 ? 116  LYS A CE  1 
+ATOM   922  N NZ  . LYS A 1 116 ? 43.504 28.549 22.341 1.00 17.12 ? 116  LYS A NZ  1 
+ATOM   923  N N   . ASP A 1 117 ? 45.182 35.464 20.861 1.00 12.61 ? 117  ASP A N   1 
+ATOM   924  C CA  . ASP A 1 117 ? 44.723 36.413 19.824 1.00 14.37 ? 117  ASP A CA  1 
+ATOM   925  C C   . ASP A 1 117 ? 45.845 37.344 19.375 1.00 10.79 ? 117  ASP A C   1 
+ATOM   926  O O   . ASP A 1 117 ? 46.008 37.658 18.178 1.00 10.79 ? 117  ASP A O   1 
+ATOM   927  C CB  . ASP A 1 117 ? 43.567 37.223 20.394 1.00 15.10 ? 117  ASP A CB  1 
+ATOM   928  C CG  . ASP A 1 117 ? 42.244 36.511 20.490 1.00 19.77 ? 117  ASP A CG  1 
+ATOM   929  O OD1 . ASP A 1 117 ? 42.117 35.403 19.954 1.00 19.22 ? 117  ASP A OD1 1 
+ATOM   930  O OD2 . ASP A 1 117 ? 41.317 37.118 21.078 1.00 22.24 ? 117  ASP A OD2 1 
+ATOM   931  N N   . PHE A 1 118 ? 46.615 37.842 20.351 1.00 8.83  ? 118  PHE A N   1 
+ATOM   932  C CA  . PHE A 1 118 ? 47.757 38.706 20.120 1.00 9.44  ? 118  PHE A CA  1 
+ATOM   933  C C   . PHE A 1 118 ? 48.820 38.008 19.277 1.00 13.06 ? 118  PHE A C   1 
+ATOM   934  O O   . PHE A 1 118 ? 49.340 38.573 18.309 1.00 10.46 ? 118  PHE A O   1 
+ATOM   935  C CB  . PHE A 1 118 ? 48.430 39.171 21.434 1.00 11.63 ? 118  PHE A CB  1 
+ATOM   936  C CG  . PHE A 1 118 ? 49.679 40.001 21.255 1.00 10.85 ? 118  PHE A CG  1 
+ATOM   937  C CD1 . PHE A 1 118 ? 49.628 41.331 20.854 1.00 12.04 ? 118  PHE A CD1 1 
+ATOM   938  C CD2 . PHE A 1 118 ? 50.919 39.443 21.499 1.00 10.59 ? 118  PHE A CD2 1 
+ATOM   939  C CE1 . PHE A 1 118 ? 50.802 42.068 20.681 1.00 10.23 ? 118  PHE A CE1 1 
+ATOM   940  C CE2 . PHE A 1 118 ? 52.103 40.146 21.332 1.00 7.81  ? 118  PHE A CE2 1 
+ATOM   941  C CZ  . PHE A 1 118 ? 52.021 41.486 20.941 1.00 9.95  ? 118  PHE A CZ  1 
+ATOM   942  N N   . PHE A 1 119 ? 49.226 36.798 19.720 1.00 10.36 ? 119  PHE A N   1 
+ATOM   943  C CA  . PHE A 1 119 ? 50.214 36.069 18.927 1.00 10.36 ? 119  PHE A CA  1 
+ATOM   944  C C   . PHE A 1 119 ? 49.715 35.586 17.583 1.00 12.31 ? 119  PHE A C   1 
+ATOM   945  O O   . PHE A 1 119 ? 50.514 35.502 16.625 1.00 10.62 ? 119  PHE A O   1 
+ATOM   946  C CB  . PHE A 1 119 ? 50.852 34.954 19.752 1.00 8.86  ? 119  PHE A CB  1 
+ATOM   947  C CG  . PHE A 1 119 ? 51.890 35.515 20.706 1.00 10.09 ? 119  PHE A CG  1 
+ATOM   948  C CD1 . PHE A 1 119 ? 53.100 36.005 20.231 1.00 8.99  ? 119  PHE A CD1 1 
+ATOM   949  C CD2 . PHE A 1 119 ? 51.667 35.522 22.072 1.00 9.07  ? 119  PHE A CD2 1 
+ATOM   950  C CE1 . PHE A 1 119 ? 54.047 36.535 21.105 1.00 9.33  ? 119  PHE A CE1 1 
+ATOM   951  C CE2 . PHE A 1 119 ? 52.608 36.031 22.940 1.00 8.32  ? 119  PHE A CE2 1 
+ATOM   952  C CZ  . PHE A 1 119 ? 53.807 36.545 22.467 1.00 9.99  ? 119  PHE A CZ  1 
+ATOM   953  N N   . ASP A 1 120 ? 48.435 35.352 17.377 1.00 7.32  ? 120  ASP A N   1 
+ATOM   954  C CA  . ASP A 1 120 ? 47.878 35.038 16.058 1.00 11.03 ? 120  ASP A CA  1 
+ATOM   955  C C   . ASP A 1 120 ? 48.095 36.236 15.139 1.00 10.91 ? 120  ASP A C   1 
+ATOM   956  O O   . ASP A 1 120 ? 48.614 36.151 14.027 1.00 12.41 ? 120  ASP A O   1 
+ATOM   957  C CB  A ASP A 1 120 ? 46.370 34.780 16.186 0.48 11.76 ? 120  ASP A CB  1 
+ATOM   958  C CB  B ASP A 1 120 ? 46.380 34.756 16.208 0.52 9.74  ? 120  ASP A CB  1 
+ATOM   959  C CG  A ASP A 1 120 ? 45.686 34.623 14.838 0.48 16.96 ? 120  ASP A CG  1 
+ATOM   960  C CG  B ASP A 1 120 ? 45.697 34.200 14.979 0.52 10.49 ? 120  ASP A CG  1 
+ATOM   961  O OD1 A ASP A 1 120 ? 46.050 33.685 14.102 0.48 13.37 ? 120  ASP A OD1 1 
+ATOM   962  O OD1 B ASP A 1 120 ? 46.368 33.591 14.116 0.52 10.73 ? 120  ASP A OD1 1 
+ATOM   963  O OD2 A ASP A 1 120 ? 44.818 35.454 14.505 0.48 15.48 ? 120  ASP A OD2 1 
+ATOM   964  O OD2 B ASP A 1 120 ? 44.466 34.396 14.853 0.52 14.00 ? 120  ASP A OD2 1 
+ATOM   965  N N   . GLU A 1 121 ? 47.760 37.437 15.656 1.00 7.83  ? 121  GLU A N   1 
+ATOM   966  C CA  . GLU A 1 121 ? 47.894 38.661 14.889 1.00 8.86  ? 121  GLU A CA  1 
+ATOM   967  C C   . GLU A 1 121 ? 49.346 38.958 14.529 1.00 10.79 ? 121  GLU A C   1 
+ATOM   968  O O   . GLU A 1 121 ? 49.629 39.244 13.346 1.00 11.88 ? 121  GLU A O   1 
+ATOM   969  C CB  . GLU A 1 121 ? 47.275 39.833 15.635 1.00 12.21 ? 121  GLU A CB  1 
+ATOM   970  C CG  . GLU A 1 121 ? 47.328 41.126 14.801 1.00 16.81 ? 121  GLU A CG  1 
+ATOM   971  C CD  . GLU A 1 121 ? 46.846 42.327 15.585 1.00 25.57 ? 121  GLU A CD  1 
+ATOM   972  O OE1 . GLU A 1 121 ? 46.346 42.173 16.716 1.00 32.41 ? 121  GLU A OE1 1 
+ATOM   973  O OE2 . GLU A 1 121 ? 46.974 43.447 15.069 1.00 28.01 ? 121  GLU A OE2 1 
+ATOM   974  N N   . MET A 1 122 ? 50.251 38.836 15.520 1.00 8.47  ? 122  MET A N   1 
+ATOM   975  C CA  . MET A 1 122 ? 51.652 39.155 15.242 1.00 9.73  ? 122  MET A CA  1 
+ATOM   976  C C   . MET A 1 122 ? 52.251 38.165 14.261 1.00 9.89  ? 122  MET A C   1 
+ATOM   977  O O   . MET A 1 122 ? 53.027 38.539 13.363 1.00 8.43  ? 122  MET A O   1 
+ATOM   978  C CB  . MET A 1 122 ? 52.521 39.213 16.513 1.00 11.27 ? 122  MET A CB  1 
+ATOM   979  C CG  . MET A 1 122 ? 52.142 40.299 17.513 1.00 11.81 ? 122  MET A CG  1 
+ATOM   980  S SD  . MET A 1 122 ? 52.308 41.950 16.804 1.00 14.50 ? 122  MET A SD  1 
+ATOM   981  C CE  . MET A 1 122 ? 50.628 42.342 16.476 1.00 20.81 ? 122  MET A CE  1 
+ATOM   982  N N   . SER A 1 123 ? 51.971 36.873 14.432 1.00 7.37  ? 123  SER A N   1 
+ATOM   983  C CA  . SER A 1 123 ? 52.554 35.884 13.515 1.00 9.48  ? 123  SER A CA  1 
+ATOM   984  C C   . SER A 1 123 ? 51.906 35.943 12.138 1.00 10.57 ? 123  SER A C   1 
+ATOM   985  O O   . SER A 1 123 ? 52.605 35.687 11.133 1.00 8.95  ? 123  SER A O   1 
+ATOM   986  C CB  . SER A 1 123 ? 52.473 34.464 14.091 1.00 10.42 ? 123  SER A CB  1 
+ATOM   987  O OG  . SER A 1 123 ? 51.135 34.088 14.332 1.00 9.90  ? 123  SER A OG  1 
+ATOM   988  N N   . GLU A 1 124 ? 50.656 36.340 12.044 1.00 9.03  ? 124  GLU A N   1 
+ATOM   989  C CA  . GLU A 1 124 ? 50.045 36.517 10.712 1.00 11.83 ? 124  GLU A CA  1 
+ATOM   990  C C   . GLU A 1 124 ? 50.709 37.704 10.012 1.00 13.31 ? 124  GLU A C   1 
+ATOM   991  O O   . GLU A 1 124 ? 51.036 37.670 8.828  1.00 11.64 ? 124  GLU A O   1 
+ATOM   992  C CB  . GLU A 1 124 ? 48.554 36.776 10.925 1.00 17.45 ? 124  GLU A CB  1 
+ATOM   993  C CG  . GLU A 1 124 ? 47.720 36.788 9.665  1.00 40.06 ? 124  GLU A CG  1 
+ATOM   994  C CD  . GLU A 1 124 ? 46.332 36.208 9.895  1.00 55.15 ? 124  GLU A CD  1 
+ATOM   995  O OE1 . GLU A 1 124 ? 46.131 35.410 10.848 1.00 56.97 ? 124  GLU A OE1 1 
+ATOM   996  O OE2 . GLU A 1 124 ? 45.417 36.548 9.098  1.00 62.00 ? 124  GLU A OE2 1 
+ATOM   997  N N   . LEU A 1 125 ? 50.959 38.804 10.729 1.00 11.12 ? 125  LEU A N   1 
+ATOM   998  C CA  . LEU A 1 125 ? 51.610 39.958 10.153 1.00 12.17 ? 125  LEU A CA  1 
+ATOM   999  C C   . LEU A 1 125 ? 53.060 39.774 9.748  1.00 11.72 ? 125  LEU A C   1 
+ATOM   1000 O O   . LEU A 1 125 ? 53.501 40.146 8.662  1.00 11.65 ? 125  LEU A O   1 
+ATOM   1001 C CB  . LEU A 1 125 ? 51.551 41.130 11.127 1.00 14.16 ? 125  LEU A CB  1 
+ATOM   1002 C CG  . LEU A 1 125 ? 50.249 41.872 11.308 1.00 21.37 ? 125  LEU A CG  1 
+ATOM   1003 C CD1 . LEU A 1 125 ? 50.387 42.843 12.482 1.00 18.32 ? 125  LEU A CD1 1 
+ATOM   1004 C CD2 . LEU A 1 125 ? 49.883 42.597 10.021 1.00 22.98 ? 125  LEU A CD2 1 
+ATOM   1005 N N   . TYR A 1 126 ? 53.885 39.181 10.624 1.00 9.06  ? 126  TYR A N   1 
+ATOM   1006 C CA  . TYR A 1 126 ? 55.317 39.131 10.451 1.00 10.47 ? 126  TYR A CA  1 
+ATOM   1007 C C   . TYR A 1 126 ? 55.935 37.750 10.338 1.00 9.13  ? 126  TYR A C   1 
+ATOM   1008 O O   . TYR A 1 126 ? 57.145 37.552 10.347 1.00 11.45 ? 126  TYR A O   1 
+ATOM   1009 C CB  . TYR A 1 126 ? 55.936 39.824 11.707 1.00 10.47 ? 126  TYR A CB  1 
+ATOM   1010 C CG  . TYR A 1 126 ? 55.464 41.234 11.892 1.00 9.75  ? 126  TYR A CG  1 
+ATOM   1011 C CD1 . TYR A 1 126 ? 55.663 42.247 10.950 1.00 9.90  ? 126  TYR A CD1 1 
+ATOM   1012 C CD2 . TYR A 1 126 ? 54.720 41.572 13.028 1.00 10.34 ? 126  TYR A CD2 1 
+ATOM   1013 C CE1 . TYR A 1 126 ? 55.186 43.527 11.142 1.00 16.24 ? 126  TYR A CE1 1 
+ATOM   1014 C CE2 . TYR A 1 126 ? 54.234 42.848 13.215 1.00 12.48 ? 126  TYR A CE2 1 
+ATOM   1015 C CZ  . TYR A 1 126 ? 54.447 43.821 12.278 1.00 13.70 ? 126  TYR A CZ  1 
+ATOM   1016 O OH  . TYR A 1 126 ? 53.967 45.097 12.500 1.00 16.10 ? 126  TYR A OH  1 
+ATOM   1017 N N   . GLY A 1 127 ? 55.101 36.725 10.235 1.00 9.87  ? 127  GLY A N   1 
+ATOM   1018 C CA  . GLY A 1 127 ? 55.471 35.344 10.200 1.00 10.45 ? 127  GLY A CA  1 
+ATOM   1019 C C   . GLY A 1 127 ? 56.317 34.965 8.987  1.00 11.94 ? 127  GLY A C   1 
+ATOM   1020 O O   . GLY A 1 127 ? 56.959 33.917 9.055  1.00 14.50 ? 127  GLY A O   1 
+ATOM   1021 N N   . ASP A 1 128 ? 56.324 35.798 7.939  1.00 10.43 ? 128  ASP A N   1 
+ATOM   1022 C CA  . ASP A 1 128 ? 57.213 35.522 6.820  1.00 11.86 ? 128  ASP A CA  1 
+ATOM   1023 C C   . ASP A 1 128 ? 58.419 36.450 6.774  1.00 12.59 ? 128  ASP A C   1 
+ATOM   1024 O O   . ASP A 1 128 ? 59.066 36.621 5.735  1.00 10.85 ? 128  ASP A O   1 
+ATOM   1025 C CB  . ASP A 1 128 ? 56.487 35.528 5.476  1.00 9.06  ? 128  ASP A CB  1 
+ATOM   1026 C CG  . ASP A 1 128 ? 57.093 34.513 4.507  1.00 14.12 ? 128  ASP A CG  1 
+ATOM   1027 O OD1 . ASP A 1 128 ? 57.967 33.713 4.850  1.00 12.74 ? 128  ASP A OD1 1 
+ATOM   1028 O OD2 . ASP A 1 128 ? 56.635 34.530 3.329  1.00 16.70 ? 128  ASP A OD2 1 
+ATOM   1029 N N   . TYR A 1 129 ? 58.880 36.900 7.955  1.00 9.84  ? 129  TYR A N   1 
+ATOM   1030 C CA  . TYR A 1 129 ? 60.165 37.567 8.084  1.00 10.84 ? 129  TYR A CA  1 
+ATOM   1031 C C   . TYR A 1 129 ? 61.016 36.747 9.048  1.00 12.81 ? 129  TYR A C   1 
+ATOM   1032 O O   . TYR A 1 129 ? 60.437 36.252 10.015 1.00 12.10 ? 129  TYR A O   1 
+ATOM   1033 C CB  . TYR A 1 129 ? 60.008 38.950 8.686  1.00 11.60 ? 129  TYR A CB  1 
+ATOM   1034 C CG  . TYR A 1 129 ? 59.326 39.961 7.819  1.00 9.25  ? 129  TYR A CG  1 
+ATOM   1035 C CD1 . TYR A 1 129 ? 57.945 40.128 7.838  1.00 9.64  ? 129  TYR A CD1 1 
+ATOM   1036 C CD2 . TYR A 1 129 ? 60.105 40.758 6.971  1.00 12.44 ? 129  TYR A CD2 1 
+ATOM   1037 C CE1 . TYR A 1 129 ? 57.338 41.078 7.031  1.00 11.47 ? 129  TYR A CE1 1 
+ATOM   1038 C CE2 . TYR A 1 129 ? 59.498 41.693 6.146  1.00 13.12 ? 129  TYR A CE2 1 
+ATOM   1039 C CZ  . TYR A 1 129 ? 58.136 41.847 6.190  1.00 14.43 ? 129  TYR A CZ  1 
+ATOM   1040 O OH  . TYR A 1 129 ? 57.575 42.810 5.396  1.00 17.85 ? 129  TYR A OH  1 
+ATOM   1041 N N   . PRO A 1 130 ? 62.303 36.628 8.836  1.00 8.06  ? 130  PRO A N   1 
+ATOM   1042 C CA  . PRO A 1 130 ? 63.232 35.892 9.652  1.00 7.00  ? 130  PRO A CA  1 
+ATOM   1043 C C   . PRO A 1 130 ? 63.650 36.653 10.914 1.00 8.45  ? 130  PRO A C   1 
+ATOM   1044 O O   . PRO A 1 130 ? 64.274 36.045 11.839 1.00 9.60  ? 130  PRO A O   1 
+ATOM   1045 C CB  . PRO A 1 130 ? 64.480 35.630 8.804  1.00 10.23 ? 130  PRO A CB  1 
+ATOM   1046 C CG  . PRO A 1 130 ? 64.391 36.732 7.769  1.00 11.33 ? 130  PRO A CG  1 
+ATOM   1047 C CD  . PRO A 1 130 ? 62.971 37.168 7.635  1.00 11.34 ? 130  PRO A CD  1 
+ATOM   1048 N N   . ASN A 1 131 ? 63.347 37.934 10.989 1.00 9.51  ? 131  ASN A N   1 
+ATOM   1049 C CA  . ASN A 1 131 ? 63.750 38.761 12.128 1.00 8.33  ? 131  ASN A CA  1 
+ATOM   1050 C C   . ASN A 1 131 ? 63.073 38.442 13.460 1.00 9.56  ? 131  ASN A C   1 
+ATOM   1051 O O   . ASN A 1 131 ? 63.569 38.778 14.535 1.00 10.37 ? 131  ASN A O   1 
+ATOM   1052 C CB  . ASN A 1 131 ? 63.361 40.230 11.857 1.00 9.46  ? 131  ASN A CB  1 
+ATOM   1053 C CG  . ASN A 1 131 ? 63.793 40.702 10.485 1.00 9.27  ? 131  ASN A CG  1 
+ATOM   1054 O OD1 . ASN A 1 131 ? 63.280 40.193 9.500  1.00 10.26 ? 131  ASN A OD1 1 
+ATOM   1055 N ND2 . ASN A 1 131 ? 64.708 41.635 10.449 1.00 8.88  ? 131  ASN A ND2 1 
+ATOM   1056 N N   . VAL A 1 132 ? 61.870 37.923 13.432 1.00 8.36  ? 132  VAL A N   1 
+ATOM   1057 C CA  . VAL A 1 132 ? 60.989 37.772 14.575 1.00 9.58  ? 132  VAL A CA  1 
+ATOM   1058 C C   . VAL A 1 132 ? 61.280 36.580 15.465 1.00 9.95  ? 132  VAL A C   1 
+ATOM   1059 O O   . VAL A 1 132 ? 61.421 35.437 15.047 1.00 9.24  ? 132  VAL A O   1 
+ATOM   1060 C CB  . VAL A 1 132 ? 59.526 37.726 14.078 1.00 13.23 ? 132  VAL A CB  1 
+ATOM   1061 C CG1 . VAL A 1 132 ? 58.544 37.571 15.223 1.00 10.52 ? 132  VAL A CG1 1 
+ATOM   1062 C CG2 . VAL A 1 132 ? 59.153 38.973 13.290 1.00 18.70 ? 132  VAL A CG2 1 
+ATOM   1063 N N   . ILE A 1 133 ? 61.318 36.863 16.770 1.00 9.67  ? 133  ILE A N   1 
+ATOM   1064 C CA  . ILE A 1 133 ? 61.461 35.885 17.847 1.00 7.23  ? 133  ILE A CA  1 
+ATOM   1065 C C   . ILE A 1 133 ? 60.280 36.139 18.810 1.00 9.60  ? 133  ILE A C   1 
+ATOM   1066 O O   . ILE A 1 133 ? 60.143 37.286 19.234 1.00 9.67  ? 133  ILE A O   1 
+ATOM   1067 C CB  . ILE A 1 133 ? 62.791 36.051 18.599 1.00 7.53  ? 133  ILE A CB  1 
+ATOM   1068 C CG1 . ILE A 1 133 ? 64.000 35.865 17.682 1.00 8.26  ? 133  ILE A CG1 1 
+ATOM   1069 C CG2 . ILE A 1 133 ? 62.897 35.155 19.811 1.00 7.46  ? 133  ILE A CG2 1 
+ATOM   1070 C CD1 . ILE A 1 133 ? 65.324 36.299 18.317 1.00 14.48 ? 133  ILE A CD1 1 
+ATOM   1071 N N   . TYR A 1 134 ? 59.460 35.148 19.116 1.00 7.76  ? 134  TYR A N   1 
+ATOM   1072 C CA  . TYR A 1 134 ? 58.296 35.375 19.979 1.00 7.44  ? 134  TYR A CA  1 
+ATOM   1073 C C   . TYR A 1 134 ? 58.623 35.018 21.409 1.00 8.52  ? 134  TYR A C   1 
+ATOM   1074 O O   . TYR A 1 134 ? 59.097 33.894 21.604 1.00 10.10 ? 134  TYR A O   1 
+ATOM   1075 C CB  . TYR A 1 134 ? 57.125 34.507 19.507 1.00 10.23 ? 134  TYR A CB  1 
+ATOM   1076 C CG  . TYR A 1 134 ? 56.781 34.678 18.055 1.00 9.78  ? 134  TYR A CG  1 
+ATOM   1077 C CD1 . TYR A 1 134 ? 55.865 35.620 17.638 1.00 11.32 ? 134  TYR A CD1 1 
+ATOM   1078 C CD2 . TYR A 1 134 ? 57.339 33.821 17.097 1.00 9.54  ? 134  TYR A CD2 1 
+ATOM   1079 C CE1 . TYR A 1 134 ? 55.541 35.795 16.312 1.00 11.43 ? 134  TYR A CE1 1 
+ATOM   1080 C CE2 . TYR A 1 134 ? 56.987 33.982 15.765 1.00 9.15  ? 134  TYR A CE2 1 
+ATOM   1081 C CZ  . TYR A 1 134 ? 56.102 34.938 15.361 1.00 10.70 ? 134  TYR A CZ  1 
+ATOM   1082 O OH  . TYR A 1 134 ? 55.746 35.061 14.051 1.00 9.99  ? 134  TYR A OH  1 
+ATOM   1083 N N   . GLU A 1 135 ? 58.366 35.895 22.363 1.00 8.42  ? 135  GLU A N   1 
+ATOM   1084 C CA  . GLU A 1 135 ? 58.572 35.528 23.775 1.00 8.11  ? 135  GLU A CA  1 
+ATOM   1085 C C   . GLU A 1 135 ? 57.165 35.574 24.416 1.00 9.52  ? 135  GLU A C   1 
+ATOM   1086 O O   . GLU A 1 135 ? 56.623 36.651 24.672 1.00 5.97  ? 135  GLU A O   1 
+ATOM   1087 C CB  . GLU A 1 135 ? 59.545 36.474 24.411 1.00 7.47  ? 135  GLU A CB  1 
+ATOM   1088 C CG  . GLU A 1 135 ? 59.845 36.314 25.871 1.00 7.95  ? 135  GLU A CG  1 
+ATOM   1089 C CD  . GLU A 1 135 ? 60.972 37.174 26.425 1.00 10.43 ? 135  GLU A CD  1 
+ATOM   1090 O OE1 . GLU A 1 135 ? 61.449 38.049 25.680 1.00 10.17 ? 135  GLU A OE1 1 
+ATOM   1091 O OE2 . GLU A 1 135 ? 61.326 36.929 27.598 1.00 8.09  ? 135  GLU A OE2 1 
+ATOM   1092 N N   . ILE A 1 136 ? 56.570 34.410 24.647 1.00 7.71  ? 136  ILE A N   1 
+ATOM   1093 C CA  . ILE A 1 136 ? 55.169 34.269 25.022 1.00 7.43  ? 136  ILE A CA  1 
+ATOM   1094 C C   . ILE A 1 136 ? 54.810 34.488 26.481 1.00 6.75  ? 136  ILE A C   1 
+ATOM   1095 O O   . ILE A 1 136 ? 53.614 34.590 26.792 1.00 9.55  ? 136  ILE A O   1 
+ATOM   1096 C CB  . ILE A 1 136 ? 54.602 32.920 24.506 1.00 9.81  ? 136  ILE A CB  1 
+ATOM   1097 C CG1 . ILE A 1 136 ? 55.263 31.721 25.196 1.00 7.98  ? 136  ILE A CG1 1 
+ATOM   1098 C CG2 . ILE A 1 136 ? 54.749 32.891 22.988 1.00 9.75  ? 136  ILE A CG2 1 
+ATOM   1099 C CD1 . ILE A 1 136 ? 54.683 30.388 24.806 1.00 6.89  ? 136  ILE A CD1 1 
+ATOM   1100 N N   . ALA A 1 137 ? 55.728 34.516 27.421 1.00 7.73  ? 137  ALA A N   1 
+ATOM   1101 C CA  . ALA A 1 137 ? 55.412 34.758 28.841 1.00 9.18  ? 137  ALA A CA  1 
+ATOM   1102 C C   . ALA A 1 137 ? 56.678 35.163 29.597 1.00 8.61  ? 137  ALA A C   1 
+ATOM   1103 O O   . ALA A 1 137 ? 57.390 34.313 30.137 1.00 9.85  ? 137  ALA A O   1 
+ATOM   1104 C CB  . ALA A 1 137 ? 54.790 33.522 29.472 1.00 11.15 ? 137  ALA A CB  1 
+ATOM   1105 N N   . ASN A 1 138 ? 56.985 36.444 29.622 1.00 9.07  ? 138  ASN A N   1 
+ATOM   1106 C CA  . ASN A 1 138 ? 58.182 37.010 30.206 1.00 7.31  ? 138  ASN A CA  1 
+ATOM   1107 C C   . ASN A 1 138 ? 58.645 36.289 31.475 1.00 7.01  ? 138  ASN A C   1 
+ATOM   1108 O O   . ASN A 1 138 ? 59.670 35.642 31.494 1.00 10.55 ? 138  ASN A O   1 
+ATOM   1109 C CB  . ASN A 1 138 ? 57.949 38.500 30.490 1.00 8.60  ? 138  ASN A CB  1 
+ATOM   1110 C CG  . ASN A 1 138 ? 59.007 39.098 31.400 1.00 11.00 ? 138  ASN A CG  1 
+ATOM   1111 O OD1 . ASN A 1 138 ? 60.195 39.020 31.113 1.00 9.93  ? 138  ASN A OD1 1 
+ATOM   1112 N ND2 . ASN A 1 138 ? 58.615 39.700 32.503 1.00 9.67  ? 138  ASN A ND2 1 
+ATOM   1113 N N   . GLU A 1 139 ? 57.919 36.467 32.564 1.00 9.02  ? 139  GLU A N   1 
+ATOM   1114 C CA  . GLU A 1 139 ? 58.316 35.929 33.838 1.00 9.13  ? 139  GLU A CA  1 
+ATOM   1115 C C   . GLU A 1 139 ? 57.199 35.334 34.683 1.00 10.41 ? 139  GLU A C   1 
+ATOM   1116 O O   . GLU A 1 139 ? 56.645 35.953 35.585 1.00 10.36 ? 139  GLU A O   1 
+ATOM   1117 C CB  . GLU A 1 139 ? 59.033 37.023 34.650 1.00 9.87  ? 139  GLU A CB  1 
+ATOM   1118 C CG  . GLU A 1 139 ? 60.482 37.294 34.243 1.00 10.25 ? 139  GLU A CG  1 
+ATOM   1119 C CD  . GLU A 1 139 ? 61.255 38.209 35.156 1.00 11.60 ? 139  GLU A CD  1 
+ATOM   1120 O OE1 . GLU A 1 139 ? 60.659 38.858 36.056 1.00 11.53 ? 139  GLU A OE1 1 
+ATOM   1121 O OE2 . GLU A 1 139 ? 62.506 38.277 35.050 1.00 11.39 ? 139  GLU A OE2 1 
+ATOM   1122 N N   . PRO A 1 140 ? 56.889 34.082 34.412 1.00 10.80 ? 140  PRO A N   1 
+ATOM   1123 C CA  . PRO A 1 140 ? 55.986 33.315 35.274 1.00 9.40  ? 140  PRO A CA  1 
+ATOM   1124 C C   . PRO A 1 140 ? 56.595 33.407 36.665 1.00 7.76  ? 140  PRO A C   1 
+ATOM   1125 O O   . PRO A 1 140 ? 57.811 33.298 36.844 1.00 9.81  ? 140  PRO A O   1 
+ATOM   1126 C CB  . PRO A 1 140 ? 55.949 31.880 34.702 1.00 10.75 ? 140  PRO A CB  1 
+ATOM   1127 C CG  . PRO A 1 140 ? 56.471 32.128 33.282 1.00 7.82  ? 140  PRO A CG  1 
+ATOM   1128 C CD  . PRO A 1 140 ? 57.501 33.239 33.382 1.00 9.01  ? 140  PRO A CD  1 
+ATOM   1129 N N   . ASN A 1 141 ? 55.739 33.552 37.706 1.00 11.71 ? 141  ASN A N   1 
+ATOM   1130 C CA  . ASN A 1 141 ? 56.288 33.579 39.058 1.00 11.15 ? 141  ASN A CA  1 
+ATOM   1131 C C   . ASN A 1 141 ? 55.218 33.150 40.079 1.00 12.50 ? 141  ASN A C   1 
+ATOM   1132 O O   . ASN A 1 141 ? 54.049 33.061 39.748 1.00 11.28 ? 141  ASN A O   1 
+ATOM   1133 C CB  . ASN A 1 141 ? 56.905 34.939 39.400 1.00 9.77  ? 141  ASN A CB  1 
+ATOM   1134 C CG  . ASN A 1 141 ? 55.927 36.071 39.400 1.00 14.72 ? 141  ASN A CG  1 
+ATOM   1135 O OD1 . ASN A 1 141 ? 55.401 36.438 40.461 1.00 15.45 ? 141  ASN A OD1 1 
+ATOM   1136 N ND2 . ASN A 1 141 ? 55.669 36.633 38.219 1.00 11.58 ? 141  ASN A ND2 1 
+ATOM   1137 N N   . GLY A 1 142 ? 55.694 32.878 41.287 1.00 12.15 ? 142  GLY A N   1 
+ATOM   1138 C CA  . GLY A 1 142 ? 54.798 32.422 42.356 1.00 12.49 ? 142  GLY A CA  1 
+ATOM   1139 C C   . GLY A 1 142 ? 54.990 30.931 42.591 1.00 15.96 ? 142  GLY A C   1 
+ATOM   1140 O O   . GLY A 1 142 ? 55.212 30.127 41.670 1.00 15.64 ? 142  GLY A O   1 
+ATOM   1141 N N   . SER A 1 143 ? 54.771 30.519 43.854 1.00 16.63 ? 143  SER A N   1 
+ATOM   1142 C CA  . SER A 1 143 ? 54.870 29.107 44.208 1.00 20.98 ? 143  SER A CA  1 
+ATOM   1143 C C   . SER A 1 143 ? 53.852 28.204 43.563 1.00 20.04 ? 143  SER A C   1 
+ATOM   1144 O O   . SER A 1 143 ? 54.076 27.011 43.415 1.00 24.32 ? 143  SER A O   1 
+ATOM   1145 C CB  . SER A 1 143 ? 54.695 28.999 45.757 1.00 25.56 ? 143  SER A CB  1 
+ATOM   1146 O OG  . SER A 1 143 ? 56.027 28.996 46.261 1.00 39.42 ? 143  SER A OG  1 
+ATOM   1147 N N   . ASP A 1 144 ? 52.679 28.701 43.228 1.00 17.31 ? 144  ASP A N   1 
+ATOM   1148 C CA  . ASP A 1 144 ? 51.579 28.013 42.601 1.00 22.19 ? 144  ASP A CA  1 
+ATOM   1149 C C   . ASP A 1 144 ? 51.606 27.996 41.072 1.00 23.38 ? 144  ASP A C   1 
+ATOM   1150 O O   . ASP A 1 144 ? 50.580 27.684 40.453 1.00 20.12 ? 144  ASP A O   1 
+ATOM   1151 C CB  . ASP A 1 144 ? 50.274 28.716 43.016 1.00 25.76 ? 144  ASP A CB  1 
+ATOM   1152 C CG  . ASP A 1 144 ? 50.270 30.217 43.001 1.00 38.38 ? 144  ASP A CG  1 
+ATOM   1153 O OD1 . ASP A 1 144 ? 51.284 30.956 42.840 1.00 36.23 ? 144  ASP A OD1 1 
+ATOM   1154 O OD2 . ASP A 1 144 ? 49.130 30.733 43.188 1.00 44.88 ? 144  ASP A OD2 1 
+ATOM   1155 N N   . VAL A 1 145 ? 52.691 28.476 40.476 1.00 17.01 ? 145  VAL A N   1 
+ATOM   1156 C CA  . VAL A 1 145 ? 52.830 28.542 39.038 1.00 11.93 ? 145  VAL A CA  1 
+ATOM   1157 C C   . VAL A 1 145 ? 54.030 27.652 38.692 1.00 12.12 ? 145  VAL A C   1 
+ATOM   1158 O O   . VAL A 1 145 ? 55.174 28.040 38.900 1.00 14.35 ? 145  VAL A O   1 
+ATOM   1159 C CB  . VAL A 1 145 ? 53.054 29.970 38.513 1.00 14.12 ? 145  VAL A CB  1 
+ATOM   1160 C CG1 . VAL A 1 145 ? 53.284 29.979 37.002 1.00 15.73 ? 145  VAL A CG1 1 
+ATOM   1161 C CG2 . VAL A 1 145 ? 51.828 30.819 38.820 1.00 13.39 ? 145  VAL A CG2 1 
+ATOM   1162 N N   . THR A 1 146 ? 53.731 26.418 38.277 1.00 11.44 ? 146  THR A N   1 
+ATOM   1163 C CA  . THR A 1 146 ? 54.829 25.516 37.958 1.00 11.45 ? 146  THR A CA  1 
+ATOM   1164 C C   . THR A 1 146 ? 54.935 25.257 36.452 1.00 12.20 ? 146  THR A C   1 
+ATOM   1165 O O   . THR A 1 146 ? 53.988 25.487 35.701 1.00 12.86 ? 146  THR A O   1 
+ATOM   1166 C CB  . THR A 1 146 ? 54.736 24.155 38.667 1.00 14.89 ? 146  THR A CB  1 
+ATOM   1167 O OG1 . THR A 1 146 ? 53.578 23.495 38.172 1.00 18.68 ? 146  THR A OG1 1 
+ATOM   1168 C CG2 . THR A 1 146 ? 54.578 24.368 40.179 1.00 21.49 ? 146  THR A CG2 1 
+ATOM   1169 N N   . TRP A 1 147 ? 56.097 24.751 36.083 1.00 11.97 ? 147  TRP A N   1 
+ATOM   1170 C CA  . TRP A 1 147 ? 56.328 24.389 34.681 1.00 11.94 ? 147  TRP A CA  1 
+ATOM   1171 C C   . TRP A 1 147 ? 55.323 23.347 34.241 1.00 13.09 ? 147  TRP A C   1 
+ATOM   1172 O O   . TRP A 1 147 ? 54.631 23.505 33.243 1.00 11.38 ? 147  TRP A O   1 
+ATOM   1173 C CB  . TRP A 1 147 ? 57.745 23.825 34.526 1.00 10.52 ? 147  TRP A CB  1 
+ATOM   1174 C CG  . TRP A 1 147 ? 58.040 23.387 33.131 1.00 7.23  ? 147  TRP A CG  1 
+ATOM   1175 C CD1 . TRP A 1 147 ? 58.131 22.095 32.651 1.00 8.67  ? 147  TRP A CD1 1 
+ATOM   1176 C CD2 . TRP A 1 147 ? 58.197 24.229 31.986 1.00 9.33  ? 147  TRP A CD2 1 
+ATOM   1177 N NE1 . TRP A 1 147 ? 58.404 22.090 31.322 1.00 10.74 ? 147  TRP A NE1 1 
+ATOM   1178 C CE2 . TRP A 1 147 ? 58.449 23.401 30.875 1.00 11.88 ? 147  TRP A CE2 1 
+ATOM   1179 C CE3 . TRP A 1 147 ? 58.230 25.616 31.791 1.00 11.56 ? 147  TRP A CE3 1 
+ATOM   1180 C CZ2 . TRP A 1 147 ? 58.655 23.892 29.588 1.00 11.96 ? 147  TRP A CZ2 1 
+ATOM   1181 C CZ3 . TRP A 1 147 ? 58.453 26.096 30.526 1.00 11.26 ? 147  TRP A CZ3 1 
+ATOM   1182 C CH2 . TRP A 1 147 ? 58.672 25.248 29.428 1.00 11.68 ? 147  TRP A CH2 1 
+ATOM   1183 N N   . GLY A 1 148 ? 55.273 22.225 34.996 1.00 14.94 ? 148  GLY A N   1 
+ATOM   1184 C CA  . GLY A 1 148 ? 54.374 21.142 34.539 1.00 13.73 ? 148  GLY A CA  1 
+ATOM   1185 C C   . GLY A 1 148 ? 52.903 21.481 34.584 1.00 11.99 ? 148  GLY A C   1 
+ATOM   1186 O O   . GLY A 1 148 ? 52.123 21.020 33.730 1.00 16.02 ? 148  GLY A O   1 
+ATOM   1187 N N   . ASN A 1 149 ? 52.420 22.210 35.575 1.00 10.64 ? 149  ASN A N   1 
+ATOM   1188 C CA  . ASN A 1 149 ? 50.972 22.427 35.702 1.00 16.50 ? 149  ASN A CA  1 
+ATOM   1189 C C   . ASN A 1 149 ? 50.450 23.674 35.033 1.00 11.78 ? 149  ASN A C   1 
+ATOM   1190 O O   . ASN A 1 149 ? 49.283 23.722 34.612 1.00 14.17 ? 149  ASN A O   1 
+ATOM   1191 C CB  . ASN A 1 149 ? 50.603 22.484 37.209 1.00 19.10 ? 149  ASN A CB  1 
+ATOM   1192 C CG  . ASN A 1 149 ? 50.894 21.182 37.940 1.00 27.22 ? 149  ASN A CG  1 
+ATOM   1193 O OD1 . ASN A 1 149 ? 50.873 20.098 37.360 1.00 22.55 ? 149  ASN A OD1 1 
+ATOM   1194 N ND2 . ASN A 1 149 ? 51.191 21.292 39.234 1.00 28.97 ? 149  ASN A ND2 1 
+ATOM   1195 N N   . GLN A 1 150 ? 51.248 24.735 34.938 1.00 9.97  ? 150  GLN A N   1 
+ATOM   1196 C CA  . GLN A 1 150 ? 50.795 26.002 34.395 1.00 10.91 ? 150  GLN A CA  1 
+ATOM   1197 C C   . GLN A 1 150 ? 51.559 26.478 33.145 1.00 8.38  ? 150  GLN A C   1 
+ATOM   1198 O O   . GLN A 1 150 ? 50.914 26.812 32.141 1.00 10.30 ? 150  GLN A O   1 
+ATOM   1199 C CB  . GLN A 1 150 ? 51.000 27.108 35.452 1.00 10.63 ? 150  GLN A CB  1 
+ATOM   1200 C CG  . GLN A 1 150 ? 49.987 27.220 36.593 1.00 15.12 ? 150  GLN A CG  1 
+ATOM   1201 C CD  . GLN A 1 150 ? 50.073 26.066 37.568 1.00 15.30 ? 150  GLN A CD  1 
+ATOM   1202 O OE1 . GLN A 1 150 ? 51.141 25.715 38.069 1.00 16.06 ? 150  GLN A OE1 1 
+ATOM   1203 N NE2 . GLN A 1 150 ? 48.950 25.432 37.836 1.00 17.26 ? 150  GLN A NE2 1 
+ATOM   1204 N N   . ILE A 1 151 ? 52.879 26.467 33.196 1.00 7.95  ? 151  ILE A N   1 
+ATOM   1205 C CA  . ILE A 1 151 ? 53.642 27.053 32.084 1.00 9.74  ? 151  ILE A CA  1 
+ATOM   1206 C C   . ILE A 1 151 ? 53.673 26.220 30.806 1.00 10.15 ? 151  ILE A C   1 
+ATOM   1207 O O   . ILE A 1 151 ? 53.403 26.740 29.706 1.00 9.50  ? 151  ILE A O   1 
+ATOM   1208 C CB  . ILE A 1 151 ? 55.044 27.461 32.530 1.00 9.56  ? 151  ILE A CB  1 
+ATOM   1209 C CG1 . ILE A 1 151 ? 55.002 28.298 33.808 1.00 10.33 ? 151  ILE A CG1 1 
+ATOM   1210 C CG2 . ILE A 1 151 ? 55.709 28.247 31.414 1.00 11.17 ? 151  ILE A CG2 1 
+ATOM   1211 C CD1 . ILE A 1 151 ? 56.375 28.438 34.432 1.00 11.28 ? 151  ILE A CD1 1 
+ATOM   1212 N N   . LYS A 1 152 ? 53.982 24.939 30.941 1.00 10.34 ? 152  LYS A N   1 
+ATOM   1213 C CA  . LYS A 1 152 ? 54.075 24.053 29.782 1.00 11.91 ? 152  LYS A CA  1 
+ATOM   1214 C C   . LYS A 1 152 ? 52.752 23.968 29.086 1.00 9.28  ? 152  LYS A C   1 
+ATOM   1215 O O   . LYS A 1 152 ? 52.624 24.184 27.865 1.00 11.22 ? 152  LYS A O   1 
+ATOM   1216 C CB  . LYS A 1 152 ? 54.659 22.698 30.147 1.00 10.63 ? 152  LYS A CB  1 
+ATOM   1217 C CG  . LYS A 1 152 ? 55.067 21.889 28.902 1.00 11.18 ? 152  LYS A CG  1 
+ATOM   1218 C CD  . LYS A 1 152 ? 55.611 20.543 29.334 1.00 11.75 ? 152  LYS A CD  1 
+ATOM   1219 C CE  . LYS A 1 152 ? 55.893 19.646 28.145 1.00 17.15 ? 152  LYS A CE  1 
+ATOM   1220 N NZ  . LYS A 1 152 ? 55.979 18.237 28.604 1.00 19.60 ? 152  LYS A NZ  1 
+ATOM   1221 N N   . PRO A 1 153 ? 51.669 23.758 29.781 1.00 9.12  ? 153  PRO A N   1 
+ATOM   1222 C CA  . PRO A 1 153 ? 50.333 23.698 29.174 1.00 10.47 ? 153  PRO A CA  1 
+ATOM   1223 C C   . PRO A 1 153 ? 49.914 24.978 28.481 1.00 8.67  ? 153  PRO A C   1 
+ATOM   1224 O O   . PRO A 1 153 ? 49.314 24.967 27.398 1.00 9.62  ? 153  PRO A O   1 
+ATOM   1225 C CB  . PRO A 1 153 ? 49.330 23.323 30.249 1.00 11.83 ? 153  PRO A CB  1 
+ATOM   1226 C CG  . PRO A 1 153 ? 50.231 22.840 31.361 1.00 15.62 ? 153  PRO A CG  1 
+ATOM   1227 C CD  . PRO A 1 153 ? 51.642 23.360 31.199 1.00 13.28 ? 153  PRO A CD  1 
+ATOM   1228 N N   . TYR A 1 154 ? 50.253 26.133 29.073 1.00 10.99 ? 154  TYR A N   1 
+ATOM   1229 C CA  . TYR A 1 154 ? 50.075 27.434 28.418 1.00 11.28 ? 154  TYR A CA  1 
+ATOM   1230 C C   . TYR A 1 154 ? 50.809 27.503 27.097 1.00 8.40  ? 154  TYR A C   1 
+ATOM   1231 O O   . TYR A 1 154 ? 50.276 27.859 26.020 1.00 10.23 ? 154  TYR A O   1 
+ATOM   1232 C CB  . TYR A 1 154 ? 50.588 28.549 29.335 1.00 12.12 ? 154  TYR A CB  1 
+ATOM   1233 C CG  . TYR A 1 154 ? 50.712 29.902 28.664 1.00 11.27 ? 154  TYR A CG  1 
+ATOM   1234 C CD1 . TYR A 1 154 ? 49.614 30.745 28.496 1.00 9.69  ? 154  TYR A CD1 1 
+ATOM   1235 C CD2 . TYR A 1 154 ? 51.944 30.337 28.182 1.00 9.33  ? 154  TYR A CD2 1 
+ATOM   1236 C CE1 . TYR A 1 154 ? 49.752 31.983 27.892 1.00 11.71 ? 154  TYR A CE1 1 
+ATOM   1237 C CE2 . TYR A 1 154 ? 52.084 31.571 27.580 1.00 9.18  ? 154  TYR A CE2 1 
+ATOM   1238 C CZ  . TYR A 1 154 ? 50.990 32.397 27.438 1.00 8.78  ? 154  TYR A CZ  1 
+ATOM   1239 O OH  . TYR A 1 154 ? 51.125 33.615 26.819 1.00 9.34  ? 154  TYR A OH  1 
+ATOM   1240 N N   . ALA A 1 155 ? 52.098 27.152 27.118 1.00 8.83  ? 155  ALA A N   1 
+ATOM   1241 C CA  . ALA A 1 155 ? 52.941 27.120 25.937 1.00 9.02  ? 155  ALA A CA  1 
+ATOM   1242 C C   . ALA A 1 155 ? 52.362 26.170 24.889 1.00 11.41 ? 155  ALA A C   1 
+ATOM   1243 O O   . ALA A 1 155 ? 52.321 26.475 23.698 1.00 9.21  ? 155  ALA A O   1 
+ATOM   1244 C CB  . ALA A 1 155 ? 54.406 26.783 26.222 1.00 10.54 ? 155  ALA A CB  1 
+ATOM   1245 N N   . GLU A 1 156 ? 51.768 25.053 25.317 1.00 7.60  ? 156  GLU A N   1 
+ATOM   1246 C CA  . GLU A 1 156 ? 51.171 24.110 24.353 1.00 8.50  ? 156  GLU A CA  1 
+ATOM   1247 C C   . GLU A 1 156 ? 49.844 24.588 23.793 1.00 9.81  ? 156  GLU A C   1 
+ATOM   1248 O O   . GLU A 1 156 ? 49.287 23.913 22.906 1.00 9.78  ? 156  GLU A O   1 
+ATOM   1249 C CB  . GLU A 1 156 ? 51.083 22.726 25.005 1.00 8.38  ? 156  GLU A CB  1 
+ATOM   1250 C CG  . GLU A 1 156 ? 52.476 22.161 25.108 1.00 10.27 ? 156  GLU A CG  1 
+ATOM   1251 C CD  . GLU A 1 156 ? 52.652 20.874 25.886 1.00 15.02 ? 156  GLU A CD  1 
+ATOM   1252 O OE1 . GLU A 1 156 ? 51.805 20.641 26.770 1.00 11.39 ? 156  GLU A OE1 1 
+ATOM   1253 O OE2 . GLU A 1 156 ? 53.655 20.165 25.593 1.00 11.38 ? 156  GLU A OE2 1 
+ATOM   1254 N N   . GLU A 1 157 ? 49.295 25.679 24.298 1.00 8.48  ? 157  GLU A N   1 
+ATOM   1255 C CA  . GLU A 1 157 ? 48.137 26.312 23.695 1.00 11.75 ? 157  GLU A CA  1 
+ATOM   1256 C C   . GLU A 1 157 ? 48.581 27.442 22.779 1.00 10.31 ? 157  GLU A C   1 
+ATOM   1257 O O   . GLU A 1 157 ? 47.948 27.675 21.735 1.00 11.84 ? 157  GLU A O   1 
+ATOM   1258 C CB  . GLU A 1 157 ? 47.183 26.866 24.744 1.00 16.11 ? 157  GLU A CB  1 
+ATOM   1259 C CG  . GLU A 1 157 ? 46.305 25.869 25.449 1.00 20.37 ? 157  GLU A CG  1 
+ATOM   1260 C CD  . GLU A 1 157 ? 45.104 26.496 26.147 1.00 21.79 ? 157  GLU A CD  1 
+ATOM   1261 O OE1 . GLU A 1 157 ? 44.525 27.464 25.621 1.00 25.66 ? 157  GLU A OE1 1 
+ATOM   1262 O OE2 . GLU A 1 157 ? 44.721 26.020 27.215 1.00 23.52 ? 157  GLU A OE2 1 
+ATOM   1263 N N   . VAL A 1 158 ? 49.582 28.240 23.181 1.00 8.40  ? 158  VAL A N   1 
+ATOM   1264 C CA  . VAL A 1 158 ? 49.964 29.405 22.378 1.00 9.78  ? 158  VAL A CA  1 
+ATOM   1265 C C   . VAL A 1 158 ? 50.895 29.091 21.213 1.00 10.18 ? 158  VAL A C   1 
+ATOM   1266 O O   . VAL A 1 158 ? 50.717 29.613 20.116 1.00 9.76  ? 158  VAL A O   1 
+ATOM   1267 C CB  . VAL A 1 158 ? 50.631 30.492 23.264 1.00 9.53  ? 158  VAL A CB  1 
+ATOM   1268 C CG1 . VAL A 1 158 ? 51.096 31.659 22.422 1.00 12.18 ? 158  VAL A CG1 1 
+ATOM   1269 C CG2 . VAL A 1 158 ? 49.637 30.936 24.345 1.00 14.56 ? 158  VAL A CG2 1 
+ATOM   1270 N N   . ILE A 1 159 ? 51.781 28.124 21.361 1.00 7.81  ? 159  ILE A N   1 
+ATOM   1271 C CA  . ILE A 1 159 ? 52.679 27.711 20.288 1.00 7.33  ? 159  ILE A CA  1 
+ATOM   1272 C C   . ILE A 1 159 ? 51.936 27.241 19.039 1.00 9.51  ? 159  ILE A C   1 
+ATOM   1273 O O   . ILE A 1 159 ? 52.249 27.721 17.935 1.00 10.84 ? 159  ILE A O   1 
+ATOM   1274 C CB  . ILE A 1 159 ? 53.771 26.746 20.735 1.00 8.01  ? 159  ILE A CB  1 
+ATOM   1275 C CG1 . ILE A 1 159 ? 54.760 27.501 21.666 1.00 8.41  ? 159  ILE A CG1 1 
+ATOM   1276 C CG2 . ILE A 1 159 ? 54.566 26.183 19.543 1.00 9.60  ? 159  ILE A CG2 1 
+ATOM   1277 C CD1 . ILE A 1 159 ? 55.683 26.589 22.427 1.00 10.35 ? 159  ILE A CD1 1 
+ATOM   1278 N N   . PRO A 1 160 ? 50.876 26.482 19.137 1.00 8.56  ? 160  PRO A N   1 
+ATOM   1279 C CA  . PRO A 1 160 ? 50.111 26.019 17.960 1.00 6.80  ? 160  PRO A CA  1 
+ATOM   1280 C C   . PRO A 1 160 ? 49.544 27.199 17.183 1.00 9.71  ? 160  PRO A C   1 
+ATOM   1281 O O   . PRO A 1 160 ? 49.520 27.192 15.946 1.00 9.69  ? 160  PRO A O   1 
+ATOM   1282 C CB  . PRO A 1 160 ? 49.027 25.081 18.496 1.00 10.21 ? 160  PRO A CB  1 
+ATOM   1283 C CG  . PRO A 1 160 ? 49.593 24.640 19.828 1.00 11.76 ? 160  PRO A CG  1 
+ATOM   1284 C CD  . PRO A 1 160 ? 50.514 25.708 20.352 1.00 8.33  ? 160  PRO A CD  1 
+ATOM   1285 N N   . ILE A 1 161 ? 49.044 28.226 17.879 1.00 7.05  ? 161  ILE A N   1 
+ATOM   1286 C CA  . ILE A 1 161 ? 48.528 29.442 17.225 1.00 10.69 ? 161  ILE A CA  1 
+ATOM   1287 C C   . ILE A 1 161 ? 49.613 30.080 16.362 1.00 10.79 ? 161  ILE A C   1 
+ATOM   1288 O O   . ILE A 1 161 ? 49.369 30.418 15.189 1.00 10.09 ? 161  ILE A O   1 
+ATOM   1289 C CB  . ILE A 1 161 ? 47.984 30.444 18.248 1.00 9.74  ? 161  ILE A CB  1 
+ATOM   1290 C CG1 . ILE A 1 161 ? 46.842 29.880 19.073 1.00 12.47 ? 161  ILE A CG1 1 
+ATOM   1291 C CG2 . ILE A 1 161 ? 47.590 31.788 17.633 1.00 11.58 ? 161  ILE A CG2 1 
+ATOM   1292 C CD1 . ILE A 1 161 ? 45.612 29.428 18.353 1.00 14.60 ? 161  ILE A CD1 1 
+ATOM   1293 N N   . ILE A 1 162 ? 50.813 30.258 16.906 1.00 8.55  ? 162  ILE A N   1 
+ATOM   1294 C CA  . ILE A 1 162 ? 51.936 30.842 16.196 1.00 10.40 ? 162  ILE A CA  1 
+ATOM   1295 C C   . ILE A 1 162 ? 52.347 29.964 15.013 1.00 10.68 ? 162  ILE A C   1 
+ATOM   1296 O O   . ILE A 1 162 ? 52.564 30.405 13.879 1.00 11.51 ? 162  ILE A O   1 
+ATOM   1297 C CB  . ILE A 1 162 ? 53.151 31.027 17.133 1.00 7.67  ? 162  ILE A CB  1 
+ATOM   1298 C CG1 . ILE A 1 162 ? 52.819 32.107 18.175 1.00 8.19  ? 162  ILE A CG1 1 
+ATOM   1299 C CG2 . ILE A 1 162 ? 54.392 31.444 16.334 1.00 9.83  ? 162  ILE A CG2 1 
+ATOM   1300 C CD1 . ILE A 1 162 ? 53.892 32.219 19.257 1.00 12.15 ? 162  ILE A CD1 1 
+ATOM   1301 N N   . ARG A 1 163 ? 52.467 28.657 15.255 1.00 10.47 ? 163  ARG A N   1 
+ATOM   1302 C CA  . ARG A 1 163 ? 52.954 27.697 14.259 1.00 9.72  ? 163  ARG A CA  1 
+ATOM   1303 C C   . ARG A 1 163 ? 52.037 27.544 13.062 1.00 9.89  ? 163  ARG A C   1 
+ATOM   1304 O O   . ARG A 1 163 ? 52.477 27.196 11.945 1.00 10.81 ? 163  ARG A O   1 
+ATOM   1305 C CB  . ARG A 1 163 ? 53.198 26.343 14.942 1.00 10.35 ? 163  ARG A CB  1 
+ATOM   1306 C CG  . ARG A 1 163 ? 54.435 26.363 15.828 1.00 10.50 ? 163  ARG A CG  1 
+ATOM   1307 C CD  . ARG A 1 163 ? 55.722 26.649 15.101 1.00 9.94  ? 163  ARG A CD  1 
+ATOM   1308 N NE  . ARG A 1 163 ? 56.937 26.736 15.902 1.00 10.65 ? 163  ARG A NE  1 
+ATOM   1309 C CZ  . ARG A 1 163 ? 57.824 27.721 15.953 1.00 10.29 ? 163  ARG A CZ  1 
+ATOM   1310 N NH1 . ARG A 1 163 ? 57.688 28.810 15.224 1.00 8.63  ? 163  ARG A NH1 1 
+ATOM   1311 N NH2 . ARG A 1 163 ? 58.894 27.644 16.748 1.00 8.75  ? 163  ARG A NH2 1 
+ATOM   1312 N N   . ASN A 1 164 ? 50.763 27.856 13.262 1.00 5.62  ? 164  ASN A N   1 
+ATOM   1313 C CA  . ASN A 1 164 ? 49.785 27.851 12.165 1.00 5.57  ? 164  ASN A CA  1 
+ATOM   1314 C C   . ASN A 1 164 ? 50.127 28.939 11.139 1.00 12.35 ? 164  ASN A C   1 
+ATOM   1315 O O   . ASN A 1 164 ? 49.768 28.782 9.953  1.00 15.51 ? 164  ASN A O   1 
+ATOM   1316 C CB  . ASN A 1 164 ? 48.362 27.998 12.682 1.00 9.66  ? 164  ASN A CB  1 
+ATOM   1317 C CG  . ASN A 1 164 ? 47.316 27.541 11.685 1.00 16.02 ? 164  ASN A CG  1 
+ATOM   1318 O OD1 . ASN A 1 164 ? 47.492 26.524 11.009 1.00 14.85 ? 164  ASN A OD1 1 
+ATOM   1319 N ND2 . ASN A 1 164 ? 46.210 28.261 11.589 1.00 22.45 ? 164  ASN A ND2 1 
+ATOM   1320 N N   . ASN A 1 165 ? 50.804 30.002 11.539 1.00 9.28  ? 165  ASN A N   1 
+ATOM   1321 C CA  . ASN A 1 165 ? 51.170 31.106 10.672 1.00 8.37  ? 165  ASN A CA  1 
+ATOM   1322 C C   . ASN A 1 165 ? 52.674 31.199 10.408 1.00 11.82 ? 165  ASN A C   1 
+ATOM   1323 O O   . ASN A 1 165 ? 53.083 31.858 9.445  1.00 11.66 ? 165  ASN A O   1 
+ATOM   1324 C CB  . ASN A 1 165 ? 50.764 32.455 11.293 1.00 9.14  ? 165  ASN A CB  1 
+ATOM   1325 C CG  . ASN A 1 165 ? 49.275 32.620 11.532 1.00 13.02 ? 165  ASN A CG  1 
+ATOM   1326 O OD1 . ASN A 1 165 ? 48.455 32.152 10.746 1.00 10.67 ? 165  ASN A OD1 1 
+ATOM   1327 N ND2 . ASN A 1 165 ? 48.901 33.276 12.633 1.00 13.53 ? 165  ASN A ND2 1 
+ATOM   1328 N N   . ASP A 1 166 ? 53.464 30.677 11.320 1.00 9.51  ? 166  ASP A N   1 
+ATOM   1329 C CA  . ASP A 1 166 ? 54.923 30.816 11.261 1.00 8.12  ? 166  ASP A CA  1 
+ATOM   1330 C C   . ASP A 1 166 ? 55.518 29.526 11.806 1.00 11.56 ? 166  ASP A C   1 
+ATOM   1331 O O   . ASP A 1 166 ? 55.640 29.301 12.999 1.00 10.36 ? 166  ASP A O   1 
+ATOM   1332 C CB  . ASP A 1 166 ? 55.328 31.964 12.171 1.00 9.52  ? 166  ASP A CB  1 
+ATOM   1333 C CG  . ASP A 1 166 ? 56.824 32.234 12.154 1.00 10.46 ? 166  ASP A CG  1 
+ATOM   1334 O OD1 . ASP A 1 166 ? 57.648 31.387 11.743 1.00 10.39 ? 166  ASP A OD1 1 
+ATOM   1335 O OD2 . ASP A 1 166 ? 57.204 33.367 12.553 1.00 10.46 ? 166  ASP A OD2 1 
+ATOM   1336 N N   . PRO A 1 167 ? 55.902 28.658 10.890 1.00 12.79 ? 167  PRO A N   1 
+ATOM   1337 C CA  . PRO A 1 167 ? 56.295 27.302 11.205 1.00 13.52 ? 167  PRO A CA  1 
+ATOM   1338 C C   . PRO A 1 167 ? 57.575 27.152 12.005 1.00 12.29 ? 167  PRO A C   1 
+ATOM   1339 O O   . PRO A 1 167 ? 57.694 26.061 12.588 1.00 14.52 ? 167  PRO A O   1 
+ATOM   1340 C CB  . PRO A 1 167 ? 56.458 26.533 9.862  1.00 17.56 ? 167  PRO A CB  1 
+ATOM   1341 C CG  . PRO A 1 167 ? 56.505 27.670 8.876  1.00 21.23 ? 167  PRO A CG  1 
+ATOM   1342 C CD  . PRO A 1 167 ? 55.725 28.851 9.445  1.00 14.12 ? 167  PRO A CD  1 
+ATOM   1343 N N   . ASN A 1 168 ? 58.481 28.119 11.971 1.00 11.51 ? 168  ASN A N   1 
+ATOM   1344 C CA  . ASN A 1 168 ? 59.742 27.808 12.642 1.00 14.83 ? 168  ASN A CA  1 
+ATOM   1345 C C   . ASN A 1 168 ? 60.579 28.983 13.098 1.00 11.52 ? 168  ASN A C   1 
+ATOM   1346 O O   . ASN A 1 168 ? 61.705 28.684 13.485 1.00 12.50 ? 168  ASN A O   1 
+ATOM   1347 C CB  . ASN A 1 168 ? 60.570 26.882 11.720 1.00 18.80 ? 168  ASN A CB  1 
+ATOM   1348 C CG  . ASN A 1 168 ? 60.628 27.373 10.288 1.00 21.57 ? 168  ASN A CG  1 
+ATOM   1349 O OD1 . ASN A 1 168 ? 60.663 26.551 9.359  1.00 19.84 ? 168  ASN A OD1 1 
+ATOM   1350 N ND2 . ASN A 1 168 ? 60.572 28.668 10.157 1.00 16.27 ? 168  ASN A ND2 1 
+ATOM   1351 N N   . ASN A 1 169 ? 60.068 30.202 13.148 1.00 9.48  ? 169  ASN A N   1 
+ATOM   1352 C CA  . ASN A 1 169 ? 60.807 31.250 13.847 1.00 9.92  ? 169  ASN A CA  1 
+ATOM   1353 C C   . ASN A 1 169 ? 60.882 30.818 15.323 1.00 8.68  ? 169  ASN A C   1 
+ATOM   1354 O O   . ASN A 1 169 ? 60.069 30.090 15.897 1.00 8.21  ? 169  ASN A O   1 
+ATOM   1355 C CB  . ASN A 1 169 ? 60.164 32.612 13.678 1.00 11.13 ? 169  ASN A CB  1 
+ATOM   1356 C CG  . ASN A 1 169 ? 60.668 33.305 12.414 1.00 10.84 ? 169  ASN A CG  1 
+ATOM   1357 O OD1 . ASN A 1 169 ? 61.774 33.066 11.924 1.00 9.76  ? 169  ASN A OD1 1 
+ATOM   1358 N ND2 . ASN A 1 169 ? 59.841 34.199 11.931 1.00 11.80 ? 169  ASN A ND2 1 
+ATOM   1359 N N   . ILE A 1 170 ? 61.917 31.307 15.998 1.00 7.68  ? 170  ILE A N   1 
+ATOM   1360 C CA  . ILE A 1 170 ? 62.198 30.948 17.404 1.00 10.65 ? 170  ILE A CA  1 
+ATOM   1361 C C   . ILE A 1 170 ? 61.105 31.448 18.354 1.00 8.21  ? 170  ILE A C   1 
+ATOM   1362 O O   . ILE A 1 170 ? 60.698 32.597 18.235 1.00 7.88  ? 170  ILE A O   1 
+ATOM   1363 C CB  . ILE A 1 170 ? 63.508 31.592 17.863 1.00 8.52  ? 170  ILE A CB  1 
+ATOM   1364 C CG1 . ILE A 1 170 ? 64.700 31.147 17.002 1.00 9.90  ? 170  ILE A CG1 1 
+ATOM   1365 C CG2 . ILE A 1 170 ? 63.767 31.269 19.344 1.00 10.80 ? 170  ILE A CG2 1 
+ATOM   1366 C CD1 . ILE A 1 170 ? 65.095 29.705 17.138 1.00 13.91 ? 170  ILE A CD1 1 
+ATOM   1367 N N   . ILE A 1 171 ? 60.755 30.592 19.302 1.00 8.84  ? 171  ILE A N   1 
+ATOM   1368 C CA  . ILE A 1 171 ? 59.816 30.925 20.363 1.00 8.71  ? 171  ILE A CA  1 
+ATOM   1369 C C   . ILE A 1 171 ? 60.560 30.779 21.698 1.00 7.80  ? 171  ILE A C   1 
+ATOM   1370 O O   . ILE A 1 171 ? 61.143 29.723 21.941 1.00 8.27  ? 171  ILE A O   1 
+ATOM   1371 C CB  . ILE A 1 171 ? 58.570 30.039 20.330 1.00 7.39  ? 171  ILE A CB  1 
+ATOM   1372 C CG1 . ILE A 1 171 ? 57.770 30.296 19.040 1.00 6.91  ? 171  ILE A CG1 1 
+ATOM   1373 C CG2 . ILE A 1 171 ? 57.705 30.369 21.556 1.00 8.96  ? 171  ILE A CG2 1 
+ATOM   1374 C CD1 . ILE A 1 171 ? 56.573 29.386 18.750 1.00 10.44 ? 171  ILE A CD1 1 
+ATOM   1375 N N   . ILE A 1 172 ? 60.603 31.841 22.503 1.00 5.71  ? 172  ILE A N   1 
+ATOM   1376 C CA  . ILE A 1 172 ? 61.231 31.793 23.831 1.00 6.89  ? 172  ILE A CA  1 
+ATOM   1377 C C   . ILE A 1 172 ? 60.087 31.608 24.853 1.00 6.91  ? 172  ILE A C   1 
+ATOM   1378 O O   . ILE A 1 172 ? 59.112 32.354 24.782 1.00 9.85  ? 172  ILE A O   1 
+ATOM   1379 C CB  . ILE A 1 172 ? 61.968 33.096 24.169 1.00 10.56 ? 172  ILE A CB  1 
+ATOM   1380 C CG1 . ILE A 1 172 ? 63.169 33.358 23.228 1.00 7.75  ? 172  ILE A CG1 1 
+ATOM   1381 C CG2 . ILE A 1 172 ? 62.541 33.072 25.603 1.00 10.18 ? 172  ILE A CG2 1 
+ATOM   1382 C CD1 . ILE A 1 172 ? 63.647 34.805 23.331 1.00 10.85 ? 172  ILE A CD1 1 
+ATOM   1383 N N   . VAL A 1 173 ? 60.166 30.639 25.736 1.00 5.38  ? 173  VAL A N   1 
+ATOM   1384 C CA  . VAL A 1 173 ? 59.166 30.348 26.750 1.00 7.85  ? 173  VAL A CA  1 
+ATOM   1385 C C   . VAL A 1 173 ? 59.737 30.629 28.160 1.00 7.42  ? 173  VAL A C   1 
+ATOM   1386 O O   . VAL A 1 173 ? 60.751 30.024 28.528 1.00 7.09  ? 173  VAL A O   1 
+ATOM   1387 C CB  . VAL A 1 173 ? 58.731 28.868 26.675 1.00 8.27  ? 173  VAL A CB  1 
+ATOM   1388 C CG1 . VAL A 1 173 ? 57.583 28.560 27.632 1.00 8.16  ? 173  VAL A CG1 1 
+ATOM   1389 C CG2 . VAL A 1 173 ? 58.265 28.576 25.243 1.00 12.37 ? 173  VAL A CG2 1 
+ATOM   1390 N N   . GLY A 1 174 ? 58.995 31.401 28.932 1.00 8.85  ? 174  GLY A N   1 
+ATOM   1391 C CA  . GLY A 1 174 ? 59.365 31.749 30.283 1.00 9.43  ? 174  GLY A CA  1 
+ATOM   1392 C C   . GLY A 1 174 ? 59.414 30.504 31.176 1.00 8.81  ? 174  GLY A C   1 
+ATOM   1393 O O   . GLY A 1 174 ? 58.759 29.474 30.938 1.00 8.92  ? 174  GLY A O   1 
+ATOM   1394 N N   . THR A 1 175 ? 60.222 30.587 32.248 1.00 8.64  ? 175  THR A N   1 
+ATOM   1395 C CA  . THR A 1 175 ? 60.301 29.502 33.213 1.00 8.64  ? 175  THR A CA  1 
+ATOM   1396 C C   . THR A 1 175 ? 59.836 29.943 34.592 1.00 8.62  ? 175  THR A C   1 
+ATOM   1397 O O   . THR A 1 175 ? 59.543 31.105 34.889 1.00 8.56  ? 175  THR A O   1 
+ATOM   1398 C CB  . THR A 1 175 ? 61.666 28.838 33.257 1.00 9.68  ? 175  THR A CB  1 
+ATOM   1399 O OG1 . THR A 1 175 ? 62.719 29.798 33.477 1.00 10.90 ? 175  THR A OG1 1 
+ATOM   1400 C CG2 . THR A 1 175 ? 61.933 28.156 31.897 1.00 7.09  ? 175  THR A CG2 1 
+ATOM   1401 N N   . GLY A 1 176 ? 59.757 28.964 35.499 1.00 8.12  ? 176  GLY A N   1 
+ATOM   1402 C CA  . GLY A 1 176 ? 59.253 29.322 36.837 1.00 9.00  ? 176  GLY A CA  1 
+ATOM   1403 C C   . GLY A 1 176 ? 60.179 30.175 37.670 1.00 10.76 ? 176  GLY A C   1 
+ATOM   1404 O O   . GLY A 1 176 ? 61.343 30.379 37.356 1.00 7.89  ? 176  GLY A O   1 
+ATOM   1405 N N   . THR A 1 177 ? 59.613 30.749 38.739 1.00 8.61  ? 177  THR A N   1 
+ATOM   1406 C CA  . THR A 1 177 ? 60.346 31.595 39.675 1.00 10.42 ? 177  THR A CA  1 
+ATOM   1407 C C   . THR A 1 177 ? 61.049 32.765 38.988 1.00 9.75  ? 177  THR A C   1 
+ATOM   1408 O O   . THR A 1 177 ? 62.264 32.968 39.085 1.00 9.74  ? 177  THR A O   1 
+ATOM   1409 C CB  . THR A 1 177 ? 61.322 30.761 40.531 1.00 15.15 ? 177  THR A CB  1 
+ATOM   1410 O OG1 . THR A 1 177 ? 60.662 29.544 40.948 1.00 12.21 ? 177  THR A OG1 1 
+ATOM   1411 C CG2 . THR A 1 177 ? 61.693 31.499 41.819 1.00 17.39 ? 177  THR A CG2 1 
+ATOM   1412 N N   . TRP A 1 178 ? 60.240 33.532 38.267 1.00 10.55 ? 178  TRP A N   1 
+ATOM   1413 C CA  . TRP A 1 178 ? 60.694 34.674 37.479 1.00 10.90 ? 178  TRP A CA  1 
+ATOM   1414 C C   . TRP A 1 178 ? 61.718 34.291 36.447 1.00 7.69  ? 178  TRP A C   1 
+ATOM   1415 O O   . TRP A 1 178 ? 62.793 34.875 36.299 1.00 9.94  ? 178  TRP A O   1 
+ATOM   1416 C CB  . TRP A 1 178 ? 61.234 35.831 38.339 1.00 13.00 ? 178  TRP A CB  1 
+ATOM   1417 C CG  . TRP A 1 178 ? 60.219 36.546 39.165 1.00 15.96 ? 178  TRP A CG  1 
+ATOM   1418 C CD1 . TRP A 1 178 ? 59.377 37.564 38.818 1.00 15.03 ? 178  TRP A CD1 1 
+ATOM   1419 C CD2 . TRP A 1 178 ? 59.963 36.300 40.558 1.00 18.06 ? 178  TRP A CD2 1 
+ATOM   1420 N NE1 . TRP A 1 178 ? 58.611 37.973 39.866 1.00 21.52 ? 178  TRP A NE1 1 
+ATOM   1421 C CE2 . TRP A 1 178 ? 58.964 37.206 40.961 1.00 17.77 ? 178  TRP A CE2 1 
+ATOM   1422 C CE3 . TRP A 1 178 ? 60.495 35.401 41.477 1.00 19.79 ? 178  TRP A CE3 1 
+ATOM   1423 C CZ2 . TRP A 1 178 ? 58.453 37.242 42.251 1.00 20.78 ? 178  TRP A CZ2 1 
+ATOM   1424 C CZ3 . TRP A 1 178 ? 59.996 35.451 42.774 1.00 23.02 ? 178  TRP A CZ3 1 
+ATOM   1425 C CH2 . TRP A 1 178 ? 58.993 36.343 43.132 1.00 23.96 ? 178  TRP A CH2 1 
+ATOM   1426 N N   . SER A 1 179 ? 61.423 33.250 35.655 1.00 10.16 ? 179  SER A N   1 
+ATOM   1427 C CA  . SER A 1 179 ? 62.289 32.727 34.613 1.00 10.22 ? 179  SER A CA  1 
+ATOM   1428 C C   . SER A 1 179 ? 63.707 32.422 35.107 1.00 10.41 ? 179  SER A C   1 
+ATOM   1429 O O   . SER A 1 179 ? 64.697 32.680 34.422 1.00 10.49 ? 179  SER A O   1 
+ATOM   1430 C CB  . SER A 1 179 ? 62.277 33.561 33.338 1.00 9.92  ? 179  SER A CB  1 
+ATOM   1431 O OG  . SER A 1 179 ? 60.979 33.438 32.744 1.00 10.58 ? 179  SER A OG  1 
+ATOM   1432 N N   . GLN A 1 180 ? 63.756 31.701 36.233 1.00 8.51  ? 180  GLN A N   1 
+ATOM   1433 C CA  . GLN A 1 180 ? 64.984 31.167 36.752 1.00 8.78  ? 180  GLN A CA  1 
+ATOM   1434 C C   . GLN A 1 180 ? 65.004 29.631 36.795 1.00 11.29 ? 180  GLN A C   1 
+ATOM   1435 O O   . GLN A 1 180 ? 66.099 29.060 36.707 1.00 12.09 ? 180  GLN A O   1 
+ATOM   1436 C CB  . GLN A 1 180 ? 65.312 31.645 38.174 1.00 11.88 ? 180  GLN A CB  1 
+ATOM   1437 C CG  . GLN A 1 180 ? 65.532 33.157 38.230 1.00 10.81 ? 180  GLN A CG  1 
+ATOM   1438 C CD  . GLN A 1 180 ? 65.806 33.560 39.683 1.00 17.71 ? 180  GLN A CD  1 
+ATOM   1439 O OE1 . GLN A 1 180 ? 66.966 33.724 40.040 1.00 16.34 ? 180  GLN A OE1 1 
+ATOM   1440 N NE2 . GLN A 1 180 ? 64.743 33.717 40.469 1.00 20.37 ? 180  GLN A NE2 1 
+ATOM   1441 N N   . ASP A 1 181 ? 63.857 28.998 36.832 1.00 11.27 ? 181  ASP A N   1 
+ATOM   1442 C CA  . ASP A 1 181 ? 63.785 27.561 37.005 1.00 10.58 ? 181  ASP A CA  1 
+ATOM   1443 C C   . ASP A 1 181 ? 63.921 26.812 35.689 1.00 8.61  ? 181  ASP A C   1 
+ATOM   1444 O O   . ASP A 1 181 ? 62.990 26.157 35.225 1.00 14.44 ? 181  ASP A O   1 
+ATOM   1445 C CB  . ASP A 1 181 ? 62.527 27.160 37.787 1.00 11.51 ? 181  ASP A CB  1 
+ATOM   1446 C CG  . ASP A 1 181 ? 62.508 25.693 38.187 1.00 18.56 ? 181  ASP A CG  1 
+ATOM   1447 O OD1 . ASP A 1 181 ? 63.508 24.975 37.956 1.00 14.11 ? 181  ASP A OD1 1 
+ATOM   1448 O OD2 . ASP A 1 181 ? 61.449 25.281 38.730 1.00 20.24 ? 181  ASP A OD2 1 
+ATOM   1449 N N   . VAL A 1 182 ? 65.142 26.917 35.125 1.00 10.82 ? 182  VAL A N   1 
+ATOM   1450 C CA  . VAL A 1 182 ? 65.424 26.201 33.891 1.00 9.35  ? 182  VAL A CA  1 
+ATOM   1451 C C   . VAL A 1 182 ? 65.601 24.714 34.110 1.00 9.62  ? 182  VAL A C   1 
+ATOM   1452 O O   . VAL A 1 182 ? 65.452 23.909 33.183 1.00 11.45 ? 182  VAL A O   1 
+ATOM   1453 C CB  . VAL A 1 182 ? 66.632 26.779 33.140 1.00 7.03  ? 182  VAL A CB  1 
+ATOM   1454 C CG1 . VAL A 1 182 ? 66.250 28.101 32.480 1.00 13.52 ? 182  VAL A CG1 1 
+ATOM   1455 C CG2 . VAL A 1 182 ? 67.846 26.950 34.039 1.00 10.79 ? 182  VAL A CG2 1 
+ATOM   1456 N N   . HIS A 1 183 ? 65.975 24.320 35.336 1.00 11.77 ? 183  HIS A N   1 
+ATOM   1457 C CA  . HIS A 1 183 ? 66.124 22.902 35.658 1.00 13.09 ? 183  HIS A CA  1 
+ATOM   1458 C C   . HIS A 1 183 ? 64.858 22.111 35.384 1.00 12.81 ? 183  HIS A C   1 
+ATOM   1459 O O   . HIS A 1 183 ? 64.903 21.106 34.671 1.00 13.57 ? 183  HIS A O   1 
+ATOM   1460 C CB  . HIS A 1 183 ? 66.504 22.799 37.137 1.00 17.39 ? 183  HIS A CB  1 
+ATOM   1461 C CG  . HIS A 1 183 ? 66.934 21.433 37.540 1.00 19.38 ? 183  HIS A CG  1 
+ATOM   1462 N ND1 . HIS A 1 183 ? 68.193 21.199 38.053 1.00 21.47 ? 183  HIS A ND1 1 
+ATOM   1463 C CD2 . HIS A 1 183 ? 66.286 20.240 37.511 1.00 18.68 ? 183  HIS A CD2 1 
+ATOM   1464 C CE1 . HIS A 1 183 ? 68.295 19.904 38.333 1.00 23.52 ? 183  HIS A CE1 1 
+ATOM   1465 N NE2 . HIS A 1 183 ? 67.150 19.286 38.011 1.00 21.54 ? 183  HIS A NE2 1 
+ATOM   1466 N N   . HIS A 1 184 ? 63.730 22.527 35.910 1.00 11.93 ? 184  HIS A N   1 
+ATOM   1467 C CA  . HIS A 1 184 ? 62.465 21.864 35.717 1.00 12.00 ? 184  HIS A CA  1 
+ATOM   1468 C C   . HIS A 1 184 ? 62.052 21.833 34.262 1.00 12.11 ? 184  HIS A C   1 
+ATOM   1469 O O   . HIS A 1 184 ? 61.619 20.787 33.788 1.00 12.21 ? 184  HIS A O   1 
+ATOM   1470 C CB  . HIS A 1 184 ? 61.352 22.421 36.576 1.00 16.58 ? 184  HIS A CB  1 
+ATOM   1471 C CG  . HIS A 1 184 ? 61.429 21.946 37.985 1.00 21.63 ? 184  HIS A CG  1 
+ATOM   1472 N ND1 . HIS A 1 184 ? 61.669 22.820 39.014 1.00 22.69 ? 184  HIS A ND1 1 
+ATOM   1473 C CD2 . HIS A 1 184 ? 61.286 20.719 38.543 1.00 27.92 ? 184  HIS A CD2 1 
+ATOM   1474 C CE1 . HIS A 1 184 ? 61.670 22.166 40.167 1.00 30.63 ? 184  HIS A CE1 1 
+ATOM   1475 N NE2 . HIS A 1 184 ? 61.449 20.897 39.899 1.00 29.32 ? 184  HIS A NE2 1 
+ATOM   1476 N N   . ALA A 1 185 ? 62.226 22.962 33.560 1.00 13.51 ? 185  ALA A N   1 
+ATOM   1477 C CA  . ALA A 1 185 ? 61.824 22.989 32.155 1.00 10.61 ? 185  ALA A CA  1 
+ATOM   1478 C C   . ALA A 1 185 ? 62.726 22.073 31.340 1.00 9.89  ? 185  ALA A C   1 
+ATOM   1479 O O   . ALA A 1 185 ? 62.228 21.350 30.473 1.00 10.67 ? 185  ALA A O   1 
+ATOM   1480 C CB  . ALA A 1 185 ? 61.934 24.406 31.609 1.00 11.47 ? 185  ALA A CB  1 
+ATOM   1481 N N   . ALA A 1 186 ? 64.006 21.999 31.682 1.00 10.54 ? 186  ALA A N   1 
+ATOM   1482 C CA  . ALA A 1 186 ? 64.935 21.167 30.887 1.00 11.38 ? 186  ALA A CA  1 
+ATOM   1483 C C   . ALA A 1 186 ? 64.673 19.679 31.101 1.00 11.82 ? 186  ALA A C   1 
+ATOM   1484 O O   . ALA A 1 186 ? 65.027 18.882 30.223 1.00 12.20 ? 186  ALA A O   1 
+ATOM   1485 C CB  . ALA A 1 186 ? 66.365 21.533 31.288 1.00 9.53  ? 186  ALA A CB  1 
+ATOM   1486 N N   . ASP A 1 187 ? 64.093 19.315 32.241 1.00 12.10 ? 187  ASP A N   1 
+ATOM   1487 C CA  . ASP A 1 187 ? 63.744 17.920 32.483 1.00 14.00 ? 187  ASP A CA  1 
+ATOM   1488 C C   . ASP A 1 187 ? 62.383 17.562 31.898 1.00 14.99 ? 187  ASP A C   1 
+ATOM   1489 O O   . ASP A 1 187 ? 61.993 16.390 31.941 1.00 13.49 ? 187  ASP A O   1 
+ATOM   1490 C CB  . ASP A 1 187 ? 63.746 17.624 33.987 1.00 15.05 ? 187  ASP A CB  1 
+ATOM   1491 C CG  . ASP A 1 187 ? 65.139 17.573 34.602 1.00 14.01 ? 187  ASP A CG  1 
+ATOM   1492 O OD1 . ASP A 1 187 ? 66.197 17.449 33.949 1.00 14.79 ? 187  ASP A OD1 1 
+ATOM   1493 O OD2 . ASP A 1 187 ? 65.131 17.664 35.851 1.00 16.15 ? 187  ASP A OD2 1 
+ATOM   1494 N N   . ASN A 1 188 ? 61.623 18.509 31.343 1.00 12.61 ? 188  ASN A N   1 
+ATOM   1495 C CA  . ASN A 1 188 ? 60.283 18.221 30.803 1.00 9.75  ? 188  ASN A CA  1 
+ATOM   1496 C C   . ASN A 1 188 ? 60.017 19.105 29.593 1.00 9.23  ? 188  ASN A C   1 
+ATOM   1497 O O   . ASN A 1 188 ? 59.178 19.989 29.608 1.00 9.39  ? 188  ASN A O   1 
+ATOM   1498 C CB  . ASN A 1 188 ? 59.283 18.419 31.934 1.00 10.02 ? 188  ASN A CB  1 
+ATOM   1499 C CG  . ASN A 1 188 ? 57.847 18.062 31.538 1.00 14.21 ? 188  ASN A CG  1 
+ATOM   1500 O OD1 . ASN A 1 188 ? 57.618 17.451 30.505 1.00 13.20 ? 188  ASN A OD1 1 
+ATOM   1501 N ND2 . ASN A 1 188 ? 56.896 18.465 32.359 1.00 14.63 ? 188  ASN A ND2 1 
+ATOM   1502 N N   . GLN A 1 189 ? 60.890 19.025 28.596 1.00 9.48  ? 189  GLN A N   1 
+ATOM   1503 C CA  . GLN A 1 189 ? 60.896 19.957 27.476 1.00 10.84 ? 189  GLN A CA  1 
+ATOM   1504 C C   . GLN A 1 189 ? 59.661 19.877 26.595 1.00 11.72 ? 189  GLN A C   1 
+ATOM   1505 O O   . GLN A 1 189 ? 58.986 18.866 26.478 1.00 9.37  ? 189  GLN A O   1 
+ATOM   1506 C CB  . GLN A 1 189 ? 62.163 19.740 26.640 1.00 10.19 ? 189  GLN A CB  1 
+ATOM   1507 C CG  . GLN A 1 189 ? 63.452 20.199 27.312 1.00 9.78  ? 189  GLN A CG  1 
+ATOM   1508 C CD  . GLN A 1 189 ? 64.726 19.865 26.597 1.00 11.20 ? 189  GLN A CD  1 
+ATOM   1509 O OE1 . GLN A 1 189 ? 64.938 20.125 25.405 1.00 13.75 ? 189  GLN A OE1 1 
+ATOM   1510 N NE2 . GLN A 1 189 ? 65.694 19.280 27.351 1.00 10.71 ? 189  GLN A NE2 1 
+ATOM   1511 N N   . LEU A 1 190 ? 59.383 20.976 25.890 1.00 10.76 ? 190  LEU A N   1 
+ATOM   1512 C CA  . LEU A 1 190 ? 58.333 21.081 24.893 1.00 10.21 ? 190  LEU A CA  1 
+ATOM   1513 C C   . LEU A 1 190 ? 58.700 20.322 23.639 1.00 10.24 ? 190  LEU A C   1 
+ATOM   1514 O O   . LEU A 1 190 ? 59.905 20.178 23.344 1.00 11.64 ? 190  LEU A O   1 
+ATOM   1515 C CB  . LEU A 1 190 ? 58.163 22.590 24.515 1.00 10.09 ? 190  LEU A CB  1 
+ATOM   1516 C CG  . LEU A 1 190 ? 57.374 23.351 25.590 1.00 8.84  ? 190  LEU A CG  1 
+ATOM   1517 C CD1 . LEU A 1 190 ? 57.596 24.853 25.491 1.00 12.11 ? 190  LEU A CD1 1 
+ATOM   1518 C CD2 . LEU A 1 190 ? 55.902 23.029 25.548 1.00 11.76 ? 190  LEU A CD2 1 
+ATOM   1519 N N   . ALA A 1 191 ? 57.737 19.909 22.816 1.00 9.57  ? 191  ALA A N   1 
+ATOM   1520 C CA  . ALA A 1 191 ? 58.031 19.209 21.596 1.00 11.13 ? 191  ALA A CA  1 
+ATOM   1521 C C   . ALA A 1 191 ? 58.609 20.075 20.470 1.00 12.14 ? 191  ALA A C   1 
+ATOM   1522 O O   . ALA A 1 191 ? 59.402 19.571 19.661 1.00 11.04 ? 191  ALA A O   1 
+ATOM   1523 C CB  . ALA A 1 191 ? 56.736 18.543 21.073 1.00 10.16 ? 191  ALA A CB  1 
+ATOM   1524 N N   . ASP A 1 192 ? 58.214 21.331 20.362 1.00 10.01 ? 192  ASP A N   1 
+ATOM   1525 C CA  . ASP A 1 192 ? 58.662 22.167 19.232 1.00 11.62 ? 192  ASP A CA  1 
+ATOM   1526 C C   . ASP A 1 192 ? 60.175 22.262 19.188 1.00 10.69 ? 192  ASP A C   1 
+ATOM   1527 O O   . ASP A 1 192 ? 60.872 22.575 20.152 1.00 11.31 ? 192  ASP A O   1 
+ATOM   1528 C CB  . ASP A 1 192 ? 58.041 23.565 19.340 1.00 11.64 ? 192  ASP A CB  1 
+ATOM   1529 C CG  . ASP A 1 192 ? 58.288 24.358 18.053 1.00 12.05 ? 192  ASP A CG  1 
+ATOM   1530 O OD1 . ASP A 1 192 ? 59.323 25.019 17.944 1.00 12.75 ? 192  ASP A OD1 1 
+ATOM   1531 O OD2 . ASP A 1 192 ? 57.396 24.300 17.168 1.00 14.66 ? 192  ASP A OD2 1 
+ATOM   1532 N N   . PRO A 1 193 ? 60.741 22.038 18.020 1.00 10.80 ? 193  PRO A N   1 
+ATOM   1533 C CA  . PRO A 1 193 ? 62.179 21.999 17.837 1.00 14.06 ? 193  PRO A CA  1 
+ATOM   1534 C C   . PRO A 1 193 ? 62.852 23.349 17.841 1.00 15.93 ? 193  PRO A C   1 
+ATOM   1535 O O   . PRO A 1 193 ? 64.071 23.432 18.043 1.00 17.29 ? 193  PRO A O   1 
+ATOM   1536 C CB  . PRO A 1 193 ? 62.417 21.281 16.494 1.00 14.98 ? 193  PRO A CB  1 
+ATOM   1537 C CG  . PRO A 1 193 ? 61.104 21.531 15.775 1.00 13.27 ? 193  PRO A CG  1 
+ATOM   1538 C CD  . PRO A 1 193 ? 60.007 21.628 16.801 1.00 14.13 ? 193  PRO A CD  1 
+ATOM   1539 N N   . ASN A 1 194 ? 62.075 24.419 17.711 1.00 9.07  ? 194  ASN A N   1 
+ATOM   1540 C CA  . ASN A 1 194 ? 62.655 25.739 17.682 1.00 10.40 ? 194  ASN A CA  1 
+ATOM   1541 C C   . ASN A 1 194 ? 62.256 26.599 18.870 1.00 11.27 ? 194  ASN A C   1 
+ATOM   1542 O O   . ASN A 1 194 ? 61.909 27.760 18.717 1.00 12.49 ? 194  ASN A O   1 
+ATOM   1543 C CB  . ASN A 1 194 ? 62.257 26.384 16.353 1.00 9.63  ? 194  ASN A CB  1 
+ATOM   1544 C CG  . ASN A 1 194 ? 62.990 25.686 15.207 1.00 9.88  ? 194  ASN A CG  1 
+ATOM   1545 O OD1 . ASN A 1 194 ? 64.199 25.641 15.220 1.00 10.85 ? 194  ASN A OD1 1 
+ATOM   1546 N ND2 . ASN A 1 194 ? 62.257 25.098 14.272 1.00 11.05 ? 194  ASN A ND2 1 
+ATOM   1547 N N   . VAL A 1 195 ? 62.246 25.959 20.041 1.00 9.60  ? 195  VAL A N   1 
+ATOM   1548 C CA  . VAL A 1 195 ? 61.915 26.658 21.282 1.00 10.17 ? 195  VAL A CA  1 
+ATOM   1549 C C   . VAL A 1 195 ? 63.189 26.813 22.093 1.00 5.85  ? 195  VAL A C   1 
+ATOM   1550 O O   . VAL A 1 195 ? 64.121 25.985 22.043 1.00 8.63  ? 195  VAL A O   1 
+ATOM   1551 C CB  . VAL A 1 195 ? 60.865 25.822 22.037 1.00 14.13 ? 195  VAL A CB  1 
+ATOM   1552 C CG1 . VAL A 1 195 ? 60.883 26.080 23.532 1.00 26.49 ? 195  VAL A CG1 1 
+ATOM   1553 C CG2 . VAL A 1 195 ? 59.468 26.100 21.518 1.00 20.86 ? 195  VAL A CG2 1 
+ATOM   1554 N N   . MET A 1 196 ? 63.218 27.911 22.862 1.00 7.80  ? 196  MET A N   1 
+ATOM   1555 C CA  . MET A 1 196 ? 64.253 28.218 23.832 1.00 7.06  ? 196  MET A CA  1 
+ATOM   1556 C C   . MET A 1 196 ? 63.568 28.525 25.165 1.00 9.71  ? 196  MET A C   1 
+ATOM   1557 O O   . MET A 1 196 ? 62.408 28.959 25.179 1.00 10.38 ? 196  MET A O   1 
+ATOM   1558 C CB  . MET A 1 196 ? 65.092 29.404 23.390 1.00 9.02  ? 196  MET A CB  1 
+ATOM   1559 C CG  . MET A 1 196 ? 65.709 29.232 22.011 1.00 10.63 ? 196  MET A CG  1 
+ATOM   1560 S SD  . MET A 1 196 ? 66.669 30.619 21.476 1.00 7.78  ? 196  MET A SD  1 
+ATOM   1561 C CE  . MET A 1 196 ? 68.242 30.257 22.252 1.00 11.11 ? 196  MET A CE  1 
+ATOM   1562 N N   . TYR A 1 197 ? 64.265 28.285 26.270 1.00 9.00  ? 197  TYR A N   1 
+ATOM   1563 C CA  . TYR A 1 197 ? 63.713 28.594 27.584 1.00 8.58  ? 197  TYR A CA  1 
+ATOM   1564 C C   . TYR A 1 197 ? 64.403 29.870 28.060 1.00 6.16  ? 197  TYR A C   1 
+ATOM   1565 O O   . TYR A 1 197 ? 65.613 30.054 27.886 1.00 9.46  ? 197  TYR A O   1 
+ATOM   1566 C CB  . TYR A 1 197 ? 63.894 27.419 28.560 1.00 9.26  ? 197  TYR A CB  1 
+ATOM   1567 C CG  . TYR A 1 197 ? 63.296 26.181 27.929 1.00 10.84 ? 197  TYR A CG  1 
+ATOM   1568 C CD1 . TYR A 1 197 ? 61.935 25.921 28.011 1.00 9.26  ? 197  TYR A CD1 1 
+ATOM   1569 C CD2 . TYR A 1 197 ? 64.085 25.336 27.152 1.00 10.66 ? 197  TYR A CD2 1 
+ATOM   1570 C CE1 . TYR A 1 197 ? 61.382 24.835 27.365 1.00 8.80  ? 197  TYR A CE1 1 
+ATOM   1571 C CE2 . TYR A 1 197 ? 63.532 24.241 26.521 1.00 12.10 ? 197  TYR A CE2 1 
+ATOM   1572 C CZ  . TYR A 1 197 ? 62.167 23.995 26.619 1.00 12.55 ? 197  TYR A CZ  1 
+ATOM   1573 O OH  . TYR A 1 197 ? 61.636 22.926 25.933 1.00 10.90 ? 197  TYR A OH  1 
+ATOM   1574 N N   . ALA A 1 198 ? 63.628 30.766 28.656 1.00 7.71  ? 198  ALA A N   1 
+ATOM   1575 C CA  . ALA A 1 198 ? 64.155 32.011 29.181 1.00 7.04  ? 198  ALA A CA  1 
+ATOM   1576 C C   . ALA A 1 198 ? 64.894 31.756 30.494 1.00 7.03  ? 198  ALA A C   1 
+ATOM   1577 O O   . ALA A 1 198 ? 64.397 30.984 31.298 1.00 10.76 ? 198  ALA A O   1 
+ATOM   1578 C CB  . ALA A 1 198 ? 63.027 32.971 29.513 1.00 7.28  ? 198  ALA A CB  1 
+ATOM   1579 N N   . PHE A 1 199 ? 65.996 32.453 30.662 1.00 7.26  ? 199  PHE A N   1 
+ATOM   1580 C CA  . PHE A 1 199 ? 66.724 32.469 31.934 1.00 8.68  ? 199  PHE A CA  1 
+ATOM   1581 C C   . PHE A 1 199 ? 67.070 33.938 32.201 1.00 9.95  ? 199  PHE A C   1 
+ATOM   1582 O O   . PHE A 1 199 ? 67.596 34.615 31.320 1.00 9.43  ? 199  PHE A O   1 
+ATOM   1583 C CB  . PHE A 1 199 ? 68.036 31.733 31.959 1.00 10.02 ? 199  PHE A CB  1 
+ATOM   1584 C CG  . PHE A 1 199 ? 68.733 31.923 33.279 1.00 10.37 ? 199  PHE A CG  1 
+ATOM   1585 C CD1 . PHE A 1 199 ? 68.230 31.284 34.411 1.00 11.37 ? 199  PHE A CD1 1 
+ATOM   1586 C CD2 . PHE A 1 199 ? 69.809 32.751 33.429 1.00 11.57 ? 199  PHE A CD2 1 
+ATOM   1587 C CE1 . PHE A 1 199 ? 68.872 31.451 35.646 1.00 15.00 ? 199  PHE A CE1 1 
+ATOM   1588 C CE2 . PHE A 1 199 ? 70.426 32.980 34.628 1.00 10.74 ? 199  PHE A CE2 1 
+ATOM   1589 C CZ  . PHE A 1 199 ? 69.953 32.320 35.751 1.00 10.27 ? 199  PHE A CZ  1 
+ATOM   1590 N N   . HIS A 1 200 ? 66.716 34.460 33.356 1.00 6.57  ? 200  HIS A N   1 
+ATOM   1591 C CA  . HIS A 1 200 ? 66.928 35.851 33.735 1.00 8.21  ? 200  HIS A CA  1 
+ATOM   1592 C C   . HIS A 1 200 ? 67.791 35.992 34.999 1.00 11.63 ? 200  HIS A C   1 
+ATOM   1593 O O   . HIS A 1 200 ? 67.652 35.144 35.881 1.00 9.54  ? 200  HIS A O   1 
+ATOM   1594 C CB  . HIS A 1 200 ? 65.567 36.463 34.052 1.00 7.08  ? 200  HIS A CB  1 
+ATOM   1595 C CG  . HIS A 1 200 ? 64.694 36.630 32.840 1.00 8.10  ? 200  HIS A CG  1 
+ATOM   1596 N ND1 . HIS A 1 200 ? 63.412 37.143 32.960 1.00 9.19  ? 200  HIS A ND1 1 
+ATOM   1597 C CD2 . HIS A 1 200 ? 64.885 36.356 31.528 1.00 10.64 ? 200  HIS A CD2 1 
+ATOM   1598 C CE1 . HIS A 1 200 ? 62.874 37.196 31.747 1.00 5.82  ? 200  HIS A CE1 1 
+ATOM   1599 N NE2 . HIS A 1 200 ? 63.748 36.711 30.856 1.00 7.10  ? 200  HIS A NE2 1 
+ATOM   1600 N N   . PHE A 1 201 ? 68.704 36.929 35.014 1.00 9.59  ? 201  PHE A N   1 
+ATOM   1601 C CA  . PHE A 1 201 ? 69.577 37.126 36.175 1.00 9.27  ? 201  PHE A CA  1 
+ATOM   1602 C C   . PHE A 1 201 ? 69.827 38.608 36.394 1.00 11.37 ? 201  PHE A C   1 
+ATOM   1603 O O   . PHE A 1 201 ? 69.670 39.454 35.510 1.00 11.07 ? 201  PHE A O   1 
+ATOM   1604 C CB  . PHE A 1 201 ? 70.923 36.424 36.071 1.00 10.63 ? 201  PHE A CB  1 
+ATOM   1605 C CG  . PHE A 1 201 ? 71.867 37.064 35.081 1.00 9.32  ? 201  PHE A CG  1 
+ATOM   1606 C CD1 . PHE A 1 201 ? 72.652 38.130 35.481 1.00 9.69  ? 201  PHE A CD1 1 
+ATOM   1607 C CD2 . PHE A 1 201 ? 71.981 36.599 33.782 1.00 11.12 ? 201  PHE A CD2 1 
+ATOM   1608 C CE1 . PHE A 1 201 ? 73.510 38.754 34.615 1.00 12.53 ? 201  PHE A CE1 1 
+ATOM   1609 C CE2 . PHE A 1 201 ? 72.884 37.202 32.921 1.00 9.72  ? 201  PHE A CE2 1 
+ATOM   1610 C CZ  . PHE A 1 201 ? 73.630 38.285 33.321 1.00 11.86 ? 201  PHE A CZ  1 
+ATOM   1611 N N   . TYR A 1 202 ? 70.189 38.919 37.653 1.00 9.89  ? 202  TYR A N   1 
+ATOM   1612 C CA  . TYR A 1 202 ? 70.509 40.268 38.100 1.00 10.21 ? 202  TYR A CA  1 
+ATOM   1613 C C   . TYR A 1 202 ? 71.871 40.195 38.770 1.00 11.93 ? 202  TYR A C   1 
+ATOM   1614 O O   . TYR A 1 202 ? 72.036 39.392 39.696 1.00 11.35 ? 202  TYR A O   1 
+ATOM   1615 C CB  . TYR A 1 202 ? 69.443 40.860 39.023 0.81 11.18 ? 202  TYR A CB  1 
+ATOM   1616 C CG  . TYR A 1 202 ? 68.076 40.526 38.455 0.81 17.40 ? 202  TYR A CG  1 
+ATOM   1617 C CD1 . TYR A 1 202 ? 67.539 41.196 37.370 0.81 15.31 ? 202  TYR A CD1 1 
+ATOM   1618 C CD2 . TYR A 1 202 ? 67.416 39.404 38.953 0.81 18.52 ? 202  TYR A CD2 1 
+ATOM   1619 C CE1 . TYR A 1 202 ? 66.324 40.819 36.838 0.81 23.22 ? 202  TYR A CE1 1 
+ATOM   1620 C CE2 . TYR A 1 202 ? 66.215 39.016 38.429 0.81 22.47 ? 202  TYR A CE2 1 
+ATOM   1621 C CZ  . TYR A 1 202 ? 65.678 39.717 37.376 0.81 22.73 ? 202  TYR A CZ  1 
+ATOM   1622 O OH  . TYR A 1 202 ? 64.464 39.344 36.858 0.81 25.50 ? 202  TYR A OH  1 
+ATOM   1623 N N   . ALA A 1 203 ? 72.835 41.025 38.394 1.00 10.86 ? 203  ALA A N   1 
+ATOM   1624 C CA  . ALA A 1 203 ? 74.175 40.977 38.914 1.00 9.88  ? 203  ALA A CA  1 
+ATOM   1625 C C   . ALA A 1 203 ? 74.279 41.285 40.407 1.00 10.69 ? 203  ALA A C   1 
+ATOM   1626 O O   . ALA A 1 203 ? 75.240 40.886 41.054 1.00 9.68  ? 203  ALA A O   1 
+ATOM   1627 C CB  . ALA A 1 203 ? 75.057 41.951 38.152 1.00 11.64 ? 203  ALA A CB  1 
+ATOM   1628 N N   . GLY A 1 204 ? 73.255 41.859 41.030 1.00 10.16 ? 204  GLY A N   1 
+ATOM   1629 C CA  . GLY A 1 204 ? 73.197 42.089 42.458 1.00 12.25 ? 204  GLY A CA  1 
+ATOM   1630 C C   . GLY A 1 204 ? 73.002 40.811 43.270 1.00 14.74 ? 204  GLY A C   1 
+ATOM   1631 O O   . GLY A 1 204 ? 73.108 40.813 44.508 1.00 13.02 ? 204  GLY A O   1 
+ATOM   1632 N N   . THR A 1 205 ? 72.667 39.726 42.607 1.00 12.42 ? 205  THR A N   1 
+ATOM   1633 C CA  . THR A 1 205 ? 72.495 38.417 43.242 1.00 12.17 ? 205  THR A CA  1 
+ATOM   1634 C C   . THR A 1 205 ? 73.753 37.606 43.034 1.00 9.49  ? 205  THR A C   1 
+ATOM   1635 O O   . THR A 1 205 ? 74.274 37.522 41.911 1.00 9.17  ? 205  THR A O   1 
+ATOM   1636 C CB  . THR A 1 205 ? 71.280 37.691 42.649 1.00 12.94 ? 205  THR A CB  1 
+ATOM   1637 O OG1 . THR A 1 205 ? 70.074 38.405 42.943 1.00 10.35 ? 205  THR A OG1 1 
+ATOM   1638 C CG2 . THR A 1 205 ? 71.141 36.286 43.235 1.00 16.10 ? 205  THR A CG2 1 
+ATOM   1639 N N   . HIS A 1 206 ? 74.334 36.994 44.084 1.00 11.18 ? 206  HIS A N   1 
+ATOM   1640 C CA  . HIS A 1 206 ? 75.502 36.130 43.896 1.00 11.57 ? 206  HIS A CA  1 
+ATOM   1641 C C   . HIS A 1 206 ? 75.093 34.966 42.996 1.00 9.90  ? 206  HIS A C   1 
+ATOM   1642 O O   . HIS A 1 206 ? 74.122 34.247 43.302 1.00 10.59 ? 206  HIS A O   1 
+ATOM   1643 C CB  . HIS A 1 206 ? 76.010 35.636 45.245 1.00 12.58 ? 206  HIS A CB  1 
+ATOM   1644 C CG  . HIS A 1 206 ? 76.501 36.754 46.129 1.00 16.16 ? 206  HIS A CG  1 
+ATOM   1645 N ND1 . HIS A 1 206 ? 77.285 36.497 47.222 1.00 18.32 ? 206  HIS A ND1 1 
+ATOM   1646 C CD2 . HIS A 1 206 ? 76.324 38.105 46.103 1.00 18.73 ? 206  HIS A CD2 1 
+ATOM   1647 C CE1 . HIS A 1 206 ? 77.616 37.615 47.812 1.00 16.31 ? 206  HIS A CE1 1 
+ATOM   1648 N NE2 . HIS A 1 206 ? 77.023 38.621 47.172 1.00 19.53 ? 206  HIS A NE2 1 
+ATOM   1649 N N   . GLY A 1 207 ? 75.749 34.813 41.841 1.00 10.58 ? 207  GLY A N   1 
+ATOM   1650 C CA  . GLY A 1 207 ? 75.240 33.911 40.831 1.00 8.98  ? 207  GLY A CA  1 
+ATOM   1651 C C   . GLY A 1 207 ? 75.879 32.587 40.567 1.00 10.59 ? 207  GLY A C   1 
+ATOM   1652 O O   . GLY A 1 207 ? 75.648 31.952 39.516 1.00 9.58  ? 207  GLY A O   1 
+ATOM   1653 N N   . GLN A 1 208 ? 76.741 32.096 41.440 1.00 8.69  ? 208  GLN A N   1 
+ATOM   1654 C CA  . GLN A 1 208 ? 77.497 30.879 41.120 1.00 11.73 ? 208  GLN A CA  1 
+ATOM   1655 C C   . GLN A 1 208 ? 76.613 29.661 40.988 1.00 11.85 ? 208  GLN A C   1 
+ATOM   1656 O O   . GLN A 1 208 ? 76.875 28.865 40.076 1.00 9.65  ? 208  GLN A O   1 
+ATOM   1657 C CB  . GLN A 1 208 ? 78.643 30.680 42.111 1.00 9.61  ? 208  GLN A CB  1 
+ATOM   1658 C CG  . GLN A 1 208 ? 79.596 29.531 41.859 1.00 15.15 ? 208  GLN A CG  1 
+ATOM   1659 C CD  . GLN A 1 208 ? 80.907 29.626 42.628 1.00 21.39 ? 208  GLN A CD  1 
+ATOM   1660 O OE1 . GLN A 1 208 ? 81.339 30.645 43.152 1.00 18.21 ? 208  GLN A OE1 1 
+ATOM   1661 N NE2 . GLN A 1 208 ? 81.630 28.513 42.718 1.00 23.94 ? 208  GLN A NE2 1 
+ATOM   1662 N N   . ASN A 1 209 ? 75.605 29.454 41.816 1.00 10.97 ? 209  ASN A N   1 
+ATOM   1663 C CA  . ASN A 1 209 ? 74.744 28.288 41.668 1.00 9.43  ? 209  ASN A CA  1 
+ATOM   1664 C C   . ASN A 1 209 ? 73.829 28.452 40.443 1.00 10.04 ? 209  ASN A C   1 
+ATOM   1665 O O   . ASN A 1 209 ? 73.451 27.472 39.764 1.00 10.28 ? 209  ASN A O   1 
+ATOM   1666 C CB  . ASN A 1 209 ? 73.885 28.042 42.898 1.00 11.91 ? 209  ASN A CB  1 
+ATOM   1667 C CG  . ASN A 1 209 ? 73.229 26.656 42.861 1.00 14.63 ? 209  ASN A CG  1 
+ATOM   1668 O OD1 . ASN A 1 209 ? 72.013 26.572 42.967 1.00 19.48 ? 209  ASN A OD1 1 
+ATOM   1669 N ND2 . ASN A 1 209 ? 74.080 25.659 42.737 1.00 12.84 ? 209  ASN A ND2 1 
+ATOM   1670 N N   . LEU A 1 210 ? 73.425 29.696 40.206 1.00 10.09 ? 210  LEU A N   1 
+ATOM   1671 C CA  . LEU A 1 210 ? 72.546 29.960 39.035 1.00 9.29  ? 210  LEU A CA  1 
+ATOM   1672 C C   . LEU A 1 210 ? 73.265 29.603 37.728 1.00 10.54 ? 210  LEU A C   1 
+ATOM   1673 O O   . LEU A 1 210 ? 72.658 29.057 36.812 1.00 11.28 ? 210  LEU A O   1 
+ATOM   1674 C CB  . LEU A 1 210 ? 72.050 31.390 39.065 1.00 8.75  ? 210  LEU A CB  1 
+ATOM   1675 C CG  . LEU A 1 210 ? 71.050 31.705 40.203 1.00 12.74 ? 210  LEU A CG  1 
+ATOM   1676 C CD1 . LEU A 1 210 ? 71.012 33.188 40.481 1.00 17.25 ? 210  LEU A CD1 1 
+ATOM   1677 C CD2 . LEU A 1 210 ? 69.671 31.132 39.915 1.00 13.92 ? 210  LEU A CD2 1 
+ATOM   1678 N N   . ARG A 1 211 ? 74.548 29.917 37.629 1.00 9.48  ? 211  ARG A N   1 
+ATOM   1679 C CA  . ARG A 1 211 ? 75.374 29.514 36.485 1.00 11.32 ? 211  ARG A CA  1 
+ATOM   1680 C C   . ARG A 1 211 ? 75.416 27.997 36.393 1.00 11.12 ? 211  ARG A C   1 
+ATOM   1681 O O   . ARG A 1 211 ? 75.320 27.419 35.304 1.00 10.14 ? 211  ARG A O   1 
+ATOM   1682 C CB  . ARG A 1 211 ? 76.779 30.109 36.570 1.00 12.27 ? 211  ARG A CB  1 
+ATOM   1683 C CG  . ARG A 1 211 ? 76.824 31.589 36.154 1.00 10.84 ? 211  ARG A CG  1 
+ATOM   1684 C CD  . ARG A 1 211 ? 78.244 32.138 36.152 1.00 8.40  ? 211  ARG A CD  1 
+ATOM   1685 N NE  . ARG A 1 211 ? 78.736 32.447 37.486 1.00 11.21 ? 211  ARG A NE  1 
+ATOM   1686 C CZ  . ARG A 1 211 ? 78.410 33.478 38.250 1.00 12.56 ? 211  ARG A CZ  1 
+ATOM   1687 N NH1 . ARG A 1 211 ? 77.536 34.395 37.898 1.00 10.17 ? 211  ARG A NH1 1 
+ATOM   1688 N NH2 . ARG A 1 211 ? 78.983 33.613 39.430 1.00 9.65  ? 211  ARG A NH2 1 
+ATOM   1689 N N   . ASP A 1 212 ? 75.615 27.301 37.539 1.00 9.93  ? 212  ASP A N   1 
+ATOM   1690 C CA  . ASP A 1 212 ? 75.596 25.836 37.509 1.00 8.82  ? 212  ASP A CA  1 
+ATOM   1691 C C   . ASP A 1 212 ? 74.251 25.296 37.058 1.00 13.01 ? 212  ASP A C   1 
+ATOM   1692 O O   . ASP A 1 212 ? 74.182 24.242 36.377 1.00 13.66 ? 212  ASP A O   1 
+ATOM   1693 C CB  . ASP A 1 212 ? 75.963 25.303 38.899 1.00 12.91 ? 212  ASP A CB  1 
+ATOM   1694 C CG  . ASP A 1 212 ? 77.416 25.492 39.254 1.00 24.85 ? 212  ASP A CG  1 
+ATOM   1695 O OD1 . ASP A 1 212 ? 78.251 25.753 38.344 1.00 25.55 ? 212  ASP A OD1 1 
+ATOM   1696 O OD2 . ASP A 1 212 ? 77.775 25.355 40.446 1.00 26.14 ? 212  ASP A OD2 1 
+ATOM   1697 N N   . GLN A 1 213 ? 73.149 25.967 37.409 1.00 10.74 ? 213  GLN A N   1 
+ATOM   1698 C CA  . GLN A 1 213 ? 71.827 25.549 36.990 1.00 11.87 ? 213  GLN A CA  1 
+ATOM   1699 C C   . GLN A 1 213 ? 71.618 25.749 35.487 1.00 9.93  ? 213  GLN A C   1 
+ATOM   1700 O O   . GLN A 1 213 ? 71.036 24.862 34.874 1.00 13.29 ? 213  GLN A O   1 
+ATOM   1701 C CB  . GLN A 1 213 ? 70.649 26.185 37.737 1.00 15.57 ? 213  GLN A CB  1 
+ATOM   1702 C CG  . GLN A 1 213 ? 70.559 25.683 39.171 1.00 24.15 ? 213  GLN A CG  1 
+ATOM   1703 C CD  . GLN A 1 213 ? 70.343 24.202 39.345 1.00 33.13 ? 213  GLN A CD  1 
+ATOM   1704 O OE1 . GLN A 1 213 ? 69.575 23.513 38.687 1.00 30.21 ? 213  GLN A OE1 1 
+ATOM   1705 N NE2 . GLN A 1 213 ? 71.073 23.609 40.298 1.00 41.06 ? 213  GLN A NE2 1 
+ATOM   1706 N N   . VAL A 1 214 ? 72.163 26.836 34.928 1.00 10.45 ? 214  VAL A N   1 
+ATOM   1707 C CA  . VAL A 1 214 ? 72.037 27.000 33.464 1.00 10.57 ? 214  VAL A CA  1 
+ATOM   1708 C C   . VAL A 1 214 ? 72.805 25.883 32.777 1.00 11.52 ? 214  VAL A C   1 
+ATOM   1709 O O   . VAL A 1 214 ? 72.346 25.276 31.786 1.00 9.52  ? 214  VAL A O   1 
+ATOM   1710 C CB  . VAL A 1 214 ? 72.585 28.373 33.060 1.00 9.56  ? 214  VAL A CB  1 
+ATOM   1711 C CG1 . VAL A 1 214 ? 72.731 28.467 31.548 1.00 12.03 ? 214  VAL A CG1 1 
+ATOM   1712 C CG2 . VAL A 1 214 ? 71.673 29.477 33.588 1.00 11.80 ? 214  VAL A CG2 1 
+ATOM   1713 N N   . ASP A 1 215 ? 73.994 25.570 33.334 1.00 11.09 ? 215  ASP A N   1 
+ATOM   1714 C CA  . ASP A 1 215 ? 74.797 24.486 32.772 1.00 11.74 ? 215  ASP A CA  1 
+ATOM   1715 C C   . ASP A 1 215 ? 74.055 23.151 32.844 1.00 14.37 ? 215  ASP A C   1 
+ATOM   1716 O O   . ASP A 1 215 ? 74.103 22.365 31.874 1.00 12.24 ? 215  ASP A O   1 
+ATOM   1717 C CB  . ASP A 1 215 ? 76.154 24.339 33.457 1.00 12.49 ? 215  ASP A CB  1 
+ATOM   1718 C CG  . ASP A 1 215 ? 77.184 25.342 33.022 1.00 16.51 ? 215  ASP A CG  1 
+ATOM   1719 O OD1 . ASP A 1 215 ? 77.008 25.933 31.944 1.00 12.10 ? 215  ASP A OD1 1 
+ATOM   1720 O OD2 . ASP A 1 215 ? 78.195 25.550 33.747 1.00 16.43 ? 215  ASP A OD2 1 
+ATOM   1721 N N   . TYR A 1 216 ? 73.310 22.903 33.919 1.00 11.80 ? 216  TYR A N   1 
+ATOM   1722 C CA  . TYR A 1 216 ? 72.510 21.677 34.025 1.00 12.58 ? 216  TYR A CA  1 
+ATOM   1723 C C   . TYR A 1 216 ? 71.495 21.627 32.870 1.00 12.66 ? 216  TYR A C   1 
+ATOM   1724 O O   . TYR A 1 216 ? 71.301 20.616 32.168 1.00 11.38 ? 216  TYR A O   1 
+ATOM   1725 C CB  . TYR A 1 216 ? 71.763 21.593 35.363 1.00 8.60  ? 216  TYR A CB  1 
+ATOM   1726 C CG  . TYR A 1 216 ? 70.804 20.426 35.378 1.00 12.32 ? 216  TYR A CG  1 
+ATOM   1727 C CD1 . TYR A 1 216 ? 71.260 19.164 35.736 1.00 17.27 ? 216  TYR A CD1 1 
+ATOM   1728 C CD2 . TYR A 1 216 ? 69.480 20.564 34.933 1.00 13.01 ? 216  TYR A CD2 1 
+ATOM   1729 C CE1 . TYR A 1 216 ? 70.420 18.060 35.704 1.00 16.47 ? 216  TYR A CE1 1 
+ATOM   1730 C CE2 . TYR A 1 216 ? 68.625 19.470 34.894 1.00 14.11 ? 216  TYR A CE2 1 
+ATOM   1731 C CZ  . TYR A 1 216 ? 69.110 18.230 35.261 1.00 16.15 ? 216  TYR A CZ  1 
+ATOM   1732 O OH  . TYR A 1 216 ? 68.276 17.138 35.223 1.00 13.80 ? 216  TYR A OH  1 
+ATOM   1733 N N   . ALA A 1 217 ? 70.783 22.745 32.692 1.00 10.25 ? 217  ALA A N   1 
+ATOM   1734 C CA  . ALA A 1 217 ? 69.801 22.819 31.599 1.00 8.88  ? 217  ALA A CA  1 
+ATOM   1735 C C   . ALA A 1 217 ? 70.394 22.585 30.240 1.00 10.34 ? 217  ALA A C   1 
+ATOM   1736 O O   . ALA A 1 217 ? 69.854 21.812 29.390 1.00 8.53  ? 217  ALA A O   1 
+ATOM   1737 C CB  . ALA A 1 217 ? 69.063 24.152 31.684 1.00 9.37  ? 217  ALA A CB  1 
+ATOM   1738 N N   . LEU A 1 218 ? 71.540 23.225 29.985 1.00 9.00  ? 218  LEU A N   1 
+ATOM   1739 C CA  . LEU A 1 218 ? 72.201 23.071 28.684 1.00 9.67  ? 218  LEU A CA  1 
+ATOM   1740 C C   . LEU A 1 218 ? 72.562 21.613 28.471 1.00 11.08 ? 218  LEU A C   1 
+ATOM   1741 O O   . LEU A 1 218 ? 72.461 21.102 27.351 1.00 10.53 ? 218  LEU A O   1 
+ATOM   1742 C CB  . LEU A 1 218 ? 73.445 23.971 28.562 1.00 10.05 ? 218  LEU A CB  1 
+ATOM   1743 C CG  . LEU A 1 218 ? 73.121 25.486 28.515 1.00 10.60 ? 218  LEU A CG  1 
+ATOM   1744 C CD1 . LEU A 1 218 ? 74.388 26.286 28.655 1.00 10.32 ? 218  LEU A CD1 1 
+ATOM   1745 C CD2 . LEU A 1 218 ? 72.353 25.827 27.248 1.00 10.65 ? 218  LEU A CD2 1 
+ATOM   1746 N N   . ASP A 1 219 ? 73.021 20.938 29.531 1.00 12.97 ? 219  ASP A N   1 
+ATOM   1747 C CA  . ASP A 1 219 ? 73.368 19.537 29.526 1.00 15.40 ? 219  ASP A CA  1 
+ATOM   1748 C C   . ASP A 1 219 ? 72.214 18.594 29.233 1.00 16.18 ? 219  ASP A C   1 
+ATOM   1749 O O   . ASP A 1 219 ? 72.493 17.447 28.819 1.00 13.99 ? 219  ASP A O   1 
+ATOM   1750 C CB  . ASP A 1 219 ? 74.023 19.078 30.829 1.00 13.28 ? 219  ASP A CB  1 
+ATOM   1751 C CG  . ASP A 1 219 ? 75.418 19.666 30.995 1.00 21.33 ? 219  ASP A CG  1 
+ATOM   1752 O OD1 . ASP A 1 219 ? 75.967 20.273 30.065 1.00 22.38 ? 219  ASP A OD1 1 
+ATOM   1753 O OD2 . ASP A 1 219 ? 75.979 19.534 32.102 1.00 22.15 ? 219  ASP A OD2 1 
+ATOM   1754 N N   . GLN A 1 220 ? 70.980 19.013 29.397 1.00 14.89 ? 220  GLN A N   1 
+ATOM   1755 C CA  . GLN A 1 220 ? 69.796 18.263 29.002 1.00 12.61 ? 220  GLN A CA  1 
+ATOM   1756 C C   . GLN A 1 220 ? 69.406 18.556 27.560 1.00 13.62 ? 220  GLN A C   1 
+ATOM   1757 O O   . GLN A 1 220 ? 68.394 18.056 27.070 1.00 12.02 ? 220  GLN A O   1 
+ATOM   1758 C CB  . GLN A 1 220 ? 68.619 18.569 29.929 1.00 13.48 ? 220  GLN A CB  1 
+ATOM   1759 C CG  . GLN A 1 220 ? 68.972 18.574 31.419 1.00 15.25 ? 220  GLN A CG  1 
+ATOM   1760 C CD  . GLN A 1 220 ? 69.847 17.392 31.808 1.00 22.12 ? 220  GLN A CD  1 
+ATOM   1761 O OE1 . GLN A 1 220 ? 69.477 16.259 31.506 1.00 16.71 ? 220  GLN A OE1 1 
+ATOM   1762 N NE2 . GLN A 1 220 ? 71.003 17.657 32.438 1.00 19.28 ? 220  GLN A NE2 1 
+ATOM   1763 N N   . GLY A 1 221 ? 70.203 19.356 26.846 1.00 11.75 ? 221  GLY A N   1 
+ATOM   1764 C CA  . GLY A 1 221 ? 69.921 19.727 25.478 1.00 16.27 ? 221  GLY A CA  1 
+ATOM   1765 C C   . GLY A 1 221 ? 68.902 20.837 25.316 1.00 15.77 ? 221  GLY A C   1 
+ATOM   1766 O O   . GLY A 1 221 ? 68.430 21.087 24.194 1.00 12.89 ? 221  GLY A O   1 
+ATOM   1767 N N   . ALA A 1 222 ? 68.523 21.509 26.413 1.00 12.00 ? 222  ALA A N   1 
+ATOM   1768 C CA  . ALA A 1 222 ? 67.611 22.633 26.305 1.00 11.83 ? 222  ALA A CA  1 
+ATOM   1769 C C   . ALA A 1 222 ? 68.354 23.862 25.789 1.00 12.24 ? 222  ALA A C   1 
+ATOM   1770 O O   . ALA A 1 222 ? 69.466 24.089 26.281 1.00 11.50 ? 222  ALA A O   1 
+ATOM   1771 C CB  . ALA A 1 222 ? 67.040 22.965 27.676 1.00 9.63  ? 222  ALA A CB  1 
+ATOM   1772 N N   . ALA A 1 223 ? 67.758 24.625 24.892 1.00 9.35  ? 223  ALA A N   1 
+ATOM   1773 C CA  . ALA A 1 223 ? 68.378 25.870 24.451 1.00 10.65 ? 223  ALA A CA  1 
+ATOM   1774 C C   . ALA A 1 223 ? 67.925 26.983 25.420 1.00 12.02 ? 223  ALA A C   1 
+ATOM   1775 O O   . ALA A 1 223 ? 66.759 26.977 25.814 1.00 11.62 ? 223  ALA A O   1 
+ATOM   1776 C CB  . ALA A 1 223 ? 68.024 26.243 23.032 1.00 10.12 ? 223  ALA A CB  1 
+ATOM   1777 N N   . ILE A 1 224 ? 68.821 27.911 25.744 1.00 8.65  ? 224  ILE A N   1 
+ATOM   1778 C CA  . ILE A 1 224 ? 68.488 28.957 26.720 1.00 8.04  ? 224  ILE A CA  1 
+ATOM   1779 C C   . ILE A 1 224 ? 68.714 30.337 26.133 1.00 10.09 ? 224  ILE A C   1 
+ATOM   1780 O O   . ILE A 1 224 ? 69.789 30.500 25.517 1.00 11.73 ? 224  ILE A O   1 
+ATOM   1781 C CB  . ILE A 1 224 ? 69.396 28.827 27.970 1.00 5.28  ? 224  ILE A CB  1 
+ATOM   1782 C CG1 . ILE A 1 224 ? 69.235 27.499 28.696 1.00 11.71 ? 224  ILE A CG1 1 
+ATOM   1783 C CG2 . ILE A 1 224 ? 69.134 29.950 28.950 1.00 8.32  ? 224  ILE A CG2 1 
+ATOM   1784 C CD1 . ILE A 1 224 ? 67.868 27.199 29.189 1.00 14.27 ? 224  ILE A CD1 1 
+ATOM   1785 N N   . PHE A 1 225 ? 67.754 31.233 26.330 1.00 9.30  ? 225  PHE A N   1 
+ATOM   1786 C CA  . PHE A 1 225 ? 67.939 32.613 25.839 1.00 7.33  ? 225  PHE A CA  1 
+ATOM   1787 C C   . PHE A 1 225 ? 67.857 33.521 27.071 1.00 8.83  ? 225  PHE A C   1 
+ATOM   1788 O O   . PHE A 1 225 ? 66.871 33.422 27.808 1.00 7.67  ? 225  PHE A O   1 
+ATOM   1789 C CB  . PHE A 1 225 ? 66.913 33.032 24.789 1.00 6.40  ? 225  PHE A CB  1 
+ATOM   1790 C CG  . PHE A 1 225 ? 67.225 34.260 23.983 1.00 8.36  ? 225  PHE A CG  1 
+ATOM   1791 C CD1 . PHE A 1 225 ? 67.347 35.520 24.518 1.00 8.13  ? 225  PHE A CD1 1 
+ATOM   1792 C CD2 . PHE A 1 225 ? 67.465 34.138 22.614 1.00 11.84 ? 225  PHE A CD2 1 
+ATOM   1793 C CE1 . PHE A 1 225 ? 67.663 36.603 23.747 1.00 11.44 ? 225  PHE A CE1 1 
+ATOM   1794 C CE2 . PHE A 1 225 ? 67.763 35.224 21.815 1.00 10.60 ? 225  PHE A CE2 1 
+ATOM   1795 C CZ  . PHE A 1 225 ? 67.881 36.476 22.373 1.00 7.70  ? 225  PHE A CZ  1 
+ATOM   1796 N N   . VAL A 1 226 ? 68.894 34.318 27.328 1.00 8.19  ? 226  VAL A N   1 
+ATOM   1797 C CA  . VAL A 1 226 ? 68.876 35.233 28.488 1.00 7.82  ? 226  VAL A CA  1 
+ATOM   1798 C C   . VAL A 1 226 ? 68.145 36.496 28.046 1.00 9.10  ? 226  VAL A C   1 
+ATOM   1799 O O   . VAL A 1 226 ? 68.730 37.523 27.688 1.00 7.69  ? 226  VAL A O   1 
+ATOM   1800 C CB  . VAL A 1 226 ? 70.303 35.465 28.990 1.00 9.18  ? 226  VAL A CB  1 
+ATOM   1801 C CG1 . VAL A 1 226 ? 70.262 36.341 30.249 1.00 10.73 ? 226  VAL A CG1 1 
+ATOM   1802 C CG2 . VAL A 1 226 ? 70.985 34.158 29.375 1.00 11.12 ? 226  VAL A CG2 1 
+ATOM   1803 N N   . SER A 1 227 ? 66.813 36.429 28.023 1.00 7.72  ? 227  SER A N   1 
+ATOM   1804 C CA  . SER A 1 227 ? 65.993 37.483 27.430 1.00 10.78 ? 227  SER A CA  1 
+ATOM   1805 C C   . SER A 1 227 ? 65.822 38.716 28.299 1.00 9.73  ? 227  SER A C   1 
+ATOM   1806 O O   . SER A 1 227 ? 65.344 39.734 27.818 1.00 7.38  ? 227  SER A O   1 
+ATOM   1807 C CB  . SER A 1 227 ? 64.640 36.917 26.968 1.00 7.55  ? 227  SER A CB  1 
+ATOM   1808 O OG  . SER A 1 227 ? 63.861 36.505 28.079 1.00 7.81  ? 227  SER A OG  1 
+ATOM   1809 N N   . GLU A 1 228 ? 66.366 38.662 29.509 1.00 9.42  ? 228  GLU A N   1 
+ATOM   1810 C CA  . GLU A 1 228 ? 66.355 39.825 30.410 1.00 7.70  ? 228  GLU A CA  1 
+ATOM   1811 C C   . GLU A 1 228 ? 67.490 39.597 31.431 1.00 8.86  ? 228  GLU A C   1 
+ATOM   1812 O O   . GLU A 1 228 ? 67.498 38.578 32.134 1.00 7.77  ? 228  GLU A O   1 
+ATOM   1813 C CB  . GLU A 1 228 ? 64.985 39.938 31.147 1.00 5.57  ? 228  GLU A CB  1 
+ATOM   1814 C CG  . GLU A 1 228 ? 64.986 41.250 31.996 1.00 5.44  ? 228  GLU A CG  1 
+ATOM   1815 C CD  . GLU A 1 228 ? 64.409 41.043 33.347 1.00 15.26 ? 228  GLU A CD  1 
+ATOM   1816 O OE1 . GLU A 1 228 ? 64.870 40.198 34.250 1.00 12.33 ? 228  GLU A OE1 1 
+ATOM   1817 O OE2 . GLU A 1 228 ? 63.316 41.720 33.820 1.00 9.23  ? 228  GLU A OE2 1 
+ATOM   1818 N N   . TRP A 1 229 ? 68.374 40.545 31.575 1.00 8.94  ? 229  TRP A N   1 
+ATOM   1819 C CA  . TRP A 1 229 ? 69.325 40.537 32.683 1.00 7.41  ? 229  TRP A CA  1 
+ATOM   1820 C C   . TRP A 1 229 ? 69.644 41.982 33.043 1.00 8.80  ? 229  TRP A C   1 
+ATOM   1821 O O   . TRP A 1 229 ? 69.505 42.879 32.188 1.00 8.49  ? 229  TRP A O   1 
+ATOM   1822 C CB  . TRP A 1 229 ? 70.574 39.743 32.322 1.00 8.86  ? 229  TRP A CB  1 
+ATOM   1823 C CG  . TRP A 1 229 ? 71.448 40.373 31.313 1.00 11.54 ? 229  TRP A CG  1 
+ATOM   1824 C CD1 . TRP A 1 229 ? 71.377 40.243 29.950 1.00 9.70  ? 229  TRP A CD1 1 
+ATOM   1825 C CD2 . TRP A 1 229 ? 72.544 41.271 31.577 1.00 10.43 ? 229  TRP A CD2 1 
+ATOM   1826 N NE1 . TRP A 1 229 ? 72.369 40.988 29.392 1.00 10.57 ? 229  TRP A NE1 1 
+ATOM   1827 C CE2 . TRP A 1 229 ? 73.105 41.620 30.337 1.00 11.47 ? 229  TRP A CE2 1 
+ATOM   1828 C CE3 . TRP A 1 229 ? 73.134 41.770 32.744 1.00 12.06 ? 229  TRP A CE3 1 
+ATOM   1829 C CZ2 . TRP A 1 229 ? 74.196 42.470 30.230 1.00 12.71 ? 229  TRP A CZ2 1 
+ATOM   1830 C CZ3 . TRP A 1 229 ? 74.212 42.612 32.625 1.00 11.05 ? 229  TRP A CZ3 1 
+ATOM   1831 C CH2 . TRP A 1 229 ? 74.747 42.961 31.381 1.00 13.20 ? 229  TRP A CH2 1 
+ATOM   1832 N N   . GLY A 1 230 ? 70.111 42.170 34.268 1.00 11.55 ? 230  GLY A N   1 
+ATOM   1833 C CA  . GLY A 1 230 ? 70.469 43.533 34.689 1.00 10.29 ? 230  GLY A CA  1 
+ATOM   1834 C C   . GLY A 1 230 ? 71.764 43.554 35.493 1.00 8.45  ? 230  GLY A C   1 
+ATOM   1835 O O   . GLY A 1 230 ? 72.246 42.574 36.059 1.00 9.81  ? 230  GLY A O   1 
+ATOM   1836 N N   . THR A 1 231 ? 72.335 44.762 35.493 1.00 10.91 ? 231  THR A N   1 
+ATOM   1837 C CA  . THR A 1 231 ? 73.541 45.035 36.276 1.00 10.82 ? 231  THR A CA  1 
+ATOM   1838 C C   . THR A 1 231 ? 73.191 45.376 37.717 1.00 12.98 ? 231  THR A C   1 
+ATOM   1839 O O   . THR A 1 231 ? 74.115 45.523 38.522 1.00 14.56 ? 231  THR A O   1 
+ATOM   1840 C CB  . THR A 1 231 ? 74.281 46.273 35.704 1.00 10.39 ? 231  THR A CB  1 
+ATOM   1841 O OG1 . THR A 1 231 ? 73.320 47.333 35.716 1.00 11.11 ? 231  THR A OG1 1 
+ATOM   1842 C CG2 . THR A 1 231 ? 74.738 45.954 34.301 1.00 12.19 ? 231  THR A CG2 1 
+ATOM   1843 N N   . SER A 1 232 ? 71.941 45.513 38.048 1.00 14.33 ? 232  SER A N   1 
+ATOM   1844 C CA  . SER A 1 232 ? 71.401 45.860 39.325 1.00 11.33 ? 232  SER A CA  1 
+ATOM   1845 C C   . SER A 1 232 ? 70.889 44.674 40.118 1.00 13.30 ? 232  SER A C   1 
+ATOM   1846 O O   . SER A 1 232 ? 71.174 43.518 39.778 1.00 11.84 ? 232  SER A O   1 
+ATOM   1847 C CB  . SER A 1 232 ? 70.125 46.741 39.053 1.00 20.05 ? 232  SER A CB  1 
+ATOM   1848 O OG  . SER A 1 232 ? 69.152 45.842 38.388 1.00 28.54 ? 232  SER A OG  1 
+ATOM   1849 N N   . ALA A 1 233 ? 70.101 44.985 41.151 1.00 14.48 ? 233  ALA A N   1 
+ATOM   1850 C CA  . ALA A 1 233 ? 69.417 43.947 41.907 1.00 12.75 ? 233  ALA A CA  1 
+ATOM   1851 C C   . ALA A 1 233 ? 68.183 43.512 41.132 1.00 13.48 ? 233  ALA A C   1 
+ATOM   1852 O O   . ALA A 1 233 ? 67.750 44.079 40.099 1.00 10.64 ? 233  ALA A O   1 
+ATOM   1853 C CB  . ALA A 1 233 ? 69.075 44.469 43.305 1.00 13.85 ? 233  ALA A CB  1 
+ATOM   1854 N N   . ALA A 1 234 ? 67.483 42.492 41.628 1.00 10.60 ? 234  ALA A N   1 
+ATOM   1855 C CA  . ALA A 1 234 ? 66.293 41.922 41.052 1.00 13.46 ? 234  ALA A CA  1 
+ATOM   1856 C C   . ALA A 1 234 ? 65.135 42.883 40.867 1.00 12.85 ? 234  ALA A C   1 
+ATOM   1857 O O   . ALA A 1 234 ? 64.269 42.730 39.997 1.00 12.39 ? 234  ALA A O   1 
+ATOM   1858 C CB  . ALA A 1 234 ? 65.840 40.714 41.867 1.00 12.87 ? 234  ALA A CB  1 
+ATOM   1859 N N   . THR A 1 235 ? 65.113 43.957 41.669 1.00 11.89 ? 235  THR A N   1 
+ATOM   1860 C CA  . THR A 1 235 ? 64.055 44.957 41.544 1.00 10.83 ? 235  THR A CA  1 
+ATOM   1861 C C   . THR A 1 235 ? 64.354 45.932 40.416 1.00 11.36 ? 235  THR A C   1 
+ATOM   1862 O O   . THR A 1 235 ? 63.474 46.711 40.024 1.00 13.51 ? 235  THR A O   1 
+ATOM   1863 C CB  . THR A 1 235 ? 64.022 45.791 42.837 1.00 13.04 ? 235  THR A CB  1 
+ATOM   1864 O OG1 . THR A 1 235 ? 65.340 46.340 42.917 1.00 12.08 ? 235  THR A OG1 1 
+ATOM   1865 C CG2 . THR A 1 235 ? 63.730 44.955 44.070 1.00 15.16 ? 235  THR A CG2 1 
+ATOM   1866 N N   . GLY A 1 236 ? 65.555 45.893 39.835 1.00 11.84 ? 236  GLY A N   1 
+ATOM   1867 C CA  . GLY A 1 236 ? 65.912 46.798 38.760 1.00 11.94 ? 236  GLY A CA  1 
+ATOM   1868 C C   . GLY A 1 236 ? 66.606 48.030 39.315 1.00 11.80 ? 236  GLY A C   1 
+ATOM   1869 O O   . GLY A 1 236 ? 67.070 48.911 38.574 1.00 12.66 ? 236  GLY A O   1 
+ATOM   1870 N N   . ASP A 1 237 ? 66.761 48.069 40.637 1.00 11.52 ? 237  ASP A N   1 
+ATOM   1871 C CA  . ASP A 1 237 ? 67.460 49.219 41.256 1.00 13.87 ? 237  ASP A CA  1 
+ATOM   1872 C C   . ASP A 1 237 ? 68.384 48.707 42.365 1.00 17.08 ? 237  ASP A C   1 
+ATOM   1873 O O   . ASP A 1 237 ? 68.548 47.494 42.467 1.00 20.44 ? 237  ASP A O   1 
+ATOM   1874 C CB  . ASP A 1 237 ? 66.386 50.132 41.828 1.00 15.68 ? 237  ASP A CB  1 
+ATOM   1875 C CG  . ASP A 1 237 ? 66.864 51.555 42.103 1.00 14.78 ? 237  ASP A CG  1 
+ATOM   1876 O OD1 . ASP A 1 237 ? 67.974 51.917 41.688 1.00 15.81 ? 237  ASP A OD1 1 
+ATOM   1877 O OD2 . ASP A 1 237 ? 66.067 52.241 42.781 1.00 20.66 ? 237  ASP A OD2 1 
+ATOM   1878 N N   . GLY A 1 238 ? 68.970 49.572 43.190 1.00 16.50 ? 238  GLY A N   1 
+ATOM   1879 C CA  . GLY A 1 238 ? 69.723 49.101 44.346 1.00 18.76 ? 238  GLY A CA  1 
+ATOM   1880 C C   . GLY A 1 238 ? 71.212 48.962 44.152 1.00 21.21 ? 238  GLY A C   1 
+ATOM   1881 O O   . GLY A 1 238 ? 71.869 48.214 44.906 1.00 24.49 ? 238  GLY A O   1 
+ATOM   1882 N N   . GLY A 1 239 ? 71.789 49.662 43.196 1.00 18.66 ? 239  GLY A N   1 
+ATOM   1883 C CA  . GLY A 1 239 ? 73.217 49.601 42.932 1.00 19.28 ? 239  GLY A CA  1 
+ATOM   1884 C C   . GLY A 1 239 ? 73.607 48.950 41.622 1.00 20.12 ? 239  GLY A C   1 
+ATOM   1885 O O   . GLY A 1 239 ? 72.774 48.286 41.005 1.00 16.33 ? 239  GLY A O   1 
+ATOM   1886 N N   . VAL A 1 240 ? 74.849 49.182 41.183 1.00 17.41 ? 240  VAL A N   1 
+ATOM   1887 C CA  . VAL A 1 240 ? 75.351 48.553 39.950 1.00 19.45 ? 240  VAL A CA  1 
+ATOM   1888 C C   . VAL A 1 240 ? 76.478 47.613 40.377 1.00 18.62 ? 240  VAL A C   1 
+ATOM   1889 O O   . VAL A 1 240 ? 77.307 47.947 41.223 1.00 18.52 ? 240  VAL A O   1 
+ATOM   1890 C CB  . VAL A 1 240 ? 75.784 49.589 38.918 1.00 23.00 ? 240  VAL A CB  1 
+ATOM   1891 C CG1 . VAL A 1 240 ? 76.338 49.027 37.625 1.00 27.75 ? 240  VAL A CG1 1 
+ATOM   1892 C CG2 . VAL A 1 240 ? 74.599 50.472 38.527 1.00 24.61 ? 240  VAL A CG2 1 
+ATOM   1893 N N   . PHE A 1 241 ? 76.408 46.354 39.968 1.00 13.45 ? 241  PHE A N   1 
+ATOM   1894 C CA  . PHE A 1 241 ? 77.376 45.326 40.389 1.00 10.70 ? 241  PHE A CA  1 
+ATOM   1895 C C   . PHE A 1 241 ? 78.161 44.799 39.217 1.00 12.70 ? 241  PHE A C   1 
+ATOM   1896 O O   . PHE A 1 241 ? 77.951 43.705 38.650 1.00 13.10 ? 241  PHE A O   1 
+ATOM   1897 C CB  . PHE A 1 241 ? 76.573 44.208 41.079 1.00 12.85 ? 241  PHE A CB  1 
+ATOM   1898 C CG  . PHE A 1 241 ? 75.720 44.673 42.233 1.00 15.12 ? 241  PHE A CG  1 
+ATOM   1899 C CD1 . PHE A 1 241 ? 74.451 45.202 42.060 1.00 11.80 ? 241  PHE A CD1 1 
+ATOM   1900 C CD2 . PHE A 1 241 ? 76.216 44.567 43.522 1.00 17.14 ? 241  PHE A CD2 1 
+ATOM   1901 C CE1 . PHE A 1 241 ? 73.691 45.621 43.131 1.00 17.48 ? 241  PHE A CE1 1 
+ATOM   1902 C CE2 . PHE A 1 241 ? 75.461 44.980 44.602 1.00 18.35 ? 241  PHE A CE2 1 
+ATOM   1903 C CZ  . PHE A 1 241 ? 74.201 45.507 44.419 1.00 16.89 ? 241  PHE A CZ  1 
+ATOM   1904 N N   . LEU A 1 242 ? 79.146 45.588 38.754 1.00 14.13 ? 242  LEU A N   1 
+ATOM   1905 C CA  . LEU A 1 242 ? 79.872 45.225 37.555 1.00 12.59 ? 242  LEU A CA  1 
+ATOM   1906 C C   . LEU A 1 242 ? 80.799 44.073 37.643 1.00 13.08 ? 242  LEU A C   1 
+ATOM   1907 O O   . LEU A 1 242 ? 81.077 43.443 36.601 1.00 11.87 ? 242  LEU A O   1 
+ATOM   1908 C CB  . LEU A 1 242 ? 80.568 46.494 36.972 1.00 13.02 ? 242  LEU A CB  1 
+ATOM   1909 C CG  . LEU A 1 242 ? 79.566 47.604 36.643 1.00 16.61 ? 242  LEU A CG  1 
+ATOM   1910 C CD1 . LEU A 1 242 ? 80.348 48.715 35.931 1.00 19.68 ? 242  LEU A CD1 1 
+ATOM   1911 C CD2 . LEU A 1 242 ? 78.367 47.142 35.831 1.00 16.59 ? 242  LEU A CD2 1 
+ATOM   1912 N N   . ASP A 1 243 ? 81.344 43.740 38.824 1.00 13.92 ? 243  ASP A N   1 
+ATOM   1913 C CA  . ASP A 1 243 ? 82.185 42.549 38.891 1.00 14.90 ? 243  ASP A CA  1 
+ATOM   1914 C C   . ASP A 1 243 ? 81.366 41.301 38.575 1.00 12.96 ? 243  ASP A C   1 
+ATOM   1915 O O   . ASP A 1 243 ? 81.751 40.496 37.726 1.00 13.66 ? 243  ASP A O   1 
+ATOM   1916 C CB  . ASP A 1 243 ? 82.820 42.416 40.280 1.00 13.50 ? 243  ASP A CB  1 
+ATOM   1917 C CG  . ASP A 1 243 ? 83.907 43.435 40.570 1.00 28.66 ? 243  ASP A CG  1 
+ATOM   1918 O OD1 . ASP A 1 243 ? 84.338 44.141 39.641 1.00 27.48 ? 243  ASP A OD1 1 
+ATOM   1919 O OD2 . ASP A 1 243 ? 84.340 43.518 41.742 1.00 27.82 ? 243  ASP A OD2 1 
+ATOM   1920 N N   . GLU A 1 244 ? 80.227 41.112 39.241 1.00 12.15 ? 244  GLU A N   1 
+ATOM   1921 C CA  . GLU A 1 244 ? 79.387 39.939 38.966 1.00 12.80 ? 244  GLU A CA  1 
+ATOM   1922 C C   . GLU A 1 244 ? 78.793 40.010 37.563 1.00 11.48 ? 244  GLU A C   1 
+ATOM   1923 O O   . GLU A 1 244 ? 78.724 38.970 36.877 1.00 11.56 ? 244  GLU A O   1 
+ATOM   1924 C CB  . GLU A 1 244 ? 78.267 39.814 40.004 1.00 11.26 ? 244  GLU A CB  1 
+ATOM   1925 C CG  . GLU A 1 244 ? 77.414 38.575 39.865 1.00 9.47  ? 244  GLU A CG  1 
+ATOM   1926 C CD  . GLU A 1 244 ? 78.107 37.279 40.228 1.00 13.20 ? 244  GLU A CD  1 
+ATOM   1927 O OE1 . GLU A 1 244 ? 79.247 37.265 40.743 1.00 15.79 ? 244  GLU A OE1 1 
+ATOM   1928 O OE2 . GLU A 1 244 ? 77.542 36.187 39.992 1.00 10.76 ? 244  GLU A OE2 1 
+ATOM   1929 N N   . ALA A 1 245 ? 78.457 41.204 37.083 1.00 12.03 ? 245  ALA A N   1 
+ATOM   1930 C CA  . ALA A 1 245 ? 77.950 41.308 35.700 1.00 11.63 ? 245  ALA A CA  1 
+ATOM   1931 C C   . ALA A 1 245 ? 78.984 40.794 34.706 1.00 9.78  ? 245  ALA A C   1 
+ATOM   1932 O O   . ALA A 1 245 ? 78.656 40.025 33.773 1.00 9.62  ? 245  ALA A O   1 
+ATOM   1933 C CB  . ALA A 1 245 ? 77.582 42.748 35.351 1.00 10.80 ? 245  ALA A CB  1 
+ATOM   1934 N N   . GLN A 1 246 ? 80.265 41.138 34.928 1.00 10.16 ? 246  GLN A N   1 
+ATOM   1935 C CA  . GLN A 1 246 ? 81.325 40.662 34.058 1.00 11.76 ? 246  GLN A CA  1 
+ATOM   1936 C C   . GLN A 1 246 ? 81.481 39.153 34.123 1.00 13.06 ? 246  GLN A C   1 
+ATOM   1937 O O   . GLN A 1 246 ? 81.799 38.531 33.112 1.00 10.68 ? 246  GLN A O   1 
+ATOM   1938 C CB  . GLN A 1 246 ? 82.678 41.329 34.338 1.00 13.61 ? 246  GLN A CB  1 
+ATOM   1939 C CG  . GLN A 1 246 ? 83.742 41.019 33.312 1.00 11.68 ? 246  GLN A CG  1 
+ATOM   1940 C CD  . GLN A 1 246 ? 83.493 41.593 31.923 1.00 16.83 ? 246  GLN A CD  1 
+ATOM   1941 O OE1 . GLN A 1 246 ? 83.283 42.786 31.731 1.00 16.41 ? 246  GLN A OE1 1 
+ATOM   1942 N NE2 . GLN A 1 246 ? 83.563 40.706 30.940 1.00 14.03 ? 246  GLN A NE2 1 
+ATOM   1943 N N   . VAL A 1 247 ? 81.295 38.559 35.305 1.00 11.67 ? 247  VAL A N   1 
+ATOM   1944 C CA  . VAL A 1 247 ? 81.393 37.103 35.396 1.00 13.92 ? 247  VAL A CA  1 
+ATOM   1945 C C   . VAL A 1 247 ? 80.285 36.500 34.517 1.00 13.85 ? 247  VAL A C   1 
+ATOM   1946 O O   . VAL A 1 247 ? 80.505 35.502 33.811 1.00 12.01 ? 247  VAL A O   1 
+ATOM   1947 C CB  . VAL A 1 247 ? 81.317 36.635 36.851 1.00 14.90 ? 247  VAL A CB  1 
+ATOM   1948 C CG1 . VAL A 1 247 ? 81.125 35.124 36.937 1.00 16.53 ? 247  VAL A CG1 1 
+ATOM   1949 C CG2 . VAL A 1 247 ? 82.573 37.057 37.612 1.00 15.86 ? 247  VAL A CG2 1 
+ATOM   1950 N N   . TRP A 1 248 ? 79.066 37.003 34.619 1.00 11.69 ? 248  TRP A N   1 
+ATOM   1951 C CA  . TRP A 1 248 ? 77.966 36.495 33.776 1.00 9.50  ? 248  TRP A CA  1 
+ATOM   1952 C C   . TRP A 1 248 ? 78.208 36.744 32.304 1.00 10.97 ? 248  TRP A C   1 
+ATOM   1953 O O   . TRP A 1 248 ? 77.927 35.904 31.451 1.00 10.34 ? 248  TRP A O   1 
+ATOM   1954 C CB  . TRP A 1 248 ? 76.661 37.176 34.204 1.00 9.95  ? 248  TRP A CB  1 
+ATOM   1955 C CG  . TRP A 1 248 ? 75.903 36.522 35.314 1.00 10.59 ? 248  TRP A CG  1 
+ATOM   1956 C CD1 . TRP A 1 248 ? 75.698 36.988 36.572 1.00 10.54 ? 248  TRP A CD1 1 
+ATOM   1957 C CD2 . TRP A 1 248 ? 75.174 35.282 35.236 1.00 9.58  ? 248  TRP A CD2 1 
+ATOM   1958 N NE1 . TRP A 1 248 ? 74.897 36.109 37.294 1.00 12.03 ? 248  TRP A NE1 1 
+ATOM   1959 C CE2 . TRP A 1 248 ? 74.598 35.041 36.500 1.00 9.25  ? 248  TRP A CE2 1 
+ATOM   1960 C CE3 . TRP A 1 248 ? 75.006 34.337 34.230 1.00 11.44 ? 248  TRP A CE3 1 
+ATOM   1961 C CZ2 . TRP A 1 248 ? 73.779 33.943 36.770 1.00 12.25 ? 248  TRP A CZ2 1 
+ATOM   1962 C CZ3 . TRP A 1 248 ? 74.215 33.227 34.505 1.00 11.93 ? 248  TRP A CZ3 1 
+ATOM   1963 C CH2 . TRP A 1 248 ? 73.640 33.012 35.772 1.00 14.85 ? 248  TRP A CH2 1 
+ATOM   1964 N N   . ILE A 1 249 ? 78.764 37.913 31.960 1.00 11.76 ? 249  ILE A N   1 
+ATOM   1965 C CA  . ILE A 1 249 ? 79.053 38.194 30.527 1.00 11.62 ? 249  ILE A CA  1 
+ATOM   1966 C C   . ILE A 1 249 ? 79.963 37.109 29.977 1.00 13.04 ? 249  ILE A C   1 
+ATOM   1967 O O   . ILE A 1 249 ? 79.749 36.526 28.903 1.00 12.59 ? 249  ILE A O   1 
+ATOM   1968 C CB  . ILE A 1 249 ? 79.687 39.587 30.387 1.00 12.77 ? 249  ILE A CB  1 
+ATOM   1969 C CG1 . ILE A 1 249 ? 78.656 40.703 30.611 1.00 12.27 ? 249  ILE A CG1 1 
+ATOM   1970 C CG2 . ILE A 1 249 ? 80.410 39.781 29.052 1.00 15.18 ? 249  ILE A CG2 1 
+ATOM   1971 C CD1 . ILE A 1 249 ? 77.557 40.736 29.547 1.00 16.68 ? 249  ILE A CD1 1 
+ATOM   1972 N N   . ASP A 1 250 ? 81.058 36.850 30.709 1.00 12.21 ? 250  ASP A N   1 
+ATOM   1973 C CA  . ASP A 1 250 ? 82.028 35.841 30.291 1.00 14.42 ? 250  ASP A CA  1 
+ATOM   1974 C C   . ASP A 1 250 ? 81.407 34.463 30.213 1.00 13.62 ? 250  ASP A C   1 
+ATOM   1975 O O   . ASP A 1 250 ? 81.692 33.702 29.297 1.00 14.26 ? 250  ASP A O   1 
+ATOM   1976 C CB  . ASP A 1 250 ? 83.265 35.827 31.209 1.00 15.75 ? 250  ASP A CB  1 
+ATOM   1977 C CG  . ASP A 1 250 ? 84.071 37.120 31.142 1.00 18.77 ? 250  ASP A CG  1 
+ATOM   1978 O OD1 . ASP A 1 250 ? 83.988 37.882 30.174 1.00 20.83 ? 250  ASP A OD1 1 
+ATOM   1979 O OD2 . ASP A 1 250 ? 84.846 37.427 32.063 1.00 23.87 ? 250  ASP A OD2 1 
+ATOM   1980 N N   . PHE A 1 251 ? 80.554 34.099 31.161 1.00 12.23 ? 251  PHE A N   1 
+ATOM   1981 C CA  . PHE A 1 251 ? 79.885 32.806 31.169 1.00 12.68 ? 251  PHE A CA  1 
+ATOM   1982 C C   . PHE A 1 251 ? 79.005 32.652 29.923 1.00 11.13 ? 251  PHE A C   1 
+ATOM   1983 O O   . PHE A 1 251 ? 79.010 31.597 29.265 1.00 11.90 ? 251  PHE A O   1 
+ATOM   1984 C CB  . PHE A 1 251 ? 79.049 32.680 32.453 1.00 11.61 ? 251  PHE A CB  1 
+ATOM   1985 C CG  . PHE A 1 251 ? 78.114 31.496 32.489 1.00 11.17 ? 251  PHE A CG  1 
+ATOM   1986 C CD1 . PHE A 1 251 ? 78.491 30.270 32.996 1.00 10.97 ? 251  PHE A CD1 1 
+ATOM   1987 C CD2 . PHE A 1 251 ? 76.802 31.642 32.050 1.00 10.33 ? 251  PHE A CD2 1 
+ATOM   1988 C CE1 . PHE A 1 251 ? 77.600 29.220 33.051 1.00 12.62 ? 251  PHE A CE1 1 
+ATOM   1989 C CE2 . PHE A 1 251 ? 75.928 30.589 32.059 1.00 13.34 ? 251  PHE A CE2 1 
+ATOM   1990 C CZ  . PHE A 1 251 ? 76.319 29.362 32.568 1.00 14.36 ? 251  PHE A CZ  1 
+ATOM   1991 N N   . MET A 1 252 ? 78.274 33.700 29.600 1.00 11.00 ? 252  MET A N   1 
+ATOM   1992 C CA  . MET A 1 252 ? 77.381 33.669 28.428 1.00 11.76 ? 252  MET A CA  1 
+ATOM   1993 C C   . MET A 1 252 ? 78.206 33.545 27.151 1.00 12.04 ? 252  MET A C   1 
+ATOM   1994 O O   . MET A 1 252 ? 77.836 32.767 26.269 1.00 12.13 ? 252  MET A O   1 
+ATOM   1995 C CB  . MET A 1 252 ? 76.422 34.857 28.380 1.00 14.42 ? 252  MET A CB  1 
+ATOM   1996 C CG  . MET A 1 252 ? 75.398 34.870 29.515 1.00 11.66 ? 252  MET A CG  1 
+ATOM   1997 S SD  . MET A 1 252 ? 74.160 36.182 29.369 1.00 8.67  ? 252  MET A SD  1 
+ATOM   1998 C CE  . MET A 1 252 ? 75.098 37.623 29.786 1.00 10.27 ? 252  MET A CE  1 
+ATOM   1999 N N   . ASP A 1 253 ? 79.355 34.197 27.055 1.00 12.96 ? 253  ASP A N   1 
+ATOM   2000 C CA  . ASP A 1 253 ? 80.209 34.035 25.875 1.00 16.40 ? 253  ASP A CA  1 
+ATOM   2001 C C   . ASP A 1 253 ? 80.759 32.617 25.753 1.00 13.89 ? 253  ASP A C   1 
+ATOM   2002 O O   . ASP A 1 253 ? 80.729 32.008 24.676 1.00 13.77 ? 253  ASP A O   1 
+ATOM   2003 C CB  . ASP A 1 253 ? 81.390 35.019 25.948 1.00 16.01 ? 253  ASP A CB  1 
+ATOM   2004 C CG  . ASP A 1 253 ? 80.957 36.407 25.507 1.00 18.69 ? 253  ASP A CG  1 
+ATOM   2005 O OD1 . ASP A 1 253 ? 79.826 36.571 25.014 1.00 14.24 ? 253  ASP A OD1 1 
+ATOM   2006 O OD2 . ASP A 1 253 ? 81.733 37.350 25.682 1.00 17.36 ? 253  ASP A OD2 1 
+ATOM   2007 N N   . GLU A 1 254 ? 81.191 32.021 26.867 1.00 15.43 ? 254  GLU A N   1 
+ATOM   2008 C CA  . GLU A 1 254 ? 81.691 30.650 26.853 1.00 15.43 ? 254  GLU A CA  1 
+ATOM   2009 C C   . GLU A 1 254 ? 80.599 29.669 26.422 1.00 15.99 ? 254  GLU A C   1 
+ATOM   2010 O O   . GLU A 1 254 ? 80.851 28.631 25.809 1.00 16.83 ? 254  GLU A O   1 
+ATOM   2011 C CB  . GLU A 1 254 ? 82.201 30.279 28.243 1.00 24.04 ? 254  GLU A CB  1 
+ATOM   2012 C CG  . GLU A 1 254 ? 83.402 31.052 28.751 1.00 44.53 ? 254  GLU A CG  1 
+ATOM   2013 C CD  . GLU A 1 254 ? 84.712 30.293 28.766 1.00 59.49 ? 254  GLU A CD  1 
+ATOM   2014 O OE1 . GLU A 1 254 ? 84.931 29.400 29.624 1.00 67.23 ? 254  GLU A OE1 1 
+ATOM   2015 O OE2 . GLU A 1 254 ? 85.579 30.586 27.904 1.00 65.17 ? 254  GLU A OE2 1 
+ATOM   2016 N N   . ARG A 1 255 ? 79.356 29.920 26.819 1.00 16.06 ? 255  ARG A N   1 
+ATOM   2017 C CA  . ARG A 1 255 ? 78.238 29.027 26.509 1.00 13.57 ? 255  ARG A CA  1 
+ATOM   2018 C C   . ARG A 1 255 ? 77.481 29.430 25.266 1.00 14.31 ? 255  ARG A C   1 
+ATOM   2019 O O   . ARG A 1 255 ? 76.448 28.798 24.969 1.00 15.15 ? 255  ARG A O   1 
+ATOM   2020 C CB  . ARG A 1 255 ? 77.270 29.000 27.697 1.00 18.39 ? 255  ARG A CB  1 
+ATOM   2021 C CG  . ARG A 1 255 ? 77.580 28.136 28.892 1.00 19.70 ? 255  ARG A CG  1 
+ATOM   2022 C CD  . ARG A 1 255 ? 78.855 28.460 29.609 1.00 26.35 ? 255  ARG A CD  1 
+ATOM   2023 N NE  . ARG A 1 255 ? 79.088 27.523 30.731 1.00 20.90 ? 255  ARG A NE  1 
+ATOM   2024 C CZ  . ARG A 1 255 ? 80.217 27.602 31.436 1.00 26.14 ? 255  ARG A CZ  1 
+ATOM   2025 N NH1 . ARG A 1 255 ? 81.119 28.525 31.112 1.00 30.93 ? 255  ARG A NH1 1 
+ATOM   2026 N NH2 . ARG A 1 255 ? 80.446 26.781 32.438 1.00 23.45 ? 255  ARG A NH2 1 
+ATOM   2027 N N   . ASN A 1 256 ? 77.907 30.488 24.589 1.00 16.04 ? 256  ASN A N   1 
+ATOM   2028 C CA  . ASN A 1 256 ? 77.220 31.006 23.421 1.00 18.05 ? 256  ASN A CA  1 
+ATOM   2029 C C   . ASN A 1 256 ? 75.753 31.338 23.666 1.00 17.32 ? 256  ASN A C   1 
+ATOM   2030 O O   . ASN A 1 256 ? 74.841 30.984 22.904 1.00 17.98 ? 256  ASN A O   1 
+ATOM   2031 C CB  . ASN A 1 256 ? 77.347 30.035 22.232 1.00 27.53 ? 256  ASN A CB  1 
+ATOM   2032 C CG  . ASN A 1 256 ? 77.462 30.828 20.934 1.00 37.89 ? 256  ASN A CG  1 
+ATOM   2033 O OD1 . ASN A 1 256 ? 76.467 31.111 20.266 1.00 30.91 ? 256  ASN A OD1 1 
+ATOM   2034 N ND2 . ASN A 1 256 ? 78.644 31.250 20.497 1.00 42.90 ? 256  ASN A ND2 1 
+ATOM   2035 N N   . LEU A 1 257 ? 75.477 32.008 24.792 1.00 11.74 ? 257  LEU A N   1 
+ATOM   2036 C CA  . LEU A 1 257 ? 74.118 32.383 25.118 1.00 13.61 ? 257  LEU A CA  1 
+ATOM   2037 C C   . LEU A 1 257 ? 73.823 33.815 24.641 1.00 13.02 ? 257  LEU A C   1 
+ATOM   2038 O O   . LEU A 1 257 ? 74.601 34.754 24.855 1.00 13.00 ? 257  LEU A O   1 
+ATOM   2039 C CB  . LEU A 1 257 ? 73.854 32.260 26.617 1.00 9.85  ? 257  LEU A CB  1 
+ATOM   2040 C CG  . LEU A 1 257 ? 74.105 30.868 27.215 1.00 10.51 ? 257  LEU A CG  1 
+ATOM   2041 C CD1 . LEU A 1 257 ? 73.942 30.913 28.730 1.00 15.00 ? 257  LEU A CD1 1 
+ATOM   2042 C CD2 . LEU A 1 257 ? 73.151 29.881 26.555 1.00 19.65 ? 257  LEU A CD2 1 
+ATOM   2043 N N   . SER A 1 258 ? 72.694 33.941 23.971 1.00 10.75 ? 258  SER A N   1 
+ATOM   2044 C CA  . SER A 1 258 ? 72.199 35.212 23.461 1.00 9.77  ? 258  SER A CA  1 
+ATOM   2045 C C   . SER A 1 258 ? 71.541 35.985 24.603 1.00 10.13 ? 258  SER A C   1 
+ATOM   2046 O O   . SER A 1 258 ? 71.043 35.349 25.530 1.00 7.53  ? 258  SER A O   1 
+ATOM   2047 C CB  . SER A 1 258 ? 71.125 34.959 22.382 1.00 10.54 ? 258  SER A CB  1 
+ATOM   2048 O OG  . SER A 1 258 ? 71.800 34.515 21.201 1.00 10.37 ? 258  SER A OG  1 
+ATOM   2049 N N   . TRP A 1 259 ? 71.559 37.320 24.531 1.00 8.25  ? 259  TRP A N   1 
+ATOM   2050 C CA  . TRP A 1 259 ? 70.990 38.094 25.634 1.00 9.14  ? 259  TRP A CA  1 
+ATOM   2051 C C   . TRP A 1 259 ? 70.482 39.475 25.260 1.00 10.85 ? 259  TRP A C   1 
+ATOM   2052 O O   . TRP A 1 259 ? 70.892 40.081 24.258 1.00 11.43 ? 259  TRP A O   1 
+ATOM   2053 C CB  . TRP A 1 259 ? 72.046 38.228 26.716 1.00 8.48  ? 259  TRP A CB  1 
+ATOM   2054 C CG  . TRP A 1 259 ? 73.390 38.808 26.483 1.00 11.11 ? 259  TRP A CG  1 
+ATOM   2055 C CD1 . TRP A 1 259 ? 74.563 38.092 26.414 1.00 8.60  ? 259  TRP A CD1 1 
+ATOM   2056 C CD2 . TRP A 1 259 ? 73.780 40.189 26.391 1.00 10.34 ? 259  TRP A CD2 1 
+ATOM   2057 N NE1 . TRP A 1 259 ? 75.627 38.939 26.309 1.00 12.39 ? 259  TRP A NE1 1 
+ATOM   2058 C CE2 . TRP A 1 259 ? 75.200 40.225 26.295 1.00 11.39 ? 259  TRP A CE2 1 
+ATOM   2059 C CE3 . TRP A 1 259 ? 73.111 41.397 26.398 1.00 11.33 ? 259  TRP A CE3 1 
+ATOM   2060 C CZ2 . TRP A 1 259 ? 75.922 41.420 26.218 1.00 11.72 ? 259  TRP A CZ2 1 
+ATOM   2061 C CZ3 . TRP A 1 259 ? 73.802 42.592 26.321 1.00 11.70 ? 259  TRP A CZ3 1 
+ATOM   2062 C CH2 . TRP A 1 259 ? 75.216 42.594 26.244 1.00 12.39 ? 259  TRP A CH2 1 
+ATOM   2063 N N   . ALA A 1 260 ? 69.601 39.968 26.134 1.00 10.07 ? 260  ALA A N   1 
+ATOM   2064 C CA  . ALA A 1 260 ? 69.012 41.284 26.038 1.00 11.19 ? 260  ALA A CA  1 
+ATOM   2065 C C   . ALA A 1 260 ? 69.066 41.937 27.436 1.00 9.73  ? 260  ALA A C   1 
+ATOM   2066 O O   . ALA A 1 260 ? 68.528 41.398 28.421 1.00 10.22 ? 260  ALA A O   1 
+ATOM   2067 C CB  . ALA A 1 260 ? 67.581 41.312 25.538 1.00 12.00 ? 260  ALA A CB  1 
+ATOM   2068 N N   . ASN A 1 261 ? 69.694 43.094 27.528 1.00 8.29  ? 261  ASN A N   1 
+ATOM   2069 C CA  . ASN A 1 261 ? 69.858 43.814 28.779 1.00 10.31 ? 261  ASN A CA  1 
+ATOM   2070 C C   . ASN A 1 261 ? 68.652 44.682 29.117 1.00 10.89 ? 261  ASN A C   1 
+ATOM   2071 O O   . ASN A 1 261 ? 68.070 45.312 28.238 1.00 6.85  ? 261  ASN A O   1 
+ATOM   2072 C CB  . ASN A 1 261 ? 71.136 44.650 28.808 1.00 9.36  ? 261  ASN A CB  1 
+ATOM   2073 C CG  . ASN A 1 261 ? 71.231 45.584 30.007 1.00 9.78  ? 261  ASN A CG  1 
+ATOM   2074 O OD1 . ASN A 1 261 ? 70.945 46.765 29.875 1.00 10.60 ? 261  ASN A OD1 1 
+ATOM   2075 N ND2 . ASN A 1 261 ? 71.617 45.042 31.135 1.00 11.76 ? 261  ASN A ND2 1 
+ATOM   2076 N N   . TRP A 1 262 ? 68.287 44.697 30.390 1.00 9.13  ? 262  TRP A N   1 
+ATOM   2077 C CA  . TRP A 1 262 ? 67.215 45.503 30.930 1.00 8.03  ? 262  TRP A CA  1 
+ATOM   2078 C C   . TRP A 1 262 ? 67.806 46.725 31.630 1.00 9.50  ? 262  TRP A C   1 
+ATOM   2079 O O   . TRP A 1 262 ? 68.529 46.530 32.618 1.00 10.64 ? 262  TRP A O   1 
+ATOM   2080 C CB  . TRP A 1 262 ? 66.458 44.670 31.981 1.00 7.85  ? 262  TRP A CB  1 
+ATOM   2081 C CG  . TRP A 1 262 ? 65.216 45.376 32.472 1.00 6.93  ? 262  TRP A CG  1 
+ATOM   2082 C CD1 . TRP A 1 262 ? 65.143 46.203 33.561 1.00 8.57  ? 262  TRP A CD1 1 
+ATOM   2083 C CD2 . TRP A 1 262 ? 63.898 45.316 31.918 1.00 9.40  ? 262  TRP A CD2 1 
+ATOM   2084 N NE1 . TRP A 1 262 ? 63.857 46.643 33.731 1.00 9.47  ? 262  TRP A NE1 1 
+ATOM   2085 C CE2 . TRP A 1 262 ? 63.069 46.118 32.728 1.00 9.12  ? 262  TRP A CE2 1 
+ATOM   2086 C CE3 . TRP A 1 262 ? 63.340 44.656 30.815 1.00 9.29  ? 262  TRP A CE3 1 
+ATOM   2087 C CZ2 . TRP A 1 262 ? 61.717 46.310 32.442 1.00 9.94  ? 262  TRP A CZ2 1 
+ATOM   2088 C CZ3 . TRP A 1 262 ? 61.985 44.842 30.540 1.00 8.78  ? 262  TRP A CZ3 1 
+ATOM   2089 C CH2 . TRP A 1 262 ? 61.202 45.695 31.336 1.00 8.06  ? 262  TRP A CH2 1 
+ATOM   2090 N N   . SER A 1 263 ? 67.493 47.918 31.182 1.00 9.69  ? 263  SER A N   1 
+ATOM   2091 C CA  . SER A 1 263 ? 66.621 48.271 30.081 1.00 6.36  ? 263  SER A CA  1 
+ATOM   2092 C C   . SER A 1 263 ? 66.931 49.658 29.519 1.00 9.20  ? 263  SER A C   1 
+ATOM   2093 O O   . SER A 1 263 ? 67.673 50.465 30.114 1.00 9.50  ? 263  SER A O   1 
+ATOM   2094 C CB  . SER A 1 263 ? 65.134 48.295 30.497 1.00 6.23  ? 263  SER A CB  1 
+ATOM   2095 O OG  . SER A 1 263 ? 64.853 49.446 31.297 1.00 10.37 ? 263  SER A OG  1 
+ATOM   2096 N N   . LEU A 1 264 ? 66.371 49.937 28.343 1.00 10.13 ? 264  LEU A N   1 
+ATOM   2097 C CA  . LEU A 1 264 ? 66.539 51.196 27.656 1.00 9.98  ? 264  LEU A CA  1 
+ATOM   2098 C C   . LEU A 1 264 ? 65.480 52.215 28.074 1.00 10.11 ? 264  LEU A C   1 
+ATOM   2099 O O   . LEU A 1 264 ? 64.378 52.302 27.535 1.00 12.02 ? 264  LEU A O   1 
+ATOM   2100 C CB  . LEU A 1 264 ? 66.528 51.021 26.133 1.00 9.65  ? 264  LEU A CB  1 
+ATOM   2101 C CG  . LEU A 1 264 ? 66.956 52.269 25.344 1.00 9.92  ? 264  LEU A CG  1 
+ATOM   2102 C CD1 . LEU A 1 264 ? 68.473 52.307 25.299 1.00 11.61 ? 264  LEU A CD1 1 
+ATOM   2103 C CD2 . LEU A 1 264 ? 66.376 52.192 23.947 1.00 8.98  ? 264  LEU A CD2 1 
+ATOM   2104 N N   . THR A 1 265 ? 65.847 52.966 29.110 1.00 12.26 ? 265  THR A N   1 
+ATOM   2105 C CA  . THR A 1 265 ? 65.026 54.035 29.665 1.00 11.70 ? 265  THR A CA  1 
+ATOM   2106 C C   . THR A 1 265 ? 65.895 55.028 30.446 1.00 12.24 ? 265  THR A C   1 
+ATOM   2107 O O   . THR A 1 265 ? 67.058 54.715 30.747 1.00 13.09 ? 265  THR A O   1 
+ATOM   2108 C CB  . THR A 1 265 ? 63.903 53.528 30.578 1.00 11.59 ? 265  THR A CB  1 
+ATOM   2109 O OG1 . THR A 1 265 ? 63.169 54.641 31.102 1.00 13.52 ? 265  THR A OG1 1 
+ATOM   2110 C CG2 . THR A 1 265 ? 64.453 52.749 31.772 1.00 11.48 ? 265  THR A CG2 1 
+ATOM   2111 N N   . HIS A 1 266 ? 65.315 56.190 30.749 1.00 11.98 ? 266  HIS A N   1 
+ATOM   2112 C CA  . HIS A 1 266 ? 66.020 57.203 31.557 1.00 14.94 ? 266  HIS A CA  1 
+ATOM   2113 C C   . HIS A 1 266 ? 65.528 57.210 32.996 1.00 14.09 ? 266  HIS A C   1 
+ATOM   2114 O O   . HIS A 1 266 ? 65.902 58.088 33.800 1.00 15.38 ? 266  HIS A O   1 
+ATOM   2115 C CB  . HIS A 1 266 ? 65.856 58.617 30.993 1.00 14.01 ? 266  HIS A CB  1 
+ATOM   2116 C CG  . HIS A 1 266 ? 64.441 59.101 30.914 1.00 13.31 ? 266  HIS A CG  1 
+ATOM   2117 N ND1 . HIS A 1 266 ? 64.113 60.150 30.064 1.00 14.16 ? 266  HIS A ND1 1 
+ATOM   2118 C CD2 . HIS A 1 266 ? 63.300 58.774 31.532 1.00 18.88 ? 266  HIS A CD2 1 
+ATOM   2119 C CE1 . HIS A 1 266 ? 62.825 60.398 30.194 1.00 12.74 ? 266  HIS A CE1 1 
+ATOM   2120 N NE2 . HIS A 1 266 ? 62.283 59.586 31.072 1.00 16.01 ? 266  HIS A NE2 1 
+ATOM   2121 N N   . LYS A 1 267 ? 64.683 56.239 33.339 1.00 11.19 ? 267  LYS A N   1 
+ATOM   2122 C CA  . LYS A 1 267 ? 64.163 56.133 34.708 1.00 13.22 ? 267  LYS A CA  1 
+ATOM   2123 C C   . LYS A 1 267 ? 65.312 56.169 35.717 1.00 14.37 ? 267  LYS A C   1 
+ATOM   2124 O O   . LYS A 1 267 ? 66.392 55.615 35.430 1.00 14.46 ? 267  LYS A O   1 
+ATOM   2125 C CB  . LYS A 1 267 ? 63.393 54.833 34.902 1.00 16.89 ? 267  LYS A CB  1 
+ATOM   2126 C CG  . LYS A 1 267 ? 62.656 54.712 36.227 1.00 14.02 ? 267  LYS A CG  1 
+ATOM   2127 C CD  . LYS A 1 267 ? 61.742 53.511 36.333 1.00 14.47 ? 267  LYS A CD  1 
+ATOM   2128 C CE  . LYS A 1 267 ? 61.137 53.432 37.732 1.00 21.71 ? 267  LYS A CE  1 
+ATOM   2129 N NZ  . LYS A 1 267 ? 59.939 52.549 37.829 1.00 23.99 ? 267  LYS A NZ  1 
+ATOM   2130 N N   . ASP A 1 268 ? 65.058 56.753 36.893 1.00 13.29 ? 268  ASP A N   1 
+ATOM   2131 C CA  . ASP A 1 268 ? 66.083 56.855 37.935 1.00 13.29 ? 268  ASP A CA  1 
+ATOM   2132 C C   . ASP A 1 268 ? 66.169 55.573 38.751 1.00 13.87 ? 268  ASP A C   1 
+ATOM   2133 O O   . ASP A 1 268 ? 65.722 55.441 39.892 1.00 14.32 ? 268  ASP A O   1 
+ATOM   2134 C CB  . ASP A 1 268 ? 65.805 58.025 38.886 1.00 17.32 ? 268  ASP A CB  1 
+ATOM   2135 C CG  . ASP A 1 268 ? 66.944 58.310 39.852 1.00 24.66 ? 268  ASP A CG  1 
+ATOM   2136 O OD1 . ASP A 1 268 ? 68.094 57.874 39.676 1.00 23.87 ? 268  ASP A OD1 1 
+ATOM   2137 O OD2 . ASP A 1 268 ? 66.677 59.001 40.848 1.00 23.87 ? 268  ASP A OD2 1 
+ATOM   2138 N N   . GLU A 1 269 ? 66.729 54.547 38.114 1.00 10.10 ? 269  GLU A N   1 
+ATOM   2139 C CA  . GLU A 1 269 ? 66.931 53.233 38.760 1.00 12.64 ? 269  GLU A CA  1 
+ATOM   2140 C C   . GLU A 1 269 ? 68.238 52.709 38.172 1.00 13.51 ? 269  GLU A C   1 
+ATOM   2141 O O   . GLU A 1 269 ? 68.584 52.977 37.011 1.00 10.80 ? 269  GLU A O   1 
+ATOM   2142 C CB  . GLU A 1 269 ? 65.815 52.226 38.573 1.00 12.12 ? 269  GLU A CB  1 
+ATOM   2143 C CG  . GLU A 1 269 ? 65.488 51.826 37.153 1.00 12.44 ? 269  GLU A CG  1 
+ATOM   2144 C CD  . GLU A 1 269 ? 64.233 51.026 36.985 1.00 13.60 ? 269  GLU A CD  1 
+ATOM   2145 O OE1 . GLU A 1 269 ? 63.434 50.919 37.968 1.00 11.02 ? 269  GLU A OE1 1 
+ATOM   2146 O OE2 . GLU A 1 269 ? 64.023 50.464 35.876 1.00 11.49 ? 269  GLU A OE2 1 
+ATOM   2147 N N   . SER A 1 270 ? 68.998 51.945 38.950 1.00 11.70 ? 270  SER A N   1 
+ATOM   2148 C CA  . SER A 1 270 ? 70.328 51.541 38.560 1.00 12.45 ? 270  SER A CA  1 
+ATOM   2149 C C   . SER A 1 270 ? 70.395 50.775 37.249 1.00 12.27 ? 270  SER A C   1 
+ATOM   2150 O O   . SER A 1 270 ? 71.416 50.850 36.567 1.00 13.39 ? 270  SER A O   1 
+ATOM   2151 C CB  . SER A 1 270 ? 70.950 50.656 39.670 1.00 15.26 ? 270  SER A CB  1 
+ATOM   2152 O OG  . SER A 1 270 ? 71.112 51.461 40.843 1.00 22.41 ? 270  SER A OG  1 
+ATOM   2153 N N   . SER A 1 271 ? 69.388 49.959 36.937 1.00 10.68 ? 271  SER A N   1 
+ATOM   2154 C CA  . SER A 1 271 ? 69.460 49.138 35.726 1.00 13.95 ? 271  SER A CA  1 
+ATOM   2155 C C   . SER A 1 271 ? 69.196 49.945 34.448 1.00 9.58  ? 271  SER A C   1 
+ATOM   2156 O O   . SER A 1 271 ? 69.433 49.436 33.364 1.00 9.87  ? 271  SER A O   1 
+ATOM   2157 C CB  . SER A 1 271 ? 68.515 47.930 35.808 1.00 11.61 ? 271  SER A CB  1 
+ATOM   2158 O OG  . SER A 1 271 ? 67.158 48.361 35.911 1.00 11.46 ? 271  SER A OG  1 
+ATOM   2159 N N   . ALA A 1 272 ? 68.679 51.151 34.603 1.00 9.47  ? 272  ALA A N   1 
+ATOM   2160 C CA  . ALA A 1 272 ? 68.392 51.981 33.411 1.00 8.88  ? 272  ALA A CA  1 
+ATOM   2161 C C   . ALA A 1 272 ? 69.690 52.302 32.689 1.00 13.02 ? 272  ALA A C   1 
+ATOM   2162 O O   . ALA A 1 272 ? 70.652 52.697 33.337 1.00 10.46 ? 272  ALA A O   1 
+ATOM   2163 C CB  . ALA A 1 272 ? 67.722 53.250 33.874 1.00 12.24 ? 272  ALA A CB  1 
+ATOM   2164 N N   . ALA A 1 273 ? 69.710 52.193 31.362 1.00 10.85 ? 273  ALA A N   1 
+ATOM   2165 C CA  . ALA A 1 273 ? 70.894 52.453 30.572 1.00 10.03 ? 273  ALA A CA  1 
+ATOM   2166 C C   . ALA A 1 273 ? 71.177 53.939 30.331 1.00 10.13 ? 273  ALA A C   1 
+ATOM   2167 O O   . ALA A 1 273 ? 72.311 54.259 29.956 1.00 12.76 ? 273  ALA A O   1 
+ATOM   2168 C CB  . ALA A 1 273 ? 70.728 51.836 29.174 1.00 7.29  ? 273  ALA A CB  1 
+ATOM   2169 N N   . LEU A 1 274 ? 70.161 54.774 30.455 1.00 9.96  ? 274  LEU A N   1 
+ATOM   2170 C CA  . LEU A 1 274 ? 70.317 56.178 30.093 1.00 8.75  ? 274  LEU A CA  1 
+ATOM   2171 C C   . LEU A 1 274 ? 70.117 57.118 31.280 1.00 11.18 ? 274  LEU A C   1 
+ATOM   2172 O O   . LEU A 1 274 ? 69.383 56.830 32.230 1.00 11.96 ? 274  LEU A O   1 
+ATOM   2173 C CB  . LEU A 1 274 ? 69.267 56.536 29.038 1.00 7.65  ? 274  LEU A CB  1 
+ATOM   2174 C CG  . LEU A 1 274 ? 69.159 55.612 27.823 1.00 9.35  ? 274  LEU A CG  1 
+ATOM   2175 C CD1 . LEU A 1 274 ? 67.950 55.951 26.960 1.00 11.84 ? 274  LEU A CD1 1 
+ATOM   2176 C CD2 . LEU A 1 274 ? 70.442 55.670 26.995 1.00 15.02 ? 274  LEU A CD2 1 
+ATOM   2177 N N   . MET A 1 275 ? 70.722 58.303 31.120 1.00 12.02 ? 275  MET A N   1 
+ATOM   2178 C CA  . MET A 1 275 ? 70.548 59.336 32.147 1.00 14.87 ? 275  MET A CA  1 
+ATOM   2179 C C   . MET A 1 275 ? 69.322 60.160 31.768 1.00 19.41 ? 275  MET A C   1 
+ATOM   2180 O O   . MET A 1 275 ? 68.872 60.234 30.619 1.00 20.04 ? 275  MET A O   1 
+ATOM   2181 C CB  . MET A 1 275 ? 71.799 60.207 32.172 1.00 15.72 ? 275  MET A CB  1 
+ATOM   2182 C CG  . MET A 1 275 ? 73.059 59.473 32.600 1.00 16.12 ? 275  MET A CG  1 
+ATOM   2183 S SD  . MET A 1 275 ? 72.915 58.806 34.261 1.00 19.36 ? 275  MET A SD  1 
+ATOM   2184 C CE  . MET A 1 275 ? 73.215 60.300 35.210 1.00 26.63 ? 275  MET A CE  1 
+ATOM   2185 N N   . PRO A 1 276 ? 68.794 60.920 32.708 1.00 24.29 ? 276  PRO A N   1 
+ATOM   2186 C CA  . PRO A 1 276 ? 67.611 61.732 32.539 1.00 31.52 ? 276  PRO A CA  1 
+ATOM   2187 C C   . PRO A 1 276 ? 67.508 62.571 31.300 1.00 33.44 ? 276  PRO A C   1 
+ATOM   2188 O O   . PRO A 1 276 ? 66.360 62.703 30.820 1.00 39.79 ? 276  PRO A O   1 
+ATOM   2189 C CB  . PRO A 1 276 ? 67.501 62.611 33.821 1.00 32.90 ? 276  PRO A CB  1 
+ATOM   2190 C CG  . PRO A 1 276 ? 68.138 61.682 34.823 1.00 29.06 ? 276  PRO A CG  1 
+ATOM   2191 C CD  . PRO A 1 276 ? 69.236 60.919 34.107 1.00 27.46 ? 276  PRO A CD  1 
+ATOM   2192 N N   . GLY A 1 277 ? 68.577 63.124 30.749 1.00 32.86 ? 277  GLY A N   1 
+ATOM   2193 C CA  . GLY A 1 277 ? 68.465 63.961 29.567 1.00 32.26 ? 277  GLY A CA  1 
+ATOM   2194 C C   . GLY A 1 277 ? 68.828 63.317 28.242 1.00 31.05 ? 277  GLY A C   1 
+ATOM   2195 O O   . GLY A 1 277 ? 69.172 63.982 27.254 1.00 30.62 ? 277  GLY A O   1 
+ATOM   2196 N N   . ALA A 1 278 ? 68.752 61.980 28.191 1.00 19.57 ? 278  ALA A N   1 
+ATOM   2197 C CA  . ALA A 1 278 ? 69.121 61.303 26.947 1.00 16.83 ? 278  ALA A CA  1 
+ATOM   2198 C C   . ALA A 1 278 ? 67.987 61.478 25.920 1.00 12.86 ? 278  ALA A C   1 
+ATOM   2199 O O   . ALA A 1 278 ? 66.810 61.384 26.257 1.00 16.24 ? 278  ALA A O   1 
+ATOM   2200 C CB  . ALA A 1 278 ? 69.381 59.842 27.224 1.00 17.75 ? 278  ALA A CB  1 
+ATOM   2201 N N   . ASN A 1 279 ? 68.394 61.771 24.710 1.00 14.30 ? 279  ASN A N   1 
+ATOM   2202 C CA  . ASN A 1 279 ? 67.449 62.003 23.621 1.00 11.48 ? 279  ASN A CA  1 
+ATOM   2203 C C   . ASN A 1 279 ? 66.779 60.693 23.290 1.00 13.21 ? 279  ASN A C   1 
+ATOM   2204 O O   . ASN A 1 279 ? 67.501 59.704 23.100 1.00 11.93 ? 279  ASN A O   1 
+ATOM   2205 C CB  . ASN A 1 279 ? 68.270 62.526 22.446 1.00 14.53 ? 279  ASN A CB  1 
+ATOM   2206 C CG  . ASN A 1 279 ? 67.466 62.993 21.259 1.00 16.58 ? 279  ASN A CG  1 
+ATOM   2207 O OD1 . ASN A 1 279 ? 66.539 62.334 20.796 1.00 13.42 ? 279  ASN A OD1 1 
+ATOM   2208 N ND2 . ASN A 1 279 ? 67.842 64.155 20.710 1.00 18.73 ? 279  ASN A ND2 1 
+ATOM   2209 N N   . PRO A 1 280 ? 65.474 60.676 23.156 1.00 11.44 ? 280  PRO A N   1 
+ATOM   2210 C CA  . PRO A 1 280 ? 64.723 59.472 22.858 1.00 12.12 ? 280  PRO A CA  1 
+ATOM   2211 C C   . PRO A 1 280 ? 65.007 58.931 21.468 1.00 12.46 ? 280  PRO A C   1 
+ATOM   2212 O O   . PRO A 1 280 ? 64.689 57.786 21.155 1.00 11.57 ? 280  PRO A O   1 
+ATOM   2213 C CB  . PRO A 1 280 ? 63.227 59.800 23.017 1.00 15.67 ? 280  PRO A CB  1 
+ATOM   2214 C CG  . PRO A 1 280 ? 63.234 61.303 22.918 1.00 14.43 ? 280  PRO A CG  1 
+ATOM   2215 C CD  . PRO A 1 280 ? 64.590 61.825 23.365 1.00 12.54 ? 280  PRO A CD  1 
+ATOM   2216 N N   . THR A 1 281 ? 65.593 59.742 20.574 1.00 11.10 ? 281  THR A N   1 
+ATOM   2217 C CA  . THR A 1 281 ? 65.930 59.297 19.243 1.00 11.98 ? 281  THR A CA  1 
+ATOM   2218 C C   . THR A 1 281 ? 67.410 58.945 19.113 1.00 9.31  ? 281  THR A C   1 
+ATOM   2219 O O   . THR A 1 281 ? 67.890 58.756 17.990 1.00 11.86 ? 281  THR A O   1 
+ATOM   2220 C CB  . THR A 1 281 ? 65.493 60.261 18.143 1.00 9.75  ? 281  THR A CB  1 
+ATOM   2221 O OG1 . THR A 1 281 ? 66.197 61.507 18.308 1.00 13.54 ? 281  THR A OG1 1 
+ATOM   2222 C CG2 . THR A 1 281 ? 63.991 60.496 18.157 1.00 12.28 ? 281  THR A CG2 1 
+ATOM   2223 N N   . GLY A 1 282 ? 68.163 58.795 20.196 1.00 12.40 ? 282  GLY A N   1 
+ATOM   2224 C CA  . GLY A 1 282 ? 69.552 58.366 20.061 1.00 12.26 ? 282  GLY A CA  1 
+ATOM   2225 C C   . GLY A 1 282 ? 70.634 59.438 20.032 1.00 15.29 ? 282  GLY A C   1 
+ATOM   2226 O O   . GLY A 1 282 ? 70.441 60.606 20.342 1.00 14.70 ? 282  GLY A O   1 
+ATOM   2227 N N   . GLY A 1 283 ? 71.859 59.030 19.690 1.00 12.01 ? 283  GLY A N   1 
+ATOM   2228 C CA  . GLY A 1 283 ? 72.991 59.951 19.575 1.00 15.35 ? 283  GLY A CA  1 
+ATOM   2229 C C   . GLY A 1 283 ? 73.642 60.279 20.906 1.00 18.68 ? 283  GLY A C   1 
+ATOM   2230 O O   . GLY A 1 283 ? 74.262 61.340 21.008 1.00 20.39 ? 283  GLY A O   1 
+ATOM   2231 N N   . TRP A 1 284 ? 73.463 59.414 21.900 1.00 14.96 ? 284  TRP A N   1 
+ATOM   2232 C CA  . TRP A 1 284 ? 73.931 59.685 23.252 1.00 16.51 ? 284  TRP A CA  1 
+ATOM   2233 C C   . TRP A 1 284 ? 75.438 59.886 23.390 1.00 17.63 ? 284  TRP A C   1 
+ATOM   2234 O O   . TRP A 1 284 ? 76.250 59.160 22.829 1.00 21.96 ? 284  TRP A O   1 
+ATOM   2235 C CB  . TRP A 1 284 ? 73.481 58.531 24.184 1.00 15.52 ? 284  TRP A CB  1 
+ATOM   2236 C CG  . TRP A 1 284 ? 72.012 58.267 23.974 1.00 12.25 ? 284  TRP A CG  1 
+ATOM   2237 C CD1 . TRP A 1 284 ? 70.994 59.177 24.040 1.00 16.68 ? 284  TRP A CD1 1 
+ATOM   2238 C CD2 . TRP A 1 284 ? 71.418 57.013 23.634 1.00 13.52 ? 284  TRP A CD2 1 
+ATOM   2239 N NE1 . TRP A 1 284 ? 69.804 58.570 23.764 1.00 11.97 ? 284  TRP A NE1 1 
+ATOM   2240 C CE2 . TRP A 1 284 ? 70.027 57.242 23.501 1.00 14.99 ? 284  TRP A CE2 1 
+ATOM   2241 C CE3 . TRP A 1 284 ? 71.929 55.727 23.435 1.00 15.68 ? 284  TRP A CE3 1 
+ATOM   2242 C CZ2 . TRP A 1 284 ? 69.116 56.221 23.187 1.00 14.77 ? 284  TRP A CZ2 1 
+ATOM   2243 C CZ3 . TRP A 1 284 ? 71.050 54.719 23.092 1.00 12.27 ? 284  TRP A CZ3 1 
+ATOM   2244 C CH2 . TRP A 1 284 ? 69.673 54.991 22.989 1.00 13.01 ? 284  TRP A CH2 1 
+ATOM   2245 N N   . THR A 1 285 ? 75.791 60.898 24.156 1.00 20.11 ? 285  THR A N   1 
+ATOM   2246 C CA  . THR A 1 285 ? 77.167 61.166 24.552 1.00 23.05 ? 285  THR A CA  1 
+ATOM   2247 C C   . THR A 1 285 ? 77.440 60.264 25.755 1.00 23.78 ? 285  THR A C   1 
+ATOM   2248 O O   . THR A 1 285 ? 76.510 59.674 26.309 1.00 17.55 ? 285  THR A O   1 
+ATOM   2249 C CB  . THR A 1 285 ? 77.386 62.604 25.021 1.00 18.68 ? 285  THR A CB  1 
+ATOM   2250 O OG1 . THR A 1 285 ? 76.362 62.908 26.018 1.00 22.53 ? 285  THR A OG1 1 
+ATOM   2251 C CG2 . THR A 1 285 ? 77.206 63.584 23.869 1.00 30.56 ? 285  THR A CG2 1 
+ATOM   2252 N N   . GLU A 1 286 ? 78.700 60.215 26.162 1.00 25.40 ? 286  GLU A N   1 
+ATOM   2253 C CA  . GLU A 1 286 ? 79.109 59.437 27.316 1.00 24.27 ? 286  GLU A CA  1 
+ATOM   2254 C C   . GLU A 1 286 ? 78.378 59.874 28.574 1.00 22.93 ? 286  GLU A C   1 
+ATOM   2255 O O   . GLU A 1 286 ? 77.966 59.019 29.372 1.00 21.29 ? 286  GLU A O   1 
+ATOM   2256 C CB  . GLU A 1 286 ? 80.626 59.578 27.528 1.00 38.56 ? 286  GLU A CB  1 
+ATOM   2257 C CG  . GLU A 1 286 ? 81.428 59.481 26.245 1.00 53.17 ? 286  GLU A CG  1 
+ATOM   2258 C CD  . GLU A 1 286 ? 81.752 60.789 25.544 1.00 60.92 ? 286  GLU A CD  1 
+ATOM   2259 O OE1 . GLU A 1 286 ? 80.903 61.338 24.796 1.00 60.80 ? 286  GLU A OE1 1 
+ATOM   2260 O OE2 . GLU A 1 286 ? 82.895 61.283 25.733 1.00 62.83 ? 286  GLU A OE2 1 
+ATOM   2261 N N   . ALA A 1 287 ? 78.122 61.162 28.769 1.00 22.03 ? 287  ALA A N   1 
+ATOM   2262 C CA  . ALA A 1 287 ? 77.394 61.686 29.909 1.00 22.25 ? 287  ALA A CA  1 
+ATOM   2263 C C   . ALA A 1 287 ? 75.919 61.340 29.982 1.00 21.24 ? 287  ALA A C   1 
+ATOM   2264 O O   . ALA A 1 287 ? 75.285 61.380 31.044 1.00 20.98 ? 287  ALA A O   1 
+ATOM   2265 C CB  . ALA A 1 287 ? 77.508 63.226 29.922 1.00 29.11 ? 287  ALA A CB  1 
+ATOM   2266 N N   . GLU A 1 288 ? 75.317 60.979 28.847 1.00 16.37 ? 288  GLU A N   1 
+ATOM   2267 C CA  . GLU A 1 288 ? 73.910 60.622 28.765 1.00 15.75 ? 288  GLU A CA  1 
+ATOM   2268 C C   . GLU A 1 288 ? 73.668 59.123 28.988 1.00 13.78 ? 288  GLU A C   1 
+ATOM   2269 O O   . GLU A 1 288 ? 72.520 58.687 29.029 1.00 14.59 ? 288  GLU A O   1 
+ATOM   2270 C CB  . GLU A 1 288 ? 73.367 61.006 27.385 1.00 16.86 ? 288  GLU A CB  1 
+ATOM   2271 C CG  . GLU A 1 288 ? 73.397 62.528 27.163 1.00 27.58 ? 288  GLU A CG  1 
+ATOM   2272 C CD  . GLU A 1 288 ? 72.898 62.771 25.747 1.00 32.17 ? 288  GLU A CD  1 
+ATOM   2273 O OE1 . GLU A 1 288 ? 73.664 62.694 24.771 1.00 31.20 ? 288  GLU A OE1 1 
+ATOM   2274 O OE2 . GLU A 1 288 ? 71.664 62.958 25.605 1.00 45.41 ? 288  GLU A OE2 1 
+ATOM   2275 N N   . LEU A 1 289 ? 74.746 58.378 29.152 1.00 15.83 ? 289  LEU A N   1 
+ATOM   2276 C CA  . LEU A 1 289 ? 74.641 56.976 29.500 1.00 16.04 ? 289  LEU A CA  1 
+ATOM   2277 C C   . LEU A 1 289 ? 74.887 56.823 30.999 1.00 14.87 ? 289  LEU A C   1 
+ATOM   2278 O O   . LEU A 1 289 ? 75.785 57.485 31.527 1.00 17.05 ? 289  LEU A O   1 
+ATOM   2279 C CB  . LEU A 1 289 ? 75.651 56.125 28.760 1.00 15.18 ? 289  LEU A CB  1 
+ATOM   2280 C CG  . LEU A 1 289 ? 75.652 56.150 27.242 1.00 17.48 ? 289  LEU A CG  1 
+ATOM   2281 C CD1 . LEU A 1 289 ? 76.713 55.204 26.710 1.00 16.85 ? 289  LEU A CD1 1 
+ATOM   2282 C CD2 . LEU A 1 289 ? 74.297 55.820 26.643 1.00 20.84 ? 289  LEU A CD2 1 
+ATOM   2283 N N   . SER A 1 290 ? 74.142 55.925 31.632 1.00 13.09 ? 290  SER A N   1 
+ATOM   2284 C CA  . SER A 1 290 ? 74.366 55.692 33.064 1.00 12.43 ? 290  SER A CA  1 
+ATOM   2285 C C   . SER A 1 290 ? 75.557 54.769 33.177 1.00 13.33 ? 290  SER A C   1 
+ATOM   2286 O O   . SER A 1 290 ? 76.056 54.192 32.203 1.00 14.68 ? 290  SER A O   1 
+ATOM   2287 C CB  . SER A 1 290 ? 73.115 54.958 33.577 1.00 15.21 ? 290  SER A CB  1 
+ATOM   2288 O OG  . SER A 1 290 ? 73.058 53.684 32.939 1.00 12.24 ? 290  SER A OG  1 
+ATOM   2289 N N   . PRO A 1 291 ? 76.006 54.493 34.389 1.00 14.89 ? 291  PRO A N   1 
+ATOM   2290 C CA  . PRO A 1 291 ? 77.072 53.534 34.633 1.00 18.06 ? 291  PRO A CA  1 
+ATOM   2291 C C   . PRO A 1 291 ? 76.654 52.163 34.069 1.00 12.30 ? 291  PRO A C   1 
+ATOM   2292 O O   . PRO A 1 291 ? 77.522 51.516 33.469 1.00 12.57 ? 291  PRO A O   1 
+ATOM   2293 C CB  . PRO A 1 291 ? 77.329 53.529 36.143 1.00 20.76 ? 291  PRO A CB  1 
+ATOM   2294 C CG  . PRO A 1 291 ? 76.716 54.848 36.562 1.00 21.48 ? 291  PRO A CG  1 
+ATOM   2295 C CD  . PRO A 1 291 ? 75.554 55.153 35.624 1.00 18.37 ? 291  PRO A CD  1 
+ATOM   2296 N N   . SER A 1 292 ? 75.412 51.763 34.208 1.00 13.50 ? 292  SER A N   1 
+ATOM   2297 C CA  . SER A 1 292 ? 74.936 50.516 33.619 1.00 12.01 ? 292  SER A CA  1 
+ATOM   2298 C C   . SER A 1 292 ? 75.016 50.543 32.096 1.00 11.15 ? 292  SER A C   1 
+ATOM   2299 O O   . SER A 1 292 ? 75.526 49.626 31.418 1.00 11.74 ? 292  SER A O   1 
+ATOM   2300 C CB  . SER A 1 292 ? 73.518 50.161 34.084 1.00 11.65 ? 292  SER A CB  1 
+ATOM   2301 O OG  . SER A 1 292 ? 73.178 48.921 33.467 1.00 12.02 ? 292  SER A OG  1 
+ATOM   2302 N N   . GLY A 1 293 ? 74.427 51.551 31.454 1.00 9.80  ? 293  GLY A N   1 
+ATOM   2303 C CA  . GLY A 1 293 ? 74.452 51.708 30.010 1.00 11.49 ? 293  GLY A CA  1 
+ATOM   2304 C C   . GLY A 1 293 ? 75.852 51.778 29.425 1.00 12.21 ? 293  GLY A C   1 
+ATOM   2305 O O   . GLY A 1 293 ? 76.120 51.201 28.370 1.00 10.11 ? 293  GLY A O   1 
+ATOM   2306 N N   . THR A 1 294 ? 76.794 52.457 30.107 1.00 12.20 ? 294  THR A N   1 
+ATOM   2307 C CA  . THR A 1 294 ? 78.179 52.525 29.641 1.00 12.21 ? 294  THR A CA  1 
+ATOM   2308 C C   . THR A 1 294 ? 78.812 51.153 29.553 1.00 10.61 ? 294  THR A C   1 
+ATOM   2309 O O   . THR A 1 294 ? 79.485 50.785 28.585 1.00 10.60 ? 294  THR A O   1 
+ATOM   2310 C CB  . THR A 1 294 ? 78.977 53.424 30.612 1.00 19.53 ? 294  THR A CB  1 
+ATOM   2311 O OG1 . THR A 1 294 ? 78.369 54.738 30.619 1.00 17.44 ? 294  THR A OG1 1 
+ATOM   2312 C CG2 . THR A 1 294 ? 80.440 53.572 30.233 1.00 18.75 ? 294  THR A CG2 1 
+ATOM   2313 N N   . PHE A 1 295 ? 78.583 50.331 30.566 1.00 9.75  ? 295  PHE A N   1 
+ATOM   2314 C CA  . PHE A 1 295 ? 79.104 48.981 30.645 1.00 11.82 ? 295  PHE A CA  1 
+ATOM   2315 C C   . PHE A 1 295 ? 78.460 48.102 29.568 1.00 12.74 ? 295  PHE A C   1 
+ATOM   2316 O O   . PHE A 1 295 ? 79.194 47.441 28.847 1.00 12.57 ? 295  PHE A O   1 
+ATOM   2317 C CB  . PHE A 1 295 ? 78.884 48.371 32.016 1.00 13.29 ? 295  PHE A CB  1 
+ATOM   2318 C CG  . PHE A 1 295 ? 79.264 46.914 32.165 1.00 12.16 ? 295  PHE A CG  1 
+ATOM   2319 C CD1 . PHE A 1 295 ? 80.572 46.537 32.392 1.00 17.16 ? 295  PHE A CD1 1 
+ATOM   2320 C CD2 . PHE A 1 295 ? 78.271 45.944 32.049 1.00 12.36 ? 295  PHE A CD2 1 
+ATOM   2321 C CE1 . PHE A 1 295 ? 80.898 45.200 32.528 1.00 13.49 ? 295  PHE A CE1 1 
+ATOM   2322 C CE2 . PHE A 1 295 ? 78.587 44.593 32.152 1.00 12.45 ? 295  PHE A CE2 1 
+ATOM   2323 C CZ  . PHE A 1 295 ? 79.914 44.237 32.397 1.00 19.25 ? 295  PHE A CZ  1 
+ATOM   2324 N N   . VAL A 1 296 ? 77.134 48.178 29.441 1.00 11.06 ? 296  VAL A N   1 
+ATOM   2325 C CA  . VAL A 1 296 ? 76.458 47.326 28.439 1.00 11.91 ? 296  VAL A CA  1 
+ATOM   2326 C C   . VAL A 1 296 ? 76.938 47.661 27.037 1.00 10.25 ? 296  VAL A C   1 
+ATOM   2327 O O   . VAL A 1 296 ? 77.286 46.784 26.216 1.00 13.03 ? 296  VAL A O   1 
+ATOM   2328 C CB  . VAL A 1 296 ? 74.945 47.444 28.591 1.00 11.04 ? 296  VAL A CB  1 
+ATOM   2329 C CG1 . VAL A 1 296 ? 74.222 46.605 27.543 1.00 12.18 ? 296  VAL A CG1 1 
+ATOM   2330 C CG2 . VAL A 1 296 ? 74.493 46.947 29.969 1.00 13.60 ? 296  VAL A CG2 1 
+ATOM   2331 N N   . ARG A 1 297 ? 77.031 48.946 26.729 1.00 9.72  ? 297  ARG A N   1 
+ATOM   2332 C CA  . ARG A 1 297 ? 77.530 49.382 25.422 1.00 11.36 ? 297  ARG A CA  1 
+ATOM   2333 C C   . ARG A 1 297 ? 78.937 48.859 25.175 1.00 7.83  ? 297  ARG A C   1 
+ATOM   2334 O O   . ARG A 1 297 ? 79.222 48.369 24.091 1.00 11.74 ? 297  ARG A O   1 
+ATOM   2335 C CB  . ARG A 1 297 ? 77.551 50.889 25.324 1.00 11.99 ? 297  ARG A CB  1 
+ATOM   2336 C CG  . ARG A 1 297 ? 78.182 51.495 24.088 1.00 13.84 ? 297  ARG A CG  1 
+ATOM   2337 C CD  . ARG A 1 297 ? 78.066 53.030 24.119 1.00 15.37 ? 297  ARG A CD  1 
+ATOM   2338 N NE  . ARG A 1 297 ? 78.687 53.606 22.921 1.00 16.94 ? 297  ARG A NE  1 
+ATOM   2339 C CZ  . ARG A 1 297 ? 79.991 53.794 22.763 1.00 20.32 ? 297  ARG A CZ  1 
+ATOM   2340 N NH1 . ARG A 1 297 ? 80.857 53.467 23.715 1.00 15.45 ? 297  ARG A NH1 1 
+ATOM   2341 N NH2 . ARG A 1 297 ? 80.475 54.320 21.639 1.00 19.66 ? 297  ARG A NH2 1 
+ATOM   2342 N N   . GLU A 1 298 ? 79.827 48.957 26.167 1.00 10.24 ? 298  GLU A N   1 
+ATOM   2343 C CA  . GLU A 1 298 ? 81.166 48.427 26.004 1.00 13.65 ? 298  GLU A CA  1 
+ATOM   2344 C C   . GLU A 1 298 ? 81.147 46.937 25.720 1.00 14.12 ? 298  GLU A C   1 
+ATOM   2345 O O   . GLU A 1 298 ? 81.922 46.442 24.909 1.00 15.63 ? 298  GLU A O   1 
+ATOM   2346 C CB  . GLU A 1 298 ? 82.009 48.624 27.279 1.00 18.43 ? 298  GLU A CB  1 
+ATOM   2347 C CG  . GLU A 1 298 ? 82.357 50.083 27.515 1.00 33.82 ? 298  GLU A CG  1 
+ATOM   2348 C CD  . GLU A 1 298 ? 83.539 50.214 28.467 1.00 46.09 ? 298  GLU A CD  1 
+ATOM   2349 O OE1 . GLU A 1 298 ? 84.253 49.204 28.684 1.00 52.79 ? 298  GLU A OE1 1 
+ATOM   2350 O OE2 . GLU A 1 298 ? 83.730 51.338 28.980 1.00 51.32 ? 298  GLU A OE2 1 
+ATOM   2351 N N   . LYS A 1 299 ? 80.304 46.185 26.458 1.00 13.18 ? 299  LYS A N   1 
+ATOM   2352 C CA  . LYS A 1 299 ? 80.259 44.749 26.224 1.00 14.56 ? 299  LYS A CA  1 
+ATOM   2353 C C   . LYS A 1 299 ? 79.847 44.432 24.788 1.00 12.59 ? 299  LYS A C   1 
+ATOM   2354 O O   . LYS A 1 299 ? 80.420 43.532 24.182 1.00 12.88 ? 299  LYS A O   1 
+ATOM   2355 C CB  . LYS A 1 299 ? 79.363 44.021 27.205 1.00 11.67 ? 299  LYS A CB  1 
+ATOM   2356 C CG  . LYS A 1 299 ? 79.696 44.133 28.664 1.00 12.82 ? 299  LYS A CG  1 
+ATOM   2357 C CD  . LYS A 1 299 ? 81.099 43.727 29.047 1.00 12.44 ? 299  LYS A CD  1 
+ATOM   2358 C CE  . LYS A 1 299 ? 82.082 44.892 29.105 1.00 12.46 ? 299  LYS A CE  1 
+ATOM   2359 N NZ  . LYS A 1 299 ? 83.428 44.366 29.511 1.00 14.68 ? 299  LYS A NZ  1 
+ATOM   2360 N N   . ILE A 1 300 ? 78.819 45.117 24.275 1.00 11.69 ? 300  ILE A N   1 
+ATOM   2361 C CA  . ILE A 1 300 ? 78.347 44.807 22.906 1.00 10.30 ? 300  ILE A CA  1 
+ATOM   2362 C C   . ILE A 1 300 ? 79.344 45.310 21.870 1.00 10.89 ? 300  ILE A C   1 
+ATOM   2363 O O   . ILE A 1 300 ? 79.632 44.572 20.928 1.00 15.56 ? 300  ILE A O   1 
+ATOM   2364 C CB  . ILE A 1 300 ? 76.938 45.356 22.677 1.00 13.24 ? 300  ILE A CB  1 
+ATOM   2365 C CG1 . ILE A 1 300 ? 75.964 44.876 23.762 1.00 14.43 ? 300  ILE A CG1 1 
+ATOM   2366 C CG2 . ILE A 1 300 ? 76.416 44.933 21.312 1.00 13.72 ? 300  ILE A CG2 1 
+ATOM   2367 C CD1 . ILE A 1 300 ? 74.550 45.428 23.574 1.00 16.99 ? 300  ILE A CD1 1 
+ATOM   2368 N N   . ARG A 1 301 ? 80.004 46.450 22.098 1.00 12.75 ? 301  ARG A N   1 
+ATOM   2369 C CA  . ARG A 1 301 ? 81.024 46.921 21.156 1.00 15.68 ? 301  ARG A CA  1 
+ATOM   2370 C C   . ARG A 1 301 ? 82.203 45.973 21.087 1.00 19.52 ? 301  ARG A C   1 
+ATOM   2371 O O   . ARG A 1 301 ? 82.775 45.754 20.009 1.00 19.72 ? 301  ARG A O   1 
+ATOM   2372 C CB  . ARG A 1 301 ? 81.489 48.347 21.459 1.00 15.33 ? 301  ARG A CB  1 
+ATOM   2373 C CG  . ARG A 1 301 ? 80.444 49.397 21.130 1.00 15.95 ? 301  ARG A CG  1 
+ATOM   2374 C CD  . ARG A 1 301 ? 80.920 50.754 21.615 1.00 14.80 ? 301  ARG A CD  1 
+ATOM   2375 N NE  . ARG A 1 301 ? 82.143 51.158 20.957 1.00 19.89 ? 301  ARG A NE  1 
+ATOM   2376 C CZ  . ARG A 1 301 ? 82.236 51.670 19.737 1.00 24.69 ? 301  ARG A CZ  1 
+ATOM   2377 N NH1 . ARG A 1 301 ? 81.171 51.911 18.963 1.00 24.53 ? 301  ARG A NH1 1 
+ATOM   2378 N NH2 . ARG A 1 301 ? 83.447 51.970 19.261 1.00 24.27 ? 301  ARG A NH2 1 
+ATOM   2379 N N   . GLU A 1 302 ? 82.624 45.424 22.222 1.00 20.63 ? 302  GLU A N   1 
+ATOM   2380 C CA  . GLU A 1 302 ? 83.745 44.504 22.365 1.00 23.90 ? 302  GLU A CA  1 
+ATOM   2381 C C   . GLU A 1 302 ? 83.437 43.205 21.604 1.00 25.20 ? 302  GLU A C   1 
+ATOM   2382 O O   . GLU A 1 302 ? 84.289 42.498 21.080 1.00 27.29 ? 302  GLU A O   1 
+ATOM   2383 C CB  . GLU A 1 302 ? 84.005 44.099 23.818 1.00 26.46 ? 302  GLU A CB  1 
+ATOM   2384 C CG  . GLU A 1 302 ? 84.684 45.107 24.713 1.00 34.32 ? 302  GLU A CG  1 
+ATOM   2385 C CD  . GLU A 1 302 ? 84.644 44.749 26.187 1.00 36.54 ? 302  GLU A CD  1 
+ATOM   2386 O OE1 . GLU A 1 302 ? 83.994 43.768 26.587 1.00 32.19 ? 302  GLU A OE1 1 
+ATOM   2387 O OE2 . GLU A 1 302 ? 85.284 45.505 26.957 1.00 42.95 ? 302  GLU A OE2 1 
+ATOM   2388 N N   . SER A 1 303 ? 82.156 42.874 21.584 1.00 29.23 ? 303  SER A N   1 
+ATOM   2389 C CA  . SER A 1 303 ? 81.684 41.681 20.912 1.00 29.85 ? 303  SER A CA  1 
+ATOM   2390 C C   . SER A 1 303 ? 81.874 41.818 19.409 1.00 29.97 ? 303  SER A C   1 
+ATOM   2391 O O   . SER A 1 303 ? 81.577 42.935 18.936 1.00 34.99 ? 303  SER A O   1 
+ATOM   2392 C CB  . SER A 1 303 ? 80.202 41.448 21.233 1.00 31.15 ? 303  SER A CB  1 
+ATOM   2393 O OG  . SER A 1 303 ? 79.921 40.105 20.917 1.00 37.04 ? 303  SER A OG  1 
+ATOM   2394 O OXT . SER A 1 303 ? 82.212 40.795 18.775 1.00 33.78 ? 303  SER A OXT 1 
+HETATM 2395 C C1  . G2F B 2 .   ? 62.507 41.654 35.024 1.00 9.17  ? 1    G2F B C1  1 
+HETATM 2396 C C2  . G2F B 2 .   ? 61.093 42.043 34.749 1.00 9.39  ? 1    G2F B C2  1 
+HETATM 2397 C C3  . G2F B 2 .   ? 61.024 43.537 34.537 1.00 6.15  ? 1    G2F B C3  1 
+HETATM 2398 C C4  . G2F B 2 .   ? 61.680 44.234 35.761 1.00 7.43  ? 1    G2F B C4  1 
+HETATM 2399 C C5  . G2F B 2 .   ? 63.129 43.763 35.875 1.00 11.41 ? 1    G2F B C5  1 
+HETATM 2400 C C6  . G2F B 2 .   ? 63.778 44.354 37.173 1.00 10.91 ? 1    G2F B C6  1 
+HETATM 2401 O O3  . G2F B 2 .   ? 59.660 43.912 34.401 1.00 11.08 ? 1    G2F B O3  1 
+HETATM 2402 O O4  . G2F B 2 .   ? 61.679 45.644 35.485 1.00 9.60  ? 1    G2F B O4  1 
+HETATM 2403 O O5  . G2F B 2 .   ? 63.155 42.341 36.081 1.00 11.59 ? 1    G2F B O5  1 
+HETATM 2404 O O6  A G2F B 2 .   ? 63.018 43.856 38.278 0.50 10.64 ? 1    G2F B O6  1 
+HETATM 2405 O O6  B G2F B 2 .   ? 65.180 44.094 37.078 0.50 7.98  ? 1    G2F B O6  1 
+HETATM 2406 F F2  . G2F B 2 .   ? 60.700 41.362 33.591 1.00 11.70 ? 1    G2F B F2  1 
+HETATM 2407 C C2  . BGC B 2 .   ? 61.464 47.837 36.290 1.00 9.80  ? 2    BGC B C2  1 
+HETATM 2408 C C3  . BGC B 2 .   ? 60.908 48.685 37.448 1.00 6.87  ? 2    BGC B C3  1 
+HETATM 2409 C C4  . BGC B 2 .   ? 59.401 48.410 37.504 1.00 12.65 ? 2    BGC B C4  1 
+HETATM 2410 C C5  . BGC B 2 .   ? 59.235 46.903 37.852 1.00 9.11  ? 2    BGC B C5  1 
+HETATM 2411 C C6  . BGC B 2 .   ? 57.778 46.479 37.972 1.00 14.14 ? 2    BGC B C6  1 
+HETATM 2412 C C1  . BGC B 2 .   ? 61.213 46.367 36.641 1.00 8.01  ? 2    BGC B C1  1 
+HETATM 2413 O O2  . BGC B 2 .   ? 62.861 47.971 36.224 1.00 8.86  ? 2    BGC B O2  1 
+HETATM 2414 O O3  . BGC B 2 .   ? 61.105 50.079 37.054 1.00 9.46  ? 2    BGC B O3  1 
+HETATM 2415 O O4  . BGC B 2 .   ? 58.962 49.199 38.632 1.00 10.83 ? 2    BGC B O4  1 
+HETATM 2416 O O5  . BGC B 2 .   ? 59.842 46.191 36.765 1.00 10.79 ? 2    BGC B O5  1 
+HETATM 2417 O O6  . BGC B 2 .   ? 57.165 46.818 36.738 1.00 12.63 ? 2    BGC B O6  1 
+HETATM 2418 O O   . HOH C 3 .   ? 60.262 34.694 28.827 1.00 7.48  ? 901  HOH A O   1 
+HETATM 2419 O O   . HOH C 3 .   ? 59.287 51.541 12.564 1.00 8.10  ? 902  HOH A O   1 
+HETATM 2420 O O   . HOH C 3 .   ? 58.443 33.662 27.238 1.00 8.58  ? 903  HOH A O   1 
+HETATM 2421 O O   . HOH C 3 .   ? 52.441 42.528 33.212 1.00 9.61  ? 904  HOH A O   1 
+HETATM 2422 O O   . HOH C 3 .   ? 49.261 20.651 27.050 1.00 9.69  ? 905  HOH A O   1 
+HETATM 2423 O O   . HOH C 3 .   ? 71.051 46.657 33.507 1.00 9.77  ? 906  HOH A O   1 
+HETATM 2424 O O   . HOH C 3 .   ? 61.786 51.785 26.822 1.00 9.99  ? 907  HOH A O   1 
+HETATM 2425 O O   . HOH C 3 .   ? 63.356 21.950 24.133 1.00 10.08 ? 908  HOH A O   1 
+HETATM 2426 O O   . HOH C 3 .   ? 54.928 20.346 23.323 1.00 10.10 ? 909  HOH A O   1 
+HETATM 2427 O O   . HOH C 3 .   ? 65.271 23.949 23.471 1.00 10.49 ? 910  HOH A O   1 
+HETATM 2428 O O   . HOH C 3 .   ? 49.066 36.488 32.554 1.00 10.47 ? 911  HOH A O   1 
+HETATM 2429 O O   . HOH C 3 .   ? 48.978 35.813 29.817 1.00 10.61 ? 912  HOH A O   1 
+HETATM 2430 O O   . HOH C 3 .   ? 73.195 32.179 21.102 1.00 10.69 ? 913  HOH A O   1 
+HETATM 2431 O O   . HOH C 3 .   ? 47.784 22.915 26.632 1.00 10.55 ? 914  HOH A O   1 
+HETATM 2432 O O   . HOH C 3 .   ? 71.389 27.430 24.110 1.00 10.68 ? 915  HOH A O   1 
+HETATM 2433 O O   . HOH C 3 .   ? 58.260 56.967 16.937 1.00 10.86 ? 916  HOH A O   1 
+HETATM 2434 O O   . HOH C 3 .   ? 64.075 40.421 7.027  1.00 10.91 ? 917  HOH A O   1 
+HETATM 2435 O O   . HOH C 3 .   ? 81.910 31.469 45.659 1.00 10.99 ? 918  HOH A O   1 
+HETATM 2436 O O   . HOH C 3 .   ? 64.578 33.435 12.276 1.00 11.06 ? 919  HOH A O   1 
+HETATM 2437 O O   . HOH C 3 .   ? 68.939 34.396 38.251 1.00 11.20 ? 920  HOH A O   1 
+HETATM 2438 O O   . HOH C 3 .   ? 65.725 49.770 33.861 1.00 11.29 ? 921  HOH A O   1 
+HETATM 2439 O O   . HOH C 3 .   ? 71.086 31.657 23.421 1.00 11.35 ? 922  HOH A O   1 
+HETATM 2440 O O   . HOH C 3 .   ? 67.534 37.040 5.673  1.00 11.28 ? 923  HOH A O   1 
+HETATM 2441 O O   . HOH C 3 .   ? 70.205 36.579 39.449 1.00 11.59 ? 924  HOH A O   1 
+HETATM 2442 O O   . HOH C 3 .   ? 65.501 38.925 5.294  1.00 11.56 ? 925  HOH A O   1 
+HETATM 2443 O O   . HOH C 3 .   ? 65.659 42.694 7.858  1.00 11.59 ? 926  HOH A O   1 
+HETATM 2444 O O   . HOH C 3 .   ? 56.825 30.369 39.313 1.00 11.57 ? 927  HOH A O   1 
+HETATM 2445 O O   . HOH C 3 .   ? 71.424 49.146 31.385 1.00 11.77 ? 928  HOH A O   1 
+HETATM 2446 O O   . HOH C 3 .   ? 73.633 31.581 42.647 1.00 11.73 ? 929  HOH A O   1 
+HETATM 2447 O O   . HOH C 3 .   ? 46.950 22.532 24.055 1.00 11.90 ? 930  HOH A O   1 
+HETATM 2448 O O   . HOH C 3 .   ? 78.278 37.792 26.771 1.00 11.98 ? 931  HOH A O   1 
+HETATM 2449 O O   . HOH C 3 .   ? 60.057 54.030 14.006 1.00 12.31 ? 932  HOH A O   1 
+HETATM 2450 O O   . HOH C 3 .   ? 61.050 54.002 9.372  1.00 12.28 ? 933  HOH A O   1 
+HETATM 2451 O O   . HOH C 3 .   ? 69.264 41.105 43.424 1.00 12.28 ? 934  HOH A O   1 
+HETATM 2452 O O   . HOH C 3 .   ? 63.502 33.529 14.975 1.00 12.41 ? 935  HOH A O   1 
+HETATM 2453 O O   . HOH C 3 .   ? 73.199 36.590 39.597 1.00 12.33 ? 936  HOH A O   1 
+HETATM 2454 O O   . HOH C 3 .   ? 75.571 55.710 22.755 1.00 12.61 ? 937  HOH A O   1 
+HETATM 2455 O O   . HOH C 3 .   ? 60.238 26.168 35.470 1.00 12.55 ? 938  HOH A O   1 
+HETATM 2456 O O   . HOH C 3 .   ? 62.796 16.806 28.588 1.00 12.96 ? 939  HOH A O   1 
+HETATM 2457 O O   . HOH C 3 .   ? 80.535 52.643 26.579 1.00 13.45 ? 940  HOH A O   1 
+HETATM 2458 O O   . HOH C 3 .   ? 55.756 22.486 21.763 1.00 13.71 ? 941  HOH A O   1 
+HETATM 2459 O O   . HOH C 3 .   ? 44.539 40.040 22.476 1.00 13.81 ? 942  HOH A O   1 
+HETATM 2460 O O   . HOH C 3 .   ? 52.735 43.435 35.803 1.00 14.36 ? 943  HOH A O   1 
+HETATM 2461 O O   . HOH C 3 .   ? 73.320 52.738 36.273 1.00 14.31 ? 944  HOH A O   1 
+HETATM 2462 O O   . HOH C 3 .   ? 72.208 29.302 22.070 1.00 14.70 ? 945  HOH A O   1 
+HETATM 2463 O O   . HOH C 3 .   ? 46.903 30.800 14.170 1.00 14.92 ? 946  HOH A O   1 
+HETATM 2464 O O   . HOH C 3 .   ? 61.262 51.641 10.428 1.00 15.49 ? 947  HOH A O   1 
+HETATM 2465 O O   . HOH C 3 .   ? 67.906 20.969 19.878 1.00 15.51 ? 948  HOH A O   1 
+HETATM 2466 O O   . HOH C 3 .   ? 52.936 47.465 27.624 1.00 15.64 ? 949  HOH A O   1 
+HETATM 2467 O O   . HOH C 3 .   ? 69.443 25.858 7.722  1.00 15.71 ? 950  HOH A O   1 
+HETATM 2468 O O   . HOH C 3 .   ? 59.223 24.746 14.640 1.00 15.87 ? 951  HOH A O   1 
+HETATM 2469 O O   . HOH C 3 .   ? 69.658 42.194 45.983 1.00 16.18 ? 952  HOH A O   1 
+HETATM 2470 O O   . HOH C 3 .   ? 70.111 57.112 14.620 1.00 16.90 ? 953  HOH A O   1 
+HETATM 2471 O O   . HOH C 3 .   ? 67.498 34.090 42.626 1.00 17.39 ? 954  HOH A O   1 
+HETATM 2472 O O   . HOH C 3 .   ? 49.058 50.187 27.379 1.00 17.44 ? 955  HOH A O   1 
+HETATM 2473 O O   . HOH C 3 .   ? 58.186 30.907 5.019  1.00 17.76 ? 956  HOH A O   1 
+HETATM 2474 O O   . HOH C 3 .   ? 67.049 25.869 37.600 1.00 17.71 ? 957  HOH A O   1 
+HETATM 2475 O O   . HOH C 3 .   ? 58.256 32.601 42.257 1.00 17.75 ? 958  HOH A O   1 
+HETATM 2476 O O   . HOH C 3 .   ? 69.001 56.690 34.942 1.00 17.83 ? 959  HOH A O   1 
+HETATM 2477 O O   . HOH C 3 .   ? 58.131 18.129 17.629 1.00 18.05 ? 960  HOH A O   1 
+HETATM 2478 O O   . HOH C 3 .   ? 77.052 40.783 43.211 1.00 18.29 ? 961  HOH A O   1 
+HETATM 2479 O O   . HOH C 3 .   ? 54.504 46.303 37.498 1.00 18.32 ? 962  HOH A O   1 
+HETATM 2480 O O   . HOH C 3 .   ? 62.027 40.063 37.985 1.00 18.26 ? 963  HOH A O   1 
+HETATM 2481 O O   . HOH C 3 .   ? 71.731 22.849 25.130 1.00 18.51 ? 964  HOH A O   1 
+HETATM 2482 O O   . HOH C 3 .   ? 57.594 19.523 35.178 1.00 18.53 ? 965  HOH A O   1 
+HETATM 2483 O O   . HOH C 3 .   ? 74.989 29.206 19.899 1.00 18.49 ? 966  HOH A O   1 
+HETATM 2484 O O   . HOH C 3 .   ? 55.180 35.868 43.166 1.00 18.99 ? 967  HOH A O   1 
+HETATM 2485 O O   . HOH C 3 .   ? 70.438 58.908 16.558 1.00 19.08 ? 968  HOH A O   1 
+HETATM 2486 O O   . HOH C 3 .   ? 54.268 17.530 25.940 1.00 18.98 ? 969  HOH A O   1 
+HETATM 2487 O O   . HOH C 3 .   ? 65.496 23.129 14.479 1.00 18.96 ? 970  HOH A O   1 
+HETATM 2488 O O   . HOH C 3 .   ? 60.563 18.896 35.465 1.00 19.00 ? 971  HOH A O   1 
+HETATM 2489 O O   . HOH C 3 .   ? 68.506 27.897 10.732 1.00 19.50 ? 972  HOH A O   1 
+HETATM 2490 O O   . HOH C 3 .   ? 62.166 21.148 21.811 1.00 19.64 ? 973  HOH A O   1 
+HETATM 2491 O O   . HOH C 3 .   ? 52.490 19.002 28.773 1.00 19.78 ? 974  HOH A O   1 
+HETATM 2492 O O   . HOH C 3 .   ? 66.707 22.068 22.185 1.00 19.97 ? 975  HOH A O   1 
+HETATM 2493 O O   . HOH C 3 .   ? 79.510 42.567 41.626 1.00 20.10 ? 976  HOH A O   1 
+HETATM 2494 O O   . HOH C 3 .   ? 58.178 58.547 29.819 1.00 20.50 ? 977  HOH A O   1 
+HETATM 2495 O O   . HOH C 3 .   ? 65.730 45.738 5.283  1.00 20.48 ? 978  HOH A O   1 
+HETATM 2496 O O   . HOH C 3 .   ? 80.188 51.891 33.955 1.00 20.41 ? 979  HOH A O   1 
+HETATM 2497 O O   . HOH C 3 .   ? 83.745 41.218 27.853 1.00 20.65 ? 980  HOH A O   1 
+HETATM 2498 O O   . HOH C 3 .   ? 72.258 44.790 10.257 1.00 20.87 ? 981  HOH A O   1 
+HETATM 2499 O O   . HOH C 3 .   ? 46.474 28.366 36.004 1.00 20.90 ? 982  HOH A O   1 
+HETATM 2500 O O   . HOH C 3 .   ? 52.498 23.463 17.806 1.00 21.35 ? 983  HOH A O   1 
+HETATM 2501 O O   . HOH C 3 .   ? 65.493 61.632 28.443 1.00 21.72 ? 984  HOH A O   1 
+HETATM 2502 O O   . HOH C 3 .   ? 80.315 47.862 40.289 1.00 21.66 ? 985  HOH A O   1 
+HETATM 2503 O O   . HOH C 3 .   ? 62.638 58.247 37.244 1.00 22.20 ? 986  HOH A O   1 
+HETATM 2504 O O   . HOH C 3 .   ? 64.551 36.521 37.494 1.00 22.50 ? 987  HOH A O   1 
+HETATM 2505 O O   . HOH C 3 .   ? 59.494 27.385 39.506 1.00 22.67 ? 988  HOH A O   1 
+HETATM 2506 O O   . HOH C 3 .   ? 55.010 55.055 26.618 1.00 22.76 ? 989  HOH A O   1 
+HETATM 2507 O O   . HOH C 3 .   ? 63.570 28.616 11.840 1.00 22.69 ? 990  HOH A O   1 
+HETATM 2508 O O   . HOH C 3 .   ? 53.207 50.761 11.622 1.00 23.00 ? 991  HOH A O   1 
+HETATM 2509 O O   . HOH C 3 .   ? 54.017 38.779 41.277 1.00 23.40 ? 992  HOH A O   1 
+HETATM 2510 O O   . HOH C 3 .   ? 70.704 54.611 35.959 1.00 23.39 ? 993  HOH A O   1 
+HETATM 2511 O O   . HOH C 3 .   ? 53.450 23.040 20.480 1.00 23.25 ? 994  HOH A O   1 
+HETATM 2512 O O   . HOH C 3 .   ? 54.180 17.616 31.965 1.00 23.66 ? 995  HOH A O   1 
+HETATM 2513 O O   . HOH C 3 .   ? 58.638 56.385 19.838 1.00 23.41 ? 996  HOH A O   1 
+HETATM 2514 O O   . HOH C 3 .   ? 61.896 18.546 19.848 1.00 23.86 ? 997  HOH A O   1 
+HETATM 2515 O O   . HOH C 3 .   ? 68.735 32.746 2.457  1.00 23.91 ? 998  HOH A O   1 
+HETATM 2516 O O   . HOH C 3 .   ? 68.788 23.725 12.519 1.00 23.98 ? 999  HOH A O   1 
+HETATM 2517 O O   . HOH C 3 .   ? 58.767 50.411 7.952  1.00 24.16 ? 1000 HOH A O   1 
+HETATM 2518 O O   . HOH C 3 .   ? 74.384 45.868 11.849 1.00 24.18 ? 1001 HOH A O   1 
+HETATM 2519 O O   . HOH C 3 .   ? 51.474 38.897 41.640 1.00 24.24 ? 1002 HOH A O   1 
+HETATM 2520 O O   . HOH C 3 .   ? 52.549 19.570 31.563 1.00 24.68 ? 1003 HOH A O   1 
+HETATM 2521 O O   . HOH C 3 .   ? 77.469 35.388 16.498 1.00 24.32 ? 1004 HOH A O   1 
+HETATM 2522 O O   . HOH C 3 .   ? 78.858 27.152 35.947 1.00 24.34 ? 1005 HOH A O   1 
+HETATM 2523 O O   . HOH C 3 .   ? 46.811 26.095 29.964 1.00 24.48 ? 1006 HOH A O   1 
+HETATM 2524 O O   . HOH C 3 .   ? 84.639 40.365 37.340 1.00 24.78 ? 1007 HOH A O   1 
+HETATM 2525 O O   . HOH C 3 .   ? 79.329 28.119 38.695 1.00 25.00 ? 1008 HOH A O   1 
+HETATM 2526 O O   . HOH C 3 .   ? 69.627 28.499 43.274 1.00 24.80 ? 1009 HOH A O   1 
+HETATM 2527 O O   . HOH C 3 .   ? 74.801 45.298 14.549 1.00 24.52 ? 1010 HOH A O   1 
+HETATM 2528 O O   . HOH C 3 .   ? 66.760 15.799 31.744 1.00 24.96 ? 1011 HOH A O   1 
+HETATM 2529 O O   . HOH C 3 .   ? 42.183 34.094 29.165 1.00 25.21 ? 1012 HOH A O   1 
+HETATM 2530 O O   . HOH C 3 .   ? 63.246 49.542 40.217 1.00 25.53 ? 1013 HOH A O   1 
+HETATM 2531 O O   . HOH C 3 .   ? 75.691 41.352 45.567 1.00 25.33 ? 1014 HOH A O   1 
+HETATM 2532 O O   . HOH C 3 .   ? 79.509 40.799 25.435 1.00 25.63 ? 1015 HOH A O   1 
+HETATM 2533 O O   . HOH C 3 .   ? 73.662 23.489 41.122 1.00 25.80 ? 1016 HOH A O   1 
+HETATM 2534 O O   . HOH C 3 .   ? 51.005 24.331 40.398 1.00 25.89 ? 1017 HOH A O   1 
+HETATM 2535 O O   . HOH C 3 .   ? 77.005 31.854 7.897  1.00 25.66 ? 1018 HOH A O   1 
+HETATM 2536 O O   . HOH C 3 .   ? 45.400 23.636 27.866 1.00 26.15 ? 1019 HOH A O   1 
+HETATM 2537 O O   . HOH C 3 .   ? 76.186 51.221 42.604 1.00 25.98 ? 1020 HOH A O   1 
+HETATM 2538 O O   . HOH C 3 .   ? 58.600 24.803 37.682 1.00 26.20 ? 1021 HOH A O   1 
+HETATM 2539 O O   . HOH C 3 .   ? 65.243 65.187 23.599 1.00 26.58 ? 1022 HOH A O   1 
+HETATM 2540 O O   . HOH C 3 .   ? 64.294 60.159 34.921 1.00 26.53 ? 1023 HOH A O   1 
+HETATM 2541 O O   . HOH C 3 .   ? 43.459 32.968 18.957 1.00 26.73 ? 1024 HOH A O   1 
+HETATM 2542 O O   . HOH C 3 .   ? 76.802 25.147 42.712 1.00 26.88 ? 1025 HOH A O   1 
+HETATM 2543 O O   . HOH C 3 .   ? 72.663 33.867 4.396  1.00 26.92 ? 1026 HOH A O   1 
+HETATM 2544 O O   . HOH C 3 .   ? 79.621 55.425 16.867 1.00 27.21 ? 1027 HOH A O   1 
+HETATM 2545 O O   . HOH C 3 .   ? 66.919 65.688 18.435 1.00 27.53 ? 1028 HOH A O   1 
+HETATM 2546 O O   . HOH C 3 .   ? 54.743 20.908 38.484 1.00 27.16 ? 1029 HOH A O   1 
+HETATM 2547 O O   . HOH C 3 .   ? 54.441 53.156 23.538 1.00 27.22 ? 1030 HOH A O   1 
+HETATM 2548 O O   . HOH C 3 .   ? 55.682 38.366 44.363 1.00 27.17 ? 1031 HOH A O   1 
+HETATM 2549 O O   . HOH C 3 .   ? 82.536 33.441 34.046 1.00 27.89 ? 1032 HOH A O   1 
+HETATM 2550 O O   . HOH C 3 .   ? 73.000 56.220 13.965 1.00 27.88 ? 1033 HOH A O   1 
+HETATM 2551 O O   . HOH C 3 .   ? 56.993 21.301 37.351 1.00 27.75 ? 1034 HOH A O   1 
+HETATM 2552 O O   . HOH C 3 .   ? 65.787 21.359 18.095 1.00 27.77 ? 1035 HOH A O   1 
+HETATM 2553 O O   . HOH C 3 .   ? 82.234 39.385 23.916 1.00 27.87 ? 1036 HOH A O   1 
+HETATM 2554 O O   . HOH C 3 .   ? 65.264 15.996 29.494 1.00 27.77 ? 1037 HOH A O   1 
+HETATM 2555 O O   . HOH C 3 .   ? 69.002 19.182 16.875 1.00 28.28 ? 1038 HOH A O   1 
+HETATM 2556 O O   . HOH C 3 .   ? 79.912 63.054 27.443 1.00 28.37 ? 1039 HOH A O   1 
+HETATM 2557 O O   . HOH C 3 .   ? 74.237 32.019 7.050  1.00 28.40 ? 1040 HOH A O   1 
+HETATM 2558 O O   . HOH C 3 .   ? 79.156 27.128 14.474 1.00 28.05 ? 1041 HOH A O   1 
+HETATM 2559 O O   . HOH C 3 .   ? 58.993 16.318 27.754 1.00 28.35 ? 1042 HOH A O   1 
+HETATM 2560 O O   . HOH C 3 .   ? 64.046 26.237 10.567 1.00 28.08 ? 1043 HOH A O   1 
+HETATM 2561 O O   . HOH C 3 .   ? 75.413 42.438 18.992 1.00 28.04 ? 1044 HOH A O   1 
+HETATM 2562 O O   . HOH C 3 .   ? 42.058 39.617 22.372 1.00 28.57 ? 1045 HOH A O   1 
+HETATM 2563 O O   . HOH C 3 .   ? 68.168 27.969 38.574 1.00 28.98 ? 1046 HOH A O   1 
+HETATM 2564 O O   . HOH C 3 .   ? 54.788 32.403 46.222 1.00 28.60 ? 1047 HOH A O   1 
+HETATM 2565 O O   . HOH C 3 .   ? 49.649 26.769 8.284  1.00 28.69 ? 1048 HOH A O   1 
+HETATM 2566 O O   . HOH C 3 .   ? 58.433 29.670 42.739 1.00 29.21 ? 1049 HOH A O   1 
+HETATM 2567 O O   . HOH C 3 .   ? 75.811 21.840 36.336 1.00 28.77 ? 1050 HOH A O   1 
+HETATM 2568 O O   . HOH C 3 .   ? 81.408 32.179 39.990 1.00 29.04 ? 1051 HOH A O   1 
+HETATM 2569 O O   . HOH C 3 .   ? 63.511 23.953 11.911 1.00 29.27 ? 1052 HOH A O   1 
+HETATM 2570 O O   . HOH C 3 .   ? 74.098 27.085 24.319 1.00 29.59 ? 1053 HOH A O   1 
+HETATM 2571 O O   . HOH C 3 .   ? 80.595 30.402 38.279 1.00 29.63 ? 1054 HOH A O   1 
+HETATM 2572 O O   . HOH C 3 .   ? 84.606 44.494 33.547 1.00 29.63 ? 1055 HOH A O   1 
+HETATM 2573 O O   . HOH C 3 .   ? 80.277 55.499 27.309 1.00 29.96 ? 1056 HOH A O   1 
+HETATM 2574 O O   . HOH C 3 .   ? 80.838 45.207 41.425 1.00 30.27 ? 1057 HOH A O   1 
+HETATM 2575 O O   . HOH C 3 .   ? 75.895 40.080 14.599 1.00 30.41 ? 1058 HOH A O   1 
+HETATM 2576 O O   . HOH C 3 .   ? 62.005 41.055 31.374 1.00 30.69 ? 1059 HOH A O   1 
+HETATM 2577 O O   . HOH C 3 .   ? 57.179 40.317 40.576 1.00 30.92 ? 1060 HOH A O   1 
+HETATM 2578 O O   . HOH C 3 .   ? 60.727 58.896 34.547 1.00 31.00 ? 1061 HOH A O   1 
+HETATM 2579 O O   . HOH C 3 .   ? 69.473 48.099 6.952  1.00 30.78 ? 1062 HOH A O   1 
+HETATM 2580 O O   . HOH C 3 .   ? 50.968 46.967 38.617 1.00 31.39 ? 1063 HOH A O   1 
+HETATM 2581 O O   . HOH C 3 .   ? 73.045 16.060 33.641 1.00 31.42 ? 1064 HOH A O   1 
+HETATM 2582 O O   . HOH C 3 .   ? 60.806 46.392 41.300 1.00 31.21 ? 1065 HOH A O   1 
+HETATM 2583 O O   . HOH C 3 .   ? 49.208 32.367 41.402 1.00 31.37 ? 1066 HOH A O   1 
+HETATM 2584 O O   . HOH C 3 .   ? 68.734 18.807 21.867 1.00 31.89 ? 1067 HOH A O   1 
+HETATM 2585 O O   . HOH C 3 .   ? 77.411 38.372 19.008 1.00 31.38 ? 1068 HOH A O   1 
+HETATM 2586 O O   . HOH C 3 .   ? 66.118 23.790 11.217 1.00 31.95 ? 1069 HOH A O   1 
+HETATM 2587 O O   . HOH C 3 .   ? 77.361 24.061 29.528 1.00 31.99 ? 1070 HOH A O   1 
+HETATM 2588 O O   . HOH C 3 .   ? 78.984 30.103 6.597  1.00 32.28 ? 1071 HOH A O   1 
+HETATM 2589 O O   . HOH C 3 .   ? 65.505 48.132 45.041 1.00 31.99 ? 1072 HOH A O   1 
+HETATM 2590 O O   . HOH C 3 .   ? 79.662 35.543 6.261  1.00 32.52 ? 1073 HOH A O   1 
+HETATM 2591 O O   . HOH C 3 .   ? 78.350 32.498 17.828 1.00 32.85 ? 1074 HOH A O   1 
+HETATM 2592 O O   . HOH C 3 .   ? 81.990 50.206 32.790 1.00 32.72 ? 1075 HOH A O   1 
+HETATM 2593 O O   . HOH C 3 .   ? 57.372 51.295 10.564 1.00 32.34 ? 1076 HOH A O   1 
+HETATM 2594 O O   . HOH C 3 .   ? 70.375 25.418 10.148 1.00 33.44 ? 1077 HOH A O   1 
+HETATM 2595 O O   . HOH C 3 .   ? 54.690 56.535 20.070 1.00 32.85 ? 1078 HOH A O   1 
+HETATM 2596 O O   . HOH C 3 .   ? 52.904 54.571 21.849 1.00 33.55 ? 1079 HOH A O   1 
+HETATM 2597 O O   . HOH C 3 .   ? 63.420 48.230 4.511  1.00 33.53 ? 1080 HOH A O   1 
+HETATM 2598 O O   . HOH C 3 .   ? 74.936 18.165 34.122 1.00 33.78 ? 1081 HOH A O   1 
+HETATM 2599 O O   . HOH C 3 .   ? 59.572 23.914 9.595  1.00 33.63 ? 1082 HOH A O   1 
+HETATM 2600 O O   . HOH C 3 .   ? 77.770 43.188 17.573 1.00 33.89 ? 1083 HOH A O   1 
+HETATM 2601 O O   . HOH C 3 .   ? 66.313 18.638 23.415 1.00 33.96 ? 1084 HOH A O   1 
+HETATM 2602 O O   . HOH C 3 .   ? 43.663 37.602 16.269 1.00 33.98 ? 1085 HOH A O   1 
+HETATM 2603 O O   . HOH C 3 .   ? 70.019 55.233 39.194 1.00 34.38 ? 1086 HOH A O   1 
+HETATM 2604 O O   . HOH C 3 .   ? 66.484 26.265 9.673  1.00 34.19 ? 1087 HOH A O   1 
+HETATM 2605 O O   . HOH C 3 .   ? 77.505 40.565 6.656  1.00 34.03 ? 1088 HOH A O   1 
+HETATM 2606 O O   . HOH C 3 .   ? 62.840 18.172 37.413 1.00 34.17 ? 1089 HOH A O   1 
+HETATM 2607 O O   . HOH C 3 .   ? 49.582 52.963 23.652 1.00 33.93 ? 1090 HOH A O   1 
+HETATM 2608 O O   . HOH C 3 .   ? 40.982 29.796 22.570 1.00 34.56 ? 1091 HOH A O   1 
+HETATM 2609 O O   . HOH C 3 .   ? 57.118 16.332 24.647 0.50 34.82 ? 1092 HOH A O   1 
+HETATM 2610 O O   . HOH C 3 .   ? 84.786 36.858 34.525 1.00 34.68 ? 1093 HOH A O   1 
+HETATM 2611 O O   . HOH C 3 .   ? 67.243 63.175 13.095 1.00 34.82 ? 1094 HOH A O   1 
+HETATM 2612 O O   . HOH C 3 .   ? 49.887 52.535 26.545 1.00 34.57 ? 1095 HOH A O   1 
+HETATM 2613 O O   . HOH C 3 .   ? 71.204 51.104 6.802  1.00 34.72 ? 1096 HOH A O   1 
+HETATM 2614 O O   . HOH C 3 .   ? 83.064 55.242 21.186 1.00 35.18 ? 1097 HOH A O   1 
+HETATM 2615 O O   . HOH C 3 .   ? 45.539 44.272 34.119 1.00 35.01 ? 1098 HOH A O   1 
+HETATM 2616 O O   . HOH C 3 .   ? 77.990 57.475 23.608 1.00 35.20 ? 1099 HOH A O   1 
+HETATM 2617 O O   . HOH C 3 .   ? 41.711 33.297 22.202 1.00 35.40 ? 1100 HOH A O   1 
+HETATM 2618 O O   . HOH C 3 .   ? 80.561 54.887 34.141 1.00 35.44 ? 1101 HOH A O   1 
+HETATM 2619 O O   . HOH C 3 .   ? 44.141 43.972 20.105 1.00 36.36 ? 1102 HOH A O   1 
+HETATM 2620 O O   . HOH C 3 .   ? 61.890 23.680 9.697  1.00 35.86 ? 1103 HOH A O   1 
+HETATM 2621 O O   . HOH C 3 .   ? 80.577 26.099 40.926 1.00 35.67 ? 1104 HOH A O   1 
+HETATM 2622 O O   . HOH C 3 .   ? 69.466 58.579 36.809 1.00 35.83 ? 1105 HOH A O   1 
+HETATM 2623 O O   . HOH C 3 .   ? 52.622 26.109 9.499  1.00 36.75 ? 1106 HOH A O   1 
+HETATM 2624 O O   . HOH C 3 .   ? 79.226 57.642 20.856 1.00 36.63 ? 1107 HOH A O   1 
+HETATM 2625 O O   . HOH C 3 .   ? 47.706 48.788 12.423 1.00 36.00 ? 1108 HOH A O   1 
+HETATM 2626 O O   . HOH C 3 .   ? 56.591 50.353 38.131 1.00 36.47 ? 1109 HOH A O   1 
+HETATM 2627 O O   . HOH C 3 .   ? 41.776 42.033 33.765 1.00 36.61 ? 1110 HOH A O   1 
+HETATM 2628 O O   . HOH C 3 .   ? 45.784 55.932 25.648 1.00 36.50 ? 1111 HOH A O   1 
+HETATM 2629 O O   . HOH C 3 .   ? 50.946 51.929 35.112 1.00 36.19 ? 1112 HOH A O   1 
+HETATM 2630 O O   . HOH C 3 .   ? 52.503 35.682 43.765 1.00 36.69 ? 1113 HOH A O   1 
+HETATM 2631 O O   . HOH C 3 .   ? 73.556 54.069 38.571 1.00 37.06 ? 1114 HOH A O   1 
+HETATM 2632 O O   . HOH C 3 .   ? 45.162 40.746 18.390 1.00 37.56 ? 1115 HOH A O   1 
+HETATM 2633 O O   . HOH C 3 .   ? 67.036 15.540 27.522 1.00 37.35 ? 1116 HOH A O   1 
+HETATM 2634 O O   . HOH C 3 .   ? 43.261 28.272 32.281 1.00 37.82 ? 1117 HOH A O   1 
+HETATM 2635 O O   . HOH C 3 .   ? 50.844 50.279 37.207 1.00 37.55 ? 1118 HOH A O   1 
+HETATM 2636 O O   . HOH C 3 .   ? 55.659 57.070 32.040 1.00 37.88 ? 1119 HOH A O   1 
+HETATM 2637 O O   . HOH C 3 .   ? 79.828 56.842 25.298 1.00 37.80 ? 1120 HOH A O   1 
+HETATM 2638 O O   . HOH C 3 .   ? 48.514 46.157 11.532 1.00 38.38 ? 1121 HOH A O   1 
+HETATM 2639 O O   . HOH C 3 .   ? 57.259 27.473 41.189 1.00 38.33 ? 1122 HOH A O   1 
+HETATM 2640 O O   . HOH C 3 .   ? 59.538 59.626 31.884 1.00 38.22 ? 1123 HOH A O   1 
+HETATM 2641 O O   . HOH C 3 .   ? 74.189 48.113 46.797 1.00 37.93 ? 1124 HOH A O   1 
+HETATM 2642 O O   . HOH C 3 .   ? 85.770 38.664 35.846 1.00 38.84 ? 1125 HOH A O   1 
+HETATM 2643 O O   . HOH C 3 .   ? 47.818 52.679 30.986 1.00 38.59 ? 1126 HOH A O   1 
+HETATM 2644 O O   . HOH C 3 .   ? 40.508 38.509 30.794 1.00 38.73 ? 1127 HOH A O   1 
+HETATM 2645 O O   . HOH C 3 .   ? 77.269 55.670 14.299 1.00 38.84 ? 1128 HOH A O   1 
+HETATM 2646 O O   . HOH C 3 .   ? 50.497 54.637 28.131 1.00 39.69 ? 1129 HOH A O   1 
+HETATM 2647 O O   . HOH C 3 .   ? 46.236 39.605 37.297 1.00 38.67 ? 1130 HOH A O   1 
+HETATM 2648 O O   . HOH C 3 .   ? 66.715 16.576 38.037 1.00 39.17 ? 1131 HOH A O   1 
+HETATM 2649 O O   . HOH C 3 .   ? 60.797 14.788 28.892 1.00 39.29 ? 1132 HOH A O   1 
+HETATM 2650 O O   . HOH C 3 .   ? 54.227 16.857 29.515 1.00 39.00 ? 1133 HOH A O   1 
+HETATM 2651 O O   . HOH C 3 .   ? 76.796 58.376 34.579 1.00 39.12 ? 1134 HOH A O   1 
+HETATM 2652 O O   . HOH C 3 .   ? 78.024 33.510 13.892 1.00 40.10 ? 1135 HOH A O   1 
+HETATM 2653 O O   . HOH C 3 .   ? 50.462 46.620 9.884  1.00 40.19 ? 1136 HOH A O   1 
+HETATM 2654 O O   . HOH C 3 .   ? 78.778 23.914 35.788 1.00 39.56 ? 1137 HOH A O   1 
+HETATM 2655 O O   . HOH C 3 .   ? 46.198 31.284 11.237 1.00 39.72 ? 1138 HOH A O   1 
+HETATM 2656 O O   . HOH C 3 .   ? 80.167 44.577 17.616 1.00 39.89 ? 1139 HOH A O   1 
+HETATM 2657 O O   . HOH C 3 .   ? 70.314 65.925 21.828 1.00 39.76 ? 1140 HOH A O   1 
+HETATM 2658 O O   . HOH C 3 .   ? 46.420 43.401 11.890 1.00 40.81 ? 1141 HOH A O   1 
+HETATM 2659 O O   . HOH C 3 .   ? 77.466 40.826 18.847 1.00 40.15 ? 1142 HOH A O   1 
+HETATM 2660 O O   . HOH C 3 .   ? 68.412 21.195 41.772 1.00 40.60 ? 1143 HOH A O   1 
+HETATM 2661 O O   . HOH C 3 .   ? 76.483 42.747 14.669 1.00 40.42 ? 1144 HOH A O   1 
+HETATM 2662 O O   . HOH C 3 .   ? 51.217 49.630 13.301 0.50 35.53 ? 1145 HOH A O   1 
+HETATM 2663 O O   . HOH C 3 .   ? 69.607 65.499 24.126 1.00 40.41 ? 1146 HOH A O   1 
+HETATM 2664 O O   . HOH C 3 .   ? 81.970 40.705 25.913 1.00 41.18 ? 1147 HOH A O   1 
+HETATM 2665 O O   . HOH C 3 .   ? 83.965 44.399 35.953 1.00 40.49 ? 1148 HOH A O   1 
+HETATM 2666 O O   . HOH C 3 .   ? 63.088 14.170 33.005 1.00 40.67 ? 1149 HOH A O   1 
+HETATM 2667 O O   . HOH C 3 .   ? 81.010 52.132 36.939 1.00 41.29 ? 1150 HOH A O   1 
+HETATM 2668 O O   . HOH C 3 .   ? 45.036 53.958 19.397 1.00 41.26 ? 1151 HOH A O   1 
+HETATM 2669 O O   . HOH C 3 .   ? 83.923 50.702 23.449 1.00 40.59 ? 1152 HOH A O   1 
+HETATM 2670 O O   . HOH C 3 .   ? 42.979 32.362 16.369 1.00 41.61 ? 1153 HOH A O   1 
+HETATM 2671 O O   . HOH C 3 .   ? 71.148 62.775 23.358 1.00 41.11 ? 1154 HOH A O   1 
+HETATM 2672 O O   . HOH C 3 .   ? 52.828 35.924 7.172  1.00 41.85 ? 1155 HOH A O   1 
+HETATM 2673 O O   . HOH C 3 .   ? 64.548 57.781 8.411  1.00 41.77 ? 1156 HOH A O   1 
+HETATM 2674 O O   . HOH C 3 .   ? 78.745 26.906 22.489 1.00 42.20 ? 1157 HOH A O   1 
+HETATM 2675 O O   . HOH C 3 .   ? 48.096 49.977 36.933 1.00 41.70 ? 1158 HOH A O   1 
+HETATM 2676 O O   . HOH C 3 .   ? 46.968 46.175 31.623 1.00 41.76 ? 1159 HOH A O   1 
+HETATM 2677 O O   . HOH C 3 .   ? 81.617 38.864 41.506 1.00 41.99 ? 1160 HOH A O   1 
+HETATM 2678 O O   . HOH C 3 .   ? 55.352 31.941 7.528  1.00 42.68 ? 1161 HOH A O   1 
+HETATM 2679 O O   . HOH C 3 .   ? 68.657 41.720 2.791  1.00 41.41 ? 1162 HOH A O   1 
+HETATM 2680 O O   . HOH C 3 .   ? 63.733 15.937 26.217 1.00 42.92 ? 1163 HOH A O   1 
+HETATM 2681 O O   . HOH C 3 .   ? 63.223 54.728 40.490 1.00 42.40 ? 1164 HOH A O   1 
+HETATM 2682 O O   . HOH C 3 .   ? 79.810 30.497 14.811 1.00 42.83 ? 1165 HOH A O   1 
+HETATM 2683 O O   . HOH C 3 .   ? 46.498 51.114 34.710 1.00 42.34 ? 1166 HOH A O   1 
+HETATM 2684 O O   . HOH C 3 .   ? 84.058 37.041 26.678 1.00 42.51 ? 1167 HOH A O   1 
+HETATM 2685 O O   . HOH C 3 .   ? 40.135 37.691 24.358 1.00 42.93 ? 1168 HOH A O   1 
+HETATM 2686 O O   . HOH C 3 .   ? 68.271 55.739 7.481  1.00 42.89 ? 1169 HOH A O   1 
+HETATM 2687 O O   . HOH C 3 .   ? 47.589 35.753 40.740 1.00 42.71 ? 1170 HOH A O   1 
+HETATM 2688 O O   . HOH C 3 .   ? 47.902 29.757 39.632 1.00 43.08 ? 1171 HOH A O   1 
+HETATM 2689 O O   . HOH C 3 .   ? 61.061 42.403 38.972 1.00 43.23 ? 1172 HOH A O   1 
+HETATM 2690 O O   . HOH C 3 .   ? 47.732 30.414 8.292  1.00 43.55 ? 1173 HOH A O   1 
+HETATM 2691 O O   . HOH C 3 .   ? 71.402 23.187 11.311 1.00 43.37 ? 1174 HOH A O   1 
+HETATM 2692 O O   . HOH C 3 .   ? 42.222 43.125 23.691 1.00 43.18 ? 1175 HOH A O   1 
+HETATM 2693 O O   . HOH C 3 .   ? 65.982 65.275 26.010 1.00 43.94 ? 1176 HOH A O   1 
+HETATM 2694 O O   . HOH C 3 .   ? 80.988 50.395 38.944 1.00 44.38 ? 1177 HOH A O   1 
+HETATM 2695 O O   . HOH C 3 .   ? 80.660 33.395 22.121 1.00 44.07 ? 1178 HOH A O   1 
+HETATM 2696 O O   . HOH C 3 .   ? 78.735 57.160 31.476 1.00 45.10 ? 1179 HOH A O   1 
+HETATM 2697 O O   . HOH C 3 .   ? 63.778 62.095 33.219 1.00 44.83 ? 1180 HOH A O   1 
+HETATM 2698 O O   . HOH C 3 .   ? 40.618 41.388 27.856 1.00 45.38 ? 1181 HOH A O   1 
+HETATM 2699 O O   . HOH C 3 .   ? 58.852 47.094 7.054  1.00 45.62 ? 1182 HOH A O   1 
+HETATM 2700 O O   . HOH C 3 .   ? 78.331 25.393 26.008 1.00 46.00 ? 1183 HOH A O   1 
+HETATM 2701 O O   . HOH C 3 .   ? 71.120 63.653 31.332 1.00 45.98 ? 1184 HOH A O   1 
+HETATM 2702 O O   . HOH C 3 .   ? 46.850 54.039 28.512 1.00 46.75 ? 1185 HOH A O   1 
+HETATM 2703 O O   . HOH C 3 .   ? 84.111 38.851 40.723 1.00 46.00 ? 1186 HOH A O   1 
+HETATM 2704 O O   . HOH C 3 .   ? 71.891 42.849 46.074 1.00 46.57 ? 1187 HOH A O   1 
+HETATM 2705 O O   . HOH C 3 .   ? 43.171 44.482 25.465 1.00 45.16 ? 1188 HOH A O   1 
+HETATM 2706 O O   . HOH C 3 .   ? 46.882 47.233 35.961 1.00 47.34 ? 1189 HOH A O   1 
+HETATM 2707 O O   . HOH C 3 .   ? 81.831 31.056 34.581 1.00 47.28 ? 1190 HOH A O   1 
+HETATM 2708 O O   . HOH C 3 .   ? 84.366 46.716 30.432 1.00 47.74 ? 1191 HOH A O   1 
+HETATM 2709 O O   . HOH C 3 .   ? 56.042 57.473 22.925 1.00 47.27 ? 1192 HOH A O   1 
+HETATM 2710 O O   . HOH C 3 .   ? 62.017 18.066 23.412 1.00 47.68 ? 1193 HOH A O   1 
+HETATM 2711 O O   . HOH C 3 .   ? 75.989 25.919 25.350 1.00 47.48 ? 1194 HOH A O   1 
+HETATM 2712 O O   . HOH C 3 .   ? 57.376 53.602 36.105 1.00 48.06 ? 1195 HOH A O   1 
+HETATM 2713 O O   . HOH C 3 .   ? 52.091 28.170 7.652  1.00 48.29 ? 1196 HOH A O   1 
+HETATM 2714 O O   . HOH C 3 .   ? 64.508 23.636 20.766 1.00 47.89 ? 1197 HOH A O   1 
+HETATM 2715 O O   . HOH C 3 .   ? 59.648 15.892 34.976 1.00 47.96 ? 1198 HOH A O   1 
+HETATM 2716 O O   . HOH C 3 .   ? 73.494 18.842 24.205 1.00 48.50 ? 1199 HOH A O   1 
+HETATM 2717 O O   . HOH C 3 .   ? 64.711 64.367 29.791 1.00 47.15 ? 1200 HOH A O   1 
+HETATM 2718 O O   . HOH C 3 .   ? 84.207 54.068 23.230 1.00 48.02 ? 1201 HOH A O   1 
+HETATM 2719 O O   . HOH C 3 .   ? 46.505 24.867 32.389 1.00 48.43 ? 1202 HOH A O   1 
+HETATM 2720 O O   . HOH C 3 .   ? 61.454 22.474 11.770 1.00 48.88 ? 1203 HOH A O   1 
+HETATM 2721 O O   . HOH C 3 .   ? 68.909 50.728 7.597  1.00 49.00 ? 1204 HOH A O   1 
+HETATM 2722 O O   . HOH C 3 .   ? 64.570 19.746 21.578 1.00 48.49 ? 1205 HOH A O   1 
+HETATM 2723 O O   . HOH C 3 .   ? 74.108 53.496 8.914  1.00 48.93 ? 1206 HOH A O   1 
+HETATM 2724 O O   . HOH C 3 .   ? 65.356 24.234 40.157 1.00 48.73 ? 1207 HOH A O   1 
+HETATM 2725 O O   . HOH C 3 .   ? 57.084 14.685 29.897 1.00 49.08 ? 1208 HOH A O   1 
+HETATM 2726 O O   . HOH C 3 .   ? 84.795 34.263 35.105 1.00 49.83 ? 1209 HOH A O   1 
+HETATM 2727 O O   . HOH C 3 .   ? 72.753 66.062 23.605 1.00 49.18 ? 1210 HOH A O   1 
+HETATM 2728 O O   . HOH C 3 .   ? 69.227 14.323 34.591 1.00 49.69 ? 1211 HOH A O   1 
+HETATM 2729 O O   . HOH C 3 .   ? 74.122 22.997 12.957 1.00 49.90 ? 1212 HOH A O   1 
+HETATM 2730 O O   . HOH C 3 .   ? 74.467 43.940 3.431  1.00 50.30 ? 1213 HOH A O   1 
+HETATM 2731 O O   . HOH C 3 .   ? 47.788 38.541 39.840 1.00 51.07 ? 1214 HOH A O   1 
+HETATM 2732 O O   . HOH C 3 .   ? 77.113 25.414 6.006  1.00 50.99 ? 1215 HOH A O   1 
+HETATM 2733 O O   . HOH C 3 .   ? 58.914 53.413 8.071  1.00 50.71 ? 1216 HOH A O   1 
+HETATM 2734 O O   . HOH C 3 .   ? 41.110 26.293 28.522 1.00 50.73 ? 1217 HOH A O   1 
+HETATM 2735 O O   . HOH C 3 .   ? 69.237 15.007 37.460 1.00 52.57 ? 1218 HOH A O   1 
+HETATM 2736 O O   . HOH C 3 .   ? 60.777 43.855 42.115 1.00 51.36 ? 1219 HOH A O   1 
+HETATM 2737 O O   . HOH C 3 .   ? 54.910 23.254 13.250 1.00 52.80 ? 1220 HOH A O   1 
+HETATM 2738 O O   . HOH C 3 .   ? 79.241 33.084 11.304 1.00 51.49 ? 1221 HOH A O   1 
+HETATM 2739 O O   . HOH C 3 .   ? 62.974 54.848 7.575  1.00 52.07 ? 1222 HOH A O   1 
+HETATM 2740 O O   . HOH C 3 .   ? 65.529 21.676 41.338 1.00 51.61 ? 1223 HOH A O   1 
+HETATM 2741 O O   . HOH C 3 .   ? 55.688 29.221 5.295  1.00 52.88 ? 1224 HOH A O   1 
+HETATM 2742 O O   . HOH C 3 .   ? 83.720 59.438 28.171 1.00 51.82 ? 1225 HOH A O   1 
+HETATM 2743 O O   . HOH C 3 .   ? 71.031 46.228 46.308 1.00 52.16 ? 1226 HOH A O   1 
+HETATM 2744 O O   . HOH C 3 .   ? 57.842 22.391 41.368 1.00 52.14 ? 1227 HOH A O   1 
+HETATM 2745 O O   . HOH C 3 .   ? 48.347 46.389 37.715 1.00 52.85 ? 1228 HOH A O   1 
+HETATM 2746 O O   . HOH C 3 .   ? 87.069 39.025 32.173 1.00 52.67 ? 1229 HOH A O   1 
+HETATM 2747 O O   . HOH C 3 .   ? 73.869 59.103 13.578 1.00 54.16 ? 1230 HOH A O   1 
+HETATM 2748 O O   . HOH C 3 .   ? 82.767 31.125 31.720 1.00 53.19 ? 1231 HOH A O   1 
+HETATM 2749 O O   . HOH C 3 .   ? 41.230 36.671 32.617 1.00 53.57 ? 1232 HOH A O   1 
+HETATM 2750 O O   . HOH C 3 .   ? 48.017 23.292 40.189 1.00 53.28 ? 1233 HOH A O   1 
+HETATM 2751 O O   . HOH C 3 .   ? 45.505 48.958 17.456 1.00 52.83 ? 1234 HOH A O   1 
+HETATM 2752 O O   . HOH C 3 .   ? 83.605 27.917 33.344 1.00 52.49 ? 1235 HOH A O   1 
+HETATM 2753 O O   . HOH C 3 .   ? 50.593 39.594 6.087  1.00 54.63 ? 1236 HOH A O   1 
+HETATM 2754 O O   . HOH C 3 .   ? 85.902 42.728 36.351 1.00 54.10 ? 1237 HOH A O   1 
+HETATM 2755 O O   . HOH C 3 .   ? 53.483 34.920 2.347  1.00 53.67 ? 1238 HOH A O   1 
+HETATM 2756 O O   . HOH C 3 .   ? 69.517 58.506 11.099 1.00 53.76 ? 1239 HOH A O   1 
+HETATM 2757 O O   . HOH C 3 .   ? 51.311 33.482 44.047 1.00 54.08 ? 1240 HOH A O   1 
+HETATM 2758 O O   . HOH C 3 .   ? 45.545 46.803 13.859 1.00 55.15 ? 1241 HOH A O   1 
+HETATM 2759 O O   . HOH C 3 .   ? 51.975 24.708 42.861 1.00 56.14 ? 1242 HOH A O   1 
+HETATM 2760 O O   . HOH C 3 .   ? 70.046 19.751 13.564 1.00 55.46 ? 1243 HOH A O   1 
+HETATM 2761 O O   . HOH C 3 .   ? 74.723 22.545 16.515 1.00 56.26 ? 1244 HOH A O   1 
+HETATM 2762 O O   . HOH C 3 .   ? 74.158 22.450 24.716 1.00 56.19 ? 1245 HOH A O   1 
+HETATM 2763 O O   . HOH C 3 .   ? 76.166 62.148 35.422 1.00 56.75 ? 1246 HOH A O   1 
+HETATM 2764 O O   . HOH C 3 .   ? 42.420 43.411 17.087 1.00 55.69 ? 1247 HOH A O   1 
+HETATM 2765 O O   . HOH C 3 .   ? 53.266 42.223 6.882  1.00 55.18 ? 1248 HOH A O   1 
+# 
+loop_
+_pdbx_poly_seq_scheme.asym_id 
+_pdbx_poly_seq_scheme.entity_id 
+_pdbx_poly_seq_scheme.seq_id 
+_pdbx_poly_seq_scheme.mon_id 
+_pdbx_poly_seq_scheme.ndb_seq_num 
+_pdbx_poly_seq_scheme.pdb_seq_num 
+_pdbx_poly_seq_scheme.auth_seq_num 
+_pdbx_poly_seq_scheme.pdb_mon_id 
+_pdbx_poly_seq_scheme.auth_mon_id 
+_pdbx_poly_seq_scheme.pdb_strand_id 
+_pdbx_poly_seq_scheme.pdb_ins_code 
+_pdbx_poly_seq_scheme.hetero 
+A 1 1   ASP 1   1   ?   ?   ?   A . n 
+A 1 2   ASN 2   2   ?   ?   ?   A . n 
+A 1 3   ASP 3   3   ?   ?   ?   A . n 
+A 1 4   SER 4   4   4   SER SER A . n 
+A 1 5   VAL 5   5   5   VAL VAL A . n 
+A 1 6   VAL 6   6   6   VAL VAL A . n 
+A 1 7   GLU 7   7   7   GLU GLU A . n 
+A 1 8   GLU 8   8   8   GLU GLU A . n 
+A 1 9   HIS 9   9   9   HIS HIS A . n 
+A 1 10  GLY 10  10  10  GLY GLY A . n 
+A 1 11  GLN 11  11  11  GLN GLN A . n 
+A 1 12  LEU 12  12  12  LEU LEU A . n 
+A 1 13  SER 13  13  13  SER SER A . n 
+A 1 14  ILE 14  14  14  ILE ILE A . n 
+A 1 15  SER 15  15  15  SER SER A . n 
+A 1 16  ASN 16  16  16  ASN ASN A . n 
+A 1 17  GLY 17  17  17  GLY GLY A . n 
+A 1 18  GLU 18  18  18  GLU GLU A . n 
+A 1 19  LEU 19  19  19  LEU LEU A . n 
+A 1 20  VAL 20  20  20  VAL VAL A . n 
+A 1 21  ASN 21  21  21  ASN ASN A . n 
+A 1 22  GLU 22  22  22  GLU GLU A . n 
+A 1 23  ARG 23  23  23  ARG ARG A . n 
+A 1 24  GLY 24  24  24  GLY GLY A . n 
+A 1 25  GLU 25  25  25  GLU GLU A . n 
+A 1 26  GLN 26  26  26  GLN GLN A . n 
+A 1 27  VAL 27  27  27  VAL VAL A . n 
+A 1 28  GLN 28  28  28  GLN GLN A . n 
+A 1 29  LEU 29  29  29  LEU LEU A . n 
+A 1 30  LYS 30  30  30  LYS LYS A . n 
+A 1 31  GLY 31  31  31  GLY GLY A . n 
+A 1 32  MET 32  32  32  MET MET A . n 
+A 1 33  SER 33  33  33  SER SER A . n 
+A 1 34  SER 34  34  34  SER SER A . n 
+A 1 35  HIS 35  35  35  HIS HIS A . n 
+A 1 36  GLY 36  36  36  GLY GLY A . n 
+A 1 37  LEU 37  37  37  LEU LEU A . n 
+A 1 38  GLN 38  38  38  GLN GLN A . n 
+A 1 39  TRP 39  39  39  TRP TRP A . n 
+A 1 40  TYR 40  40  40  TYR TYR A . n 
+A 1 41  GLY 41  41  41  GLY GLY A . n 
+A 1 42  GLN 42  42  42  GLN GLN A . n 
+A 1 43  PHE 43  43  43  PHE PHE A . n 
+A 1 44  VAL 44  44  44  VAL VAL A . n 
+A 1 45  ASN 45  45  45  ASN ASN A . n 
+A 1 46  TYR 46  46  46  TYR TYR A . n 
+A 1 47  GLU 47  47  47  GLU GLU A . n 
+A 1 48  SER 48  48  48  SER SER A . n 
+A 1 49  MET 49  49  49  MET MET A . n 
+A 1 50  LYS 50  50  50  LYS LYS A . n 
+A 1 51  TRP 51  51  51  TRP TRP A . n 
+A 1 52  LEU 52  52  52  LEU LEU A . n 
+A 1 53  ARG 53  53  53  ARG ARG A . n 
+A 1 54  ASP 54  54  54  ASP ASP A . n 
+A 1 55  ASP 55  55  55  ASP ASP A . n 
+A 1 56  TRP 56  56  56  TRP TRP A . n 
+A 1 57  GLY 57  57  57  GLY GLY A . n 
+A 1 58  ILE 58  58  58  ILE ILE A . n 
+A 1 59  ASN 59  59  59  ASN ASN A . n 
+A 1 60  VAL 60  60  60  VAL VAL A . n 
+A 1 61  PHE 61  61  61  PHE PHE A . n 
+A 1 62  ARG 62  62  62  ARG ARG A . n 
+A 1 63  ALA 63  63  63  ALA ALA A . n 
+A 1 64  ALA 64  64  64  ALA ALA A . n 
+A 1 65  MET 65  65  65  MET MET A . n 
+A 1 66  TYR 66  66  66  TYR TYR A . n 
+A 1 67  THR 67  67  67  THR THR A . n 
+A 1 68  SER 68  68  68  SER SER A . n 
+A 1 69  SER 69  69  69  SER SER A . n 
+A 1 70  GLY 70  70  70  GLY GLY A . n 
+A 1 71  GLY 71  71  71  GLY GLY A . n 
+A 1 72  TYR 72  72  72  TYR TYR A . n 
+A 1 73  ILE 73  73  73  ILE ILE A . n 
+A 1 74  ASP 74  74  74  ASP ASP A . n 
+A 1 75  ASP 75  75  75  ASP ASP A . n 
+A 1 76  PRO 76  76  76  PRO PRO A . n 
+A 1 77  SER 77  77  77  SER SER A . n 
+A 1 78  VAL 78  78  78  VAL VAL A . n 
+A 1 79  LYS 79  79  79  LYS LYS A . n 
+A 1 80  GLU 80  80  80  GLU GLU A . n 
+A 1 81  LYS 81  81  81  LYS LYS A . n 
+A 1 82  VAL 82  82  82  VAL VAL A . n 
+A 1 83  LYS 83  83  83  LYS LYS A . n 
+A 1 84  GLU 84  84  84  GLU GLU A . n 
+A 1 85  ALA 85  85  85  ALA ALA A . n 
+A 1 86  VAL 86  86  86  VAL VAL A . n 
+A 1 87  GLU 87  87  87  GLU GLU A . n 
+A 1 88  ALA 88  88  88  ALA ALA A . n 
+A 1 89  ALA 89  89  89  ALA ALA A . n 
+A 1 90  ILE 90  90  90  ILE ILE A . n 
+A 1 91  ASP 91  91  91  ASP ASP A . n 
+A 1 92  LEU 92  92  92  LEU LEU A . n 
+A 1 93  ASP 93  93  93  ASP ASP A . n 
+A 1 94  ILE 94  94  94  ILE ILE A . n 
+A 1 95  TYR 95  95  95  TYR TYR A . n 
+A 1 96  VAL 96  96  96  VAL VAL A . n 
+A 1 97  ILE 97  97  97  ILE ILE A . n 
+A 1 98  ILE 98  98  98  ILE ILE A . n 
+A 1 99  ASP 99  99  99  ASP ASP A . n 
+A 1 100 TRP 100 100 100 TRP TRP A . n 
+A 1 101 HIS 101 101 101 HIS HIS A . n 
+A 1 102 ILE 102 102 102 ILE ILE A . n 
+A 1 103 LEU 103 103 103 LEU LEU A . n 
+A 1 104 SER 104 104 104 SER SER A . n 
+A 1 105 ASP 105 105 105 ASP ASP A . n 
+A 1 106 ASN 106 106 106 ASN ASN A . n 
+A 1 107 ASP 107 107 107 ASP ASP A . n 
+A 1 108 PRO 108 108 108 PRO PRO A . n 
+A 1 109 ASN 109 109 109 ASN ASN A . n 
+A 1 110 ILE 110 110 110 ILE ILE A . n 
+A 1 111 TYR 111 111 111 TYR TYR A . n 
+A 1 112 LYS 112 112 112 LYS LYS A . n 
+A 1 113 GLU 113 113 113 GLU GLU A . n 
+A 1 114 GLU 114 114 114 GLU GLU A . n 
+A 1 115 ALA 115 115 115 ALA ALA A . n 
+A 1 116 LYS 116 116 116 LYS LYS A . n 
+A 1 117 ASP 117 117 117 ASP ASP A . n 
+A 1 118 PHE 118 118 118 PHE PHE A . n 
+A 1 119 PHE 119 119 119 PHE PHE A . n 
+A 1 120 ASP 120 120 120 ASP ASP A . n 
+A 1 121 GLU 121 121 121 GLU GLU A . n 
+A 1 122 MET 122 122 122 MET MET A . n 
+A 1 123 SER 123 123 123 SER SER A . n 
+A 1 124 GLU 124 124 124 GLU GLU A . n 
+A 1 125 LEU 125 125 125 LEU LEU A . n 
+A 1 126 TYR 126 126 126 TYR TYR A . n 
+A 1 127 GLY 127 127 127 GLY GLY A . n 
+A 1 128 ASP 128 128 128 ASP ASP A . n 
+A 1 129 TYR 129 129 129 TYR TYR A . n 
+A 1 130 PRO 130 130 130 PRO PRO A . n 
+A 1 131 ASN 131 131 131 ASN ASN A . n 
+A 1 132 VAL 132 132 132 VAL VAL A . n 
+A 1 133 ILE 133 133 133 ILE ILE A . n 
+A 1 134 TYR 134 134 134 TYR TYR A . n 
+A 1 135 GLU 135 135 135 GLU GLU A . n 
+A 1 136 ILE 136 136 136 ILE ILE A . n 
+A 1 137 ALA 137 137 137 ALA ALA A . n 
+A 1 138 ASN 138 138 138 ASN ASN A . n 
+A 1 139 GLU 139 139 139 GLU GLU A . n 
+A 1 140 PRO 140 140 140 PRO PRO A . n 
+A 1 141 ASN 141 141 141 ASN ASN A . n 
+A 1 142 GLY 142 142 142 GLY GLY A . n 
+A 1 143 SER 143 143 143 SER SER A . n 
+A 1 144 ASP 144 144 144 ASP ASP A . n 
+A 1 145 VAL 145 145 145 VAL VAL A . n 
+A 1 146 THR 146 146 146 THR THR A . n 
+A 1 147 TRP 147 147 147 TRP TRP A . n 
+A 1 148 GLY 148 148 148 GLY GLY A . n 
+A 1 149 ASN 149 149 149 ASN ASN A . n 
+A 1 150 GLN 150 150 150 GLN GLN A . n 
+A 1 151 ILE 151 151 151 ILE ILE A . n 
+A 1 152 LYS 152 152 152 LYS LYS A . n 
+A 1 153 PRO 153 153 153 PRO PRO A . n 
+A 1 154 TYR 154 154 154 TYR TYR A . n 
+A 1 155 ALA 155 155 155 ALA ALA A . n 
+A 1 156 GLU 156 156 156 GLU GLU A . n 
+A 1 157 GLU 157 157 157 GLU GLU A . n 
+A 1 158 VAL 158 158 158 VAL VAL A . n 
+A 1 159 ILE 159 159 159 ILE ILE A . n 
+A 1 160 PRO 160 160 160 PRO PRO A . n 
+A 1 161 ILE 161 161 161 ILE ILE A . n 
+A 1 162 ILE 162 162 162 ILE ILE A . n 
+A 1 163 ARG 163 163 163 ARG ARG A . n 
+A 1 164 ASN 164 164 164 ASN ASN A . n 
+A 1 165 ASN 165 165 165 ASN ASN A . n 
+A 1 166 ASP 166 166 166 ASP ASP A . n 
+A 1 167 PRO 167 167 167 PRO PRO A . n 
+A 1 168 ASN 168 168 168 ASN ASN A . n 
+A 1 169 ASN 169 169 169 ASN ASN A . n 
+A 1 170 ILE 170 170 170 ILE ILE A . n 
+A 1 171 ILE 171 171 171 ILE ILE A . n 
+A 1 172 ILE 172 172 172 ILE ILE A . n 
+A 1 173 VAL 173 173 173 VAL VAL A . n 
+A 1 174 GLY 174 174 174 GLY GLY A . n 
+A 1 175 THR 175 175 175 THR THR A . n 
+A 1 176 GLY 176 176 176 GLY GLY A . n 
+A 1 177 THR 177 177 177 THR THR A . n 
+A 1 178 TRP 178 178 178 TRP TRP A . n 
+A 1 179 SER 179 179 179 SER SER A . n 
+A 1 180 GLN 180 180 180 GLN GLN A . n 
+A 1 181 ASP 181 181 181 ASP ASP A . n 
+A 1 182 VAL 182 182 182 VAL VAL A . n 
+A 1 183 HIS 183 183 183 HIS HIS A . n 
+A 1 184 HIS 184 184 184 HIS HIS A . n 
+A 1 185 ALA 185 185 185 ALA ALA A . n 
+A 1 186 ALA 186 186 186 ALA ALA A . n 
+A 1 187 ASP 187 187 187 ASP ASP A . n 
+A 1 188 ASN 188 188 188 ASN ASN A . n 
+A 1 189 GLN 189 189 189 GLN GLN A . n 
+A 1 190 LEU 190 190 190 LEU LEU A . n 
+A 1 191 ALA 191 191 191 ALA ALA A . n 
+A 1 192 ASP 192 192 192 ASP ASP A . n 
+A 1 193 PRO 193 193 193 PRO PRO A . n 
+A 1 194 ASN 194 194 194 ASN ASN A . n 
+A 1 195 VAL 195 195 195 VAL VAL A . n 
+A 1 196 MET 196 196 196 MET MET A . n 
+A 1 197 TYR 197 197 197 TYR TYR A . n 
+A 1 198 ALA 198 198 198 ALA ALA A . n 
+A 1 199 PHE 199 199 199 PHE PHE A . n 
+A 1 200 HIS 200 200 200 HIS HIS A . n 
+A 1 201 PHE 201 201 201 PHE PHE A . n 
+A 1 202 TYR 202 202 202 TYR TYR A . n 
+A 1 203 ALA 203 203 203 ALA ALA A . n 
+A 1 204 GLY 204 204 204 GLY GLY A . n 
+A 1 205 THR 205 205 205 THR THR A . n 
+A 1 206 HIS 206 206 206 HIS HIS A . n 
+A 1 207 GLY 207 207 207 GLY GLY A . n 
+A 1 208 GLN 208 208 208 GLN GLN A . n 
+A 1 209 ASN 209 209 209 ASN ASN A . n 
+A 1 210 LEU 210 210 210 LEU LEU A . n 
+A 1 211 ARG 211 211 211 ARG ARG A . n 
+A 1 212 ASP 212 212 212 ASP ASP A . n 
+A 1 213 GLN 213 213 213 GLN GLN A . n 
+A 1 214 VAL 214 214 214 VAL VAL A . n 
+A 1 215 ASP 215 215 215 ASP ASP A . n 
+A 1 216 TYR 216 216 216 TYR TYR A . n 
+A 1 217 ALA 217 217 217 ALA ALA A . n 
+A 1 218 LEU 218 218 218 LEU LEU A . n 
+A 1 219 ASP 219 219 219 ASP ASP A . n 
+A 1 220 GLN 220 220 220 GLN GLN A . n 
+A 1 221 GLY 221 221 221 GLY GLY A . n 
+A 1 222 ALA 222 222 222 ALA ALA A . n 
+A 1 223 ALA 223 223 223 ALA ALA A . n 
+A 1 224 ILE 224 224 224 ILE ILE A . n 
+A 1 225 PHE 225 225 225 PHE PHE A . n 
+A 1 226 VAL 226 226 226 VAL VAL A . n 
+A 1 227 SER 227 227 227 SER SER A . n 
+A 1 228 GLU 228 228 228 GLU GLU A . n 
+A 1 229 TRP 229 229 229 TRP TRP A . n 
+A 1 230 GLY 230 230 230 GLY GLY A . n 
+A 1 231 THR 231 231 231 THR THR A . n 
+A 1 232 SER 232 232 232 SER SER A . n 
+A 1 233 ALA 233 233 233 ALA ALA A . n 
+A 1 234 ALA 234 234 234 ALA ALA A . n 
+A 1 235 THR 235 235 235 THR THR A . n 
+A 1 236 GLY 236 236 236 GLY GLY A . n 
+A 1 237 ASP 237 237 237 ASP ASP A . n 
+A 1 238 GLY 238 238 238 GLY GLY A . n 
+A 1 239 GLY 239 239 239 GLY GLY A . n 
+A 1 240 VAL 240 240 240 VAL VAL A . n 
+A 1 241 PHE 241 241 241 PHE PHE A . n 
+A 1 242 LEU 242 242 242 LEU LEU A . n 
+A 1 243 ASP 243 243 243 ASP ASP A . n 
+A 1 244 GLU 244 244 244 GLU GLU A . n 
+A 1 245 ALA 245 245 245 ALA ALA A . n 
+A 1 246 GLN 246 246 246 GLN GLN A . n 
+A 1 247 VAL 247 247 247 VAL VAL A . n 
+A 1 248 TRP 248 248 248 TRP TRP A . n 
+A 1 249 ILE 249 249 249 ILE ILE A . n 
+A 1 250 ASP 250 250 250 ASP ASP A . n 
+A 1 251 PHE 251 251 251 PHE PHE A . n 
+A 1 252 MET 252 252 252 MET MET A . n 
+A 1 253 ASP 253 253 253 ASP ASP A . n 
+A 1 254 GLU 254 254 254 GLU GLU A . n 
+A 1 255 ARG 255 255 255 ARG ARG A . n 
+A 1 256 ASN 256 256 256 ASN ASN A . n 
+A 1 257 LEU 257 257 257 LEU LEU A . n 
+A 1 258 SER 258 258 258 SER SER A . n 
+A 1 259 TRP 259 259 259 TRP TRP A . n 
+A 1 260 ALA 260 260 260 ALA ALA A . n 
+A 1 261 ASN 261 261 261 ASN ASN A . n 
+A 1 262 TRP 262 262 262 TRP TRP A . n 
+A 1 263 SER 263 263 263 SER SER A . n 
+A 1 264 LEU 264 264 264 LEU LEU A . n 
+A 1 265 THR 265 265 265 THR THR A . n 
+A 1 266 HIS 266 266 266 HIS HIS A . n 
+A 1 267 LYS 267 267 267 LYS LYS A . n 
+A 1 268 ASP 268 268 268 ASP ASP A . n 
+A 1 269 GLU 269 269 269 GLU GLU A . n 
+A 1 270 SER 270 270 270 SER SER A . n 
+A 1 271 SER 271 271 271 SER SER A . n 
+A 1 272 ALA 272 272 272 ALA ALA A . n 
+A 1 273 ALA 273 273 273 ALA ALA A . n 
+A 1 274 LEU 274 274 274 LEU LEU A . n 
+A 1 275 MET 275 275 275 MET MET A . n 
+A 1 276 PRO 276 276 276 PRO PRO A . n 
+A 1 277 GLY 277 277 277 GLY GLY A . n 
+A 1 278 ALA 278 278 278 ALA ALA A . n 
+A 1 279 ASN 279 279 279 ASN ASN A . n 
+A 1 280 PRO 280 280 280 PRO PRO A . n 
+A 1 281 THR 281 281 281 THR THR A . n 
+A 1 282 GLY 282 282 282 GLY GLY A . n 
+A 1 283 GLY 283 283 283 GLY GLY A . n 
+A 1 284 TRP 284 284 284 TRP TRP A . n 
+A 1 285 THR 285 285 285 THR THR A . n 
+A 1 286 GLU 286 286 286 GLU GLU A . n 
+A 1 287 ALA 287 287 287 ALA ALA A . n 
+A 1 288 GLU 288 288 288 GLU GLU A . n 
+A 1 289 LEU 289 289 289 LEU LEU A . n 
+A 1 290 SER 290 290 290 SER SER A . n 
+A 1 291 PRO 291 291 291 PRO PRO A . n 
+A 1 292 SER 292 292 292 SER SER A . n 
+A 1 293 GLY 293 293 293 GLY GLY A . n 
+A 1 294 THR 294 294 294 THR THR A . n 
+A 1 295 PHE 295 295 295 PHE PHE A . n 
+A 1 296 VAL 296 296 296 VAL VAL A . n 
+A 1 297 ARG 297 297 297 ARG ARG A . n 
+A 1 298 GLU 298 298 298 GLU GLU A . n 
+A 1 299 LYS 299 299 299 LYS LYS A . n 
+A 1 300 ILE 300 300 300 ILE ILE A . n 
+A 1 301 ARG 301 301 301 ARG ARG A . n 
+A 1 302 GLU 302 302 302 GLU GLU A . n 
+A 1 303 SER 303 303 303 SER SER A . n 
+# 
+loop_
+_pdbx_nonpoly_scheme.asym_id 
+_pdbx_nonpoly_scheme.entity_id 
+_pdbx_nonpoly_scheme.mon_id 
+_pdbx_nonpoly_scheme.ndb_seq_num 
+_pdbx_nonpoly_scheme.pdb_seq_num 
+_pdbx_nonpoly_scheme.auth_seq_num 
+_pdbx_nonpoly_scheme.pdb_mon_id 
+_pdbx_nonpoly_scheme.auth_mon_id 
+_pdbx_nonpoly_scheme.pdb_strand_id 
+_pdbx_nonpoly_scheme.pdb_ins_code 
+C 3 HOH 1   901  1   HOH HOH A . 
+C 3 HOH 2   902  2   HOH HOH A . 
+C 3 HOH 3   903  3   HOH HOH A . 
+C 3 HOH 4   904  4   HOH HOH A . 
+C 3 HOH 5   905  5   HOH HOH A . 
+C 3 HOH 6   906  6   HOH HOH A . 
+C 3 HOH 7   907  7   HOH HOH A . 
+C 3 HOH 8   908  8   HOH HOH A . 
+C 3 HOH 9   909  9   HOH HOH A . 
+C 3 HOH 10  910  10  HOH HOH A . 
+C 3 HOH 11  911  11  HOH HOH A . 
+C 3 HOH 12  912  12  HOH HOH A . 
+C 3 HOH 13  913  13  HOH HOH A . 
+C 3 HOH 14  914  14  HOH HOH A . 
+C 3 HOH 15  915  15  HOH HOH A . 
+C 3 HOH 16  916  16  HOH HOH A . 
+C 3 HOH 17  917  17  HOH HOH A . 
+C 3 HOH 18  918  18  HOH HOH A . 
+C 3 HOH 19  919  19  HOH HOH A . 
+C 3 HOH 20  920  20  HOH HOH A . 
+C 3 HOH 21  921  21  HOH HOH A . 
+C 3 HOH 22  922  22  HOH HOH A . 
+C 3 HOH 23  923  23  HOH HOH A . 
+C 3 HOH 24  924  24  HOH HOH A . 
+C 3 HOH 25  925  25  HOH HOH A . 
+C 3 HOH 26  926  26  HOH HOH A . 
+C 3 HOH 27  927  27  HOH HOH A . 
+C 3 HOH 28  928  28  HOH HOH A . 
+C 3 HOH 29  929  29  HOH HOH A . 
+C 3 HOH 30  930  30  HOH HOH A . 
+C 3 HOH 31  931  31  HOH HOH A . 
+C 3 HOH 32  932  32  HOH HOH A . 
+C 3 HOH 33  933  33  HOH HOH A . 
+C 3 HOH 34  934  34  HOH HOH A . 
+C 3 HOH 35  935  35  HOH HOH A . 
+C 3 HOH 36  936  36  HOH HOH A . 
+C 3 HOH 37  937  37  HOH HOH A . 
+C 3 HOH 38  938  38  HOH HOH A . 
+C 3 HOH 39  939  39  HOH HOH A . 
+C 3 HOH 40  940  40  HOH HOH A . 
+C 3 HOH 41  941  41  HOH HOH A . 
+C 3 HOH 42  942  42  HOH HOH A . 
+C 3 HOH 43  943  43  HOH HOH A . 
+C 3 HOH 44  944  44  HOH HOH A . 
+C 3 HOH 45  945  45  HOH HOH A . 
+C 3 HOH 46  946  46  HOH HOH A . 
+C 3 HOH 47  947  47  HOH HOH A . 
+C 3 HOH 48  948  48  HOH HOH A . 
+C 3 HOH 49  949  49  HOH HOH A . 
+C 3 HOH 50  950  50  HOH HOH A . 
+C 3 HOH 51  951  51  HOH HOH A . 
+C 3 HOH 52  952  52  HOH HOH A . 
+C 3 HOH 53  953  53  HOH HOH A . 
+C 3 HOH 54  954  54  HOH HOH A . 
+C 3 HOH 55  955  55  HOH HOH A . 
+C 3 HOH 56  956  56  HOH HOH A . 
+C 3 HOH 57  957  57  HOH HOH A . 
+C 3 HOH 58  958  58  HOH HOH A . 
+C 3 HOH 59  959  59  HOH HOH A . 
+C 3 HOH 60  960  60  HOH HOH A . 
+C 3 HOH 61  961  61  HOH HOH A . 
+C 3 HOH 62  962  62  HOH HOH A . 
+C 3 HOH 63  963  63  HOH HOH A . 
+C 3 HOH 64  964  64  HOH HOH A . 
+C 3 HOH 65  965  65  HOH HOH A . 
+C 3 HOH 66  966  66  HOH HOH A . 
+C 3 HOH 67  967  67  HOH HOH A . 
+C 3 HOH 68  968  68  HOH HOH A . 
+C 3 HOH 69  969  69  HOH HOH A . 
+C 3 HOH 70  970  70  HOH HOH A . 
+C 3 HOH 71  971  71  HOH HOH A . 
+C 3 HOH 72  972  72  HOH HOH A . 
+C 3 HOH 73  973  73  HOH HOH A . 
+C 3 HOH 74  974  74  HOH HOH A . 
+C 3 HOH 75  975  75  HOH HOH A . 
+C 3 HOH 76  976  76  HOH HOH A . 
+C 3 HOH 77  977  77  HOH HOH A . 
+C 3 HOH 78  978  78  HOH HOH A . 
+C 3 HOH 79  979  79  HOH HOH A . 
+C 3 HOH 80  980  80  HOH HOH A . 
+C 3 HOH 81  981  81  HOH HOH A . 
+C 3 HOH 82  982  82  HOH HOH A . 
+C 3 HOH 83  983  83  HOH HOH A . 
+C 3 HOH 84  984  84  HOH HOH A . 
+C 3 HOH 85  985  85  HOH HOH A . 
+C 3 HOH 86  986  86  HOH HOH A . 
+C 3 HOH 87  987  87  HOH HOH A . 
+C 3 HOH 88  988  88  HOH HOH A . 
+C 3 HOH 89  989  89  HOH HOH A . 
+C 3 HOH 90  990  90  HOH HOH A . 
+C 3 HOH 91  991  91  HOH HOH A . 
+C 3 HOH 92  992  92  HOH HOH A . 
+C 3 HOH 93  993  93  HOH HOH A . 
+C 3 HOH 94  994  94  HOH HOH A . 
+C 3 HOH 95  995  95  HOH HOH A . 
+C 3 HOH 96  996  96  HOH HOH A . 
+C 3 HOH 97  997  97  HOH HOH A . 
+C 3 HOH 98  998  98  HOH HOH A . 
+C 3 HOH 99  999  99  HOH HOH A . 
+C 3 HOH 100 1000 100 HOH HOH A . 
+C 3 HOH 101 1001 101 HOH HOH A . 
+C 3 HOH 102 1002 102 HOH HOH A . 
+C 3 HOH 103 1003 103 HOH HOH A . 
+C 3 HOH 104 1004 104 HOH HOH A . 
+C 3 HOH 105 1005 105 HOH HOH A . 
+C 3 HOH 106 1006 106 HOH HOH A . 
+C 3 HOH 107 1007 107 HOH HOH A . 
+C 3 HOH 108 1008 108 HOH HOH A . 
+C 3 HOH 109 1009 109 HOH HOH A . 
+C 3 HOH 110 1010 110 HOH HOH A . 
+C 3 HOH 111 1011 111 HOH HOH A . 
+C 3 HOH 112 1012 112 HOH HOH A . 
+C 3 HOH 113 1013 113 HOH HOH A . 
+C 3 HOH 114 1014 114 HOH HOH A . 
+C 3 HOH 115 1015 115 HOH HOH A . 
+C 3 HOH 116 1016 116 HOH HOH A . 
+C 3 HOH 117 1017 117 HOH HOH A . 
+C 3 HOH 118 1018 118 HOH HOH A . 
+C 3 HOH 119 1019 119 HOH HOH A . 
+C 3 HOH 120 1020 120 HOH HOH A . 
+C 3 HOH 121 1021 121 HOH HOH A . 
+C 3 HOH 122 1022 122 HOH HOH A . 
+C 3 HOH 123 1023 123 HOH HOH A . 
+C 3 HOH 124 1024 124 HOH HOH A . 
+C 3 HOH 125 1025 125 HOH HOH A . 
+C 3 HOH 126 1026 126 HOH HOH A . 
+C 3 HOH 127 1027 127 HOH HOH A . 
+C 3 HOH 128 1028 128 HOH HOH A . 
+C 3 HOH 129 1029 129 HOH HOH A . 
+C 3 HOH 130 1030 130 HOH HOH A . 
+C 3 HOH 131 1031 131 HOH HOH A . 
+C 3 HOH 132 1032 132 HOH HOH A . 
+C 3 HOH 133 1033 133 HOH HOH A . 
+C 3 HOH 134 1034 134 HOH HOH A . 
+C 3 HOH 135 1035 135 HOH HOH A . 
+C 3 HOH 136 1036 136 HOH HOH A . 
+C 3 HOH 137 1037 137 HOH HOH A . 
+C 3 HOH 138 1038 138 HOH HOH A . 
+C 3 HOH 139 1039 139 HOH HOH A . 
+C 3 HOH 140 1040 140 HOH HOH A . 
+C 3 HOH 141 1041 141 HOH HOH A . 
+C 3 HOH 142 1042 142 HOH HOH A . 
+C 3 HOH 143 1043 143 HOH HOH A . 
+C 3 HOH 144 1044 144 HOH HOH A . 
+C 3 HOH 145 1045 145 HOH HOH A . 
+C 3 HOH 146 1046 146 HOH HOH A . 
+C 3 HOH 147 1047 147 HOH HOH A . 
+C 3 HOH 148 1048 148 HOH HOH A . 
+C 3 HOH 149 1049 149 HOH HOH A . 
+C 3 HOH 150 1050 150 HOH HOH A . 
+C 3 HOH 151 1051 151 HOH HOH A . 
+C 3 HOH 152 1052 152 HOH HOH A . 
+C 3 HOH 153 1053 153 HOH HOH A . 
+C 3 HOH 154 1054 154 HOH HOH A . 
+C 3 HOH 155 1055 155 HOH HOH A . 
+C 3 HOH 156 1056 156 HOH HOH A . 
+C 3 HOH 157 1057 157 HOH HOH A . 
+C 3 HOH 158 1058 158 HOH HOH A . 
+C 3 HOH 159 1059 159 HOH HOH A . 
+C 3 HOH 160 1060 160 HOH HOH A . 
+C 3 HOH 161 1061 161 HOH HOH A . 
+C 3 HOH 162 1062 162 HOH HOH A . 
+C 3 HOH 163 1063 163 HOH HOH A . 
+C 3 HOH 164 1064 164 HOH HOH A . 
+C 3 HOH 165 1065 165 HOH HOH A . 
+C 3 HOH 166 1066 166 HOH HOH A . 
+C 3 HOH 167 1067 167 HOH HOH A . 
+C 3 HOH 168 1068 168 HOH HOH A . 
+C 3 HOH 169 1069 169 HOH HOH A . 
+C 3 HOH 170 1070 170 HOH HOH A . 
+C 3 HOH 171 1071 171 HOH HOH A . 
+C 3 HOH 172 1072 172 HOH HOH A . 
+C 3 HOH 173 1073 173 HOH HOH A . 
+C 3 HOH 174 1074 174 HOH HOH A . 
+C 3 HOH 175 1075 175 HOH HOH A . 
+C 3 HOH 176 1076 176 HOH HOH A . 
+C 3 HOH 177 1077 177 HOH HOH A . 
+C 3 HOH 178 1078 178 HOH HOH A . 
+C 3 HOH 179 1079 179 HOH HOH A . 
+C 3 HOH 180 1080 180 HOH HOH A . 
+C 3 HOH 181 1081 181 HOH HOH A . 
+C 3 HOH 182 1082 182 HOH HOH A . 
+C 3 HOH 183 1083 183 HOH HOH A . 
+C 3 HOH 184 1084 184 HOH HOH A . 
+C 3 HOH 185 1085 185 HOH HOH A . 
+C 3 HOH 186 1086 186 HOH HOH A . 
+C 3 HOH 187 1087 187 HOH HOH A . 
+C 3 HOH 188 1088 188 HOH HOH A . 
+C 3 HOH 189 1089 189 HOH HOH A . 
+C 3 HOH 190 1090 190 HOH HOH A . 
+C 3 HOH 191 1091 191 HOH HOH A . 
+C 3 HOH 192 1092 192 HOH HOH A . 
+C 3 HOH 193 1093 193 HOH HOH A . 
+C 3 HOH 194 1094 194 HOH HOH A . 
+C 3 HOH 195 1095 195 HOH HOH A . 
+C 3 HOH 196 1096 196 HOH HOH A . 
+C 3 HOH 197 1097 197 HOH HOH A . 
+C 3 HOH 198 1098 198 HOH HOH A . 
+C 3 HOH 199 1099 199 HOH HOH A . 
+C 3 HOH 200 1100 200 HOH HOH A . 
+C 3 HOH 201 1101 201 HOH HOH A . 
+C 3 HOH 202 1102 202 HOH HOH A . 
+C 3 HOH 203 1103 203 HOH HOH A . 
+C 3 HOH 204 1104 204 HOH HOH A . 
+C 3 HOH 205 1105 205 HOH HOH A . 
+C 3 HOH 206 1106 206 HOH HOH A . 
+C 3 HOH 207 1107 207 HOH HOH A . 
+C 3 HOH 208 1108 208 HOH HOH A . 
+C 3 HOH 209 1109 209 HOH HOH A . 
+C 3 HOH 210 1110 210 HOH HOH A . 
+C 3 HOH 211 1111 211 HOH HOH A . 
+C 3 HOH 212 1112 212 HOH HOH A . 
+C 3 HOH 213 1113 213 HOH HOH A . 
+C 3 HOH 214 1114 214 HOH HOH A . 
+C 3 HOH 215 1115 215 HOH HOH A . 
+C 3 HOH 216 1116 216 HOH HOH A . 
+C 3 HOH 217 1117 217 HOH HOH A . 
+C 3 HOH 218 1118 218 HOH HOH A . 
+C 3 HOH 219 1119 219 HOH HOH A . 
+C 3 HOH 220 1120 220 HOH HOH A . 
+C 3 HOH 221 1121 221 HOH HOH A . 
+C 3 HOH 222 1122 222 HOH HOH A . 
+C 3 HOH 223 1123 223 HOH HOH A . 
+C 3 HOH 224 1124 224 HOH HOH A . 
+C 3 HOH 225 1125 225 HOH HOH A . 
+C 3 HOH 226 1126 226 HOH HOH A . 
+C 3 HOH 227 1127 227 HOH HOH A . 
+C 3 HOH 228 1128 228 HOH HOH A . 
+C 3 HOH 229 1129 229 HOH HOH A . 
+C 3 HOH 230 1130 230 HOH HOH A . 
+C 3 HOH 231 1131 231 HOH HOH A . 
+C 3 HOH 232 1132 232 HOH HOH A . 
+C 3 HOH 233 1133 233 HOH HOH A . 
+C 3 HOH 234 1134 234 HOH HOH A . 
+C 3 HOH 235 1135 235 HOH HOH A . 
+C 3 HOH 236 1136 236 HOH HOH A . 
+C 3 HOH 237 1137 237 HOH HOH A . 
+C 3 HOH 238 1138 238 HOH HOH A . 
+C 3 HOH 239 1139 239 HOH HOH A . 
+C 3 HOH 240 1140 240 HOH HOH A . 
+C 3 HOH 241 1141 241 HOH HOH A . 
+C 3 HOH 242 1142 242 HOH HOH A . 
+C 3 HOH 243 1143 243 HOH HOH A . 
+C 3 HOH 244 1144 244 HOH HOH A . 
+C 3 HOH 245 1145 245 HOH HOH A . 
+C 3 HOH 246 1146 246 HOH HOH A . 
+C 3 HOH 247 1147 247 HOH HOH A . 
+C 3 HOH 248 1148 248 HOH HOH A . 
+C 3 HOH 249 1149 249 HOH HOH A . 
+C 3 HOH 250 1150 250 HOH HOH A . 
+C 3 HOH 251 1151 251 HOH HOH A . 
+C 3 HOH 252 1152 252 HOH HOH A . 
+C 3 HOH 253 1153 253 HOH HOH A . 
+C 3 HOH 254 1154 254 HOH HOH A . 
+C 3 HOH 255 1155 255 HOH HOH A . 
+C 3 HOH 256 1156 256 HOH HOH A . 
+C 3 HOH 257 1157 257 HOH HOH A . 
+C 3 HOH 258 1158 258 HOH HOH A . 
+C 3 HOH 259 1159 259 HOH HOH A . 
+C 3 HOH 260 1160 260 HOH HOH A . 
+C 3 HOH 261 1161 261 HOH HOH A . 
+C 3 HOH 262 1162 262 HOH HOH A . 
+C 3 HOH 263 1163 263 HOH HOH A . 
+C 3 HOH 264 1164 264 HOH HOH A . 
+C 3 HOH 265 1165 265 HOH HOH A . 
+C 3 HOH 266 1166 266 HOH HOH A . 
+C 3 HOH 267 1167 267 HOH HOH A . 
+C 3 HOH 268 1168 268 HOH HOH A . 
+C 3 HOH 269 1169 269 HOH HOH A . 
+C 3 HOH 270 1170 270 HOH HOH A . 
+C 3 HOH 271 1171 271 HOH HOH A . 
+C 3 HOH 272 1172 272 HOH HOH A . 
+C 3 HOH 273 1173 273 HOH HOH A . 
+C 3 HOH 274 1174 274 HOH HOH A . 
+C 3 HOH 275 1175 275 HOH HOH A . 
+C 3 HOH 276 1176 276 HOH HOH A . 
+C 3 HOH 277 1177 277 HOH HOH A . 
+C 3 HOH 278 1178 278 HOH HOH A . 
+C 3 HOH 279 1179 279 HOH HOH A . 
+C 3 HOH 280 1180 280 HOH HOH A . 
+C 3 HOH 281 1181 281 HOH HOH A . 
+C 3 HOH 282 1182 282 HOH HOH A . 
+C 3 HOH 283 1183 283 HOH HOH A . 
+C 3 HOH 284 1184 284 HOH HOH A . 
+C 3 HOH 285 1185 285 HOH HOH A . 
+C 3 HOH 286 1186 286 HOH HOH A . 
+C 3 HOH 287 1187 287 HOH HOH A . 
+C 3 HOH 288 1188 288 HOH HOH A . 
+C 3 HOH 289 1189 289 HOH HOH A . 
+C 3 HOH 290 1190 290 HOH HOH A . 
+C 3 HOH 291 1191 291 HOH HOH A . 
+C 3 HOH 292 1192 292 HOH HOH A . 
+C 3 HOH 293 1193 293 HOH HOH A . 
+C 3 HOH 294 1194 294 HOH HOH A . 
+C 3 HOH 295 1195 295 HOH HOH A . 
+C 3 HOH 296 1196 296 HOH HOH A . 
+C 3 HOH 297 1197 297 HOH HOH A . 
+C 3 HOH 298 1198 298 HOH HOH A . 
+C 3 HOH 299 1199 299 HOH HOH A . 
+C 3 HOH 300 1200 300 HOH HOH A . 
+C 3 HOH 301 1201 301 HOH HOH A . 
+C 3 HOH 302 1202 302 HOH HOH A . 
+C 3 HOH 303 1203 303 HOH HOH A . 
+C 3 HOH 304 1204 304 HOH HOH A . 
+C 3 HOH 305 1205 305 HOH HOH A . 
+C 3 HOH 306 1206 306 HOH HOH A . 
+C 3 HOH 307 1207 307 HOH HOH A . 
+C 3 HOH 308 1208 308 HOH HOH A . 
+C 3 HOH 309 1209 309 HOH HOH A . 
+C 3 HOH 310 1210 310 HOH HOH A . 
+C 3 HOH 311 1211 311 HOH HOH A . 
+C 3 HOH 312 1212 312 HOH HOH A . 
+C 3 HOH 313 1213 313 HOH HOH A . 
+C 3 HOH 314 1214 314 HOH HOH A . 
+C 3 HOH 315 1215 315 HOH HOH A . 
+C 3 HOH 316 1216 316 HOH HOH A . 
+C 3 HOH 317 1217 317 HOH HOH A . 
+C 3 HOH 318 1218 318 HOH HOH A . 
+C 3 HOH 319 1219 319 HOH HOH A . 
+C 3 HOH 320 1220 320 HOH HOH A . 
+C 3 HOH 321 1221 321 HOH HOH A . 
+C 3 HOH 322 1222 322 HOH HOH A . 
+C 3 HOH 323 1223 323 HOH HOH A . 
+C 3 HOH 324 1224 324 HOH HOH A . 
+C 3 HOH 325 1225 325 HOH HOH A . 
+C 3 HOH 326 1226 326 HOH HOH A . 
+C 3 HOH 327 1227 327 HOH HOH A . 
+C 3 HOH 328 1228 328 HOH HOH A . 
+C 3 HOH 329 1229 329 HOH HOH A . 
+C 3 HOH 330 1230 330 HOH HOH A . 
+C 3 HOH 331 1231 331 HOH HOH A . 
+C 3 HOH 332 1232 332 HOH HOH A . 
+C 3 HOH 333 1233 333 HOH HOH A . 
+C 3 HOH 334 1234 334 HOH HOH A . 
+C 3 HOH 335 1235 335 HOH HOH A . 
+C 3 HOH 336 1236 336 HOH HOH A . 
+C 3 HOH 337 1237 337 HOH HOH A . 
+C 3 HOH 338 1238 338 HOH HOH A . 
+C 3 HOH 339 1239 339 HOH HOH A . 
+C 3 HOH 340 1240 340 HOH HOH A . 
+C 3 HOH 341 1241 341 HOH HOH A . 
+C 3 HOH 342 1242 342 HOH HOH A . 
+C 3 HOH 343 1243 343 HOH HOH A . 
+C 3 HOH 344 1244 344 HOH HOH A . 
+C 3 HOH 345 1245 345 HOH HOH A . 
+C 3 HOH 346 1246 346 HOH HOH A . 
+C 3 HOH 347 1247 347 HOH HOH A . 
+C 3 HOH 348 1248 348 HOH HOH A . 
+# 
+_pdbx_molecule_features.prd_id    PRD_900050 
+_pdbx_molecule_features.name      2-deoxy-2-fluoro-beta-cellobiose 
+_pdbx_molecule_features.type      Oligosaccharide 
+_pdbx_molecule_features.class     'Substrate analog' 
+_pdbx_molecule_features.details   oligosaccharide 
+# 
+_pdbx_molecule.instance_id   1 
+_pdbx_molecule.prd_id        PRD_900050 
+_pdbx_molecule.asym_id       B 
+# 
+_pdbx_struct_assembly.id                   1 
+_pdbx_struct_assembly.details              author_defined_assembly 
+_pdbx_struct_assembly.method_details       ? 
+_pdbx_struct_assembly.oligomeric_details   monomeric 
+_pdbx_struct_assembly.oligomeric_count     1 
+# 
+_pdbx_struct_assembly_gen.assembly_id       1 
+_pdbx_struct_assembly_gen.oper_expression   1 
+_pdbx_struct_assembly_gen.asym_id_list      A,B,C 
+# 
+_pdbx_struct_oper_list.id                   1 
+_pdbx_struct_oper_list.type                 'identity operation' 
+_pdbx_struct_oper_list.name                 1_555 
+_pdbx_struct_oper_list.symmetry_operation   x,y,z 
+_pdbx_struct_oper_list.matrix[1][1]         1.0000000000 
+_pdbx_struct_oper_list.matrix[1][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[1][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[1]            0.0000000000 
+_pdbx_struct_oper_list.matrix[2][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[2][2]         1.0000000000 
+_pdbx_struct_oper_list.matrix[2][3]         0.0000000000 
+_pdbx_struct_oper_list.vector[2]            0.0000000000 
+_pdbx_struct_oper_list.matrix[3][1]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][2]         0.0000000000 
+_pdbx_struct_oper_list.matrix[3][3]         1.0000000000 
+_pdbx_struct_oper_list.vector[3]            0.0000000000 
+# 
+loop_
+_pdbx_audit_revision_history.ordinal 
+_pdbx_audit_revision_history.data_content_type 
+_pdbx_audit_revision_history.major_revision 
+_pdbx_audit_revision_history.minor_revision 
+_pdbx_audit_revision_history.revision_date 
+1 'Structure model' 1 0 1999-07-24 
+2 'Structure model' 1 1 2008-03-25 
+3 'Structure model' 1 2 2011-07-13 
+4 'Structure model' 2 0 2020-07-29 
+5 'Structure model' 2 1 2023-08-09 
+# 
+loop_
+_pdbx_audit_revision_details.ordinal 
+_pdbx_audit_revision_details.revision_ordinal 
+_pdbx_audit_revision_details.data_content_type 
+_pdbx_audit_revision_details.provider 
+_pdbx_audit_revision_details.type 
+_pdbx_audit_revision_details.description 
+_pdbx_audit_revision_details.details 
+1 1 'Structure model' repository 'Initial release' ?                          ? 
+2 4 'Structure model' repository Remediation       'Carbohydrate remediation' ? 
+# 
+loop_
+_pdbx_audit_revision_group.ordinal 
+_pdbx_audit_revision_group.revision_ordinal 
+_pdbx_audit_revision_group.data_content_type 
+_pdbx_audit_revision_group.group 
+1  2 'Structure model' 'Version format compliance' 
+2  3 'Structure model' 'Version format compliance' 
+3  4 'Structure model' 'Atomic model'              
+4  4 'Structure model' 'Data collection'           
+5  4 'Structure model' 'Derived calculations'      
+6  4 'Structure model' 'Non-polymer description'   
+7  4 'Structure model' Other                       
+8  4 'Structure model' 'Structure summary'         
+9  5 'Structure model' 'Database references'       
+10 5 'Structure model' 'Refinement description'    
+11 5 'Structure model' 'Structure summary'         
+# 
+loop_
+_pdbx_audit_revision_category.ordinal 
+_pdbx_audit_revision_category.revision_ordinal 
+_pdbx_audit_revision_category.data_content_type 
+_pdbx_audit_revision_category.category 
+1  4 'Structure model' atom_site                     
+2  4 'Structure model' chem_comp                     
+3  4 'Structure model' entity                        
+4  4 'Structure model' entity_name_com               
+5  4 'Structure model' pdbx_branch_scheme            
+6  4 'Structure model' pdbx_chem_comp_identifier     
+7  4 'Structure model' pdbx_database_status          
+8  4 'Structure model' pdbx_entity_branch            
+9  4 'Structure model' pdbx_entity_branch_descriptor 
+10 4 'Structure model' pdbx_entity_branch_link       
+11 4 'Structure model' pdbx_entity_branch_list       
+12 4 'Structure model' pdbx_entity_nonpoly           
+13 4 'Structure model' pdbx_molecule_features        
+14 4 'Structure model' pdbx_nonpoly_scheme           
+15 4 'Structure model' struct_conn                   
+16 4 'Structure model' struct_site                   
+17 4 'Structure model' struct_site_gen               
+18 5 'Structure model' chem_comp                     
+19 5 'Structure model' database_2                    
+20 5 'Structure model' pdbx_initial_refinement_model 
+# 
+loop_
+_pdbx_audit_revision_item.ordinal 
+_pdbx_audit_revision_item.revision_ordinal 
+_pdbx_audit_revision_item.data_content_type 
+_pdbx_audit_revision_item.item 
+1  4 'Structure model' '_atom_site.B_iso_or_equiv'           
+2  4 'Structure model' '_atom_site.Cartn_x'                  
+3  4 'Structure model' '_atom_site.Cartn_y'                  
+4  4 'Structure model' '_atom_site.Cartn_z'                  
+5  4 'Structure model' '_atom_site.auth_asym_id'             
+6  4 'Structure model' '_atom_site.auth_atom_id'             
+7  4 'Structure model' '_atom_site.auth_comp_id'             
+8  4 'Structure model' '_atom_site.auth_seq_id'              
+9  4 'Structure model' '_atom_site.label_alt_id'             
+10 4 'Structure model' '_atom_site.label_atom_id'            
+11 4 'Structure model' '_atom_site.label_comp_id'            
+12 4 'Structure model' '_atom_site.occupancy'                
+13 4 'Structure model' '_atom_site.type_symbol'              
+14 4 'Structure model' '_chem_comp.formula'                  
+15 4 'Structure model' '_chem_comp.formula_weight'           
+16 4 'Structure model' '_chem_comp.id'                       
+17 4 'Structure model' '_chem_comp.mon_nstd_flag'            
+18 4 'Structure model' '_chem_comp.name'                     
+19 4 'Structure model' '_chem_comp.type'                     
+20 4 'Structure model' '_entity.pdbx_description'            
+21 4 'Structure model' '_entity.src_method'                  
+22 4 'Structure model' '_entity.type'                        
+23 4 'Structure model' '_pdbx_database_status.process_site'  
+24 5 'Structure model' '_chem_comp.pdbx_synonyms'            
+25 5 'Structure model' '_database_2.pdbx_DOI'                
+26 5 'Structure model' '_database_2.pdbx_database_accession' 
+# 
+loop_
+_software.name 
+_software.classification 
+_software.version 
+_software.citation_id 
+_software.pdbx_ordinal 
+CCP4      'model building' . ? 1 
+REFMAC    refinement       . ? 2 
+DENZO     'data reduction' . ? 3 
+SCALEPACK 'data scaling'   . ? 4 
+CCP4      phasing          . ? 5 
+# 
+_pdbx_entry_details.entry_id                 5A3H 
+_pdbx_entry_details.compound_details         
+;CEL5A IS A MEMBER OF GLYCOSIDE HYDROLASE FAMILY 5, IT IS
+ONE OF THE GH-A CLAN MEMBERS.
+
+THIS ENTRY REPRESENTS THE NATURALLY OCCURRING CATALYTIC
+CORE DOMAIN AFTER LOSS OF THE CELLULOSE-BINDING DOMAIN(S).
+;
+_pdbx_entry_details.source_details           ? 
+_pdbx_entry_details.nonpolymer_details       ? 
+_pdbx_entry_details.sequence_details         ? 
+_pdbx_entry_details.has_ligand_of_interest   ? 
+# 
+loop_
+_pdbx_validate_rmsd_bond.id 
+_pdbx_validate_rmsd_bond.PDB_model_num 
+_pdbx_validate_rmsd_bond.auth_atom_id_1 
+_pdbx_validate_rmsd_bond.auth_asym_id_1 
+_pdbx_validate_rmsd_bond.auth_comp_id_1 
+_pdbx_validate_rmsd_bond.auth_seq_id_1 
+_pdbx_validate_rmsd_bond.PDB_ins_code_1 
+_pdbx_validate_rmsd_bond.label_alt_id_1 
+_pdbx_validate_rmsd_bond.auth_atom_id_2 
+_pdbx_validate_rmsd_bond.auth_asym_id_2 
+_pdbx_validate_rmsd_bond.auth_comp_id_2 
+_pdbx_validate_rmsd_bond.auth_seq_id_2 
+_pdbx_validate_rmsd_bond.PDB_ins_code_2 
+_pdbx_validate_rmsd_bond.label_alt_id_2 
+_pdbx_validate_rmsd_bond.bond_value 
+_pdbx_validate_rmsd_bond.bond_target_value 
+_pdbx_validate_rmsd_bond.bond_deviation 
+_pdbx_validate_rmsd_bond.bond_standard_deviation 
+_pdbx_validate_rmsd_bond.linker_flag 
+1 1 CD A GLU 228 ? ? OE1 A GLU 228 ? ? 1.320 1.252 0.068 0.011 N 
+2 1 CD A GLU 228 ? ? OE2 A GLU 228 ? ? 1.370 1.252 0.118 0.011 N 
+# 
+loop_
+_pdbx_validate_rmsd_angle.id 
+_pdbx_validate_rmsd_angle.PDB_model_num 
+_pdbx_validate_rmsd_angle.auth_atom_id_1 
+_pdbx_validate_rmsd_angle.auth_asym_id_1 
+_pdbx_validate_rmsd_angle.auth_comp_id_1 
+_pdbx_validate_rmsd_angle.auth_seq_id_1 
+_pdbx_validate_rmsd_angle.PDB_ins_code_1 
+_pdbx_validate_rmsd_angle.label_alt_id_1 
+_pdbx_validate_rmsd_angle.auth_atom_id_2 
+_pdbx_validate_rmsd_angle.auth_asym_id_2 
+_pdbx_validate_rmsd_angle.auth_comp_id_2 
+_pdbx_validate_rmsd_angle.auth_seq_id_2 
+_pdbx_validate_rmsd_angle.PDB_ins_code_2 
+_pdbx_validate_rmsd_angle.label_alt_id_2 
+_pdbx_validate_rmsd_angle.auth_atom_id_3 
+_pdbx_validate_rmsd_angle.auth_asym_id_3 
+_pdbx_validate_rmsd_angle.auth_comp_id_3 
+_pdbx_validate_rmsd_angle.auth_seq_id_3 
+_pdbx_validate_rmsd_angle.PDB_ins_code_3 
+_pdbx_validate_rmsd_angle.label_alt_id_3 
+_pdbx_validate_rmsd_angle.angle_value 
+_pdbx_validate_rmsd_angle.angle_target_value 
+_pdbx_validate_rmsd_angle.angle_deviation 
+_pdbx_validate_rmsd_angle.angle_standard_deviation 
+_pdbx_validate_rmsd_angle.linker_flag 
+1 1 NE  A ARG 62  ? ? CZ A ARG 62  ? ? NH2 A ARG 62  ? ? 117.22 120.30 -3.08  0.50 N 
+2 1 CB  A ASP 144 ? ? CG A ASP 144 ? ? OD1 A ASP 144 ? ? 125.68 118.30 7.38   0.90 N 
+3 1 CB  A ASP 187 ? ? CG A ASP 187 ? ? OD1 A ASP 187 ? ? 124.51 118.30 6.21   0.90 N 
+4 1 NE  A ARG 211 ? ? CZ A ARG 211 ? ? NH1 A ARG 211 ? ? 123.53 120.30 3.23   0.50 N 
+5 1 OE1 A GLU 228 ? ? CD A GLU 228 ? ? OE2 A GLU 228 ? ? 111.03 123.30 -12.27 1.20 N 
+# 
+loop_
+_pdbx_validate_torsion.id 
+_pdbx_validate_torsion.PDB_model_num 
+_pdbx_validate_torsion.auth_comp_id 
+_pdbx_validate_torsion.auth_asym_id 
+_pdbx_validate_torsion.auth_seq_id 
+_pdbx_validate_torsion.PDB_ins_code 
+_pdbx_validate_torsion.label_alt_id 
+_pdbx_validate_torsion.phi 
+_pdbx_validate_torsion.psi 
+1 1 LEU A 103 ? ? -158.45 -81.51  
+2 1 ALA A 137 ? ? -162.30 87.98   
+3 1 ASN A 138 ? ? -35.92  -72.11  
+4 1 ASN A 168 ? ? -157.32 14.10   
+5 1 ASN A 188 ? ? -146.23 56.76   
+6 1 SER A 232 ? ? -100.06 -164.65 
+7 1 PHE A 241 ? ? -116.38 76.94   
+# 
+loop_
+_pdbx_unobs_or_zero_occ_residues.id 
+_pdbx_unobs_or_zero_occ_residues.PDB_model_num 
+_pdbx_unobs_or_zero_occ_residues.polymer_flag 
+_pdbx_unobs_or_zero_occ_residues.occupancy_flag 
+_pdbx_unobs_or_zero_occ_residues.auth_asym_id 
+_pdbx_unobs_or_zero_occ_residues.auth_comp_id 
+_pdbx_unobs_or_zero_occ_residues.auth_seq_id 
+_pdbx_unobs_or_zero_occ_residues.PDB_ins_code 
+_pdbx_unobs_or_zero_occ_residues.label_asym_id 
+_pdbx_unobs_or_zero_occ_residues.label_comp_id 
+_pdbx_unobs_or_zero_occ_residues.label_seq_id 
+1 1 Y 1 A ASP 1 ? A ASP 1 
+2 1 Y 1 A ASN 2 ? A ASN 2 
+3 1 Y 1 A ASP 3 ? A ASP 3 
+# 
+loop_
+_pdbx_branch_scheme.asym_id 
+_pdbx_branch_scheme.entity_id 
+_pdbx_branch_scheme.mon_id 
+_pdbx_branch_scheme.num 
+_pdbx_branch_scheme.pdb_asym_id 
+_pdbx_branch_scheme.pdb_mon_id 
+_pdbx_branch_scheme.pdb_seq_num 
+_pdbx_branch_scheme.auth_asym_id 
+_pdbx_branch_scheme.auth_mon_id 
+_pdbx_branch_scheme.auth_seq_num 
+_pdbx_branch_scheme.hetero 
+B 2 G2F 1 B G2F 1 ? FFC 900 n 
+B 2 BGC 2 B BGC 2 ? FFC 900 n 
+# 
+loop_
+_pdbx_chem_comp_identifier.comp_id 
+_pdbx_chem_comp_identifier.type 
+_pdbx_chem_comp_identifier.program 
+_pdbx_chem_comp_identifier.program_version 
+_pdbx_chem_comp_identifier.identifier 
+BGC 'CONDENSED IUPAC CARBOHYDRATE SYMBOL' GMML     1.0 DGlcpb            
+BGC 'COMMON NAME'                         GMML     1.0 b-D-glucopyranose 
+BGC 'IUPAC CARBOHYDRATE SYMBOL'           PDB-CARE 1.0 b-D-Glcp          
+BGC 'SNFG CARBOHYDRATE SYMBOL'            GMML     1.0 Glc               
+G2F 'IUPAC CARBOHYDRATE SYMBOL'           PDB-CARE 1.0 a-D-Glcp2fluoro   
+# 
+_pdbx_entity_branch.entity_id   2 
+_pdbx_entity_branch.type        oligosaccharide 
+# 
+loop_
+_pdbx_entity_branch_descriptor.ordinal 
+_pdbx_entity_branch_descriptor.entity_id 
+_pdbx_entity_branch_descriptor.descriptor 
+_pdbx_entity_branch_descriptor.type 
+_pdbx_entity_branch_descriptor.program 
+_pdbx_entity_branch_descriptor.program_version 
+1 2 'WURCS=2.0/2,2,1/[a2122h-1a_1-5_2*F][a2122h-1b_1-5]/1-2/a4-b1' WURCS  PDB2Glycan 1.1.0 
+2 2 '[][D-1-deoxy-Glcp2fluoro]{[(4+1)][b-D-Glcp]{}}'               LINUCS PDB-CARE   ?     
+# 
+_pdbx_entity_branch_link.link_id                    1 
+_pdbx_entity_branch_link.entity_id                  2 
+_pdbx_entity_branch_link.entity_branch_list_num_1   2 
+_pdbx_entity_branch_link.comp_id_1                  BGC 
+_pdbx_entity_branch_link.atom_id_1                  C1 
+_pdbx_entity_branch_link.leaving_atom_id_1          O1 
+_pdbx_entity_branch_link.entity_branch_list_num_2   1 
+_pdbx_entity_branch_link.comp_id_2                  G2F 
+_pdbx_entity_branch_link.atom_id_2                  O4 
+_pdbx_entity_branch_link.leaving_atom_id_2          HO4 
+_pdbx_entity_branch_link.value_order                sing 
+_pdbx_entity_branch_link.details                    ? 
+# 
+loop_
+_pdbx_entity_branch_list.entity_id 
+_pdbx_entity_branch_list.comp_id 
+_pdbx_entity_branch_list.num 
+_pdbx_entity_branch_list.hetero 
+2 G2F 1 n 
+2 BGC 2 n 
+# 
+_pdbx_entity_nonpoly.entity_id   3 
+_pdbx_entity_nonpoly.name        water 
+_pdbx_entity_nonpoly.comp_id     HOH 
+# 
+_pdbx_initial_refinement_model.id               1 
+_pdbx_initial_refinement_model.entity_id_list   ? 
+_pdbx_initial_refinement_model.type             'experimental model' 
+_pdbx_initial_refinement_model.source_name      PDB 
+_pdbx_initial_refinement_model.accession_code   1A3H 
+_pdbx_initial_refinement_model.details          'PDB ENTRY 1A3H' 
+# 

--- a/coot/gemmi-wrappers.cc
+++ b/coot/gemmi-wrappers.cc
@@ -230,6 +230,14 @@ void cif_parse_string(gemmi::cif::Document& doc, const std::string& data) {
   gemmi::cif::parse_input(doc, in);
 }
 
+int guess_coord_data_format(const std::string &file_contents) {
+    char *c_data = (char *)file_contents.c_str();
+    size_t size = file_contents.length();
+    const char* end = c_data + size;
+    gemmi::CoorFormat coor_format = gemmi::coor_format_from_content(c_data, end);
+    return int(coor_format);
+}
+
 struct SequenceResInfo {
     int resNum;
     std::string resCode;
@@ -2565,4 +2573,5 @@ GlobWalk
     function("get_atom_info_for_selection", &get_atom_info_for_selection);
     function("get_sequence_info", &get_sequence_info);
     function("get_structure_bfactors", &get_structure_bfactors);
+    function("guess_coord_data_format", &guess_coord_data_format);
 }

--- a/coot/gemmi-wrappers.cc
+++ b/coot/gemmi-wrappers.cc
@@ -247,6 +247,8 @@ std::vector<SequenceEntry> get_sequence_info(const gemmi::Structure &Structure, 
     std::vector<SequenceEntry> sequences;
     auto structure_copy = Structure;
 
+    gemmi::remove_ligands_and_waters(structure_copy);
+    structure_copy.remove_empty_chains();
     const auto models = structure_copy.models;
     for (auto modelIndex = 0; modelIndex < models.size(); modelIndex++) {
         const auto model = models[modelIndex];
@@ -254,7 +256,6 @@ std::vector<SequenceEntry> get_sequence_info(const gemmi::Structure &Structure, 
         for (auto chainIndex = 0; chainIndex < chains.size(); chainIndex++) {
             std::vector<SequenceResInfo> currentSequence;
             auto chain = chains[chainIndex];
-            gemmi::remove_ligands_and_waters(chain);
             const auto residues = chain.residues;
             const auto polymerType = gemmi::check_polymer_type(chain.get_polymer());
             for (auto residueIndex = 0; residueIndex < residues.size(); residueIndex++) {

--- a/coot/gemmi-wrappers.cc
+++ b/coot/gemmi-wrappers.cc
@@ -23,6 +23,7 @@
 #include <gemmi/gz.hpp>
 #include <gemmi/model.hpp>
 #include <gemmi/monlib.hpp>
+#include <gemmi/polyheur.hpp>
 #include <gemmi/select.hpp>
 #include <gemmi/small.hpp>
 #include <gemmi/asudata.hpp>
@@ -2521,6 +2522,7 @@ GlobWalk
     function("split_chains_by_segments", &gemmi::split_chains_by_segments);
     function("check_polymer_type", &gemmi::check_polymer_type);
     function("make_one_letter_sequence", &gemmi::make_one_letter_sequence);
+    function("gemmi_add_entity_types",select_overload<void(gemmi::Structure&, bool)>(&gemmi::add_entity_types));
     function("remove_alternative_conformations_structure",select_overload<void(gemmi::Structure&)>(&gemmi::remove_alternative_conformations));
     function("remove_alternative_conformations_model",    select_overload<void(gemmi::Model&)>(&gemmi::remove_alternative_conformations));
     function("remove_alternative_conformations_chain",    select_overload<void(gemmi::Chain&)>(&gemmi::remove_alternative_conformations));

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -279,15 +279,12 @@ class molecules_container_js : public molecules_container_t {
             return imol;
         }
 
-        void replace_molecule_by_model_from_string (int imol, const std::string &format, const std::string &pdb_string) {
+        void replace_molecule_by_model_from_string (int imol, const std::string &pdb_string) {
             std::string file_name = generate_rand_str(32);
-            if (format == "mmcif") {
+            if (pdb_string.find("data_") == 0) {
                 file_name += ".mmcif";
-            } else if (format == "pdb") {
-                file_name += ".pdb";
             } else {
-                std::cout << "Unrecognised format " << format << std::endl;
-                return;
+                file_name += ".pdb";
             }
             write_text_file(file_name, pdb_string);
             molecules_container_t::replace_molecule_by_model_from_file(imol, file_name); 


### PR DESCRIPTION
This update includes:
- New attribute `coordsFormat` has been added to `MoorhenMolecule` to indicate if the file format for the coordinates is either `pdb` or `mmcif`. This uses `gemmi::coor_format_from_content` to determine the format based on file contents used to create the molecule.
- If a user downloads a molecule, the downloaded file will have the same format that was originally used to create the molecule.
- Communication between libcoot API, the front-end and gemmi will be done in whatever file format was originally used to create the molecule. This means full support of `mmcif` files and long ligands won't be lost (resolves #204).
- Due to inconsistencies in the mmcif files created by `mmdb`, entities are set using `gemmi::add_entity_types(overwrite=True)` when reading mmcif files originating from libcoot api.
- Move code in `MoorhenMolecule.getLigandInfo` to C++ in `gemmi-wrappers`.