### PR TITLE
Add rotate/translate to residue selection menu and add ATOM option again.

### DIFF
--- a/baby-gru/src/components/button/MoorhenRotateTranslateZoneButton.tsx
+++ b/baby-gru/src/components/button/MoorhenRotateTranslateZoneButton.tsx
@@ -1,63 +1,30 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useRef } from "react";
 import { moorhen } from "../../types/moorhen";
 import { MoorhenContextButtonBase } from "./MoorhenContextButtonBase";
-import { MoorhenNotification } from "../misc/MoorhenNotification"
-import { OverlayTrigger, Stack, Tooltip } from "react-bootstrap";
-import { getTooltipShortcutLabel } from '../../utils/MoorhenUtils';
-import { IconButton } from '@mui/material';
-import { CheckOutlined, CloseOutlined, InfoOutlined } from "@mui/icons-material";
-import { useSelector, useDispatch, batch } from 'react-redux';
+import { MoorhenAcceptRejectRotateTranslate } from '../misc/MoorhenAcceptRejectRotateTranslate';
+import { useDispatch, batch } from 'react-redux';
 import { setHoveredAtom } from "../../store/hoveringStatesSlice";
 import { setIsRotatingAtoms } from "../../store/generalStatesSlice";
 
 export const MoorhenRotateTranslateZoneButton = (props: moorhen.ContextButtonProps) => {
 
-    const fragmentMolecule = useRef<null | moorhen.Molecule>(null)
     const chosenMolecule = useRef<null | moorhen.Molecule>(null)
     const fragmentCid = useRef<null | string>(null)
     const customCid = useRef<null | string>(null)
 
-    const [tips, setTips] = useState<null | JSX.Element>(null)
-
     const dispatch = useDispatch()
-    const shortCuts = useSelector((state: moorhen.State) => state.shortcutSettings.shortCuts)
-    const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
 
     const rotateTranslateModes = ['ATOM', 'RESIDUE', 'CHAIN', 'MOLECULE']
 
-    useEffect(() => {
-        if (shortCuts) {
-            const shortCut = JSON.parse(shortCuts as string).residue_camera_wiggle
-            setTips(<>
-                <em>{"Hold <Shift><Alt> to translate"}</em>
-                <br></br>
-                <em>{`Hold ${getTooltipShortcutLabel(shortCut)} to move view`}</em>
-                <br></br>
-                <br></br>
-            </>
-            )
-        }
-    }, [shortCuts])
+    const onExit = () => {
+        props.setOverrideMenuContents(false)
+        props.setOpacity(1)
+        props.setShowContextMenu(false)
+    }
 
-    const acceptTransform = useCallback(async () => {
-        props.glRef.current.setActiveMolecule(null)
-        const transformedAtoms = fragmentMolecule.current.transformedCachedAtomsAsMovedAtoms()
-        await chosenMolecule.current.updateWithMovedAtoms(transformedAtoms)
-        fragmentMolecule.current.delete()
-        chosenMolecule.current.unhideAll()
-        const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { modifiedMolecule: chosenMolecule.current.molNo } })
-        document.dispatchEvent(scoresUpdateEvent)
-        dispatch(setIsRotatingAtoms(false))
-    }, [props, chosenMolecule, fragmentMolecule])
+    const contextMenuOverride = <MoorhenAcceptRejectRotateTranslate onExit={onExit} cidRef={fragmentCid} glRef={props.glRef} moleculeRef={chosenMolecule}/>
 
