### PR TITLE
Use molecule to string methods from libcoot in `getAtoms`

### DIFF
--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -616,8 +616,8 @@ export class MoorhenMolecule implements moorhen.Molecule {
     async getAtoms(format?: 'mmcif' | 'pdb'): Promise<string> {
         const response = await this.commandCentre.current.cootCommand({
             returnType: "string",
-            command: 'get_molecule_atoms',
-            commandArgs: [this.molNo, format ? format : this.coordsFormat ? this.coordsFormat : 'pdb'],
+            command: format === 'mmcif' ? 'molecule_to_mmCIF_string' : 'molecule_to_PDB_string',
+            commandArgs: [this.molNo],
         }, false) as moorhen.WorkerResponse<string>
         return response.data.result.result
     }

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -614,9 +614,15 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @returns {string}  A string representation file contents
      */
     async getAtoms(format?: 'mmcif' | 'pdb'): Promise<string> {
+        let cootCommand = 'molecule_to_PDB_string'
+        if (format) {
+            cootCommand = format === 'mmcif' ? 'molecule_to_mmCIF_string' : 'molecule_to_PDB_string'
+        } else if (this.coordsFormat) {
+            cootCommand = this.coordsFormat === 'mmcif' ? 'molecule_to_mmCIF_string' : 'molecule_to_PDB_string'
+        }
         const response = await this.commandCentre.current.cootCommand({
             returnType: "string",
-            command: format === 'mmcif' ? 'molecule_to_mmCIF_string' : 'molecule_to_PDB_string',
+            command: cootCommand,
             commandArgs: [this.molNo],
         }, false) as moorhen.WorkerResponse<string>
         return response.data.result.result

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -901,6 +901,37 @@ describe('Testing molecules_container_js', () => {
 
         cleanUpVariables.push(merge_info, old_chains, old_model, old_st, st, model, chains, chain, ligands)
     })
+
+    test.skip('Test test_the_threading --pool false', () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const mapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'FWT', 'PHWT', "", false, false)
+        expect(mapMolNo).toBe(0)
+
+        molecules_container.set_map_is_contoured_with_thread_pool(false)
+        const maxThreads = 8
+        molecules_container.set_max_number_of_threads_in_thread_pool(maxThreads)
+        for (let nThreads = 1; nThreads < 9; nThreads++) {
+            for (let nIteration = 0; nIteration < 6; nIteration++) {
+                const t = molecules_container.test_the_threading(nThreads, mapMolNo)
+                console.log(`RESULT: ${nIteration} ${nThreads} ${t} 0 ${maxThreads}`)    
+            }
+        }
+    })
+
+    test.skip('Test test_the_threading --pool true', () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const mapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'FWT', 'PHWT', "", false, false)
+        expect(mapMolNo).toBe(0)
+
+        molecules_container.set_map_is_contoured_with_thread_pool(true)
+        for (let nThreads = 1; nThreads < 9; nThreads++) {
+            for (let nIteration = 0; nIteration < 6; nIteration++) {
+                const t = molecules_container.test_the_threading(nThreads, mapMolNo)
+                console.log(`RESULT: ${nIteration} ${nThreads} ${t} 1 0`)    
+            }
+        }
+    })
+
 })
 
 const testDataFiles = ['5fjj.pdb', '5a3h.pdb', '5a3h.mmcif', '5a3h_no_ligand.pdb', 'MOI.restraints.cif', 'LZA.cif', 'nitrobenzene.cif', 'benzene.cif', '5a3h_sigmaa.mtz', 'rnasa-1.8-all_refmac1.mtz', 'tm-A.pdb']

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -766,6 +766,66 @@ describe('Testing molecules_container_js', () => {
         cleanUpVariables.push(merge_info, st, model, chains, chain, ligands)
     })
 
