### PR TITLE
Handle changes in focus of draggable modals

### DIFF
--- a/baby-gru/public/baby-gru/moorhen.css
+++ b/baby-gru/public/baby-gru/moorhen.css
@@ -177,6 +177,10 @@ div.darkly text.end-label {fill:#FFF !important;}
 }
 
 .moorhen-draggable-card {
+  box-shadow: 0px 2px 2px -1px rgba(0,0,0,0.2),0px 3px 5px 0px rgba(0,0,0,0.14),0px 1px 9px 0px rgba(0,0,0,0.12);
+}
+
+.moorhen-draggable-card-focused {
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
 }
 

--- a/baby-gru/src/components/modal/MoorhenControlsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenControlsModal.tsx
@@ -77,6 +77,7 @@ export const MoorhenControlsModal = (props: {
     }
 
     return <MoorhenDraggableModalBase
+                modalId="show-controls-modal"
                 left={width / 5}
                 top={height / 5}
                 defaultHeight={convertViewtoPx(60, height)}

--- a/baby-gru/src/components/modal/MoorhenCreateAcedrgLinkModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenCreateAcedrgLinkModal.tsx
@@ -269,6 +269,7 @@ export const MoorhenCreateAcedrgLinkModal = (props: {
     }
 
     return <MoorhenDraggableModalBase 
+                modalId="create-acedrg-link-modal"
                 headerTitle="Create covalent link"
                 left={width / 2}
                 top={height / 3}

--- a/baby-gru/src/components/modal/MoorhenDraggableModalBase.tsx
+++ b/baby-gru/src/components/modal/MoorhenDraggableModalBase.tsx
@@ -186,7 +186,7 @@ export const MoorhenDraggableModalBase = (props: {
             <Card
                 id={modalIdRef.current}
                 onClick={() => dispatch(focusOnModal(modalIdRef.current))}
-                className="moorhen-draggable-card"
+                className={`moorhen-draggable-card${focusHierarchy[0] === modalIdRef.current ? '-focused' : ''}`}
                 ref={draggableNodeRef}
                 style={{ display: props.show ? 'block' : 'none', position: 'absolute', opacity: opacity, zIndex: currentZIndex}}
                 onMouseOver={() => setOpacity(1.0)}

--- a/baby-gru/src/components/modal/MoorhenDraggableModalBase.tsx
+++ b/baby-gru/src/components/modal/MoorhenDraggableModalBase.tsx
@@ -6,27 +6,31 @@ import { moorhen } from "../../types/moorhen";
 import { useDispatch, useSelector } from "react-redux";
 import { Resizable } from "re-resizable";
 import { setEnableAtomHovering } from "../../moorhen";
+import { focusOnModal, unFocusModal } from "../../store/activeModalsSlice";
+import { guid } from "../../utils/MoorhenUtils";
 
 /**
  * The base component used to create draggable modals.
+ * @property {string} headerTitle - The title displayed on the modal header
+ * @property {boolean} show - Indicates if the modal is to be displayed
+ * @property {function} setShow - Setter function for props.show
+ * @property {JSX.Element} body - Element rendered as the modal body
+ * @property {string} [modalId=null] - The id assigned to the modal used to keep track of the focused modal and the z-index. If empty then random string is used.
  * @property {number} [width=35] - The width of the modal measured in wh
  * @property {number} [height=45] - The height of the modal measured in vh
  * @property {number} [top=500] - The intial top location of the modal
  * @property {number} [left=500] - The intial top location of the modal
  * @property {JSX.Element[]} [additionalHeaderButtons=null] - Additional buttons rendered on the modal header
  * @property {JSX.Element[]} [additionalChildren=null] - Additional JSX elements rendered inside the modal
- * @property {string} headerTitle - The title displayed on the modal header
  * @property {string} [overflowY="scroll"] - Indicates how to handle content overflow on vertical axis
  * @property {string} [handleClassName="handle"] - The css class name for the draggable handle
- * @property {boolean} show - Indicates if the modal is to be displayed
- * @property {function} setShow - Setter function for props.show
  * @property {JSX.Element} [footer=null] - Element rendered as the modal footer
- * @property {JSX.Element} body - Element rendered as the modal body
  * @example 
  * import { MoorhenDraggableModalBase } from "moorhen";
  * 
  * const example = () => {
  *   return <MoorhenDraggableModalBase 
+ *                modalId="example-modal-id"
  *                headerTitle="Create covalent link"
  *                additionalChildren={
  *                    <Backdrop sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1 }} open={awaitAtomClick !== -1}>
@@ -59,8 +63,13 @@ import { setEnableAtomHovering } from "../../moorhen";
  * 
  */
 export const MoorhenDraggableModalBase = (props: {
-    enforceMaxBodyDimensions: boolean;
-    resizeNodeRef: null | React.RefObject<HTMLDivElement>;
+    headerTitle: string;
+    show: boolean;
+    setShow: React.Dispatch<React.SetStateAction<boolean>>;
+    body: JSX.Element | JSX.Element[];
+    modalId?: string;
+    enforceMaxBodyDimensions?: boolean;
+    resizeNodeRef?: null | React.RefObject<HTMLDivElement>;
     defaultWidth?: number;
     defaultHeight?: number;
     maxWidth?: number;
@@ -70,11 +79,7 @@ export const MoorhenDraggableModalBase = (props: {
     top?: number;
     left?: number;
     additionalHeaderButtons?: JSX.Element[];
-    headerTitle: string;
-    show: boolean;
-    setShow: React.Dispatch<React.SetStateAction<boolean>>;
-    body: JSX.Element | JSX.Element[];
-    footer: JSX.Element;
+    footer?: JSX.Element;
     additionalChildren?: JSX.Element;
     overflowY?: 'visible' | 'hidden' | 'clip' | 'scroll' | 'auto';
     overflowX?: 'visible' | 'hidden' | 'clip' | 'scroll' | 'auto';
@@ -86,11 +91,13 @@ export const MoorhenDraggableModalBase = (props: {
 }) => {
 
     const dispatch = useDispatch()
+    const focusHierarchy = useSelector((state: moorhen.State) => state.activeModals.focusHierarchy)
     const windowWidth = useSelector((state: moorhen.State) => state.sceneSettings.width)
     const windowHeight = useSelector((state: moorhen.State) => state.sceneSettings.height)
     const transparentModalsOnMouseOut = useSelector((state: moorhen.State) => state.miscAppSettings.transparentModalsOnMouseOut)
     const enableAtomHovering = useSelector((state: moorhen.State) => state.hoveringStates.enableAtomHovering)
     
+    const [currentZIndex, setCurrentZIndex] = useState<number>(999)
     const [opacity, setOpacity] = useState<number>(1.0)
     const [collapse, setCollapse] = useState<boolean>(false)
     const [position, setPosition] = useState<{x: number, y: number}>({x: props.left, y: props.top})
@@ -98,7 +105,26 @@ export const MoorhenDraggableModalBase = (props: {
     const draggableNodeRef = useRef<HTMLDivElement>();
     const resizeNodeRef = useRef<HTMLDivElement>();
     const cachedEnableAtomHovering = useRef<boolean>(false);
+    const modalIdRef = useRef<string>(props.modalId ? props.modalId : guid());
 
+    useEffect(() => {
+        const focusIndex = focusHierarchy.findIndex(item => item === modalIdRef.current)
+        setCurrentZIndex(999 - focusIndex)
+    }, [focusHierarchy])
+
+    useEffect(() => {
+        return () => {
+            dispatch(unFocusModal(modalIdRef.current))
+        }
+    }, [])
+
+    useEffect(() => {
+        if (props.show) {
+            dispatch(focusOnModal(modalIdRef.current))
+        } else {
+            dispatch(unFocusModal(modalIdRef.current))
+        }
+    }, [props.show])
 
     useEffect(() => {
         setPosition({
@@ -158,9 +184,11 @@ export const MoorhenDraggableModalBase = (props: {
                 onStart={handleStart}
                 >
             <Card
+                id={modalIdRef.current}
+                onClick={() => dispatch(focusOnModal(modalIdRef.current))}
                 className="moorhen-draggable-card"
                 ref={draggableNodeRef}
-                style={{ display: props.show ? 'block' : 'none', position: 'absolute', opacity: opacity}}
+                style={{ display: props.show ? 'block' : 'none', position: 'absolute', opacity: opacity, zIndex: currentZIndex}}
                 onMouseOver={() => setOpacity(1.0)}
                 onMouseOut={() => {
                     if(transparentModalsOnMouseOut) setOpacity(0.5)
@@ -227,6 +255,6 @@ export const MoorhenDraggableModalBase = (props: {
 MoorhenDraggableModalBase.defaultProps = { 
     showCloseButton: true, handleClassName: 'handle', additionalHeaderButtons:null, additionalChildren: null, 
     enableResize: { top: false, right: true, bottom: true, left: false, topRight: false, bottomRight: true, bottomLeft: true, topLeft: false },
-    top: 500, left: 500, overflowY: 'auto', overflowX: 'hidden', lockAspectRatio: false, maxHeight: 100, maxWidth: 100, 
+    top: 500, left: 500, overflowY: 'auto', overflowX: 'hidden', lockAspectRatio: false, maxHeight: 100, maxWidth: 100, modalId: null,
     minHeight: 100, minWidth: 100, deafultWidth: 100, defaultHeight: 100, onResizeStop: () => {}, resizeNodeRef: null, enforceMaxBodyDimensions: true,
 }

--- a/baby-gru/src/components/modal/MoorhenFindLigandModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenFindLigandModal.tsx
@@ -177,6 +177,7 @@ export const MoorheFindLigandModal = (props: { show: boolean; setShow: React.Dis
                             </Backdrop>
 
     return <MoorhenDraggableModalBase
+                modalId="find-ligand-modal"
                 left={width / 6}
                 top={height / 6}
                 show={props.show}

--- a/baby-gru/src/components/modal/MoorhenMapsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenMapsModal.tsx
@@ -54,6 +54,7 @@ export const MoorhenMapsModal = (props: MoorhenMapsModalProps) => {
     displayData.sort((a, b) => (a.props.index > b.props.index) ? 1 : ((b.props.index > a.props.index) ? -1 : 0))
 
     return <MoorhenDraggableModalBase
+                modalId="maps-modal"
                 left={width - (convertRemToPx(55) + 100)}
                 top={height / 2}
                 show={props.show}

--- a/baby-gru/src/components/modal/MoorhenModelsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenModelsModal.tsx
@@ -23,7 +23,7 @@ export const MoorhenModelsModal = (props: MoorhenModelsModalProps) => {
 
     useEffect(() => {
         cardListRef.current = cardListRef.current.slice(0, molecules.length);
-    }, [molecules]); 
+    }, [molecules])
  
     const handleCollapseAll = useCallback(() => {
         cardListRef.current.forEach(card => {
@@ -50,6 +50,7 @@ export const MoorhenModelsModal = (props: MoorhenModelsModalProps) => {
     displayData.sort((a, b) => (a.props.index > b.props.index) ? 1 : ((b.props.index > a.props.index) ? -1 : 0))
 
     return <MoorhenDraggableModalBase
+                modalId="models-modal"
                 left={width - (convertRemToPx(55) + 100)}
                 top={height / 4}
                 show={props.show}

--- a/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
@@ -287,6 +287,7 @@ export const MoorhenQuerySequenceModal = (props: {
     }, [numberOfHits])
 
     return <MoorhenDraggableModalBase
+        modalId="query-sequence-modal"
         left={width / 4}
         top={height / 4}
         defaultHeight={convertViewtoPx(10, height)}

--- a/baby-gru/src/components/modal/MoorhenScriptModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenScriptModal.tsx
@@ -46,6 +46,7 @@ export const MoorhenScriptModal = (props: {
     }, [])
 
     return <MoorhenDraggableModalBase
+                modalId="script-modal"
                 left={width / 5}
                 top={height / 6}
                 headerTitle="Interactive scripting"

--- a/baby-gru/src/components/modal/MoorhenValidationToolsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenValidationToolsModal.tsx
@@ -62,6 +62,7 @@ export const MoorhenValidationToolsModal = (props: MoorhenValidationModalProps) 
     ]
 
     return <MoorhenDraggableModalBase
+                modalId="validation-tools-modal"
                 left={width / 6}
                 top={height / 3}
                 show={props.show}

--- a/baby-gru/src/store/activeModalsSlice.ts
+++ b/baby-gru/src/store/activeModalsSlice.ts
@@ -11,8 +11,15 @@ export const activeModalsSlice = createSlice({
     showScriptingModal: false,
     showControlsModal: false,
     showFitLigandModal: false,
+    focusHierarchy: [],
   },
   reducers: {
+    focusOnModal: (state, action: { payload: string, type: string }) => {
+      return { ...state, focusHierarchy: [action.payload, ...state.focusHierarchy.filter(item => item !== action.payload)] }
+    },
+    unFocusModal: (state, action: { payload: string, type: string }) => {
+      return { ...state, focusHierarchy: [...state.focusHierarchy.filter(item => item !== action.payload)] }
+    },
     setShowModelsModal: (state, action: { payload: boolean, type: string }) => {
       return { ...state, showModelsModal: action.payload }
     },
@@ -41,8 +48,9 @@ export const activeModalsSlice = createSlice({
 })
 
 export const {
-  setShowModelsModal, setShowMapsModal, setShowCreateAcedrgLinkModal, setShowValidationModal,
-  setShowQuerySequenceModal, setShowScriptingModal, setShowControlsModal, setShowFitLigandModal
+  setShowModelsModal, setShowMapsModal, setShowCreateAcedrgLinkModal, 
+  setShowQuerySequenceModal, setShowScriptingModal, setShowControlsModal,
+  focusOnModal, unFocusModal, setShowValidationModal, setShowFitLigandModal
 } = activeModalsSlice.actions
 
 export default activeModalsSlice.reducer

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -822,6 +822,7 @@ export namespace moorhen {
             showScriptingModal: boolean;
             showControlsModal: boolean;
             showFitLigandModal: boolean;
+            focusHierarchy: string[];
         };
     }
     

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -667,7 +667,6 @@ export function rgbToHex(r: number, g: number, b: number): string {
 }
 
 const getBfactorColourRules = (bFactors: { cid: string; bFactor: number; normalised_bFactor: number }[], normaliseBFactors: boolean = true): string => {
-
     const getColour = (bFactor: number): string => {
         let r: number, g: number, b: number
         if (bFactor <= 25) {


### PR DESCRIPTION
After this update, the `zIndex` of the draggable modals changes depending on the focus. When the user clicks on a modal, that modal becomes the focused modal and is displayed on top of the others. The order of "focused" modals is kept when a new modal is shown or hidden.