### PR TITLE
Add B-Factor smoothing to gaussian surfaces

### DIFF
--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moorhen",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "private": false,
   "main": "moorhen.js",
   "types": "./types/main.d.ts",

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -95,6 +95,7 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
     const [surfaceLevel, setSurfaceLevel] = useState<number>(4.0)
     const [surfaceRadius, setSurfaceRadius] = useState<number>(5.0)
     const [surfaceGridScale, setSurfaceGridScale] = useState<number>(0.7)
+    const [surfaceBFactor, setSurfaceBFactor] = useState<number>(100)
     const [symmetryRadius, setSymmetryRadius] = useState<number>(25.0)
 
     useImperativeHandle(cardRef, () => ({
@@ -114,8 +115,8 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
     }
 
     const gaussianSettingsProps = {
-        surfaceSigma, setSurfaceSigma, surfaceLevel, setSurfaceLevel,
-        surfaceRadius, setSurfaceRadius, surfaceGridScale, setSurfaceGridScale
+        surfaceSigma, setSurfaceSigma, surfaceLevel, setSurfaceLevel, surfaceBFactor,
+        setSurfaceBFactor, surfaceRadius, setSurfaceRadius, surfaceGridScale, setSurfaceGridScale
     }
 
     const redrawMolIfDirty = async (representationIds: string[]) => {
@@ -328,6 +329,25 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
         }
 
     }, [surfaceGridScale]);
+
+    useEffect(() => {
+        if (surfaceBFactor === null) {
+            return
+        }
+
+        const representations = props.molecule.representations.filter(representation => representation.visible && representation.style === 'gaussian')
+
+        if (isVisible && representations.length > 0 && props.molecule.gaussianSurfaceSettings.bFactor !== surfaceBFactor) {
+            props.molecule.gaussianSurfaceSettings.bFactor = surfaceBFactor
+            isDirty.current = true
+            if (!busyRedrawing.current) {
+                redrawMolIfDirty(representations.map(representation => representation.uniqueId))
+            }
+        } else {
+            props.molecule.gaussianSurfaceSettings.bFactor = surfaceBFactor
+        }
+
+    }, [surfaceBFactor]);
 
     useEffect(() => {
         if (isVisible !== props.molecule.isVisible) {

--- a/baby-gru/src/components/card/MoorhenMoleculeRepresentationSettingsCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeRepresentationSettingsCard.tsx
@@ -26,6 +26,8 @@ export const MoorhenMoleculeRepresentationSettingsCard = (props: {
         setSurfaceRadius: React.Dispatch<React.SetStateAction<number>>;
         surfaceGridScale: number;
         setSurfaceGridScale: React.Dispatch<React.SetStateAction<number>>;
+        surfaceBFactor: number;
+        setSurfaceBFactor: React.Dispatch<React.SetStateAction<number>>;
     };
     bondSettingsProps: {
         bondWidth: number;
@@ -47,8 +49,8 @@ export const MoorhenMoleculeRepresentationSettingsCard = (props: {
     } = props.bondSettingsProps
 
     const {
-        surfaceSigma, setSurfaceSigma, surfaceLevel, setSurfaceLevel,
-        surfaceRadius, setSurfaceRadius, surfaceGridScale, setSurfaceGridScale
+        surfaceSigma, setSurfaceSigma, surfaceLevel, setSurfaceLevel, surfaceBFactor,
+        surfaceRadius, setSurfaceRadius, surfaceGridScale, setSurfaceGridScale, setSurfaceBFactor
     } = props.gaussianSettingsProps
 
     const {
@@ -187,6 +189,17 @@ export const MoorhenMoleculeRepresentationSettingsCard = (props: {
                         incrementButton={getSliderButton(surfaceGridScale, setSurfaceGridScale, 0.1)}
                         minVal={0.01}
                         maxVal={1.5}
+                        logScale={false}/>
+                    <MoorhenSlider 
+                        sliderTitle="Gauss. Surf. B-Factor"
+                        initialValue={surfaceBFactor}
+                        externalValue={surfaceBFactor}
+                        setExternalValue={setSurfaceBFactor} 
+                        showMinMaxVal={false}
+                        decrementButton={getSliderButton(surfaceBFactor, setSurfaceBFactor, -10)}
+                        incrementButton={getSliderButton(surfaceBFactor, setSurfaceBFactor, 10)}
+                        minVal={0}
+                        maxVal={100}
                         logScale={false}/>
                 </div>
                 <div style={{paddingLeft: '2rem', paddingRight: '2rem', paddingTop: '0.5rem', paddingBottom: '0.5rem', borderStyle: 'solid', borderWidth: '1px', borderColor: 'grey', borderRadius: '1.5rem'}}>

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -134,6 +134,7 @@ declare module 'moorhen' {
             countourLevel: number;
             boxRadius: number;
             gridScale: number;
+            bFactor: number;
         };
         isDarkBackground: boolean;
         representations: _moorhen.MoleculeRepresentation[];

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -175,6 +175,7 @@ export namespace moorhen {
             countourLevel: number;
             boxRadius: number;
             gridScale: number;
+            bFactor: number;
         };
         isDarkBackground: boolean;
         representations: MoleculeRepresentation[];

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -72,6 +72,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         countourLevel: number;
         boxRadius: number;
         gridScale: number;
+        bFactor: number;
     };
     isDarkBackground: boolean;
     defaultBondOptions: moorhen.cootBondOptions;
@@ -115,7 +116,8 @@ export class MoorhenMolecule implements moorhen.Molecule {
             sigma: 4.4,
             countourLevel: 4.0,
             boxRadius: 5.0,
-            gridScale: 0.7
+            gridScale: 0.7,
+            bFactor: 100
         }
         this.defaultBondOptions = {
             smoothness: 1,

--- a/baby-gru/src/utils/MoorhenMoleculeRepresentation.ts
+++ b/baby-gru/src/utils/MoorhenMoleculeRepresentation.ts
@@ -659,7 +659,8 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
                 this.parentMolecule.molNo, this.parentMolecule.gaussianSurfaceSettings.sigma,
                 this.parentMolecule.gaussianSurfaceSettings.countourLevel,
                 this.parentMolecule.gaussianSurfaceSettings.boxRadius,
-                this.parentMolecule.gaussianSurfaceSettings.gridScale
+                this.parentMolecule.gaussianSurfaceSettings.gridScale,
+                this.parentMolecule.gaussianSurfaceSettings.bFactor
             ]
         }, false) as moorhen.WorkerResponse<libcootApi.InstancedMeshJS>
         try {


### PR DESCRIPTION
After this update Moorhen makes use o the additional argument in `molecules_container.get_gaussian_surface()` to apply FFT B-factor.