+    test("Test merge ligand.restraints dict and gemmi parse -pdb", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        
+        const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
+        expect(coordMolNo_1).toBe(0)
+        
+        const result_import_dict = molecules_container.import_cif_dictionary('./MOI.restraints.cif', -999999)
+        expect(result_import_dict).toBe(1)
+        
+        const ligandMolNo = molecules_container.get_monomer_and_position_at(
+            'MOI', -999999, 0, 0, 0
+        )
+        expect(ligandMolNo).toBe(1)
+
+        const merge_info = molecules_container.merge_molecules(coordMolNo_1, ligandMolNo.toString())
+        expect(merge_info.second.size()).toBe(1)
+        
+        const mmcifString = molecules_container.get_molecule_atoms(coordMolNo_1, 'pdb')
+        const st = cootModule.read_structure_from_string(mmcifString, 'test-molecule')
+        cootModule.gemmi_setup_entities(st)
+        cootModule.gemmi_add_entity_types(st, true)
+        const model = st.first_model()
+        const chains = model.chains
+        const chain = chains.get(2)
+        const ligands = chain.get_ligands_const()
+        expect(ligands.length()).toBe(1)
+
+        cleanUpVariables.push(merge_info, st, model, chains, chain, ligands)
+    })
+
+    test("Test merge ligand.restraints dict and gemmi parse -mmcif", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        
+        const coordMolNo_1 = molecules_container.read_pdb('./5a3h.mmcif')
+        expect(coordMolNo_1).toBe(0)
+        
+        const result_import_dict = molecules_container.import_cif_dictionary('./MOI.restraints.cif', -999999)
+        expect(result_import_dict).toBe(1)
+        
+        const ligandMolNo = molecules_container.get_monomer_and_position_at(
+            'MOI', -999999, 0, 0, 0
+        )
+        expect(ligandMolNo).toBe(1)
+
+        const merge_info = molecules_container.merge_molecules(coordMolNo_1, ligandMolNo.toString())
+        expect(merge_info.second.size()).toBe(1)
+        
+        const mmcifString = molecules_container.get_molecule_atoms(coordMolNo_1, 'mmcif')
+        const st = cootModule.read_structure_from_string(mmcifString, 'test-molecule')
+        cootModule.gemmi_setup_entities(st)
+        cootModule.gemmi_add_entity_types(st, true)
+        const model = st.first_model()
+        const chains = model.chains
+        const chain = chains.get(2)
+        const ligands = chain.get_ligands_const()
+        expect(ligands.length()).toBe(1)
+
+        cleanUpVariables.push(merge_info, st, model, chains, chain, ligands)
+    })
+
     test("Test merge ligand and gemmi parse cross-format 1", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -130,7 +130,7 @@ describe("Testing MoorhenMolecule", () => {
         const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
         await molecule.loadToCootFromURL(fileUrl, 'mol-test')
         const coordData = await molecule.getAtoms()
-        expect(coordData).toHaveLength(258719)
+        expect(coordData).toHaveLength(258718)
     }) 
 
     test("Test get_atoms mmcif", async () => {
@@ -145,7 +145,7 @@ describe("Testing MoorhenMolecule", () => {
         const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
         await molecule.loadToCootFromURL(fileUrl, 'mol-test')
         const coordData = await molecule.getAtoms()
-        expect(coordData).toHaveLength(278728)
+        expect(coordData).toHaveLength(231178)
     }) 
 
     test("Test get_number_of_atoms", async () => {

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -1017,6 +1017,8 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("is_EM_map",&molecules_container_t::is_EM_map)
     .function("set_map_sampling_rate",&molecules_container_t::set_map_sampling_rate)
     .function("get_mesh_for_ligand_validation_vs_dictionary",&molecules_container_t::get_mesh_for_ligand_validation_vs_dictionary)
+    .function("molecule_to_mmCIF_string", &molecules_container_t::molecule_to_mmCIF_string)
+    .function("molecule_to_PDB_string", &molecules_container_t::molecule_to_PDB_string)
     .function("clear_refinement",&molecules_container_t::clear_refinement)
     .function("get_suggested_initial_contour_level",&molecules_container_t::get_suggested_initial_contour_level)
     .function("clear_target_position_restraints",&molecules_container_t::clear_target_position_restraints)

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -1012,6 +1012,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     ;
     class_<molecules_container_t>("molecules_container_t")
     .constructor<bool>()
+    .function("generate_local_self_restraints", &molecules_container_t::generate_local_self_restraints)
     .function("get_ncs_related_chains", &molecules_container_t::get_ncs_related_chains)
     .function("is_EM_map",&molecules_container_t::is_EM_map)
     .function("set_map_sampling_rate",&molecules_container_t::set_map_sampling_rate)

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -1014,6 +1014,8 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .constructor<bool>()
     .function("generate_local_self_restraints", &molecules_container_t::generate_local_self_restraints)
     .function("get_ncs_related_chains", &molecules_container_t::get_ncs_related_chains)
+    .function("set_max_number_of_threads_in_thread_pool", &molecules_container_t::set_max_number_of_threads_in_thread_pool)
+    .function("set_map_is_contoured_with_thread_pool", &molecules_container_t::set_map_is_contoured_with_thread_pool)
     .function("is_EM_map",&molecules_container_t::is_EM_map)
     .function("set_map_sampling_rate",&molecules_container_t::set_map_sampling_rate)
     .function("get_mesh_for_ligand_validation_vs_dictionary",&molecules_container_t::get_mesh_for_ligand_validation_vs_dictionary)


### PR DESCRIPTION
After this update `MoorhenMolecule.getAtoms` uses `molecules_container_t::molecule_to_mmCIF_string` and `molecules_container_t::molecule_to_PDB_string`.