-    const rejectTransform = useCallback(async () => {
-        props.glRef.current.setActiveMolecule(null)
-        fragmentMolecule.current.delete()
-        chosenMolecule.current.unhideAll()
-        dispatch(setIsRotatingAtoms(false))
-    }, [props, chosenMolecule, fragmentMolecule])
-
-    const startRotateTranslate = async (molecule: moorhen.Molecule, chosenAtom: moorhen.ResidueSpec, selectedMode: string) => {
+    const nonCootCommand = async (molecule: moorhen.Molecule, chosenAtom: moorhen.ResidueSpec, selectedMode: string) => {
         chosenMolecule.current = molecule
         switch (selectedMode) {
             case 'ATOM':
@@ -86,69 +53,6 @@ export const MoorhenRotateTranslateZoneButton = (props: moorhen.ContextButtonPro
         if (!fragmentCid.current) {
             return
         }
-        /* Copy the component to move into a new molecule */
-        const newMolecule = await molecule.copyFragmentUsingCid(fragmentCid.current, false)
-        await newMolecule.updateAtoms()
-        /* redraw after delay so that the context menu does not refresh empty */
-        setTimeout(async () => {
-            chosenMolecule.current.hideCid(fragmentCid.current)
-            await Promise.all(molecule.representations
-                .filter(item => { return ['CRs', 'CBs', 'CAs', 'ligands', 'gaussian', 'MolecularSurface', 'VdWSurface', 'DishyBases', 'VdwSpheres', 'allHBonds', 'glycoBlocks', 'MetaBalls'].includes(item.style) })
-                .map(representation => {
-                    if (representation.buffers.length > 0 && representation.buffers[0].visible) {
-                        return newMolecule.addRepresentation(representation.style, representation.cid)
-                    } else {
-                        return Promise.resolve()
-                    }
-                }))
-            fragmentMolecule.current = newMolecule
-            props.glRef.current.setActiveMolecule(newMolecule)
-        }, 1)
-    }
-
-    const contextMenuOverride = (
-        <MoorhenNotification>
-            <Stack gap={2} direction='horizontal' style={{ width: '100%', display: 'flex', justifyContent: 'space-between' }}>
-                <OverlayTrigger
-                    placement="bottom"
-                    overlay={
-                        <Tooltip id="tip-tooltip" className="moorhen-tooltip">
-                            <div>
-                                <em>{"Hold <Shift><Alt> to translate"}</em>
-                                <br></br>
-                                <em>{shortCuts ? `Hold ${getTooltipShortcutLabel(JSON.parse(shortCuts as string).residue_camera_wiggle)} to move view` : null}</em>
-                            </div>
-                        </Tooltip>
-                    }>
-                    <InfoOutlined />
-                </OverlayTrigger>
-                <div>
-                    <span>Accept changes?</span>
-                </div>
-                <div>
-                    <IconButton style={{ padding: 0, color: isDark ? 'white' : 'grey', }} onClick={async () => {
-                        await acceptTransform()
-                        props.setOverrideMenuContents(false)
-                        props.setOpacity(1)
-                        props.setShowContextMenu(false)
-                    }}>
-                        <CheckOutlined />
-                    </IconButton>
-                    <IconButton style={{ padding: 0, color: isDark ? 'white' : 'grey' }} onClick={async () => {
-                        await rejectTransform()
-                        props.setOverrideMenuContents(false)
-                        props.setOpacity(1)
-                        props.setShowContextMenu(false)
-                    }}>
-                        <CloseOutlined />
-                    </IconButton>
-                </div>
-            </Stack>
-        </MoorhenNotification>
-    )
-
-    const nonCootCommand = async (molecule: moorhen.Molecule, chosenAtom: moorhen.ResidueSpec, selectedMode: string) => {
-        await startRotateTranslate(molecule, chosenAtom, selectedMode)
         props.setShowOverlay(false)
         props.setOverrideMenuContents(contextMenuOverride)
         batch(() => {

--- a/baby-gru/src/components/button/MoorhenRotateTranslateZoneButton.tsx
+++ b/baby-gru/src/components/button/MoorhenRotateTranslateZoneButton.tsx
@@ -23,7 +23,7 @@ export const MoorhenRotateTranslateZoneButton = (props: moorhen.ContextButtonPro
     const shortCuts = useSelector((state: moorhen.State) => state.shortcutSettings.shortCuts)
     const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
 
-    const rotateTranslateModes = ['RESIDUE', 'CHAIN', 'MOLECULE']
+    const rotateTranslateModes = ['ATOM', 'RESIDUE', 'CHAIN', 'MOLECULE']
 
     useEffect(() => {
         if (shortCuts) {

--- a/baby-gru/src/components/misc/MoorhenAcceptRejectRotateTranslate.tsx
+++ b/baby-gru/src/components/misc/MoorhenAcceptRejectRotateTranslate.tsx
@@ -1,0 +1,121 @@
+import { OverlayTrigger, Stack, Tooltip } from "react-bootstrap"
+import { MoorhenNotification } from "./MoorhenNotification"
+import { CheckOutlined, CloseOutlined, InfoOutlined } from "@mui/icons-material"
+import { IconButton } from "@mui/material"
+import { useDispatch, useSelector } from "react-redux"
+import { moorhen } from "../../types/moorhen"
+import { useCallback, useEffect, useRef, useState } from "react"
+import { getTooltipShortcutLabel } from '../../utils/MoorhenUtils';
+import { setIsRotatingAtoms } from "../../store/generalStatesSlice"
+import { webGL } from "../../types/mgWebGL"
+
+export const MoorhenAcceptRejectRotateTranslate = (props: {
+    onExit: () => void;
+    moleculeRef: React.RefObject<moorhen.Molecule>;
+    cidRef: React.RefObject<string>;
+    glRef: React.RefObject<webGL.MGWebGL>;
+}) => {
+
+    const dispatch = useDispatch()
+    const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
+    const shortCuts = useSelector((state: moorhen.State) => state.shortcutSettings.shortCuts)
+
+    const [tips, setTips] = useState<null | JSX.Element>(null)
+
+    const fragmentMoleculeRef = useRef<null | moorhen.Molecule>(null)
+
+    const stopRotateTranslate = useCallback(async (acceptTransform: boolean = false) => {
+        props.glRef.current.setActiveMolecule(null)
+        if (acceptTransform) {
+            const transformedAtoms = fragmentMoleculeRef.current.transformedCachedAtomsAsMovedAtoms()
+            await props.moleculeRef.current.updateWithMovedAtoms(transformedAtoms)
+            const scoresUpdateEvent: moorhen.ScoresUpdateEvent = new CustomEvent("scoresUpdate", { detail: { modifiedMolecule: props.moleculeRef.current.molNo } })
+            document.dispatchEvent(scoresUpdateEvent)       
+        }
+        fragmentMoleculeRef.current.delete()
+        props.moleculeRef.current.unhideAll()
+        dispatch( setIsRotatingAtoms(false) )
+    }, [props, props.moleculeRef, fragmentMoleculeRef])
+
+    useEffect(() => {
+        if (shortCuts) {
+            const shortCut = JSON.parse(shortCuts as string).residue_camera_wiggle
+            setTips(<>
+                <em>{"Hold <Shift><Alt> to translate"}</em>
+                <br></br>
+                <em>{`Hold ${getTooltipShortcutLabel(shortCut)} to move view`}</em>
+                <br></br>
+                <br></br>
+            </>
+            )
+        }
+    }, [shortCuts])
+
+    useEffect(() => {
+        const startRotateTranslate = async () => {
+            if (fragmentMoleculeRef.current || props.glRef.current.activeMolecule) {
+                console.warn('There is already an active molecule... Doing nothing.')
+                return
+            }
+            // This is only necessary in development because React.StrictMode mounts components twice
+            // @ts-ignore
+            fragmentMoleculeRef.current = 1
+            /* Copy the component to move into a new molecule */
+            const newMolecule = await props.moleculeRef.current.copyFragmentUsingCid(props.cidRef.current, false)
+            await newMolecule.updateAtoms()
+            /* redraw after delay so that the context menu does not refresh empty */
+            setTimeout(async () => {
+                props.moleculeRef.current.hideCid(props.cidRef.current)
+                await Promise.all(props.moleculeRef.current.representations
+                    .filter(item => { return ['CRs', 'CBs', 'CAs', 'ligands', 'gaussian', 'MolecularSurface', 'VdWSurface', 'DishyBases', 'VdwSpheres', 'allHBonds', 'glycoBlocks', 'MetaBalls'].includes(item.style) })
+                    .map(representation => {
+                        if (representation.buffers.length > 0 && representation.buffers[0].visible) {
+                            return newMolecule.addRepresentation(representation.style, representation.cid)
+                        } else {
+                            return Promise.resolve()
+                        }
+                    }))
+                props.glRef.current.setActiveMolecule(newMolecule)
+                fragmentMoleculeRef.current = newMolecule
+            }, 1)
+        }
+    
+        startRotateTranslate()
+    }, [])
+
+    return  <MoorhenNotification>
+                <Stack gap={2} direction='horizontal' style={{ width: '100%', display: 'flex', justifyContent: 'space-between' }}>
+                    <OverlayTrigger
+                        placement="bottom"
+                        overlay={
+                            <Tooltip id="tip-tooltip" className="moorhen-tooltip">
+                                <div>
+                                    <em>{"Hold <Shift><Alt> to translate"}</em>
+                                    <br></br>
+                                    <em>{shortCuts ? `Hold ${getTooltipShortcutLabel(JSON.parse(shortCuts as string).residue_camera_wiggle)} to move view` : null}</em>
+                                </div>
+                            </Tooltip>
+                        }>
+                        <InfoOutlined />
+                    </OverlayTrigger>
+                    <div>
+                        <span>Accept changes?</span>
+                    </div>
+                    <div>
+                        <IconButton style={{ padding: 0, color: isDark ? 'white' : 'grey', }} onClick={async () => {
+                            await stopRotateTranslate(true)
+                            props.onExit()
+                        }}>
+                            <CheckOutlined />
+                        </IconButton>
+                        <IconButton style={{ padding: 0, color: isDark ? 'white' : 'grey' }} onClick={async () => {
+                            await stopRotateTranslate()
+                            props.onExit()
+                        }}>
+                            <CloseOutlined />
+                        </IconButton>
+                    </div>
+                </Stack>
+            </MoorhenNotification>
+
+}

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -12,6 +12,7 @@ declare global {
 
 export namespace libcootApi {
     type CCP4ModuleType = {
+        parse_multi_cids(gemmiStructure: gemmi.Structure, cid: string): emscriptem.vector<string>;
         parse_ligand_dict_info(fileContent: string): emscriptem.vector<{ comp_id: string; dict_contents: string; }>;
         get_ligand_info_for_structure(gemmiStructure: gemmi.Structure): emscriptem.vector<{
             resName: string;

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1437,50 +1437,39 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @param {boolean} [redraw=true] - Indicates if the molecule should be redrawn
      */
     async hideCid(cid: string, redraw: boolean = true): Promise<void> {
-        await this.commandCentre.current.cootCommand({
-            message: 'coot_command',
-            command: "add_to_non_drawn_bonds",
-            returnType: 'status',
-            commandArgs: [this.molNo, cid],
-        }, false)
-
-        // A list with the segment CIDs
-        this.excludedSelections.push(cid)
-
-        // We also want a list with individual atom CIDs
-        const selection = new window.CCP4Module.Selection(cid)
-        const toSeqId = selection.to_seqid
-        const fromSeqId = selection.from_seqid
-        const chainIds = selection.chain_ids
-
-        let chainIdList: string[] = [chainIds.str()]
-        if (chainIds.all) {
-            chainIdList = this.sequences.map(sequence => sequence.chain)
-        }
-
-        if (!fromSeqId.empty()) {
-            chainIdList.forEach(chainName => {
-                if (toSeqId.empty()) {
-                    this.excludedCids.push(`//${chainName}/${fromSeqId.seqnum}/*`)
-                } else {
-                    for (let resNum = fromSeqId.seqnum; resNum <= toSeqId.seqnum; resNum++) {
-                        this.excludedCids.push(`//${chainName}/${resNum}/*`)
-                    }
-                }
-            })
+        if (cid.includes('||')) {
+            await Promise.all(cid.split('||').map(i => {
+                this.commandCentre.current.cootCommand({
+                    message: 'coot_command',
+                    command: "add_to_non_drawn_bonds",
+                    returnType: 'status',
+                    commandArgs: [this.molNo, i],
+                }, false)
+            }))
         } else {
-            chainIdList.forEach(chainName => {
-                const currentSequence = this.sequences.find(sequence => sequence.chain === chainName)
-                currentSequence.sequence.forEach(residue => {
-                    this.excludedCids.push(`//${chainName}/${residue.resNum}/*`)                    
-                })
-            })
+            await this.commandCentre.current.cootCommand({
+                message: 'coot_command',
+                command: "add_to_non_drawn_bonds",
+                returnType: 'status',
+                commandArgs: [this.molNo, cid],
+            }, false)    
         }
-        
-        chainIds.delete()
-        toSeqId.delete()
-        fromSeqId.delete()
-        selection.delete()
+
+        // We want a list with the CID ranges (e.g. //A/1-10)
+        if (cid.includes("||")) {
+            this.excludedSelections.push(...cid.split("||"))
+        } else {
+            this.excludedSelections.push(cid)
+        }
+
+        // We also want a list with individual residue CIDs
+        const cidVect = window.CCP4Module.parse_multi_cids(this.gemmiStructure, cid)
+        const cidVectSize = cidVect.size()
+        for (let i = 0; i < cidVectSize; i++) {
+            const cid = cidVect.get(i)
+            this.excludedCids.push(cid)
+        }
+        cidVect.delete()
 
         // Redraw to apply changes
         if (redraw) {

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -1177,6 +1177,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("get_map_histogram",&molecules_container_t::get_map_histogram)
     .function("sharpen_blur_map_with_resample",&molecules_container_t::sharpen_blur_map_with_resample)
     .function("find_water_baddies",&molecules_container_t::find_water_baddies)
+    .function("get_gphl_chem_comp_info",&molecules_container_t::get_gphl_chem_comp_info)
     ;
     class_<molecules_container_js, base<molecules_container_t>>("molecules_container_js")
     .constructor<bool>()


### PR DESCRIPTION
This update includes:
- Button to rotate/translate residue selection is now working.
- Added again the "ATOM" option to the rotate/translate context menu button.
- Refactor rotate/translate code into a separate component, which is now shared between the context menu and the residue selection menu.
- Refactor code used to parse multi CIDs with gemmi into C++.
- Add visual feedback when the CID used to create a residue selection is invalid.