### PR TITLE
Fix multi-CID bug and add option to invert selections

### DIFF
--- a/baby-gru/public/baby-gru/CootWorker.ts
+++ b/baby-gru/public/baby-gru/CootWorker.ts
@@ -1032,7 +1032,9 @@ onmessage = function (e) {
                 molecules_container.set_show_timings(false)
                 molecules_container.fill_rotamer_probability_tables()
                 molecules_container.set_map_sampling_rate(1.7)
-                cootModule.FS.mkdir("COOT_BACKUP");
+                molecules_container.set_map_is_contoured_with_thread_pool(true)
+                molecules_container.set_max_number_of_threads_in_thread_pool(4)
+                cootModule.FS.mkdir("COOT_BACKUP")
             })
             .catch((e) => {
                 console.log(e)

--- a/baby-gru/public/baby-gru/CootWorker.ts
+++ b/baby-gru/public/baby-gru/CootWorker.ts
@@ -1033,7 +1033,7 @@ onmessage = function (e) {
                 molecules_container.fill_rotamer_probability_tables()
                 molecules_container.set_map_sampling_rate(1.7)
                 molecules_container.set_map_is_contoured_with_thread_pool(true)
-                molecules_container.set_max_number_of_threads_in_thread_pool(4)
+                molecules_container.set_max_number_of_threads_in_thread_pool(3)
                 cootModule.FS.mkdir("COOT_BACKUP")
             })
             .catch((e) => {

--- a/baby-gru/src/components/misc/MoorhenMapHistogram.tsx
+++ b/baby-gru/src/components/misc/MoorhenMapHistogram.tsx
@@ -139,12 +139,10 @@ export const MoorhenMapHistogram = forwardRef<Chart, MapHistogramProps>((props, 
     }, [isDark, props.showHistogram, width, height, zoomFactor])
 
     return <Row>
-        <Col style={{display: 'flex', marginTop: '0.5rem'}}>
-        <div className="histogram-plot-div" style={{width: '100%'}}>
-            <canvas id={`${props.map.molNo}-histogram`}></canvas>
-        </div>
-        </Col>
-        <Col style={{display: 'flex', paddingLeft: 0}} md="auto">
+        <Stack style={{display: 'flex', marginTop: '0.5rem'}} gap={1} direction="horizontal">
+            <div className="histogram-plot-div" style={{width: '95%'}}>
+                <canvas id={`${props.map.molNo}-histogram`}></canvas>
+            </div>
             <Stack style={{display: 'flex', width: '1.5rem', justifyContent: 'center', alignContent: 'center', alignItems: 'center', verticalAlign: 'center'}} gap={1} direction="vertical">
                 <IconButton onClick={() => setZoomFactor((prev) => {
                     if (prev + 2 > 20) {
@@ -164,6 +162,6 @@ export const MoorhenMapHistogram = forwardRef<Chart, MapHistogramProps>((props, 
                     <ZoomOutOutlined/>
                 </IconButton>
             </Stack>
-        </Col>
+        </Stack>
     </Row>
 })

--- a/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
+++ b/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
@@ -1,7 +1,7 @@
 import { IconButton, Popover, Tooltip } from "@mui/material"
 import { cidToSpec, guid } from "../../utils/MoorhenUtils"
 import { MoorhenNotification } from "./MoorhenNotification"
-import { AdsClickOutlined, AllOutOutlined, CloseOutlined, CopyAllOutlined, CrisisAlertOutlined, DeleteOutlined, EditOutlined, FormatColorFillOutlined, Rotate90DegreesCw, SwipeRightAlt } from "@mui/icons-material"
+import { AdsClickOutlined, AllOutOutlined, CloseOutlined, CopyAllOutlined, CrisisAlertOutlined, DeleteOutlined, EditOutlined, FormatColorFillOutlined, Rotate90DegreesCw, SwapVertOutlined, SwipeRightAlt } from "@mui/icons-material"
 import { batch, useDispatch, useSelector } from "react-redux"
 import { moorhen } from "../../types/moorhen"
 import { Button, Stack } from "react-bootstrap"
@@ -240,6 +240,35 @@ export const MoorhenResidueSelectionActions = (props) => {
         }
     }, [residueSelection, clearSelection])
 
+    const handleInvertSelection = useCallback(async () => {
+        let cid: string
+        
+        if (residueSelection.isMultiCid && Array.isArray(residueSelection.cid)) {
+            cid = residueSelection.cid.join('||')
+        } else if (residueSelection.molecule && residueSelection.cid) {
+            cid = residueSelection.cid as string
+        } else if (residueSelection.molecule && residueSelection.first) {
+            const startResSpec = cidToSpec(residueSelection.first)
+            cid = `/${startResSpec.mol_no}/${startResSpec.chain_id}/${startResSpec.res_no}-${startResSpec.res_no}`
+        }
+
+        if (cid) {
+            const result = residueSelection.molecule.getNonSelectedCids(cid)
+            const newCid = result.join('||')
+            await residueSelection.molecule.drawResidueSelection(newCid)
+            dispatch(
+                setResidueSelection({
+                    molecule: residueSelection.molecule,
+                    first: residueSelection.first,
+                    second: residueSelection.second,
+                    cid: result,
+                    isMultiCid: true,
+                    label: newCid
+                })
+            )
+        }
+    }, [residueSelection, clearResidueSelection])
+
     const handleColourChange = useCallback(async () => {
         let newColourRules: moorhen.ColourRule[] = []
 
@@ -416,6 +445,9 @@ export const MoorhenResidueSelectionActions = (props) => {
                             setInvalidCid(false)
                         }} onMouseEnter={() => setTooltipContents('Edit selection')}>
                             <EditOutlined style={{height: '23px', width: '23px', padding: '0.05rem', marginLeft: '0.2rem'}}/>
+                        </IconButton>
+                        <IconButton onClick={handleInvertSelection} onMouseEnter={() => setTooltipContents('Invert selection')}>
+                            <SwapVertOutlined/>
                         </IconButton>
                         <IconButton ref={changeColourAnchorRef} onClick={() => {
                             setShowColourPopover((prev) => !prev)

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -12,6 +12,7 @@ declare global {
 
 export namespace libcootApi {
     type CCP4ModuleType = {
+        get_non_selected_cids(gemmiStructure: gemmi.Structure, cid: string): emscriptem.vector<string>;
         parse_multi_cids(gemmiStructure: gemmi.Structure, cid: string): emscriptem.vector<string>;
         parse_ligand_dict_info(fileContent: string): emscriptem.vector<{ comp_id: string; dict_contents: string; }>;
         get_ligand_info_for_structure(gemmiStructure: gemmi.Structure): emscriptem.vector<{
@@ -27,7 +28,7 @@ export namespace libcootApi {
         get_atom_info_for_selection(gemmiStructure: gemmi.Structure, arg1: string, arg2: string): emscriptem.vector<AtomInfo>;
         structure_is_ligand(gemmiStructure: gemmi.Structure): boolean;
         count_residues_in_selection(gemmiStructure: gemmi.Structure, selection: gemmi.Selection): number;
-        remove_non_selected_residues(gemmiStructure: gemmi.Structure, selection: gemmi.Selection): gemmi.Structure;
+        remove_non_selected_atoms(gemmiStructure: gemmi.Structure, selection: gemmi.Selection): gemmi.Structure;
         check_polymer_type(polymerConst: emscriptem.instance<number>): {value: number};
         remove_ligands_and_waters_chain(chain: gemmi.Chain): void;
         gemmi_setup_entities(gemmiStructure: gemmi.Structure): void;
@@ -463,6 +464,8 @@ export namespace libcootApi {
         getRamachandranData(arg0: string, arg1: string): emscriptem.vector<RamaData>
     }
     interface MoleculesContainerJS {
+        set_max_number_of_threads_in_thread_pool(arg0: number): void;
+        set_map_is_contoured_with_thread_pool(arg0: boolean): void;
         close_molecule(molNo: number): number;
         copy_fragment_using_residue_range(molNo: number, chainId: string, res_no_start: number, res_no_end: number): number;
         writeCCP4Map(molNo: number, tempFilename: string): void;

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -50,6 +50,7 @@ declare module 'moorhen' {
 
     class MoorhenMolecule implements _moorhen.Molecule {
         constructor(commandCentre: React.RefObject<_moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, monomerLibrary: string)
+        getNonSelectedCids(cid: string): string[];
         parseCidIntoSelection(selectedCid: string): Promise<_moorhen.ResidueSelection>;
         animateRefine(n_cyc: number, n_iteration: number, final_n_cyc?: number): Promise<void>;
         refineResidueRange(chainId: string, start: number, stop: number, ncyc?: number, redraw?: boolean): Promise<void>;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -92,6 +92,7 @@ export namespace moorhen {
     type coorFormats = 'pdb' | 'mmcif';
     
     interface Molecule {
+        getNonSelectedCids(cid: string): string[];
         parseCidIntoSelection(selectedCid: string): Promise<ResidueSelection>;
         downloadAtoms(format?: 'mmcif' | 'pdb'): Promise<void>;
         getResidueBFactors(): { cid: string; bFactor: number; normalised_bFactor: number }[];

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1786,4 +1786,21 @@ export class MoorhenMolecule implements moorhen.Molecule {
             label: cid
         }
     }
+
+    /**
+     * Get the CIDs of residues not included in the input CID
+     * @param {string} cid - The input CID selection
+     * @returns {string[]} An array of CIDs for the residue ranges not included in the input CID
+     */
+    getNonSelectedCids(cid: string): string[] {
+        let result: string[] = []
+        const nonSelectedCidVec = window.CCP4Module.get_non_selected_cids(this.gemmiStructure, cid)
+        const nonSelectedCidVecSize = nonSelectedCidVec.size()
+        for (let i = 0; i < nonSelectedCidVecSize; i++) {
+            const iCid = nonSelectedCidVec.get(i)
+            result.push(iCid)
+        }
+        nonSelectedCidVec.delete()
+        return result
+    }
 }

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1527,9 +1527,9 @@ export class MoorhenMolecule implements moorhen.Molecule {
      */
     async generateSelfRestraints(cid: string = "//", maxRadius: number = 4.2): Promise<void> {
         await this.commandCentre.current.cootCommand({
-            command: "generate_self_restraints",
+            command: "generate_local_self_restraints",
             returnType: 'status',
-            commandArgs: [this.molNo, maxRadius],
+            commandArgs: [this.molNo, maxRadius, cid],
         }, false)
         this.restraints.push({ maxRadius, cid })
     }

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -1149,7 +1149,7 @@ export const countResiduesInSelection = (gemmiStructure: gemmi.Structure, cidSel
 
 export const copyStructureSelection = (gemmiStructure: gemmi.Structure, cidSelection?: string) => {
     const selection = new window.CCP4Module.Selection(cidSelection ? cidSelection : '/*/*/*')
-    const newStruct = window.CCP4Module.remove_non_selected_residues(gemmiStructure, selection)
+    const newStruct = window.CCP4Module.remove_non_selected_atoms(gemmiStructure, selection)
     selection.delete()
     return newStruct
 }

--- a/baby-gru/tests/__tests__/gemmi.test.js
+++ b/baby-gru/tests/__tests__/gemmi.test.js
@@ -138,7 +138,7 @@ describe("Testing gemmi", () => {
         const selection = new cootModule.Selection('//A/31-33/*')
         const st_1 = cootModule.read_structure_file('./5a3h.pdb', cootModule.CoorFormat.Pdb)
         cootModule.gemmi_setup_entities(st_1)
-        const st_2 = cootModule.remove_non_selected_residues(st_1, selection)
+        const st_2 = cootModule.remove_non_selected_atoms(st_1, selection)
 
         const model_1 = st_1.first_model()
         const chains_1 = model_1.chains
@@ -167,7 +167,7 @@ describe("Testing gemmi", () => {
         expect(is_ligand_1).toBeFalsy()
 
         const selection = new cootModule.Selection('//B')
-        const st_2 = cootModule.remove_non_selected_residues(st_1, selection)
+        const st_2 = cootModule.remove_non_selected_atoms(st_1, selection)
         const is_ligand_2 = cootModule.structure_is_ligand(st_2)
         expect(is_ligand_2).toBeTruthy()
     })

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -560,6 +560,96 @@ describe("Testing MoorhenMolecule", () => {
         ])
     })
 
+    test("Test getNonSelectedCids 1", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl_1, 'mol-test')
+        molecule.setAtomsDirty(true)
+        await molecule.updateAtoms()
+        const result = molecule.getNonSelectedCids("//A")
+        expect(result).toEqual(["/1/B/"])
+    })
+
+    test("Test getNonSelectedCids 2", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl_1, 'mol-test')
+        molecule.setAtomsDirty(true)
+        await molecule.updateAtoms()
+        const result = molecule.getNonSelectedCids("//A||//B/1")
+        expect(result).toEqual(["/1/B/2-2"])
+    })
+
+    test("Test getNonSelectedCids 3", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl_1, 'mol-test')
+        molecule.setAtomsDirty(true)
+        await molecule.updateAtoms()
+        const result = molecule.getNonSelectedCids("//A/4-100")
+        expect(result).toEqual(["/1/A/101-303", "/1/A/901-1248", "/1/B/"])
+    })
+
+    test("Test getNonSelectedCids 4", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl_1, 'mol-test')
+        molecule.setAtomsDirty(true)
+        await molecule.updateAtoms()
+        const result = molecule.getNonSelectedCids("//B||//A/4-100||//A/103-303")
+        expect(result).toEqual(["/1/A/101-102", "/1/A/901-1248"])
+    })
+
+    test("Test getNonSelectedCids 5", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl_1, 'mol-test')
+        molecule.setAtomsDirty(true)
+        await molecule.updateAtoms()
+        const result = molecule.getNonSelectedCids("//B/1")
+        expect(result).toEqual(["/1/A/", "/1/B/2-2"])
+    })
+    
     test("Test parseSequences pdb", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -145,7 +145,7 @@ describe("Testing MoorhenMolecule", () => {
         const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
         await molecule.loadToCootFromURL(fileUrl, 'mol-test')
         const coordData = await molecule.getAtoms()
-        expect(coordData).toHaveLength(231178)
+        expect(coordData).toHaveLength(278727)
     }) 
 
     test("Test get_number_of_atoms", async () => {

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -514,6 +514,52 @@ describe("Testing MoorhenMolecule", () => {
         ])
     })
 
+    test("Test gemmiAtomsForCid 5", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
+        const glRef = {
+            current: new MockWebGL()
+        }
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        const f = jest.spyOn(molecule, 'updateAtoms')
+        await molecule.loadToCootFromURL(fileUrl_1, 'mol-test')
+        molecule.setAtomsDirty(true)
+        const gemmiAtoms = await molecule.gemmiAtomsForCid('//A/30-31/CA||//B')
+        expect(f).toHaveBeenCalled()
+        expect(gemmiAtoms).toHaveLength(25)
+        expect(gemmiAtoms.map(atomInfo => atomInfo.label)).toEqual([
+            "/1/A/30(LYS)/CA",
+            "/1/A/31(GLY)/CA",
+            "/1/B/1(G2F)/C1",
+            "/1/B/1(G2F)/C2",
+            "/1/B/1(G2F)/C3",
+            "/1/B/1(G2F)/C4",
+            "/1/B/1(G2F)/C5",
+            "/1/B/1(G2F)/C6",
+            "/1/B/1(G2F)/O3",
+            "/1/B/1(G2F)/O4",
+            "/1/B/1(G2F)/O5",
+            "/1/B/1(G2F)/O6:A",
+            "/1/B/1(G2F)/O6:B",
+            "/1/B/1(G2F)/F2",
+            "/1/B/2(BGC)/C2",
+            "/1/B/2(BGC)/C3",
+            "/1/B/2(BGC)/C4",
+            "/1/B/2(BGC)/C5",
+            "/1/B/2(BGC)/C6",
+            "/1/B/2(BGC)/C1",
+            "/1/B/2(BGC)/O2",
+            "/1/B/2(BGC)/O3",
+            "/1/B/2(BGC)/O4",
+            "/1/B/2(BGC)/O5",
+            "/1/B/2(BGC)/O6",
+        ])
+    })
+
     test("Test parseSequences pdb", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')

--- a/coot/gemmi-wrappers.cc
+++ b/coot/gemmi-wrappers.cc
@@ -162,7 +162,7 @@ gemmi::Structure remove_selected_residues(const gemmi::Structure &Structure, con
     return new_structure;
 }
 
-gemmi::Structure remove_non_selected_residues(const gemmi::Structure &Structure, const gemmi::Selection &Selection) {
+gemmi::Structure remove_non_selected_atoms(const gemmi::Structure &Structure, const gemmi::Selection &Selection) {
     auto new_structure = Structure;
 
     gemmi::vector_remove_if(new_structure.models, [&](const gemmi::Model& model) { return !Selection.matches(model); });
@@ -571,7 +571,7 @@ std::vector<AtomInfo> get_atom_info_for_selection(const gemmi::Structure &Struct
 
     for (int i_selection = 0; i_selection < selections_vec.size(); i_selection++) {
         auto selection = selections_vec[i_selection];
-        auto structure_copy = remove_non_selected_residues(_structure, selection);
+        auto structure_copy = remove_non_selected_atoms(_structure, selection);
         auto models = structure_copy.models;
         for (int modelIndex = 0; modelIndex < models.size(); modelIndex++) {
             const auto model = models[modelIndex];
@@ -2678,7 +2678,7 @@ GlobWalk
     */
 
     //TODO Here we need to put *lots* of gemmi functions
-    function("remove_non_selected_residues",&remove_non_selected_residues);
+    function("remove_non_selected_atoms",&remove_non_selected_atoms);
     function("count_residues_in_selection",&count_residues_in_selection);
     function("get_pdb_string_from_gemmi_struct",&get_pdb_string_from_gemmi_struct);
     function("structure_is_ligand",&structure_is_ligand);


### PR DESCRIPTION
This update includes:
- Set 3 threads for map contouring on init.
- Fix nightly tests.
- Fix for the issue causing map histogram zoom buttons to disappear on window resize.
- Use `mc.generate_local_self_restraints` in `MoorhenMolecule.generateSelfRestraints` instead of `mc.generate_self_restraints`.
- Fix bug where `get_atom_info_for_selection` would return the wrong residue info with multi-CID selections (fixes #230).
- Add a option to invert a given residue selection (resolves #226).
- Add method `getNonSelectedCids` to `MoorhenMolecule`
