### PR TITLE
Add UI for cheme. comp. info and more tests

### DIFF
--- a/baby-gru/public/baby-gru/CootWorker.ts
+++ b/baby-gru/public/baby-gru/CootWorker.ts
@@ -518,6 +518,17 @@ const residueSpecToJSArray = (residueSpecs: emscriptem.vector<libcootApi.Residue
     return returnResult
 }
 
+const stringPairVectorToJSArray = (stringPairsVector: emscriptem.vector<libcootApi.PairType<string, string>>) => {
+    let result: { first: string; second: string }[] = []
+    const stringPairsVectorSize = stringPairsVector.size()
+    for (let ic = 0; ic < stringPairsVectorSize; ic++) {
+        const data = stringPairsVector.get(ic)
+        result.push({first: data.first, second: data.second})
+    }
+    stringPairsVector.delete()
+    return result
+}
+
 const validationDataToJSArray = (validationData: libcootApi.ValidationInformationT, chainID: string | null = null): libcootApi.ValidationInformationJS[] => {
     let returnResult: { chainId: string; insCode: string; seqNum: number; restype: string; value: number; }[] = []
     const cviv = validationData.cviv
@@ -971,6 +982,9 @@ const doCootCommand = (messageData: {
             case 'status_instanced_mesh_pair':
                 returnResult = { status: cootResult.first, mesh: instancedMeshToMeshData(cootResult.second, false, false, 5) }
                 break;
+            case 'string_string_pair_vector':
+                returnResult = stringPairVectorToJSArray(cootResult)
+                break
             case 'void':
                 returnResult = null
                 break

--- a/baby-gru/src/WebGLgComponents/mgWebGL.tsx
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.tsx
@@ -3483,8 +3483,13 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
     }
 
     setOriginAnimated(oldOrigin: number[]) : void {
-        this.nAnimationFrames = 15
-        const [ dx, dy, dz ] = this.calculateOriginDelta(oldOrigin as [number, number, number], this.origin, this.nAnimationFrames)
+        const [ DX, DY, DZ ] = this.calculateOriginDelta(oldOrigin as [number, number, number], this.origin, 1)
+        const distance = Math.sqrt(DX**2 + DY**2 + DZ**2)
+        const nFrames = Math.floor(distance / 1.5)
+        this.nAnimationFrames = nFrames > 15 ? 15 : nFrames < 5 ? 5 : nFrames
+        const dx = DX/this.nAnimationFrames
+        const dy = DY/this.nAnimationFrames
+        const dz = DZ/this.nAnimationFrames
         requestAnimationFrame(this.drawOriginFrame.bind(this, [...this.origin], [dx, dy, dz], 1))
     }
 

--- a/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
+++ b/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
@@ -175,7 +175,7 @@ export const MoorhenAddCustomRepresentationCard = (props: {
                 open={props.show}
                 anchorEl={props.anchorEl.current}
                 anchorOrigin={{ vertical: 'center', horizontal: 'center' }}
-                transformOrigin={{ vertical: 'center', horizontal: 'center', }}
+                transformOrigin={{ vertical: 'center', horizontal: 'center' }}
                 sx={{'& .MuiPaper-root': {backgroundColor: isDark ? 'grey' : 'white', marginTop: '0.1rem', borderRadius: '1rem', borderStyle: 'solid', borderColor: 'grey', borderWidth: '1px'}}}
                 
             >

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -537,7 +537,7 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
                         Ligands
                     </AccordionSummary>
                     <AccordionDetails style={{padding: '0.2rem', backgroundColor: isDark ? '#ced5d6' : 'white'}}>
-                        <MoorhenLigandList setBusy={setBusyLoadingLigands} commandCentre={props.commandCentre} molecule={props.molecule} glRef={props.glRef} height={convertViewtoPx(30, height)}/>
+                        <MoorhenLigandList setBusy={setBusyLoadingLigands} commandCentre={props.commandCentre} molecule={props.molecule} glRef={props.glRef} height={convertViewtoPx(40, height)}/>
                     </AccordionDetails>
                 </Accordion>
             </div>

--- a/baby-gru/src/components/card/MoorhenMoleculeRepresentationSettingsCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeRepresentationSettingsCard.tsx
@@ -85,7 +85,6 @@ export const MoorhenMoleculeRepresentationSettingsCard = (props: {
                 anchorOrigin={{ vertical: 'center', horizontal: 'center' }}
                 transformOrigin={{ vertical: 'center', horizontal: 'center', }}
                 sx={{'& .MuiPaper-root': {backgroundColor: isDark ? 'grey' : 'white', marginTop: '0.1rem', borderRadius: '1rem', borderStyle: 'solid', borderColor: 'grey', borderWidth: '1px'}}}
-                
             >
             <Stack gap={2} direction='vertical' style={{width: '25rem', margin: '0.5rem'}}>
                 <div style={{paddingLeft: '2rem', paddingRight: '2rem', paddingTop: '0.5rem', paddingBottom: '0.5rem', borderStyle: 'solid', borderWidth: '1px', borderColor: 'grey', borderRadius: '1.5rem'}}>

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -28,6 +28,7 @@ export namespace moorhen {
         modelName: string;
         cid: string;
         svg?: string;
+        chem_comp_info?: {first: string; second: string}[];
     }
     
     type Sequence = {

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -705,9 +705,145 @@ describe('Testing molecules_container_js', () => {
 
         cleanUpVariables.push(merge_info, result_1, result_2, result_3, result_4)
     })
+
+    test("Test merge ligand and gemmi parse -mmcif", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        
+        const coordMolNo_1 = molecules_container.read_pdb('./5a3h.mmcif')
+        expect(coordMolNo_1).toBe(0)
+        
+        const result_import_dict = molecules_container.import_cif_dictionary('./LZA.cif', -999999)
+        expect(result_import_dict).toBe(1)
+        
+        const ligandMolNo = molecules_container.get_monomer_and_position_at(
+            'LZA', -999999, 0, 0, 0
+        )
+        expect(ligandMolNo).toBe(1)
+
+        const merge_info = molecules_container.merge_molecules(coordMolNo_1, ligandMolNo.toString())
+        expect(merge_info.second.size()).toBe(1)
+        
+        const mmcifString = molecules_container.get_molecule_atoms(coordMolNo_1, 'mmcif')        
+        const st = cootModule.read_structure_from_string(mmcifString, 'test-molecule')
+        cootModule.gemmi_setup_entities(st)
+        cootModule.gemmi_add_entity_types(st, true)
+        const model = st.first_model()
+        const chains = model.chains
+        const chain = chains.get(2)
+        const ligands = chain.get_ligands_const()
+        expect(ligands.length()).toBe(1)
+
+        cleanUpVariables.push(merge_info, st, model, chains, chain, ligands)
+    })
+
+    test("Test merge ligand and gemmi parse -pdb", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        
+        const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
+        expect(coordMolNo_1).toBe(0)
+        
+        const result_import_dict = molecules_container.import_cif_dictionary('./LZA.cif', -999999)
+        expect(result_import_dict).toBe(1)
+        
+        const ligandMolNo = molecules_container.get_monomer_and_position_at(
+            'LZA', -999999, 0, 0, 0
+        )
+        expect(ligandMolNo).toBe(1)
+
+        const merge_info = molecules_container.merge_molecules(coordMolNo_1, ligandMolNo.toString())
+        expect(merge_info.second.size()).toBe(1)
+        
+        const mmcifString = molecules_container.get_molecule_atoms(coordMolNo_1, 'pdb')
+        const st = cootModule.read_structure_from_string(mmcifString, 'test-molecule')
+        cootModule.gemmi_setup_entities(st)
+        cootModule.gemmi_add_entity_types(st, true)
+        const model = st.first_model()
+        const chains = model.chains
+        const chain = chains.get(2)
+        const ligands = chain.get_ligands_const()
+        expect(ligands.length()).toBe(1)
+
+        cleanUpVariables.push(merge_info, st, model, chains, chain, ligands)
+    })
+
+    test("Test merge ligand and gemmi parse cross-format 1", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        
+        const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
+        expect(coordMolNo_1).toBe(0)
+
+        const old_mmcifString = molecules_container.get_molecule_atoms(coordMolNo_1, 'mmcif')
+        const old_st = cootModule.read_structure_from_string(old_mmcifString, 'test-molecule')
+        cootModule.gemmi_setup_entities(old_st)
+        cootModule.gemmi_add_entity_types(old_st, true)
+        const old_model = old_st.first_model()
+        const old_chains = old_model.chains
+
+        const result_import_dict = molecules_container.import_cif_dictionary('./LZA.cif', -999999)
+        expect(result_import_dict).toBe(1)
+        
+        const ligandMolNo = molecules_container.get_monomer_and_position_at(
+            'LZA', -999999, 0, 0, 0
+        )
+        expect(ligandMolNo).toBe(1)
+
+        const merge_info = molecules_container.merge_molecules(coordMolNo_1, ligandMolNo.toString())
+        expect(merge_info.second.size()).toBe(1)
+        
+        const mmcifString = molecules_container.get_molecule_atoms(coordMolNo_1, 'mmcif')
+        const st = cootModule.read_structure_from_string(mmcifString, 'test-molecule')
+        cootModule.gemmi_setup_entities(st)
+        cootModule.gemmi_add_entity_types(st, true)
+        const model = st.first_model()
+        const chains = model.chains
+        expect(chains.size()).toBe(old_chains.size() + 1)
+        const chain = chains.get(2)
+        const ligands = chain.get_ligands_const()
+        expect(ligands.length()).toBe(1)
+
+        cleanUpVariables.push(merge_info, old_chains, old_model, old_st, st, model, chains, chain, ligands)
+    })
+
+    test("Test merge ligand and gemmi parse cross-format 2", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        
+        const coordMolNo_1 = molecules_container.read_pdb('./5a3h.mmcif')
+        expect(coordMolNo_1).toBe(0)
+
+        const old_mmcifString = molecules_container.get_molecule_atoms(coordMolNo_1, 'pdb')
+        const old_st = cootModule.read_structure_from_string(old_mmcifString, 'test-molecule')
+        cootModule.gemmi_setup_entities(old_st)
+        cootModule.gemmi_add_entity_types(old_st, true)
+        const old_model = old_st.first_model()
+        const old_chains = old_model.chains
+
+        const result_import_dict = molecules_container.import_cif_dictionary('./LZA.cif', -999999)
+        expect(result_import_dict).toBe(1)
+        
+        const ligandMolNo = molecules_container.get_monomer_and_position_at(
+            'LZA', -999999, 0, 0, 0
+        )
+        expect(ligandMolNo).toBe(1)
+
+        const merge_info = molecules_container.merge_molecules(coordMolNo_1, ligandMolNo.toString())
+        expect(merge_info.second.size()).toBe(1)
+        
+        const mmcifString = molecules_container.get_molecule_atoms(coordMolNo_1, 'pdb')
+        const st = cootModule.read_structure_from_string(mmcifString, 'test-molecule')
+        cootModule.gemmi_setup_entities(st)
+        cootModule.gemmi_add_entity_types(st, true)
+        const model = st.first_model()
+        const chains = model.chains
+        expect(chains.size()).toBe(old_chains.size() + 1)
+        const chain = chains.get(2)
+        const ligands = chain.get_ligands_const()
+        expect(ligands.length()).toBe(1)
+
+        cleanUpVariables.push(merge_info, old_chains, old_model, old_st, st, model, chains, chain, ligands)
+    })
 })
 
-const testDataFiles = ['5fjj.pdb', '5a3h.pdb', '5a3h.mmcif', '5a3h_no_ligand.pdb', 'LZA.cif', 'nitrobenzene.cif', 'benzene.cif', '5a3h_sigmaa.mtz', 'rnasa-1.8-all_refmac1.mtz', 'tm-A.pdb']
+const testDataFiles = ['5fjj.pdb', '5a3h.pdb', '5a3h.mmcif', '5a3h_no_ligand.pdb', 'MOI.restraints.cif', 'LZA.cif', 'nitrobenzene.cif', 'benzene.cif', '5a3h_sigmaa.mtz', 'rnasa-1.8-all_refmac1.mtz', 'tm-A.pdb']
 
 const setupFunctions = {
     removeTestDataFromFauxFS: () => {

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -583,6 +583,128 @@ describe('Testing molecules_container_js', () => {
         const pdbString_2  = molecules_container.get_molecule_atoms(coordMolNo_2, "pdb")
         expect(pdbString_2).toBe(pdbString_1)
     })
+
+    test("Test get_gphl_chem_comp_info 1 -pdb", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        
+        const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
+        expect(coordMolNo_1).toBe(0)
+        
+        const result_import_dict = molecules_container.import_cif_dictionary('./MOI.restraints.cif', -999999)
+        expect(result_import_dict).toBe(1)
+        
+        const ligandMolNo = molecules_container.get_monomer_and_position_at(
+            'MOI', -999999, 0, 0, 0
+        )
+        expect(ligandMolNo).toBe(1)
+        
+        const result_1 = molecules_container.get_gphl_chem_comp_info('MOI', coordMolNo_1)
+        expect(result_1.size()).toBe(30)
+        
+        const result_2 = molecules_container.get_gphl_chem_comp_info('MOI', ligandMolNo)
+        expect(result_2.size()).toBe(30)
+
+        const merge_info = molecules_container.merge_molecules(coordMolNo_1, ligandMolNo.toString())
+        expect(merge_info.second.size()).toBe(1)
+        
+        const result_3 = molecules_container.get_gphl_chem_comp_info('MOI', coordMolNo_1)
+        expect(result_3.size()).toBe(30)
+        
+        const result_4 = molecules_container.get_gphl_chem_comp_info('MOI', ligandMolNo)
+        expect(result_4.size()).toBe(30)
+
+        cleanUpVariables.push(merge_info, result_1, result_2, result_3, result_4)
+    })
+
+    test("Test get_gphl_chem_comp_info 1 -mmcif", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        
+        const coordMolNo_1 = molecules_container.read_pdb('./5a3h.mmcif')
+        expect(coordMolNo_1).toBe(0)
+        
+        const result_import_dict = molecules_container.import_cif_dictionary('./MOI.restraints.cif', -999999)
+        expect(result_import_dict).toBe(1)
+        
+        const ligandMolNo = molecules_container.get_monomer_and_position_at(
+            'MOI', -999999, 0, 0, 0
+        )
+        expect(ligandMolNo).toBe(1)
+        
+        const result_1 = molecules_container.get_gphl_chem_comp_info('MOI', coordMolNo_1)
+        expect(result_1.size()).toBe(30)
+        
+        const result_2 = molecules_container.get_gphl_chem_comp_info('MOI', ligandMolNo)
+        expect(result_2.size()).toBe(30)
+
+        const merge_info = molecules_container.merge_molecules(coordMolNo_1, ligandMolNo.toString())
+        expect(merge_info.second.size()).toBe(1)
+        
+        const result_3 = molecules_container.get_gphl_chem_comp_info('MOI', coordMolNo_1)
+        expect(result_3.size()).toBe(30)
+        
+        const result_4 = molecules_container.get_gphl_chem_comp_info('MOI', ligandMolNo)
+        expect(result_4.size()).toBe(30)
+
+        cleanUpVariables.push(merge_info, result_1, result_2, result_3, result_4)
+    })
+
+    test("Test get_gphl_chem_comp_info 2", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        
+        const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
+        expect(coordMolNo_1).toBe(0)
+        
+        const result_import_dict = molecules_container.import_cif_dictionary('./MOI.restraints.cif', coordMolNo_1)
+        expect(result_import_dict).toBe(1)
+        
+        const ligandMolNo = molecules_container.get_monomer_and_position_at(
+            'MOI', coordMolNo_1, 0, 0, 0
+        )
+        expect(ligandMolNo).toBe(1)
+        
+        const result_1 = molecules_container.get_gphl_chem_comp_info('MOI', coordMolNo_1)
+        expect(result_1.size()).toBe(30)
+        
+        const result_2 = molecules_container.get_gphl_chem_comp_info('MOI', ligandMolNo)
+        expect(result_2.size()).toBe(0)
+
+        const merge_info = molecules_container.merge_molecules(coordMolNo_1, ligandMolNo.toString())
+        expect(merge_info.second.size()).toBe(1)
+        
+        const result_3 = molecules_container.get_gphl_chem_comp_info('MOI', coordMolNo_1)
+        expect(result_3.size()).toBe(30)
+        
+        const result_4 = molecules_container.get_gphl_chem_comp_info('MOI', ligandMolNo)
+        expect(result_4.size()).toBe(0)
+
+        cleanUpVariables.push(merge_info, result_1, result_2, result_3, result_4)
+    })
+
+    test.skip("Test get_gphl_chem_comp_info 3", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        
+        const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
+        expect(coordMolNo_1).toBe(0)
+        
+        const result_import_dict_1 = molecules_container.import_cif_dictionary('./MOI.restraints.cif', -999999)
+        expect(result_import_dict_1).toBe(1)
+        
+        const ligandMolNo = molecules_container.get_monomer_and_position_at(
+            'MOI', -999999, 0, 0, 0
+        )
+        expect(ligandMolNo).toBe(1)
+        
+        const result_import_dict_2 = molecules_container.import_cif_dictionary('./MOI.restraints.cif', ligandMolNo)
+        expect(result_import_dict_2).toBe(1)
+
+        const result_1 = molecules_container.get_gphl_chem_comp_info('MOI', coordMolNo_1)
+        expect(result_1.size()).toBe(30)
+        
+        const result_2 = molecules_container.get_gphl_chem_comp_info('MOI', ligandMolNo)
+        expect(result_2.size()).toBe(30)
+
+        cleanUpVariables.push(merge_info, result_1, result_2, result_3, result_4)
+    })
 })
 
 const testDataFiles = ['5fjj.pdb', '5a3h.pdb', '5a3h.mmcif', '5a3h_no_ligand.pdb', 'LZA.cif', 'nitrobenzene.cif', 'benzene.cif', '5a3h_sigmaa.mtz', 'rnasa-1.8-all_refmac1.mtz', 'tm-A.pdb']

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -837,7 +837,80 @@ describe("Testing MoorhenMolecule", () => {
         expect(simpleMesh_3.data.result.result.instance_sizes).toEqual(simpleMesh_1.data.result.result.instance_sizes)
     })
 
