### PR TITLE
Optionally normalise bfactors

### DIFF
--- a/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
+++ b/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
@@ -113,6 +113,7 @@ export const MoorhenAddCustomRepresentationCard = (props: {
                     break
                 case 'mol-symm':
                 case "b-factor":
+                case "b-factor-norm":
                 case "af2-plddt":
                     const ruleArgs = await getMultiColourRuleArgs(props.molecule, colourModeSelectRef.current.value)
                     colourRules = [{

--- a/baby-gru/src/components/card/MoorhenColourRuleCard.tsx
+++ b/baby-gru/src/components/card/MoorhenColourRuleCard.tsx
@@ -98,7 +98,7 @@ export const MoorhenColourRuleCard = (props: {
                 </>
                 : rule.ruleType === "mol-symm" ?
                     <GrainOutlined style={{height:'23px', width:'`23px', marginLeft: '0.5rem', marginRight: '0.5rem', borderStyle: 'solid', borderColor: '#ced4da', borderWidth: '3px', borderRadius: '8px'}}/>            
-                : rule.ruleType === "b-factor" ?
+                : (rule.ruleType === "b-factor" || rule.ruleType === "b-factor-norm") ?
                     <img className="colour-rule-icon" src={`${urlPrefix}/baby-gru/pixmaps/temperature.svg`} alt='b-factor' style={{height:'28px', width:'`12px', margin: '0.1rem'}}/>
                 :
                 <>

--- a/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
+++ b/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
@@ -254,6 +254,7 @@ export const MoorhenModifyColourRulesCard = (props: {
                             <FormSelect size="sm" ref={ruleSelectRef} defaultValue={'b-factor'} onChange={(val) => setColourProperty(val.target.value)}>
                                 {devMode && <option value={'mol-symm'} key={'mol-symm'}>Mol. Symmetry</option>}
                                 <option value={'b-factor'} key={'b-factor'}>B-Factor</option>
+                                <option value={'b-factor-norm'} key={'b-factor-norm'}>B-Factor (normalised)</option>
                                 <option value={'af2-plddt'} key={'af2-plddt'}>AF2 PLDDT</option>
                         </FormSelect>
                     </Form.Group>

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -21,7 +21,7 @@ export namespace libcootApi {
             cid: string;
         }>;
         guess_coord_data_format(coordDataString: string): number;
-        get_structure_bfactors(gemmiStructure: gemmi.Structure): emscriptem.vector<{ cid: string; bFactor: number }>;
+        get_structure_bfactors(gemmiStructure: gemmi.Structure): emscriptem.vector<{ cid: string; bFactor: number; normalised_bFactor }>;
         get_sequence_info(gemmiStructure: gemmi.Structure, molName: string): emscriptem.vector<SequenceEntry>;
         get_atom_info_for_selection(gemmiStructure: gemmi.Structure, arg1: string, arg2: string): emscriptem.vector<AtomInfo>;
         structure_is_ligand(gemmiStructure: gemmi.Structure): boolean;

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -83,7 +83,7 @@ declare module 'moorhen' {
         clearExtraRestraints(): Promise<_moorhen.WorkerResponse>;
         refineResiduesUsingAtomCid(cid: string, mode: string, ncyc?: number, redraw?: boolean): Promise<void>;
         getNcsRelatedChains(): Promise<string[][]>;
-        getResidueBFactors(): { cid: string, bFactor: number }[];
+        getResidueBFactors(): { cid: string; bFactor: number; normalised_bFactor: number }[];
         redo(): Promise<void>;
         undo(): Promise<void>;
         show(style: string, cid?: string): void;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -92,7 +92,7 @@ export namespace moorhen {
     
     interface Molecule {
         downloadAtoms(format?: 'mmcif' | 'pdb'): Promise<void>;
-        getResidueBFactors(): { cid: string, bFactor: number }[];
+        getResidueBFactors(): { cid: string; bFactor: number; normalised_bFactor: number }[];
         getNcsRelatedChains(): Promise<string[][]>;
         animateRefine(n_cyc: number, n_iteration: number, final_n_cyc?: number): Promise<void>;
         refineResidueRange(chainId: string, start: number, stop: number, ncyc?: number, redraw?: boolean): Promise<void>;

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1709,7 +1709,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @returns {object[]} An array of objects indicating the residue CID and B-factor
      */
     getResidueBFactors() {
-        let result: { cid: string, bFactor: number }[] = []
+        let result: { cid: string; bFactor: number; normalised_bFactor: number }[] = []
         const resBfactorInfoVec = window.CCP4Module.get_structure_bfactors(this.gemmiStructure)
         const resBfactorInfoVecSize = resBfactorInfoVec.size()
         for (let i = 0; i < resBfactorInfoVecSize; i++) {

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -717,8 +717,10 @@ describe("Testing MoorhenMolecule", () => {
         expect(bFactors).toHaveLength(650)
         expect(bFactors[0].cid).toBe('/1/A/4(SER)/*')
         expect(bFactors[0].bFactor).toBeCloseTo(27.18, 1)
+        expect(bFactors[0].normalised_bFactor).toBeCloseTo(39.99, 1)
         expect(bFactors[bFactors.length - 1].cid).toBe('/1/A/1248(HOH)/*')
         expect(bFactors[bFactors.length - 1].bFactor).toBeCloseTo(55.18, 1)
+        expect(bFactors[bFactors.length - 1].normalised_bFactor).toBeCloseTo(96.81, 1)
     })
 
     test("Test checkIsLigand pdb", async () => {


### PR DESCRIPTION
This update adds the option to control whether B-factors should be normalised within the molecule when coloring the molecule.