### PR TITLE
Add `setZoomAnimated` to mgWebGL

### DIFF
--- a/baby-gru/src/WebGLgComponents/mgWebGL.tsx
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.tsx
@@ -3459,20 +3459,42 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
         requestAnimationFrame(this.setOriginOrientationAndZoomFrame.bind(this,[old_x,old_y,old_z],[dx,dy,dz],oldQuat,q,oldZoom,zoomDelta,1))
     }
 
-    setOriginAnimated(o: number[]) : void {
-        const [old_x, old_y, old_z] = this.origin
-        const [new_x, new_y, new_z] = o
-        const DX = new_x - old_x
-        const DY = new_y - old_y
-        const DZ = new_z - old_z
-        const distance = Math.sqrt(DX**2 + DY**2 + DZ**2)
-        // Optimal speed is 1A per frame, with upper limit of 15 frames and lower limit of 5
-        const nFrames = Math.floor(distance / 1.5)
-        this.nAnimationFrames = nFrames > 15 ? 15 : nFrames < 5 ? 5 : nFrames
-        const dx = DX/this.nAnimationFrames
-        const dy = DY/this.nAnimationFrames
-        const dz = DZ/this.nAnimationFrames
-        requestAnimationFrame(this.drawOriginFrame.bind(this,[old_x,old_y,old_z],[dx,dy,dz],1))
+    calculateOriginDelta(newOrigin: [number, number, number], oldOrigin: [number, number, number], nFrames: number): [number, number, number] {
+        const [old_x, old_y, old_z] = oldOrigin
+        const [new_x, new_y, new_z] = newOrigin
+        const DX = (new_x - old_x) / nFrames
+        const DY = (new_y - old_y) / nFrames
+        const DZ = (new_z - old_z) / nFrames
+        return [ DX, DY, DZ ]
+    }
+
+    setOriginAndZoomAnimated(newOrigin: [number, number, number], newZoom: number) {
+        this.nAnimationFrames = 15
+        const deltaOrigin = this.calculateOriginDelta(newOrigin, this.origin, this.nAnimationFrames)
+        const deltaZoom = (newZoom - this.zoom) / this.nAnimationFrames
+        requestAnimationFrame(this.drawOriginAndZoomFrame.bind(this, this.origin, this.zoom, deltaOrigin, deltaZoom, 1))
+    }
+
+    drawOriginAndZoomFrame(oldOrigin: [number, number, number], oldZoom: number, deltaOrigin: [number, number, number], deltaZoom: number, iframe: number) {
+        const [ DX, DY, DZ ] = deltaOrigin
+        const [ X, Y, Z ] = oldOrigin
+        this.origin = [ X + iframe * DX , Y + iframe * DY, Z + iframe * DZ ]
+        this.zoom = oldZoom + deltaZoom * iframe
+        this.drawScene()
+        if (iframe < this.nAnimationFrames) {
+            requestAnimationFrame(this.drawOriginAndZoomFrame.bind(this, oldOrigin, oldZoom, deltaOrigin, deltaZoom, iframe + 1))
+        } else {
+            const zoomChanged = new CustomEvent("zoomChanged", { detail: { oldZoom, newZoom: this.zoom } })
+            const originUpdateEvent = new CustomEvent("originUpdate", { detail: {origin: this.origin} })
+            document.dispatchEvent(zoomChanged)
+            document.dispatchEvent(originUpdateEvent)
+        }
+    }
+
+    setOriginAnimated(oldOrigin: number[]) : void {
+        this.nAnimationFrames = 15
+        const [ dx, dy, dz ] = this.calculateOriginDelta(oldOrigin as [number, number, number], this.origin, this.nAnimationFrames)
+        requestAnimationFrame(this.drawOriginFrame.bind(this, [...this.origin], [dx, dy, dz], 1))
     }
 
     drawOriginFrame(oo,d,iframe){
@@ -3585,7 +3607,7 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
     setZoom(z: number, drawScene?: boolean) {
         const oldZoom = this.zoom
         this.zoom = z;
-        var zoomChanged = new CustomEvent("zoomChanged", {
+        const zoomChanged = new CustomEvent("zoomChanged", {
             "detail": {
                 oldZoom,
                 newZoom: z

--- a/baby-gru/src/components/card/MoorhenLigandCard.tsx
+++ b/baby-gru/src/components/card/MoorhenLigandCard.tsx
@@ -72,7 +72,7 @@ export const MoorhenLigandCard = (props: {
                     <Col className='col-3' style={{margin: '0', padding:'0', justifyContent: 'right', display:'flex'}}>
                         <Stack direction='vertical' gap={1} style={{display: 'flex', justifyContent: 'center'}}>
                             <Button variant="secondary" style={{marginRight:'0.5rem', display: 'flex', justifyContent: 'left'}} onClick={() => {
-                                molecule.centreOn(ligand.cid, true)
+                                molecule.centreOn(ligand.cid, true, true)
                             }}>
                                 <CenterFocusStrongOutlined style={{marginRight: '0.5rem'}}/>
                                 {ligand.cid}

--- a/baby-gru/src/components/menu-item/MoorhenCentreOnLigandMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenCentreOnLigandMenuItem.tsx
@@ -29,7 +29,7 @@ export const MoorhenCentreOnLigandMenuItem = (props: {
                                     key={`${molecule.molNo}-${ligand.cid}`}
                                     nodeId={`${molecule.molNo}-${ligand.cid}`}
                                     label={ligand.cid}
-                                    onClick={() => molecule.centreOn(ligand.cid, true)}/>
+                                    onClick={() => molecule.centreOn(ligand.cid, true, true)}/>
                             })}
                         </TreeItem>
                     })}

--- a/baby-gru/src/components/menu-item/MoorhenGoToMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenGoToMenuItem.tsx
@@ -48,7 +48,7 @@ export const MoorhenGoToMenuItem = (props: {
             return
         }
 
-        molecule.centreOn(`/${residueSpec.mol_no ? residueSpec.mol_no : '*'}/${residueSpec.chain_id}/${residueSpec.res_no}-${residueSpec.res_no}/*`)
+        molecule.centreOn(`/${residueSpec.mol_no ? residueSpec.mol_no : '*'}/${residueSpec.chain_id}/${residueSpec.res_no}-${residueSpec.res_no}/*`, true, true)
     }
 
     return <MoorhenBaseMenuItem

--- a/baby-gru/src/components/modal/MoorhenFitLigandModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenFitLigandModal.tsx
@@ -49,7 +49,7 @@ export const MoorheFitLigandModal = (props: { show: boolean; setShow: React.Disp
                     </Col>
                     <Col className='col-3' style={{margin: '0', padding:'0', justifyContent: 'right', display:'flex'}}>
                         <Tooltip title="View">
-                        <IconButton style={{marginRight:'0.5rem'}} onClick={() => newLigandMolecule.centreOn('/*/*/*/*', true)}>
+                        <IconButton style={{marginRight:'0.5rem'}} onClick={() => newLigandMolecule.centreOn('/*/*/*/*', true, true)}>
                             <CenterFocusWeakOutlined/>
                         </IconButton>
                         </Tooltip>

--- a/baby-gru/src/components/modal/MoorhenValidationToolsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenValidationToolsModal.tsx
@@ -11,7 +11,6 @@ import { MoorhenMMRRCCPlot } from "../validation-tools/MoorhenMMRRCCPlot"
 import { MoorhenWaterValidation } from "../validation-tools/MoorhenWaterValidation"
 import { MoorhenLigandValidation } from "../validation-tools/MoorhenLigandValidation"
 import { MoorhenUnmodelledBlobs } from "../validation-tools/MoorhenUnmodelledBlobs"
-import { MoorhenIrisValidation } from "../validation-tools/MoorhenIrisValidation"
 import { convertRemToPx, convertViewtoPx} from '../../utils/MoorhenUtils';
 import { useSelector } from "react-redux";
 
@@ -29,7 +28,6 @@ export const MoorhenValidationToolsModal = (props: MoorhenValidationModalProps) 
     
     const width = useSelector((state: moorhen.State) => state.sceneSettings.width)
     const height = useSelector((state: moorhen.State) => state.sceneSettings.height)
-    const devMode = useSelector((state: moorhen.State) => state.generalStates.devMode)
 
     const collectedProps = {
         sideBarWidth: convertViewtoPx(35, width), dropdownId: 1, busy: false, 
@@ -47,12 +45,6 @@ export const MoorhenValidationToolsModal = (props: MoorhenValidationModalProps) 
             {label: "MMRRCC plot", toolWidget: <MoorhenMMRRCCPlot {...collectedProps}/>},
             {label: "Water validation", toolWidget: <MoorhenWaterValidation {...collectedProps}/>}
     ]
-
-    if (devMode) {
-        toolOptions.push(
-            {label: "Iris validation", toolWidget: <MoorhenIrisValidation resizeNodeRef={resizeNodeRef} resizeTrigger={draggableResizeTrigger} {...collectedProps}/>}
-        )
-    }
 
     const handleChange = (evt: React.ChangeEvent<HTMLSelectElement>) => {
         if (evt.target.value) {

--- a/baby-gru/src/components/validation-tools/MoorhenFillMissingAtoms.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenFillMissingAtoms.tsx
@@ -69,7 +69,7 @@ export const MoorhenFillMissingAtoms = (props: Props) => {
                                 {label}
                             </Col>
                             <Col className='col-3' style={{margin: '0', padding:'0', justifyContent: 'right', display:'flex'}}>
-                                <Button style={{marginRight:'0.5rem'}} onClick={() => selectedMolecule.centreOn(`/*/${residue.chainId}/${residue.resNum}-${residue.resNum}/*`)}>
+                                <Button style={{marginRight:'0.5rem'}} onClick={() => selectedMolecule.centreOn(`/*/${residue.chainId}/${residue.resNum}-${residue.resNum}/*`, true, true)}>
                                     View
                                 </Button>
                                 <Button style={{marginRight:'0.5rem'}} onClick={() => {

--- a/baby-gru/src/components/validation-tools/MoorhenMMRRCCPlot.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenMMRRCCPlot.tsx
@@ -82,7 +82,7 @@ export const MoorhenMMRRCCPlot = (props: {
         if(selectedMolecule) {
             const clickedResidue = getResidueInfo(molecules, selectedMolecule.molNo, chainSelectRef.current.value, residueIndex)
             if (clickedResidue) {
-                selectedMolecule.centreOn(`/*/${clickedResidue.chain}/${clickedResidue.seqNum}-${clickedResidue.seqNum}/*`)
+                selectedMolecule.centreOn(`/*/${clickedResidue.chain}/${clickedResidue.seqNum}-${clickedResidue.seqNum}/*`, true, true)
             }
         }
     }

--- a/baby-gru/src/components/validation-tools/MoorhenRamachandran.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenRamachandran.tsx
@@ -474,7 +474,7 @@ export const MoorhenRamachandran = (props: Props) => {
             return
         }
 
-        molecules[selectedMoleculeIndex].centreOn(`/*/${clickedResidue.chain}/${clickedResidue.seqNum}-${clickedResidue.seqNum}/*`)
+        molecules[selectedMoleculeIndex].centreOn(`/*/${clickedResidue.chain}/${clickedResidue.seqNum}-${clickedResidue.seqNum}/*`, true, true)
 
     }, [clickedResidue])
 

--- a/baby-gru/src/components/validation-tools/MoorhenValidation.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenValidation.tsx
@@ -145,7 +145,7 @@ export const MoorhenValidation = (props: Props) => {
             if(selectedMolecule) {
                 const clickedResidue = getResidueInfo(molecules, selectedMolecule.molNo, selectedChain, residueIndex)
                 if (clickedResidue) {
-                    selectedMolecule.centreOn(`/*/${clickedResidue.chain}/${clickedResidue.seqNum}-${clickedResidue.seqNum}/*`)
+                    selectedMolecule.centreOn(`/*/${clickedResidue.chain}/${clickedResidue.seqNum}-${clickedResidue.seqNum}/*`, true, true)
                 }
             }
         }

--- a/baby-gru/src/components/validation-tools/MoorhenWaterValidation.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenWaterValidation.tsx
@@ -39,7 +39,7 @@ export const MoorhenWaterValidation = (props: Props) => {
         const selectedMolecule = molecules.find(molecule => molecule.molNo === selectedModel)
         if (selectedMolecule) {
             const cid = `/${water.model_number}/${water.chain_id}/${water.res_no}`
-            await selectedMolecule.centreOn(cid, true)
+            await selectedMolecule.centreOn(cid, true, true)
         }
     }, [molecules])
 

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -95,7 +95,7 @@ declare module 'moorhen' {
         fetchDefaultColourRules(): Promise<void>;
         fetchIfDirtyAndDraw(arg0: string): Promise<void>;
         drawEnvironment: (cid: string, labelled?: boolean) => Promise<void>;
-        centreOn: (selectionCid?: string, animate?: boolean) => Promise<void>;
+        centreOn: (selectionCid?: string, animate?: boolean, setZoom?: boolean) => Promise<void>;
         drawHover: (cid: string) => Promise<void>;
         drawResidueSelection: (cid: string) => Promise<void>;
         clearBuffersOfStyle: (style: string) => void;

--- a/baby-gru/src/types/mgWebGL.d.ts
+++ b/baby-gru/src/types/mgWebGL.d.ts
@@ -18,7 +18,8 @@ export namespace webGL {
         createIndexBuffer(tri: number[]) : void;
         createSizeBuffer(tri: number[]) : void;
         addSupplementaryInfo(info: any, name: string) : void;
-
+        setZoomAnimated(newZoom: number): void;
+        drawZoomFrame(oldZoom: number, newZoom: number, iframe: number): void;
         createInstanceSizesBuffer(tri: number[]) : void;
         createVertexBuffer(tri: number[]) : void;
         createRealNormalBuffer(tri: number[]) : void;
@@ -115,7 +116,7 @@ export namespace webGL {
         appendOtherData(jsondata: any, skipRebuild?: boolean, name?: string) : any;
         setZoom(z: number, drawScene?: boolean);
         setOriginOrientationAndZoomAnimated(o: number[],q: quat4,z: number) : void;
-        setOriginAnimated(o: number[], doDrawScene=true) : void;
+        setOriginAnimated(o: number[]) : void;
         initTextureFramebuffer() : void;
         clearMeasureCylinderBuffers() : void;
         getFrontAndBackPos(event: KeyboardEvent) : [number[], number[], number, number];

--- a/baby-gru/src/types/mgWebGL.d.ts
+++ b/baby-gru/src/types/mgWebGL.d.ts
@@ -18,6 +18,9 @@ export namespace webGL {
         createIndexBuffer(tri: number[]) : void;
         createSizeBuffer(tri: number[]) : void;
         addSupplementaryInfo(info: any, name: string) : void;
+        calculateOriginDelta(newOrigin: [number, number, number], oldOrigin: [number, number, number], nFrames: number): [number, number, number];
+        setOriginAndZoomAnimated(newOrigin: [number, number, number], newZoom: number): void;
+        drawOriginAndZoomFrame(oldOrigin: [number, number, number], oldZoom: number, deltaOrigin: [number, number, number], deltaZoom: number, iframe: number): void;
         setZoomAnimated(newZoom: number): void;
         drawZoomFrame(oldZoom: number, newZoom: number, iframe: number): void;
         createInstanceSizesBuffer(tri: number[]) : void;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -137,7 +137,7 @@ export namespace moorhen {
         fetchDefaultColourRules(): Promise<void>;
         fetchIfDirtyAndDraw(arg0: string): Promise<void>;
         drawEnvironment: (cid: string, labelled?: boolean) => Promise<void>;
-        centreOn: (selectionCid?: string, animate?: boolean) => Promise<void>;
+        centreOn: (selectionCid?: string, animate?: boolean, setZoom?: boolean) => Promise<void>;
         drawHover: (cid: string) => Promise<void>;
         drawResidueSelection: (cid: string) => Promise<void>;
         clearBuffersOfStyle: (style: string) => void;

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -422,7 +422,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         if (doRecentre) {
             newMolecule.setAtomsDirty(true)
             await newMolecule.fetchIfDirtyAndDraw(style)
-            await newMolecule.centreOn()
+            await newMolecule.centreOn('/*/*/*/*', true, true)
         }
         return newMolecule
     }
@@ -763,7 +763,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @param {string} selectionCid - CID selection for the residue to centre the view on
      * @param {boolean} [animate=true] - Indicates whether the change will be animated
      */
-    async centreOn(selectionCid: string = '/*/*/*/*', animate: boolean = true): Promise<void> {
+    async centreOn(selectionCid: string = '/*/*/*/*', animate: boolean = true, setZoom: boolean = false): Promise<void> {
         if (this.atomsDirty) {
             await this.updateAtoms()
         }
@@ -778,8 +778,10 @@ export class MoorhenMolecule implements moorhen.Molecule {
         let selectionCentre = centreOnGemmiAtoms(selectionAtoms)
 
         if (animate) {
+            if (setZoom) this.glRef.current.setZoomAnimated(0.4)
             this.glRef.current.setOriginAnimated(selectionCentre);
         } else {
+            if (setZoom) this.glRef.current.setZoom(0.4)
             this.glRef.current.setOrigin(selectionCentre);
         }
     }

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -777,12 +777,15 @@ export class MoorhenMolecule implements moorhen.Molecule {
 
         let selectionCentre = centreOnGemmiAtoms(selectionAtoms)
 
-        if (animate) {
-            if (setZoom) this.glRef.current.setZoomAnimated(0.4)
-            this.glRef.current.setOriginAnimated(selectionCentre);
+        if (animate && setZoom) {
+            this.glRef.current.setOriginAndZoomAnimated(selectionCentre, 0.4)
+        } else if (animate) {
+            this.glRef.current.setOriginAnimated(selectionCentre)
+        } else if (setZoom) {
+            this.glRef.current.setOrigin(selectionCentre)
+            this.glRef.current.setZoom(0.4)
         } else {
-            if (setZoom) this.glRef.current.setZoom(0.4)
-            this.glRef.current.setOrigin(selectionCentre);
+            this.glRef.current.setOrigin(selectionCentre)
         }
     }
 


### PR DESCRIPTION
This update adds a new method `setZoomAnimated` and makes use of it when centering on ligands and specific residues to set the zoom level.