-    test.skip("Test hideCid", async () => {
+    test("Test hideCid 1", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+        const glRef = {
+            current: new MockWebGL()
+        }
+
+        const molecule_1 = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule_1.loadToCootFromURL(fileUrl, 'mol-test-1')
+        expect(molecule_1.molNo).toBe(0)
+        await molecule_1.hideCid("A/32/*")
+        expect(molecule_1.excludedSelections).toEqual([ "A/32/*" ])
+        expect(molecule_1.excludedCids).toEqual([ '/1/A/32/*' ])
+    })
+
+    test("Test hideCid 2", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+        const glRef = {
+            current: new MockWebGL()
+        }
+
+        const molecule_1 = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule_1.loadToCootFromURL(fileUrl, 'mol-test-1')
+        expect(molecule_1.molNo).toBe(0)
+        await molecule_1.hideCid("A/32-33/*")
+        expect(molecule_1.excludedSelections).toEqual([ "A/32-33/*" ])
+        expect(molecule_1.excludedCids).toEqual([ '/1/A/32/*', '/1/A/33/*' ])
+    })
+
+    test("Test hideCid 3", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+        const glRef = {
+            current: new MockWebGL()
+        }
+
+        const molecule_1 = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule_1.loadToCootFromURL(fileUrl, 'mol-test-1')
+        expect(molecule_1.molNo).toBe(0)
+        await molecule_1.hideCid("A/32-33/*||//A/1-2")
+        expect(molecule_1.excludedSelections).toEqual([ "A/32-33/*", "//A/1-2" ])
+        expect(molecule_1.excludedCids).toEqual([ '/1/A/32/*', '/1/A/33/*', '/1/A/1/*', '/1/A/2/*' ])
+    })
+
+    test("Test hideCid 4", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+        const glRef = {
+            current: new MockWebGL()
+        }
+
+        const molecule_1 = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule_1.loadToCootFromURL(fileUrl, 'mol-test-1')
+        expect(molecule_1.molNo).toBe(0)
+        await molecule_1.hideCid("A/32-33/*")
+        await molecule_1.hideCid("A/1-2/*")
+        expect(molecule_1.excludedSelections).toEqual([ "A/32-33/*", "A/1-2/*" ])
+        expect(molecule_1.excludedCids).toEqual([ '/1/A/32/*', '/1/A/33/*', '/1/A/1/*', '/1/A/2/*' ])
+    })
+
+    test.skip("Test hideCid 5", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const commandCentre = {

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -3,7 +3,7 @@ import { MockMoorhenCommandCentre } from "../helpers/mockMoorhenCommandCentre"
 import { MockWebGL } from "../helpers/mockWebGL"
 import fetch from 'node-fetch';
 
-jest.setTimeout(40000)
+jest.setTimeout(60000)
 
 const fs = require('fs')
 const path = require('path')

--- a/baby-gru/tests/test_data/MOI.restraints.cif
+++ b/baby-gru/tests/test_data/MOI.restraints.cif
@@ -1,0 +1,418 @@
+data_comp_list
+#
+loop_
+_chem_comp.id                      
+_chem_comp.three_letter_code       
+_chem_comp.name                    
+_chem_comp.group                   
+_chem_comp.number_atoms_all        
+_chem_comp.number_atoms_nh         
+_chem_comp.desc_level              
+_chem_comp.type                    
+MOI MOI (7R,7AS,12BS)-3-METHYL-2,3,4,4A,7,7A-HEXAHYDRO-1H-4,12-METHANO[1]BENZOFURO[3,2-E]ISOQUINOLINE-7,9-DIOL NON-POLYMER 40 21 . NON-POLYMER
+#
+data_comp_MOI
+#
+loop_
+_chem_comp_atom.comp_id              
+_chem_comp_atom.atom_id              
+_chem_comp_atom.type_symbol          
+_chem_comp_atom.type_energy          
+_chem_comp_atom.partial_charge       
+_chem_comp_atom.charge               
+_chem_comp_atom.x                    
+_chem_comp_atom.y                    
+_chem_comp_atom.z                    
+MOI  C1 C CR16 -0.055 0  1.797  2.157  0.548
+MOI  C2 C  CH2 -0.011 0  0.637  1.648 -1.701
+MOI  C3 C CR66 -0.039 0  1.020  1.342 -0.272
+MOI  C4 C CR56  0.012 0  0.469  0.227  0.326
+MOI  C5 C   CT  0.048 0 -0.356 -0.844 -0.336
+MOI  C6 C  CH1  0.006 0 -1.208 -0.138 -1.416
+MOI  C7 C  CH2 -0.026 0  0.528 -1.924 -0.999
+MOI  C8 C  CH2 -0.001 0  1.358 -1.377 -2.155
+MOI  C9 C  CH3 -0.013 0  1.344 -0.069 -4.198
+MOI C10 C CR16 -0.016 0  1.945  1.897  1.904
+MOI C11 C  CR6  0.158 0  1.344  0.780  2.489
+MOI C12 C CR56  0.165 0  0.569 -0.032  1.668
+MOI C13 C  CH1  0.139 0 -1.100 -1.397  0.915
+MOI C14 C  CH1  0.110 0 -2.521 -0.796  1.113
+MOI C15 C CR16 -0.056 0 -2.760  0.498  0.390
+MOI C16 C CR16 -0.080 0 -2.194  0.791 -0.775
+MOI C17 C  CH1  0.021 0 -0.217  0.541 -2.399
+MOI  N1 N   NT -0.302 0  0.551 -0.542 -3.061
+MOI  O1 O  OH1 -0.504 0  1.516  0.510  3.810
+MOI  O2 O  OH1 -0.385 0 -2.831 -0.644  2.501
+MOI  O3 O   OC -0.482 0 -0.246 -1.069  2.072
+MOI  H1 H HCR6  0.063 0  2.303  3.018  0.127
+MOI H21 H HCH2  0.033 0  0.021  2.551 -1.669
+MOI H22 H HCH2  0.033 0  1.534  1.926 -2.259
+MOI  H6 H HCH1  0.037 0 -1.799 -0.873 -1.969
+MOI H71 H HCH2  0.029 0 -0.118 -2.720 -1.378
+MOI H72 H HCH2  0.029 0  1.200 -2.389 -0.273
+MOI H81 H HCH2  0.043 0  1.744 -2.235 -2.712
+MOI H82 H HCH2  0.043 0  2.237 -0.848 -1.778
+MOI H91 H HCH3  0.039 0  2.303  0.365 -3.903
+MOI H92 H HCH3  0.039 0  1.558 -0.906 -4.869
+MOI H93 H HCH3  0.039 0  0.800  0.665 -4.798
+MOI H10 H HCR6  0.066 0  2.534  2.568  2.518
+MOI H13 H HCH1  0.078 0 -1.160 -2.490  0.895
+MOI H14 H HCH1  0.069 0 -3.265 -1.492  0.713
+MOI H15 H HCR6  0.060 0 -3.428  1.211  0.857
+MOI H16 H HCR6  0.058 0 -2.445  1.717 -1.279
+MOI H17 H HCH1  0.048 0 -0.813  1.032 -3.172
+MOI HO1 H HOH1  0.293 0  1.016 -0.303  4.003
+MOI HO2 H HOH1  0.211 0 -2.272  0.083  2.822
+#
+loop_
+_chem_comp_bond.comp_id                             
+_chem_comp_bond.atom_id_1                           
+_chem_comp_bond.atom_id_2                           
+_chem_comp_bond.type                                
+_chem_comp_bond.aromatic                            
+_chem_comp_bond.value_dist_nucleus                  
+_chem_comp_bond.value_dist_nucleus_esd              
+_chem_comp_bond.value_dist                          
+_chem_comp_bond.value_dist_esd                      
+_chem_comp_bond.source_value_dist_nucleus           
+_chem_comp_bond.source_value_dist_nucleus_esd       
+_chem_comp_bond.source_value_dist                   
+_chem_comp_bond.source_value_dist_esd               
+MOI  C1  C3 single y 1.392 0.009 1.392 0.009 Mogul_mean_2614_hits     Mogul_sd Mogul_mean_2614_hits Mogul_sd
+MOI  C1 C10 double y 1.384 0.010 1.384 0.010 Mogul_mean_5074_hits     Mogul_sd Mogul_mean_5074_hits Mogul_sd
+MOI  C1  H1 single n 1.084 0.020 0.979 0.015  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+MOI  C2  C3 single n 1.509 0.009 1.509 0.009 Mogul_mean_1284_hits     Mogul_sd Mogul_mean_1284_hits Mogul_sd
+MOI  C2 C17 single n 1.538 0.018 1.538 0.018   Mogul_mean_99_hits     Mogul_sd   Mogul_mean_99_hits Mogul_sd
+MOI  C2 H21 single n 1.093 0.020 0.979 0.015  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+MOI  C2 H22 single n 1.093 0.020 0.979 0.015  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+MOI  C3  C4 double y 1.390 0.014 1.390 0.014  Mogul_mean_365_hits     Mogul_sd  Mogul_mean_365_hits Mogul_sd
+MOI  C4  C5 single n 1.509 0.012 1.509 0.012   Mogul_mean_80_hits     Mogul_sd   Mogul_mean_80_hits Mogul_sd
+MOI  C4 C12 single y 1.377 0.009 1.377 0.009  Mogul_mean_289_hits     Mogul_sd  Mogul_mean_289_hits Mogul_sd
+MOI  C5  C6 single n 1.540 0.010 1.540 0.010   Mogul_mean_43_hits     Mogul_sd   Mogul_mean_43_hits Mogul_sd
+MOI  C5  C7 single n 1.539 0.010 1.539 0.010   Mogul_mean_93_hits     Mogul_sd   Mogul_mean_93_hits Mogul_sd
+MOI  C5 C13 single n 1.550 0.012 1.550 0.012   Mogul_mean_62_hits     Mogul_sd   Mogul_mean_62_hits Mogul_sd
+MOI  C6 C16 single n 1.495 0.016 1.495 0.016  Mogul_mean_310_hits     Mogul_sd  Mogul_mean_310_hits Mogul_sd
+MOI  C6 C17 single n 1.540 0.017 1.540 0.017   Mogul_mean_37_hits     Mogul_sd   Mogul_mean_37_hits Mogul_sd
+MOI  C6  H6 single n 1.093 0.020 0.979 0.015  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+MOI  C7  C8 single n 1.519 0.011 1.519 0.011  Mogul_mean_734_hits     Mogul_sd  Mogul_mean_734_hits Mogul_sd
+MOI  C7 H71 single n 1.093 0.020 0.979 0.015  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+MOI  C7 H72 single n 1.093 0.020 0.979 0.015  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+MOI  C8  N1 single n 1.467 0.011 1.467 0.011  Mogul_mean_243_hits     Mogul_sd  Mogul_mean_243_hits Mogul_sd
+MOI  C8 H81 single n 1.093 0.020 0.979 0.015  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+MOI  C8 H82 single n 1.093 0.020 0.979 0.015  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+MOI  C9  N1 single n 1.462 0.014 1.462 0.014  Mogul_mean_569_hits     Mogul_sd  Mogul_mean_569_hits Mogul_sd
+MOI  C9 H91 single n 1.093 0.020 0.979 0.015  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+MOI  C9 H92 single n 1.093 0.020 0.979 0.015  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+MOI  C9 H93 single n 1.093 0.020 0.979 0.015  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+MOI C10 C11 single y 1.391 0.012 1.391 0.012 Mogul_mean_3979_hits     Mogul_sd Mogul_mean_3979_hits Mogul_sd
+MOI C10 H10 single n 1.084 0.020 0.979 0.015  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+MOI C11 C12 double y 1.394 0.017 1.394 0.017  Mogul_mean_250_hits     Mogul_sd  Mogul_mean_250_hits Mogul_sd
+MOI C11  O1 single n 1.358 0.013 1.358 0.013 Mogul_mean_3973_hits     Mogul_sd Mogul_mean_3973_hits Mogul_sd
+MOI C12  O3 single n 1.377 0.012 1.377 0.012  Mogul_mean_358_hits     Mogul_sd  Mogul_mean_358_hits Mogul_sd
+MOI C13 C14 single n 1.531 0.020 1.531 0.020   Mogul_mean_54_hits     Mogul_sd   Mogul_mean_54_hits Mogul_sd
+MOI C13  O3 single n 1.467 0.014 1.467 0.014   Mogul_mean_97_hits     Mogul_sd   Mogul_mean_97_hits Mogul_sd
+MOI C13 H13 single n 1.093 0.020 0.979 0.015  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+MOI C14 C15 single n 1.500 0.010 1.500 0.010  Mogul_mean_189_hits     Mogul_sd  Mogul_mean_189_hits Mogul_sd
+MOI C14  O2 single n 1.430 0.010 1.430 0.010  Mogul_mean_542_hits     Mogul_sd  Mogul_mean_542_hits Mogul_sd
+MOI C14 H14 single n 1.093 0.020 0.979 0.015  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+MOI C15 C16 double n 1.323 0.017 1.323 0.017 Mogul_mean_1126_hits     Mogul_sd Mogul_mean_1126_hits Mogul_sd
+MOI C15 H15 single n 1.083 0.020 0.979 0.015  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+MOI C16 H16 single n 1.083 0.020 0.979 0.015  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+MOI C17  N1 single n 1.479 0.009 1.479 0.009   Mogul_mean_89_hits     Mogul_sd   Mogul_mean_89_hits Mogul_sd
+MOI C17 H17 single n 1.093 0.020 0.979 0.015  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+MOI  O1 HO1 single n 0.973 0.020 0.850 0.020  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+MOI  O2 HO2 single n 0.972 0.020 0.850 0.020  MMFF94s_equilibrium default_to_H               ecloud   ecloud
+#
+loop_
+_chem_comp_angle.comp_id                      
+_chem_comp_angle.atom_id_1                    
+_chem_comp_angle.atom_id_2                    
+_chem_comp_angle.atom_id_3                    
+_chem_comp_angle.value_angle                  
+_chem_comp_angle.value_angle_esd              
+_chem_comp_angle.source_value_angle           
+_chem_comp_angle.source_value_angle_esd       
+MOI  C3  C1 C10 121.4 1.1     Mogul_mean_2647_hits Mogul_sd
+MOI  C3  C1  H1 120.4 3.0 MMFF94s_optimised_coords  default
+MOI C10  C1  H1 119.2 3.0 MMFF94s_optimised_coords  default
+MOI  C3  C2 C17 113.8 1.8       Mogul_mean_79_hits Mogul_sd
+MOI  C3  C2 H21 107.0 3.0 MMFF94s_optimised_coords  default
+MOI  C3  C2 H22 109.6 3.0 MMFF94s_optimised_coords  default
+MOI C17  C2 H21 107.3 3.0 MMFF94s_optimised_coords  default
+MOI C17  C2 H22 111.4 3.0 MMFF94s_optimised_coords  default
+MOI H21  C2 H22 106.4 3.0 MMFF94s_optimised_coords  default
+MOI  C1  C3  C2 121.6 2.6      Mogul_mean_904_hits Mogul_sd
+MOI  C1  C3  C4 117.1 1.7      Mogul_mean_323_hits Mogul_sd
+MOI  C2  C3  C4 118.8 2.0      Mogul_mean_213_hits Mogul_sd
+MOI  C3  C4  C5 126.7 0.6       Mogul_mean_58_hits Mogul_sd
+MOI  C3  C4 C12 123.0 1.2      Mogul_mean_200_hits Mogul_sd
+MOI  C5  C4 C12 109.3 0.7       Mogul_mean_68_hits Mogul_sd
+MOI  C4  C5  C6 106.6 1.1       Mogul_mean_43_hits Mogul_sd
+MOI  C4  C5  C7 111.7 1.2       Mogul_mean_61_hits Mogul_sd
+MOI  C4  C5 C13 100.3 1.0       Mogul_mean_49_hits Mogul_sd
+MOI  C6  C5  C7 109.2 0.8       Mogul_mean_43_hits Mogul_sd
+MOI  C6  C5 C13 116.3 1.0       Mogul_mean_42_hits Mogul_sd
+MOI  C7  C5 C13 111.9 0.6       Mogul_mean_48_hits Mogul_sd
+MOI  C5  C6 C16 109.9 0.9       Mogul_mean_42_hits Mogul_sd
+MOI  C5  C6 C17 106.8 0.4       Mogul_mean_25_hits Mogul_sd
+MOI  C5  C6  H6 109.5 3.0 MMFF94s_optimised_coords  default
+MOI C16  C6 C17 114.1 1.1       Mogul_mean_24_hits Mogul_sd
+MOI C16  C6  H6 105.4 3.0 MMFF94s_optimised_coords  default
+MOI C17  C6  H6 107.9 3.0 MMFF94s_optimised_coords  default
+MOI  C5  C7  C8 111.4 1.1       Mogul_mean_50_hits Mogul_sd
+MOI  C5  C7 H71 108.7 3.0 MMFF94s_optimised_coords  default
+MOI  C5  C7 H72 111.4 3.0 MMFF94s_optimised_coords  default
+MOI  C8  C7 H71 108.7 3.0 MMFF94s_optimised_coords  default
+MOI  C8  C7 H72 108.8 3.0 MMFF94s_optimised_coords  default
+MOI H71  C7 H72 106.5 3.0 MMFF94s_optimised_coords  default
+MOI  C7  C8  N1 111.0 1.0      Mogul_mean_133_hits Mogul_sd
+MOI  C7  C8 H81 107.7 3.0 MMFF94s_optimised_coords  default
+MOI  C7  C8 H82 110.0 3.0 MMFF94s_optimised_coords  default
+MOI  N1  C8 H81 109.5 3.0 MMFF94s_optimised_coords  default
+MOI  N1  C8 H82 111.1 3.0 MMFF94s_optimised_coords  default
+MOI H81  C8 H82 106.2 3.0 MMFF94s_optimised_coords  default
+MOI  N1  C9 H91 112.9 3.0 MMFF94s_optimised_coords  default
+MOI  N1  C9 H92 110.1 3.0 MMFF94s_optimised_coords  default
+MOI  N1  C9 H93 110.8 3.0 MMFF94s_optimised_coords  default
+MOI H91  C9 H92 107.8 3.0 MMFF94s_optimised_coords  default
+MOI H91  C9 H93 108.5 3.0 MMFF94s_optimised_coords  default
+MOI H92  C9 H93 106.4 3.0 MMFF94s_optimised_coords  default
+MOI  C1 C10 C11 120.6 0.7     Mogul_mean_3513_hits Mogul_sd
+MOI  C1 C10 H10 119.9 3.0 MMFF94s_optimised_coords  default
+MOI C11 C10 H10 119.7 3.0 MMFF94s_optimised_coords  default
+MOI C10 C11 C12 117.6 1.7      Mogul_mean_145_hits Mogul_sd
+MOI C10 C11  O1 119.5 2.6     Mogul_mean_3933_hits Mogul_sd
+MOI C12 C11  O1 120.0 2.5      Mogul_mean_250_hits Mogul_sd
+MOI  C4 C12 C11 121.1 0.7       Mogul_mean_67_hits Mogul_sd
+MOI  C4 C12  O3 112.9 0.9      Mogul_mean_229_hits Mogul_sd
+MOI C11 C12  O3 125.9 1.4       Mogul_mean_78_hits Mogul_sd
+MOI  C5 C13 C14 112.9 0.7       Mogul_mean_33_hits Mogul_sd
+MOI  C5 C13  O3 106.1 1.0       Mogul_mean_53_hits Mogul_sd
+MOI  C5 C13 H13 110.8 3.0 MMFF94s_optimised_coords  default
+MOI C14 C13  O3 109.8 1.0       Mogul_mean_33_hits Mogul_sd
+MOI C14 C13 H13 107.6 3.0 MMFF94s_optimised_coords  default
+MOI  O3 C13 H13 105.5 3.0 MMFF94s_optimised_coords  default
+MOI C13 C14 C15 112.7 1.7       Mogul_mean_46_hits Mogul_sd
+MOI C13 C14  O2 111.1 1.8       Mogul_mean_54_hits Mogul_sd
+MOI C13 C14 H14 108.0 3.0 MMFF94s_optimised_coords  default
+MOI C15 C14  O2 110.0 2.3      Mogul_mean_189_hits Mogul_sd
+MOI C15 C14 H14 106.0 3.0 MMFF94s_optimised_coords  default
+MOI  O2 C14 H14 106.2 3.0 MMFF94s_optimised_coords  default
+MOI C14 C15 C16 122.5 1.6      Mogul_mean_112_hits Mogul_sd
+MOI C14 C15 H15 117.2 3.0 MMFF94s_optimised_coords  default
+MOI C16 C15 H15 119.8 3.0 MMFF94s_optimised_coords  default
+MOI  C6 C16 C15 119.8 3.7      Mogul_mean_207_hits Mogul_sd
+MOI  C6 C16 H16 118.9 3.0 MMFF94s_optimised_coords  default
+MOI C15 C16 H16 119.9 3.0 MMFF94s_optimised_coords  default
+MOI  C2 C17  C6 111.6 2.1       Mogul_mean_36_hits Mogul_sd
+MOI  C2 C17  N1 115.4 1.3       Mogul_mean_57_hits Mogul_sd
+MOI  C2 C17 H17 107.2 3.0 MMFF94s_optimised_coords  default
+MOI  C6 C17  N1 107.4 0.7       Mogul_mean_36_hits Mogul_sd
+MOI  C6 C17 H17 107.6 3.0 MMFF94s_optimised_coords  default
+MOI  N1 C17 H17 106.8 3.0 MMFF94s_optimised_coords  default
+MOI  C8  N1  C9 110.7 1.3      Mogul_mean_243_hits Mogul_sd
+MOI  C8  N1 C17 112.9 1.4       Mogul_mean_63_hits Mogul_sd
+MOI  C9  N1 C17 112.7 0.6       Mogul_mean_89_hits Mogul_sd
+MOI C11  O1 HO1 106.2 3.0 MMFF94s_optimised_coords  default
+MOI C14  O2 HO2 106.0 3.0 MMFF94s_optimised_coords  default
+MOI C12  O3 C13 106.1 1.4       Mogul_mean_73_hits Mogul_sd
+#
+loop_
+_chem_comp_plane_atom.comp_id        
+_chem_comp_plane_atom.plane_id       
+_chem_comp_plane_atom.atom_id        
+_chem_comp_plane_atom.dist_esd       
+_chem_comp_plane_atom.source         
+MOI  atom-C1  C3  0.02       MMFF_out_of_plane_koop_0.015
+MOI  atom-C1  C1  0.02       MMFF_out_of_plane_koop_0.015
+MOI  atom-C1 C10  0.02       MMFF_out_of_plane_koop_0.015
+MOI  atom-C1  H1  0.02       MMFF_out_of_plane_koop_0.015
+MOI  atom-C3  C1  0.02               Mogul_sum_angles_358
+MOI  atom-C3  C3  0.02               Mogul_sum_angles_358
+MOI  atom-C3  C2  0.02               Mogul_sum_angles_358
+MOI  atom-C3  C4  0.02               Mogul_sum_angles_358
+MOI  atom-C4  C3  0.02               Mogul_sum_angles_359
+MOI  atom-C4  C4  0.02               Mogul_sum_angles_359
+MOI  atom-C4  C5  0.02               Mogul_sum_angles_359
+MOI  atom-C4 C12  0.02               Mogul_sum_angles_359
+MOI atom-C10  C1  0.02       MMFF_out_of_plane_koop_0.015
+MOI atom-C10 C10  0.02       MMFF_out_of_plane_koop_0.015
+MOI atom-C10 C11  0.02       MMFF_out_of_plane_koop_0.015
+MOI atom-C10 H10  0.02       MMFF_out_of_plane_koop_0.015
+MOI atom-C11 C10  0.02               Mogul_sum_angles_357
+MOI atom-C11 C11  0.02               Mogul_sum_angles_357
+MOI atom-C11 C12  0.02               Mogul_sum_angles_357
+MOI atom-C11  O1  0.02               Mogul_sum_angles_357
+MOI atom-C12  C4  0.02               Mogul_sum_angles_360
+MOI atom-C12 C12  0.02               Mogul_sum_angles_360
+MOI atom-C12 C11  0.02               Mogul_sum_angles_360
+MOI atom-C12  O3  0.02               Mogul_sum_angles_360
+MOI atom-C15 C14  0.02       MMFF_out_of_plane_koop_0.013
+MOI atom-C15 C15  0.02       MMFF_out_of_plane_koop_0.013
+MOI atom-C15 C16  0.02       MMFF_out_of_plane_koop_0.013
+MOI atom-C15 H15  0.02       MMFF_out_of_plane_koop_0.013
+MOI atom-C16  C6  0.02       MMFF_out_of_plane_koop_0.013
+MOI atom-C16 C16  0.02       MMFF_out_of_plane_koop_0.013
+MOI atom-C16 C15  0.02       MMFF_out_of_plane_koop_0.013
+MOI atom-C16 H16  0.02       MMFF_out_of_plane_koop_0.013
+MOI   ring6A  C1 0.014 Mogul+_ring_tors_rmsd_2.7_284_hits
+MOI   ring6A C10 0.014 Mogul+_ring_tors_rmsd_2.7_284_hits
+MOI   ring6A C11 0.014 Mogul+_ring_tors_rmsd_2.7_284_hits
+MOI   ring6A C12 0.014 Mogul+_ring_tors_rmsd_2.7_284_hits
+MOI   ring6A  C4 0.014 Mogul+_ring_tors_rmsd_2.7_284_hits
+MOI   ring6A  C3 0.014 Mogul+_ring_tors_rmsd_2.7_284_hits
+MOI 2fold-24 C10  0.02     MMFF94s_2fold_torsion_V2_2.801
+MOI 2fold-24 C11  0.02     MMFF94s_2fold_torsion_V2_2.801
+MOI 2fold-24  O1  0.02     MMFF94s_2fold_torsion_V2_2.801
+MOI 2fold-24 HO1  0.02     MMFF94s_2fold_torsion_V2_2.801
+#
+loop_
+_chem_comp_tor.comp_id               
+_chem_comp_tor.id                    
+_chem_comp_tor.atom_id_1             
+_chem_comp_tor.atom_id_2             
+_chem_comp_tor.atom_id_3             
+_chem_comp_tor.atom_id_4             
+_chem_comp_tor.value_angle           
+_chem_comp_tor.value_angle_esd       
+_chem_comp_tor.period                
+_chem_comp_tor.source                
+MOI CONST_ring6A-1  C1 C10 C11 C12   0.0 1000000.0  0                              planar_ring
+MOI CONST_ring6A-2 C10 C11 C12  C4   0.0 1000000.0  0                              planar_ring
+MOI CONST_ring6A-3 C11 C12  C4  C3   0.0 1000000.0  0                              planar_ring
+MOI CONST_ring6A-4 C12  C4  C3  C1   0.0 1000000.0  0                              planar_ring
+MOI CONST_ring6A-5  C4  C3  C1 C10   0.0 1000000.0  0                              planar_ring
+MOI CONST_ring6A-6  C3  C1 C10 C11   0.0 1000000.0  0                              planar_ring
+MOI  free_ring6B-1  C2 C17  C6  C5   0.0 1000000.0 10  Mogul+_free_ring_tors_rmsd_39.7_50_hits
+MOI  free_ring6B-2 C17  C6  C5  C4   0.0 1000000.0 10  Mogul+_free_ring_tors_rmsd_39.7_50_hits
+MOI  free_ring6B-3  C6  C5  C4  C3   0.0 1000000.0 10  Mogul+_free_ring_tors_rmsd_39.7_50_hits
+MOI  free_ring6B-5  C4  C3  C2 C17   0.0 1000000.0 10  Mogul+_free_ring_tors_rmsd_39.7_50_hits
+MOI  free_ring6B-6  C3  C2 C17  C6   0.0 1000000.0 10  Mogul+_free_ring_tors_rmsd_39.7_50_hits
+MOI  puck_ring6C-1  C7  C8  N1 C17 -60.0      12.3  3     Mogul+_pucker_tors_rmsd_59.3_33_hits
+MOI  puck_ring6C-2  C8  N1 C17  C6  60.0      12.3  3     Mogul+_pucker_tors_rmsd_59.3_33_hits
+MOI  puck_ring6C-5  C6  C5  C7  C8 -60.0      12.3  3     Mogul+_pucker_tors_rmsd_59.3_33_hits
+MOI  puck_ring6C-6  C5  C7  C8  N1  60.0      12.3  3     Mogul+_pucker_tors_rmsd_59.3_33_hits
+MOI  free_ring6D-1 C14 C15 C16  C6   0.0 1000000.0 10  Mogul+_free_ring_tors_rmsd_32.6_41_hits
+MOI  free_ring6D-2 C15 C16  C6  C5   0.0 1000000.0 10  Mogul+_free_ring_tors_rmsd_32.6_41_hits
+MOI  free_ring6D-4  C6  C5 C13 C14   0.0 1000000.0 10  Mogul+_free_ring_tors_rmsd_32.6_41_hits
+MOI  free_ring6D-5  C5 C13 C14 C15   0.0 1000000.0 10  Mogul+_free_ring_tors_rmsd_32.6_41_hits
+MOI  free_ring6D-6 C13 C14 C15 C16   0.0 1000000.0 10  Mogul+_free_ring_tors_rmsd_32.6_41_hits
+MOI  free_ring5A-4  C5 C13  O3 C12   0.0 1000000.0 10 Mogul+_free_ring_tors_rmsd_19.5_112_hits
+MOI  free_ring5A-5 C13  O3 C12  C4   0.0 1000000.0 10 Mogul+_free_ring_tors_rmsd_19.5_112_hits
+MOI        free-23 H91  C9  N1  C8   0.0 1000000.0 10                     unrestrained_default
+MOI       2fold-24 C10 C11  O1 HO1 180.0 1000000.0  2           MMFF94s_2fold_torsion_V2_2.801
+MOI        free-25 C13 C14  O2 HO2   0.0 1000000.0 10                     unrestrained_default
+#
+loop_
+_chem_comp_chir.comp_id              
+_chem_comp_chir.id                   
+_chem_comp_chir.atom_id_centre       
+_chem_comp_chir.atom_id_1            
+_chem_comp_chir.atom_id_2            
+_chem_comp_chir.atom_id_3            
+_chem_comp_chir.volume_sign          
+_chem_comp_chir.source               
+MOI chir_01  C5  C4  C6  C7 negativ rdkit
+MOI chir_02  C6  C5 C16 C17 negativ rdkit
+MOI chir_03 C13  C5 C14  O3 positiv rdkit
+MOI chir_04 C14 C13 C15  O2 positiv rdkit
+MOI chir_05 C17  C2  C6  N1 positiv rdkit
+#
+loop_
+_pdbx_chem_comp_descriptor.comp_id               
+_pdbx_chem_comp_descriptor.type                  
+_pdbx_chem_comp_descriptor.program               
+_pdbx_chem_comp_descriptor.program_version       
+_pdbx_chem_comp_descriptor.descriptor            
+MOI           SMILES "RDKit (grade2)" 2022.03.5                                                                                                    CN1CC[C]23c4c5ccc(O)c4O[CH]2[CH](O)C=C[CH]3[CH]1C5
+MOI SMILES_CANONICAL "RDKit (grade2)" 2022.03.5                                                                                              CN1CC[C@]23c4c5ccc(O)c4O[C@H]2[C@@H](O)C=C[C@H]3[C@H]1C5
+MOI            InChI "RDKit (grade2)" 2022.03.5 InChI=1S/C17H19NO3/c1-18-7-6-17-10-3-5-13(20)16(17)21-15-12(19)4-2-9(14(15)17)8-11(10)18/h2-5,10-11,13,16,19-20H,6-8H2,1H3/t10-,11+,13-,16-,17-/m0/s1
+MOI         InChIKey "RDKit (grade2)" 2022.03.5                                                                                                                           BQJCRHHNABKAKU-KBQPJGBKSA-N
+#
+loop_
+_pdbx_chem_comp_identifier.comp_id               
+_pdbx_chem_comp_identifier.type                  
+_pdbx_chem_comp_identifier.program               
+_pdbx_chem_comp_identifier.program_version       
+_pdbx_chem_comp_identifier.identifier            
+MOI "SYSTEMATIC NAME" ACDLabs 10.04 (5alpha,6beta)-17-methyl-7,8-didehydro-4,5-epoxymorphinan-3,6-diol
+#
+_gphl_chem_comp_info.comp_id                                            MOI
+_gphl_chem_comp_info.arguments                                          "-P MOI -N -f"
+_gphl_chem_comp_info.run_date                                           2023-11-28
+_gphl_chem_comp_info.grade2_version                                     1.5.0.dev1
+_gphl_chem_comp_info.grade2_date                                        2023-09-??
+_gphl_chem_comp_info.rdkit_version                                      2022.03.5
+_gphl_chem_comp_info.input_from                                         PDB_chemical_components_definition_file
+_gphl_chem_comp_info.input_data                                         https://www.ebi.ac.uk/pdbe/static/files/pdbechem_v2/MOI.cif
+_gphl_chem_comp_info.input_inchi                                        InChI=1S/C17H19NO3/c1-18-7-6-17-10-3-5-13(20)16(17)21-15-12(19)4-2-9(14(15)17)8-11(10)18/h2-5,10-11,13,16,19-20H,6-8H2,1H3/t10-,11+,13-,16-,17-/m0/s1
+_gphl_chem_comp_info.input_inchikey                                     BQJCRHHNABKAKU-KBQPJGBKSA-N
+_gphl_chem_comp_info.input_inchi_match                                  y
+_gphl_chem_comp_info.rdkit_sanitization_problem                         .
+_gphl_chem_comp_info.partial_charges_source                             "RDKit Gasteiger"
+_gphl_chem_comp_info.force_field                                        MMFF94s
+_gphl_chem_comp_info.initial_energy                                     163.55226
+_gphl_chem_comp_info.final_energy                                       94.32056
+_gphl_chem_comp_info.mogul_version                                      2023.2.0
+_gphl_chem_comp_info.mogul_data_libraries                               "as544be_ASER, Jun23_ASER"
+_gphl_chem_comp_info.csd_version                                        544
+_gphl_chem_comp_info.csd_python_api                                     3.0.16
+_gphl_chem_comp_info.coordinates_source                                 "gelly from MMFF94s_optimised"
+_gphl_chem_comp_info.geometry_optimize_program                          gelly
+_gphl_chem_comp_info.geometry_optimize_steps                            140
+_gphl_chem_comp_info.geometry_optimize_initial_function                 413.255
+_gphl_chem_comp_info.geometry_optimize_final_function                   251.603
+_gphl_chem_comp_info.geometry_optimize_initial_rms_gradient             308.698
+_gphl_chem_comp_info.geometry_optimize_final_rms_gradient               0.0490046
+_gphl_chem_comp_info.geometry_optimize_initial_rms_bond_deviation       0.0119101
+_gphl_chem_comp_info.geometry_optimize_final_rms_bond_deviation         0.00654091
+_gphl_chem_comp_info.elapsed_seconds                                    9
+
+#
+loop_
+_gphl_chem_comp_database.comp_id        
+_gphl_chem_comp_database.id             
+_gphl_chem_comp_database.database       
+_gphl_chem_comp_database.url            
+_gphl_chem_comp_database.details        
+MOI MOI PDB                                   https://www.rcsb.org/ligand/MOI "RCSB PDB"
+MOI MOI PDB https://www.ebi.ac.uk/pdbe-srv/pdbechem/chemicalCompound/show/MOI       PDBe
+#
+loop_
+_gphl_check_inchikey_pdb_ccd.comp_id       
+_gphl_check_inchikey_pdb_ccd.text          
+_gphl_check_inchikey_pdb_ccd.ordinal       
+MOI                                                                                                      "CHECK: Exact match to PDB chemical component(s):" 1
+MOI 'CHECK:   MOI https://www.rcsb.org/ligand/MOI "(7R,7as,12bs)-3-methyl-2,3,4,4A,7,7A-hexahydro-1H-4,12-methano[1]benzofuro[3,2-E]isoquinoline-7,9-diol"' 2
+MOI                                                                                         "For help on checks against known PDB components, , see:  ...." 3
+MOI                                                                                       "---- https://gphl.gitlab.io/grade2_docs/faqs.html#checkpdbmatch" 4
+#
+loop_
+_pdbe_chem_comp_atom_depiction.comp_id             
+_pdbe_chem_comp_atom_depiction.atom_id             
+_pdbe_chem_comp_atom_depiction.element             
+_pdbe_chem_comp_atom_depiction.model_Cartn_x       
+_pdbe_chem_comp_atom_depiction.model_Cartn_y       
+_pdbe_chem_comp_atom_depiction.pdbx_ordinal        
+MOI  C1 C  6.770  2.853  1
+MOI  C2 C  8.005  0.713  2
+MOI  C3 C  6.770  1.427  3
+MOI  C4 C  5.535  0.713  4
+MOI  C5 C  5.535 -0.713  5
+MOI  C6 C  6.770 -1.427  6
+MOI  C7 C  6.359  0.333  7
+MOI  C8 C  8.388  0.333  8
+MOI  C9 C 10.263 -2.525  9
+MOI C10 C  5.535  3.567 10
+MOI C11 C  4.299  2.853 11
+MOI C12 C  4.299  1.427 12
+MOI C13 C  4.299 -1.427 13
+MOI C14 C  4.299 -2.853 14
+MOI C15 C  5.535 -3.567 15
+MOI C16 C  6.770 -2.853 16
+MOI C17 C  8.005 -0.713 17
+MOI  N1 N  9.241 -1.427 18
+MOI  O1 O  3.000  3.603 19
+MOI  O2 O  3.000 -3.603 20
+MOI  O3 O  3.347  0.079 21
+#


### PR DESCRIPTION
This update includes:
- New UI for chem. comp. info when the ligand dictionary contains such info
- Add more tests for `MoorhenMolecule` methods used when merging and parsing ligands
