### PR TITLE
Fix issue with residue selection buttons

### DIFF
--- a/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
+++ b/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
@@ -408,7 +408,7 @@ export const MoorhenResidueSelectionActions = (props) => {
 
     return showResidueSelection ?
         <MoorhenNotification key={notificationKeyRef.current} width={19}>
-            <Tooltip className="moorhen-tooltip" title={tooltipContents}>
+            <Tooltip className="moorhen-tooltip" title={tooltipContents} style={{zIndex: 99}}>
             <Stack ref={notificationComponentRef} direction="vertical" gap={1}>
                 <Stack gap={0} direction="horizontal" style={{ width: '100%', display: 'flex', justifyContent: 'space-between' }}>
                     <span style={{paddingLeft: '2.2rem', width: '100%', display: 'flex', justifyContent: 'center'}}>{

--- a/baby-gru/tests/test_data/1cxq.cif
+++ b/baby-gru/tests/test_data/1cxq.cif
@@ -1,0 +1,4293 @@
+data_1CXQ
+# 
+_entry.id   1CXQ 
+# 
+_audit_conform.dict_name       mmcif_pdbx.dic 
+_audit_conform.dict_version    5.286 
+_audit_conform.dict_location   http://mmcif.pdb.org/dictionaries/ascii/mmcif_pdbx.dic 
+# 
+loop_
+_database_2.database_id 
+_database_2.database_code 
+PDB   1CXQ         
+RCSB  RCSB009610   
+WWPDB D_1000009610 
+# 
+loop_
+_pdbx_database_related.db_name 
+_pdbx_database_related.db_id 
+_pdbx_database_related.details 
+_pdbx_database_related.content_type 
+PDB 1ASV 'same protein at lower resolution' unspecified 
+PDB 1CXU .                                  unspecified 
+PDB 1CZ9 .                                  unspecified 
+PDB 1CZB .                                  unspecified 
+# 
+_pdbx_database_status.status_code                     REL 
+_pdbx_database_status.entry_id                        1CXQ 
+_pdbx_database_status.recvd_initial_deposition_date   1999-08-30 
+_pdbx_database_status.deposit_site                    RCSB 
+_pdbx_database_status.process_site                    RCSB 
+_pdbx_database_status.status_code_sf                  REL 
+_pdbx_database_status.SG_entry                        . 
+_pdbx_database_status.pdb_format_compatible           Y 
+_pdbx_database_status.status_code_mr                  ? 
+_pdbx_database_status.status_code_cs                  ? 
+_pdbx_database_status.methods_development_category    ? 
+# 
+loop_
+_audit_author.name 
+_audit_author.pdbx_ordinal 
+'Lubkowski, J.'    1 
+'Dauter, Z.'       2 
+'Yang, F.'         3 
+'Alexandratos, J.' 4 
+'Merkel, G.'       5 
+'Skalka, A.M.'     6 
+'Wlodawer, A.'     7 
+# 
+_citation.id                        primary 
+_citation.title                     
+'Atomic resolution structures of the core domain of avian sarcoma virus integrase and its D64N mutant.' 
+_citation.journal_abbrev            Biochemistry 
+_citation.journal_volume            38 
+_citation.page_first                13512 
+_citation.page_last                 13522 
+_citation.year                      1999 
+_citation.journal_id_ASTM           BICHAW 
+_citation.country                   US 
+_citation.journal_id_ISSN           0006-2960 
+_citation.journal_id_CSD            0033 
+_citation.book_publisher            ? 
+_citation.pdbx_database_id_PubMed   10521258 
+_citation.pdbx_database_id_DOI      10.1021/bi991362q 
+# 
+loop_
+_citation_author.citation_id 
+_citation_author.name 
+_citation_author.ordinal 
+primary 'Lubkowski, J.'    1 
+primary 'Dauter, Z.'       2 
+primary 'Yang, F.'         3 
+primary 'Alexandratos, J.' 4 
+primary 'Merkel, G.'       5 
+primary 'Skalka, A.M.'     6 
+primary 'Wlodawer, A.'     7 
+# 
+_cell.entry_id           1CXQ 
+_cell.length_a           65.540 
+_cell.length_b           65.540 
+_cell.length_c           80.120 
+_cell.angle_alpha        90.00 
+_cell.angle_beta         90.00 
+_cell.angle_gamma        90.00 
+_cell.Z_PDB              8 
+_cell.pdbx_unique_axis   ? 
+# 
+_symmetry.entry_id                         1CXQ 
+_symmetry.space_group_name_H-M             'P 43 21 2' 
+_symmetry.pdbx_full_space_group_name_H-M   ? 
+_symmetry.cell_setting                     ? 
+_symmetry.Int_Tables_number                96 
+# 
+loop_
+_entity.id 
+_entity.type 
+_entity.src_method 
+_entity.pdbx_description 
+_entity.formula_weight 
+_entity.pdbx_number_of_molecules 
+_entity.pdbx_ec 
+_entity.pdbx_mutation 
+_entity.pdbx_fragment 
+_entity.details 
+1 polymer     man 'AVIAN SARCOMA VIRUS INTEGRASE'                       17855.441 1   ? 'INS(P48, L49, R50, E51, N208, L209)' 
+'CATALYTIC CORE DOMAIN' ? 
+2 non-polymer syn '4-(2-HYDROXYETHYL)-1-PIPERAZINE ETHANESULFONIC ACID' 238.305   1   ? ?                                     ? ? 
+3 non-polymer syn GLYCEROL                                              92.094    2   ? ?                                     ? ? 
+4 water       nat water                                                 18.015    192 ? ?                                     ? ? 
+# 
+_entity_poly.entity_id                      1 
+_entity_poly.type                           'polypeptide(L)' 
+_entity_poly.nstd_linkage                   no 
+_entity_poly.nstd_monomer                   no 
+_entity_poly.pdbx_seq_one_letter_code       
+;PLREGRGLGPLQIWQTDFTLEPRMAPRSWLAVTVDTASSAIVVTQHGRVTSVAAQHHWATAIAVLGRPKAIKTDNGSCFT
+SKSTREWLARWGIAHTTGIPGNSQGQAMVERANRLLKDKIRVLAEGDGFMKRIPTSKQGELLAKAMYALNHFERGENTKT
+NL
+;
+_entity_poly.pdbx_seq_one_letter_code_can   
+;PLREGRGLGPLQIWQTDFTLEPRMAPRSWLAVTVDTASSAIVVTQHGRVTSVAAQHHWATAIAVLGRPKAIKTDNGSCFT
+SKSTREWLARWGIAHTTGIPGNSQGQAMVERANRLLKDKIRVLAEGDGFMKRIPTSKQGELLAKAMYALNHFERGENTKT
+NL
+;
+_entity_poly.pdbx_strand_id                 A 
+_entity_poly.pdbx_target_identifier         ? 
+# 
+loop_
+_entity_poly_seq.entity_id 
+_entity_poly_seq.num 
+_entity_poly_seq.mon_id 
+_entity_poly_seq.hetero 
+1 1   PRO n 
+1 2   LEU n 
+1 3   ARG n 
+1 4   GLU n 
+1 5   GLY n 
+1 6   ARG n 
+1 7   GLY n 
+1 8   LEU n 
+1 9   GLY n 
+1 10  PRO n 
+1 11  LEU n 
+1 12  GLN n 
+1 13  ILE n 
+1 14  TRP n 
+1 15  GLN n 
+1 16  THR n 
+1 17  ASP n 
+1 18  PHE n 
+1 19  THR n 
+1 20  LEU n 
+1 21  GLU n 
+1 22  PRO n 
+1 23  ARG n 
+1 24  MET n 
+1 25  ALA n 
+1 26  PRO n 
+1 27  ARG n 
+1 28  SER n 
+1 29  TRP n 
+1 30  LEU n 
+1 31  ALA n 
+1 32  VAL n 
+1 33  THR n 
+1 34  VAL n 
+1 35  ASP n 
+1 36  THR n 
+1 37  ALA n 
+1 38  SER n 
+1 39  SER n 
+1 40  ALA n 
+1 41  ILE n 
+1 42  VAL n 
+1 43  VAL n 
+1 44  THR n 
+1 45  GLN n 
+1 46  HIS n 
+1 47  GLY n 
+1 48  ARG n 
+1 49  VAL n 
+1 50  THR n 
+1 51  SER n 
+1 52  VAL n 
+1 53  ALA n 
+1 54  ALA n 
+1 55  GLN n 
+1 56  HIS n 
+1 57  HIS n 
+1 58  TRP n 
+1 59  ALA n 
+1 60  THR n 
+1 61  ALA n 
+1 62  ILE n 
+1 63  ALA n 
+1 64  VAL n 
+1 65  LEU n 
+1 66  GLY n 
+1 67  ARG n 
+1 68  PRO n 
+1 69  LYS n 
+1 70  ALA n 
+1 71  ILE n 
+1 72  LYS n 
+1 73  THR n 
+1 74  ASP n 
+1 75  ASN n 
+1 76  GLY n 
+1 77  SER n 
+1 78  CYS n 
+1 79  PHE n 
+1 80  THR n 
+1 81  SER n 
+1 82  LYS n 
+1 83  SER n 
+1 84  THR n 
+1 85  ARG n 
+1 86  GLU n 
+1 87  TRP n 
+1 88  LEU n 
+1 89  ALA n 
+1 90  ARG n 
+1 91  TRP n 
+1 92  GLY n 
+1 93  ILE n 
+1 94  ALA n 
+1 95  HIS n 
+1 96  THR n 
+1 97  THR n 
+1 98  GLY n 
+1 99  ILE n 
+1 100 PRO n 
+1 101 GLY n 
+1 102 ASN n 
+1 103 SER n 
+1 104 GLN n 
+1 105 GLY n 
+1 106 GLN n 
+1 107 ALA n 
+1 108 MET n 
+1 109 VAL n 
+1 110 GLU n 
+1 111 ARG n 
+1 112 ALA n 
+1 113 ASN n 
+1 114 ARG n 
+1 115 LEU n 
+1 116 LEU n 
+1 117 LYS n 
+1 118 ASP n 
+1 119 LYS n 
+1 120 ILE n 
+1 121 ARG n 
+1 122 VAL n 
+1 123 LEU n 
+1 124 ALA n 
+1 125 GLU n 
+1 126 GLY n 
+1 127 ASP n 
+1 128 GLY n 
+1 129 PHE n 
+1 130 MET n 
+1 131 LYS n 
+1 132 ARG n 
+1 133 ILE n 
+1 134 PRO n 
+1 135 THR n 
+1 136 SER n 
+1 137 LYS n 
+1 138 GLN n 
+1 139 GLY n 
+1 140 GLU n 
+1 141 LEU n 
+1 142 LEU n 
+1 143 ALA n 
+1 144 LYS n 
+1 145 ALA n 
+1 146 MET n 
+1 147 TYR n 
+1 148 ALA n 
+1 149 LEU n 
+1 150 ASN n 
+1 151 HIS n 
+1 152 PHE n 
+1 153 GLU n 
+1 154 ARG n 
+1 155 GLY n 
+1 156 GLU n 
+1 157 ASN n 
+1 158 THR n 
+1 159 LYS n 
+1 160 THR n 
+1 161 ASN n 
+1 162 LEU n 
+# 
+_entity_src_gen.entity_id                          1 
+_entity_src_gen.pdbx_src_id                        1 
+_entity_src_gen.pdbx_alt_source_flag               sample 
+_entity_src_gen.pdbx_seq_type                      ? 
+_entity_src_gen.pdbx_beg_seq_num                   ? 
+_entity_src_gen.pdbx_end_seq_num                   ? 
+_entity_src_gen.gene_src_common_name               ? 
+_entity_src_gen.gene_src_genus                     Alpharetrovirus 
+_entity_src_gen.pdbx_gene_src_gene                 ? 
+_entity_src_gen.gene_src_species                   ? 
+_entity_src_gen.gene_src_strain                    ? 
+_entity_src_gen.gene_src_tissue                    ? 
+_entity_src_gen.gene_src_tissue_fraction           ? 
+_entity_src_gen.gene_src_details                   ? 
+_entity_src_gen.pdbx_gene_src_fragment             ? 
+_entity_src_gen.pdbx_gene_src_scientific_name      'Avian sarcoma virus' 
+_entity_src_gen.pdbx_gene_src_ncbi_taxonomy_id     11876 
+_entity_src_gen.pdbx_gene_src_variant              ? 
+_entity_src_gen.pdbx_gene_src_cell_line            ? 
+_entity_src_gen.pdbx_gene_src_atcc                 ? 
+_entity_src_gen.pdbx_gene_src_organ                ? 
+_entity_src_gen.pdbx_gene_src_organelle            ? 
+_entity_src_gen.pdbx_gene_src_cell                 ? 
+_entity_src_gen.pdbx_gene_src_cellular_location    ? 
+_entity_src_gen.host_org_common_name               ? 
+_entity_src_gen.pdbx_host_org_scientific_name      'Escherichia coli' 
+_entity_src_gen.pdbx_host_org_ncbi_taxonomy_id     562 
+_entity_src_gen.host_org_genus                     Escherichia 
+_entity_src_gen.pdbx_host_org_gene                 ? 
+_entity_src_gen.pdbx_host_org_organ                ? 
+_entity_src_gen.host_org_species                   ? 
+_entity_src_gen.pdbx_host_org_tissue               ? 
+_entity_src_gen.pdbx_host_org_tissue_fraction      ? 
+_entity_src_gen.pdbx_host_org_strain               ? 
+_entity_src_gen.pdbx_host_org_variant              ? 
+_entity_src_gen.pdbx_host_org_cell_line            ? 
+_entity_src_gen.pdbx_host_org_atcc                 ? 
+_entity_src_gen.pdbx_host_org_culture_collection   ? 
+_entity_src_gen.pdbx_host_org_cell                 ? 
+_entity_src_gen.pdbx_host_org_organelle            ? 
+_entity_src_gen.pdbx_host_org_cellular_location    ? 
+_entity_src_gen.pdbx_host_org_vector_type          ? 
+_entity_src_gen.pdbx_host_org_vector               ? 
+_entity_src_gen.host_org_details                   ? 
+_entity_src_gen.expression_system_id               ? 
+_entity_src_gen.plasmid_name                       'PRC23IN(52-207)' 
+_entity_src_gen.plasmid_details                    ? 
+_entity_src_gen.pdbx_description                   ? 
+# 
+_struct_ref.id                         1 
+_struct_ref.db_name                    UNP 
+_struct_ref.db_code                    POL_RSVP 
+_struct_ref.entity_id                  1 
+_struct_ref.pdbx_db_accession          P03354 
+_struct_ref.pdbx_align_begin           ? 
+_struct_ref.pdbx_seq_one_letter_code   ? 
+_struct_ref.pdbx_db_isoform            ? 
+# 
+_struct_ref_seq.align_id                      1 
+_struct_ref_seq.ref_id                        1 
+_struct_ref_seq.pdbx_PDB_id_code              1CXQ 
+_struct_ref_seq.pdbx_strand_id                A 
+_struct_ref_seq.seq_align_beg                 5 
+_struct_ref_seq.pdbx_seq_align_beg_ins_code   ? 
+_struct_ref_seq.seq_align_end                 160 
+_struct_ref_seq.pdbx_seq_align_end_ins_code   ? 
+_struct_ref_seq.pdbx_db_accession             P03354 
+_struct_ref_seq.db_align_beg                  624 
+_struct_ref_seq.pdbx_db_align_beg_ins_code    ? 
+_struct_ref_seq.db_align_end                  779 
+_struct_ref_seq.pdbx_db_align_end_ins_code    ? 
+_struct_ref_seq.pdbx_auth_seq_align_beg       52 
+_struct_ref_seq.pdbx_auth_seq_align_end       207 
+# 
+loop_
+_struct_ref_seq_dif.align_id 
+_struct_ref_seq_dif.pdbx_pdb_id_code 
+_struct_ref_seq_dif.mon_id 
+_struct_ref_seq_dif.pdbx_pdb_strand_id 
+_struct_ref_seq_dif.seq_num 
+_struct_ref_seq_dif.pdbx_pdb_ins_code 
+_struct_ref_seq_dif.pdbx_seq_db_name 
+_struct_ref_seq_dif.pdbx_seq_db_accession_code 
+_struct_ref_seq_dif.db_mon_id 
+_struct_ref_seq_dif.pdbx_seq_db_seq_num 
+_struct_ref_seq_dif.details 
+_struct_ref_seq_dif.pdbx_auth_seq_num 
+_struct_ref_seq_dif.pdbx_ordinal 
+1 1CXQ PRO A 1   ? UNP P03354 ?   ?   INSERTION        48  1 
+1 1CXQ LEU A 2   ? UNP P03354 ?   ?   INSERTION        49  2 
+1 1CXQ ARG A 3   ? UNP P03354 ?   ?   INSERTION        50  3 
+1 1CXQ GLU A 4   ? UNP P03354 ?   ?   INSERTION        51  4 
+1 1CXQ GLY A 5   ? UNP P03354 PRO 624 CONFLICT         52  5 
+1 1CXQ ALA A 54  ? UNP P03354 VAL 673 'SEE REMARK 999' 101 6 
+1 1CXQ LYS A 119 ? UNP P03354 ARG 738 'SEE REMARK 999' 166 7 
+1 1CXQ ASN A 161 ? UNP P03354 ?   ?   INSERTION        208 8 
+1 1CXQ LEU A 162 ? UNP P03354 ?   ?   INSERTION        209 9 
+# 
+loop_
+_chem_comp.id 
+_chem_comp.type 
+_chem_comp.mon_nstd_flag 
+_chem_comp.name 
+_chem_comp.pdbx_synonyms 
+_chem_comp.formula 
+_chem_comp.formula_weight 
+ALA 'L-peptide linking' y ALANINE                                               ?                               'C3 H7 N O2'     
+89.093  
+ARG 'L-peptide linking' y ARGININE                                              ?                               'C6 H15 N4 O2 1' 
+175.209 
+ASN 'L-peptide linking' y ASPARAGINE                                            ?                               'C4 H8 N2 O3'    
+132.118 
+ASP 'L-peptide linking' y 'ASPARTIC ACID'                                       ?                               'C4 H7 N O4'     
+133.103 
+CYS 'L-peptide linking' y CYSTEINE                                              ?                               'C3 H7 N O2 S'   
+121.158 
+EPE non-polymer         . '4-(2-HYDROXYETHYL)-1-PIPERAZINE ETHANESULFONIC ACID' HEPES                           'C8 H18 N2 O4 S' 
+238.305 
+GLN 'L-peptide linking' y GLUTAMINE                                             ?                               'C5 H10 N2 O3'   
+146.144 
+GLU 'L-peptide linking' y 'GLUTAMIC ACID'                                       ?                               'C5 H9 N O4'     
+147.129 
+GLY 'peptide linking'   y GLYCINE                                               ?                               'C2 H5 N O2'     
+75.067  
+GOL non-polymer         . GLYCEROL                                              'GLYCERIN; PROPANE-1,2,3-TRIOL' 'C3 H8 O3'       
+92.094  
+HIS 'L-peptide linking' y HISTIDINE                                             ?                               'C6 H10 N3 O2 1' 
+156.162 
+HOH non-polymer         . WATER                                                 ?                               'H2 O'           
+18.015  
+ILE 'L-peptide linking' y ISOLEUCINE                                            ?                               'C6 H13 N O2'    
+131.173 
+LEU 'L-peptide linking' y LEUCINE                                               ?                               'C6 H13 N O2'    
+131.173 
+LYS 'L-peptide linking' y LYSINE                                                ?                               'C6 H15 N2 O2 1' 
+147.195 
+MET 'L-peptide linking' y METHIONINE                                            ?                               'C5 H11 N O2 S'  
+149.211 
+PHE 'L-peptide linking' y PHENYLALANINE                                         ?                               'C9 H11 N O2'    
+165.189 
+PRO 'L-peptide linking' y PROLINE                                               ?                               'C5 H9 N O2'     
+115.130 
+SER 'L-peptide linking' y SERINE                                                ?                               'C3 H7 N O3'     
+105.093 
+THR 'L-peptide linking' y THREONINE                                             ?                               'C4 H9 N O3'     
+119.119 
+TRP 'L-peptide linking' y TRYPTOPHAN                                            ?                               'C11 H12 N2 O2'  
+204.225 
+TYR 'L-peptide linking' y TYROSINE                                              ?                               'C9 H11 N O3'    
+181.189 
+VAL 'L-peptide linking' y VALINE                                                ?                               'C5 H11 N O2'    
+117.146 
+# 
+_exptl.entry_id          1CXQ 
+_exptl.method            'X-RAY DIFFRACTION' 
+_exptl.crystals_number   1 
+# 
+_exptl_crystal.id                    1 
+_exptl_crystal.density_meas          ? 
+_exptl_crystal.density_Matthews      2.41 
+_exptl_crystal.density_percent_sol   48.93 
+_exptl_crystal.description           ? 
+# 
+_exptl_crystal_grow.crystal_id      1 
+_exptl_crystal_grow.method          'VAPOR DIFFUSION, HANGING DROP' 
+_exptl_crystal_grow.temp            277.0 
+_exptl_crystal_grow.temp_details    ? 
+_exptl_crystal_grow.pH              7.5 
+_exptl_crystal_grow.pdbx_details    
+'2% Peg 400, 2M Ammonium Sulfate, HEPES pH 7.5, VAPOR DIFFUSION, HANGING DROP, temperature 277.0K' 
+_exptl_crystal_grow.pdbx_pH_range   . 
+# 
+_diffrn.ambient_temp           95.0 
+_diffrn.ambient_temp_details   ? 
+_diffrn.crystal_id             1 
+_diffrn.id                     1 
+# 
+_diffrn_detector.diffrn_id              1 
+_diffrn_detector.detector               'IMAGE PLATE' 
+_diffrn_detector.type                   MARRESEARCH 
+_diffrn_detector.pdbx_collection_date   1998-03-21 
+_diffrn_detector.details                ? 
+# 
+_diffrn_radiation.diffrn_id                        1 
+_diffrn_radiation.wavelength_id                    1 
+_diffrn_radiation.pdbx_monochromatic_or_laue_m_l   M 
+_diffrn_radiation.monochromator                    ? 
+_diffrn_radiation.pdbx_diffrn_protocol             'SINGLE WAVELENGTH' 
+_diffrn_radiation.pdbx_scattering_type             x-ray 
+# 
+_diffrn_radiation_wavelength.id           1 
+_diffrn_radiation_wavelength.wavelength   0.98 
+_diffrn_radiation_wavelength.wt           1.0 
+# 
+_diffrn_source.diffrn_id                   1 
+_diffrn_source.source                      SYNCHROTRON 
+_diffrn_source.type                        'NSLS BEAMLINE X9B' 
+_diffrn_source.pdbx_synchrotron_site       NSLS 
+_diffrn_source.pdbx_synchrotron_beamline   X9B 
+_diffrn_source.pdbx_wavelength             0.98 
+_diffrn_source.pdbx_wavelength_list        ? 
+# 
+_reflns.entry_id                     1CXQ 
+_reflns.observed_criterion_sigma_I   -3.0 
+_reflns.observed_criterion_sigma_F   ? 
+_reflns.d_resolution_low             20.0 
+_reflns.d_resolution_high            1.02 
+_reflns.number_obs                   89063 
+_reflns.number_all                   89063 
+_reflns.percent_possible_obs         100 
+_reflns.pdbx_Rmerge_I_obs            0.0560000 
+_reflns.pdbx_Rsym_value              ? 
+_reflns.pdbx_netI_over_sigmaI        43.6 
+_reflns.B_iso_Wilson_estimate        13.2 
+_reflns.pdbx_redundancy              11.6 
+_reflns.R_free_details               ? 
+_reflns.limit_h_max                  ? 
+_reflns.limit_h_min                  ? 
+_reflns.limit_k_max                  ? 
+_reflns.limit_k_min                  ? 
+_reflns.limit_l_max                  ? 
+_reflns.limit_l_min                  ? 
+_reflns.observed_criterion_F_max     ? 
+_reflns.observed_criterion_F_min     ? 
+_reflns.pdbx_ordinal                 1 
+_reflns.pdbx_diffrn_id               1 
+# 
+_reflns_shell.d_res_high             1.02 
+_reflns_shell.d_res_low              1.04 
+_reflns_shell.percent_possible_all   99.6 
+_reflns_shell.Rmerge_I_obs           0.0290000 
+_reflns_shell.pdbx_Rsym_value        ? 
+_reflns_shell.meanI_over_sigI_obs    ? 
+_reflns_shell.pdbx_redundancy        7.7 
+_reflns_shell.percent_possible_obs   ? 
+_reflns_shell.number_unique_all      4376 
+_reflns_shell.pdbx_ordinal           1 
+_reflns_shell.pdbx_diffrn_id         1 
+# 
+_refine.entry_id                                 1CXQ 
+_refine.ls_number_reflns_obs                     88865 
+_refine.ls_number_reflns_all                     88865 
+_refine.pdbx_ls_sigma_I                          ? 
+_refine.pdbx_ls_sigma_F                          0.0 
+_refine.pdbx_data_cutoff_high_absF               ? 
+_refine.pdbx_data_cutoff_low_absF                ? 
+_refine.ls_d_res_low                             10.00 
+_refine.ls_d_res_high                            1.02 
+_refine.ls_percent_reflns_obs                    99.9 
+_refine.ls_R_factor_obs                          0.1290000 
+_refine.ls_R_factor_all                          0.1290000 
+_refine.ls_R_factor_R_work                       0.1299000 
+_refine.ls_R_factor_R_free                       0.1573000 
+_refine.ls_R_factor_R_free_error                 ? 
+_refine.ls_R_factor_R_free_error_details         ? 
+_refine.ls_percent_reflns_R_free                 ? 
+_refine.ls_number_reflns_R_free                  1777 
+_refine.ls_number_parameters                     1238 
+_refine.ls_number_restraints                     1519 
+_refine.occupancy_min                            ? 
+_refine.occupancy_max                            ? 
+_refine.B_iso_mean                               ? 
+_refine.aniso_B[1][1]                            ? 
+_refine.aniso_B[2][2]                            ? 
+_refine.aniso_B[3][3]                            ? 
+_refine.aniso_B[1][2]                            ? 
+_refine.aniso_B[1][3]                            ? 
+_refine.aniso_B[2][3]                            ? 
+_refine.solvent_model_details                    ? 
+_refine.solvent_model_param_ksol                 ? 
+_refine.solvent_model_param_bsol                 ? 
+_refine.pdbx_ls_cross_valid_method               ? 
+_refine.details                                  ? 
+_refine.pdbx_starting_model                      ? 
+_refine.pdbx_method_to_determine_struct          'AB INITIO' 
+_refine.pdbx_isotropic_thermal_model             ? 
+_refine.pdbx_stereochemistry_target_values       'ENGH AND HUBER' 
+_refine.pdbx_stereochem_target_val_spec_case     ? 
+_refine.pdbx_R_Free_selection_details            random 
+_refine.pdbx_overall_ESU_R_Free                  ? 
+_refine.overall_SU_B                             ? 
+_refine.ls_redundancy_reflns_obs                 ? 
+_refine.overall_SU_ML                            ? 
+_refine.pdbx_overall_ESU_R                       ? 
+_refine.pdbx_data_cutoff_high_rms_absF           ? 
+_refine.B_iso_min                                ? 
+_refine.B_iso_max                                ? 
+_refine.pdbx_refine_id                           'X-RAY DIFFRACTION' 
+_refine.pdbx_diffrn_id                           1 
+_refine.pdbx_TLS_residual_ADP_flag               ? 
+_refine.correlation_coeff_Fo_to_Fc               ? 
+_refine.correlation_coeff_Fo_to_Fc_free          ? 
+_refine.pdbx_solvent_vdw_probe_radii             ? 
+_refine.pdbx_solvent_ion_probe_radii             ? 
+_refine.pdbx_solvent_shrinkage_radii             ? 
+_refine.pdbx_overall_phase_error                 ? 
+_refine.overall_SU_R_Cruickshank_DPI             ? 
+_refine.pdbx_overall_SU_R_free_Cruickshank_DPI   ? 
+_refine.pdbx_overall_SU_R_Blow_DPI               ? 
+_refine.pdbx_overall_SU_R_free_Blow_DPI          ? 
+# 
+_refine_analyze.entry_id                        1CXQ 
+_refine_analyze.Luzzati_coordinate_error_obs    ? 
+_refine_analyze.Luzzati_sigma_a_obs             ? 
+_refine_analyze.Luzzati_d_res_low_obs           ? 
+_refine_analyze.Luzzati_coordinate_error_free   ? 
+_refine_analyze.Luzzati_sigma_a_free            ? 
+_refine_analyze.Luzzati_d_res_low_free          ? 
+_refine_analyze.number_disordered_residues      1 
+_refine_analyze.occupancy_sum_hydrogen          953. 
+_refine_analyze.occupancy_sum_non_hydrogen      1248. 
+_refine_analyze.pdbx_Luzzati_d_res_high_obs     ? 
+_refine_analyze.pdbx_refine_id                  'X-RAY DIFFRACTION' 
+# 
+_refine_hist.pdbx_refine_id                   'X-RAY DIFFRACTION' 
+_refine_hist.cycle_id                         LAST 
+_refine_hist.pdbx_number_atoms_protein        1101 
+_refine_hist.pdbx_number_atoms_nucleic_acid   0 
+_refine_hist.pdbx_number_atoms_ligand         27 
+_refine_hist.number_atoms_solvent             192 
+_refine_hist.number_atoms_total               1320 
+_refine_hist.d_res_high                       1.02 
+_refine_hist.d_res_low                        10.00 
+# 
+loop_
+_refine_ls_restr.type 
+_refine_ls_restr.dev_ideal 
+_refine_ls_restr.dev_ideal_target 
+_refine_ls_restr.weight 
+_refine_ls_restr.number 
+_refine_ls_restr.pdbx_refine_id 
+_refine_ls_restr.pdbx_restraint_function 
+s_bond_d               0.015 ? ? ? 'X-RAY DIFFRACTION' ? 
+s_angle_d              0.030 ? ? ? 'X-RAY DIFFRACTION' ? 
+s_similar_dist         0.028 ? ? ? 'X-RAY DIFFRACTION' ? 
+s_from_restr_planes    0.338 ? ? ? 'X-RAY DIFFRACTION' ? 
+s_zero_chiral_vol      0.087 ? ? ? 'X-RAY DIFFRACTION' ? 
+s_non_zero_chiral_vol  0.097 ? ? ? 'X-RAY DIFFRACTION' ? 
+s_anti_bump_dis_restr  ?     ? ? ? 'X-RAY DIFFRACTION' ? 
+s_rigid_bond_adp_cmpnt 0.006 ? ? ? 'X-RAY DIFFRACTION' ? 
+s_similar_adp_cmpnt    0.047 ? ? ? 'X-RAY DIFFRACTION' ? 
+s_approx_iso_adps      0.082 ? ? ? 'X-RAY DIFFRACTION' ? 
+# 
+_pdbx_refine.entry_id                                    1CXQ 
+_pdbx_refine.R_factor_all_no_cutoff                      0.1290000 
+_pdbx_refine.R_factor_obs_no_cutoff                      ? 
+_pdbx_refine.free_R_factor_no_cutoff                     ? 
+_pdbx_refine.free_R_val_test_set_size_perc_no_cutoff     ? 
+_pdbx_refine.free_R_val_test_set_ct_no_cutoff            ? 
+_pdbx_refine.R_factor_all_4sig_cutoff                    0.1150000 
+_pdbx_refine.R_factor_obs_4sig_cutoff                    ? 
+_pdbx_refine.free_R_factor_4sig_cutoff                   ? 
+_pdbx_refine.free_R_val_test_set_size_perc_4sig_cutoff   ? 
+_pdbx_refine.free_R_val_test_set_ct_4sig_cutoff          ? 
+_pdbx_refine.number_reflns_obs_4sig_cutoff               7339 
+_pdbx_refine.number_reflns_obs_no_cutoff                 ? 
+_pdbx_refine.pdbx_refine_id                              'X-RAY DIFFRACTION' 
+_pdbx_refine.free_R_error_no_cutoff                      ? 
+# 
+_struct.entry_id                  1CXQ 
+_struct.title                     'ATOMIC RESOLUTION ASV INTEGRASE CORE DOMAIN FROM AMMONIUM SULFATE' 
+_struct.pdbx_descriptor           'ASV INTEGRASE' 
+_struct.pdbx_model_details        ? 
+_struct.pdbx_CASP_flag            ? 
+_struct.pdbx_model_type_details   ? 
+# 
+_struct_keywords.entry_id        1CXQ 
+_struct_keywords.pdbx_keywords   TRANSFERASE 
+_struct_keywords.text            'MIXED BETA-SHEET SURROUNDED BY ALPHA-HELICES, TRANSFERASE' 
+# 
+loop_
+_struct_asym.id 
+_struct_asym.pdbx_blank_PDB_chainid_flag 
+_struct_asym.pdbx_modified 
+_struct_asym.entity_id 
+_struct_asym.details 
+A N N 1 ? 
+B N N 2 ? 
+C N N 3 ? 
+D N N 3 ? 
+E N N 4 ? 
+# 
+_struct_biol.id                    1 
+_struct_biol.details               
+;The biological assembly is (at least) a dimer constructed from chain A and a  
+symmetry partner generated by the two-fold symmetry operator.
+;
+_struct_biol.pdbx_parent_biol_id   ? 
+# 
+loop_
+_struct_conf.conf_type_id 
+_struct_conf.id 
+_struct_conf.pdbx_PDB_helix_id 
+_struct_conf.beg_label_comp_id 
+_struct_conf.beg_label_asym_id 
+_struct_conf.beg_label_seq_id 
+_struct_conf.pdbx_beg_PDB_ins_code 
+_struct_conf.end_label_comp_id 
+_struct_conf.end_label_asym_id 
+_struct_conf.end_label_seq_id 
+_struct_conf.pdbx_end_PDB_ins_code 
+_struct_conf.beg_auth_comp_id 
+_struct_conf.beg_auth_asym_id 
+_struct_conf.beg_auth_seq_id 
+_struct_conf.end_auth_comp_id 
+_struct_conf.end_auth_asym_id 
+_struct_conf.end_auth_seq_id 
+_struct_conf.pdbx_PDB_helix_class 
+_struct_conf.details 
+_struct_conf.pdbx_PDB_helix_length 
+HELX_P HELX_P1 1 PRO A 22  ? ALA A 25  ? PRO A 69  ALA A 72  5 ? 4  
+HELX_P HELX_P2 2 THR A 50  ? GLY A 66  ? THR A 97  GLY A 113 1 ? 17 
+HELX_P HELX_P3 3 GLY A 76  ? SER A 81  ? GLY A 123 SER A 128 1 ? 6  
+HELX_P HELX_P4 4 SER A 81  ? GLY A 92  ? SER A 128 GLY A 139 1 ? 12 
+HELX_P HELX_P5 5 GLN A 106 ? ASP A 127 ? GLN A 153 ASP A 174 1 ? 22 
+HELX_P HELX_P6 6 PRO A 134 ? HIS A 151 ? PRO A 181 HIS A 198 1 ? 18 
+# 
+_struct_conf_type.id          HELX_P 
+_struct_conf_type.criteria    ? 
+_struct_conf_type.reference   ? 
+# 
+_struct_mon_prot_cis.pdbx_id                1 
+_struct_mon_prot_cis.label_comp_id          ALA 
+_struct_mon_prot_cis.label_seq_id           25 
+_struct_mon_prot_cis.label_asym_id          A 
+_struct_mon_prot_cis.label_alt_id           . 
+_struct_mon_prot_cis.pdbx_PDB_ins_code      ? 
+_struct_mon_prot_cis.auth_comp_id           ALA 
+_struct_mon_prot_cis.auth_seq_id            72 
+_struct_mon_prot_cis.auth_asym_id           A 
+_struct_mon_prot_cis.pdbx_label_comp_id_2   PRO 
+_struct_mon_prot_cis.pdbx_label_seq_id_2    26 
+_struct_mon_prot_cis.pdbx_label_asym_id_2   A 
+_struct_mon_prot_cis.pdbx_PDB_ins_code_2    ? 
+_struct_mon_prot_cis.pdbx_auth_comp_id_2    PRO 
+_struct_mon_prot_cis.pdbx_auth_seq_id_2     73 
+_struct_mon_prot_cis.pdbx_auth_asym_id_2    A 
+_struct_mon_prot_cis.pdbx_PDB_model_num     1 
+_struct_mon_prot_cis.pdbx_omega_angle       6.22 
+# 
+_struct_sheet.id               A 
+_struct_sheet.type             ? 
+_struct_sheet.number_strands   5 
+_struct_sheet.details          ? 
+# 
+loop_
+_struct_sheet_order.sheet_id 
+_struct_sheet_order.range_id_1 
+_struct_sheet_order.range_id_2 
+_struct_sheet_order.offset 
+_struct_sheet_order.sense 
+A 1 2 ? anti-parallel 
+A 2 3 ? anti-parallel 
+A 3 4 ? parallel      
+A 4 5 ? parallel      
+# 
+loop_
+_struct_sheet_range.sheet_id 
+_struct_sheet_range.id 
+_struct_sheet_range.beg_label_comp_id 
+_struct_sheet_range.beg_label_asym_id 
+_struct_sheet_range.beg_label_seq_id 
+_struct_sheet_range.pdbx_beg_PDB_ins_code 
+_struct_sheet_range.end_label_comp_id 
+_struct_sheet_range.end_label_asym_id 
+_struct_sheet_range.end_label_seq_id 
+_struct_sheet_range.pdbx_end_PDB_ins_code 
+_struct_sheet_range.beg_auth_comp_id 
+_struct_sheet_range.beg_auth_asym_id 
+_struct_sheet_range.beg_auth_seq_id 
+_struct_sheet_range.end_auth_comp_id 
+_struct_sheet_range.end_auth_asym_id 
+_struct_sheet_range.end_auth_seq_id 
+A 1 ILE A 41 ? HIS A 46 ? ILE A 88  HIS A 93  
+A 2 TRP A 29 ? ASP A 35 ? TRP A 76  ASP A 82  
+A 3 ILE A 13 ? LEU A 20 ? ILE A 60  LEU A 67  
+A 4 ALA A 70 ? LYS A 72 ? ALA A 117 LYS A 119 
+A 5 ALA A 94 ? THR A 96 ? ALA A 141 THR A 143 
+# 
+loop_
+_pdbx_struct_sheet_hbond.sheet_id 
+_pdbx_struct_sheet_hbond.range_id_1 
+_pdbx_struct_sheet_hbond.range_id_2 
+_pdbx_struct_sheet_hbond.range_1_label_atom_id 
+_pdbx_struct_sheet_hbond.range_1_label_comp_id 
+_pdbx_struct_sheet_hbond.range_1_label_asym_id 
+_pdbx_struct_sheet_hbond.range_1_label_seq_id 
+_pdbx_struct_sheet_hbond.range_1_PDB_ins_code 
+_pdbx_struct_sheet_hbond.range_1_auth_atom_id 
+_pdbx_struct_sheet_hbond.range_1_auth_comp_id 
+_pdbx_struct_sheet_hbond.range_1_auth_asym_id 
+_pdbx_struct_sheet_hbond.range_1_auth_seq_id 
+_pdbx_struct_sheet_hbond.range_2_label_atom_id 
+_pdbx_struct_sheet_hbond.range_2_label_comp_id 
+_pdbx_struct_sheet_hbond.range_2_label_asym_id 
+_pdbx_struct_sheet_hbond.range_2_label_seq_id 
+_pdbx_struct_sheet_hbond.range_2_PDB_ins_code 
+_pdbx_struct_sheet_hbond.range_2_auth_atom_id 
+_pdbx_struct_sheet_hbond.range_2_auth_comp_id 
+_pdbx_struct_sheet_hbond.range_2_auth_asym_id 
+_pdbx_struct_sheet_hbond.range_2_auth_seq_id 
+A 1 2 O HIS A 46 ? O HIS A 93  N TRP A 29 ? N TRP A 76  
+A 2 3 N VAL A 34 ? N VAL A 81  O GLN A 15 ? O GLN A 62  
+A 3 4 N TRP A 14 ? N TRP A 61  O ALA A 70 ? O ALA A 117 
+A 4 5 N ILE A 71 ? N ILE A 118 O ALA A 94 ? O ALA A 141 
+# 
+loop_
+_struct_site.id 
+_struct_site.pdbx_evidence_code 
+_struct_site.pdbx_auth_asym_id 
+_struct_site.pdbx_auth_comp_id 
+_struct_site.pdbx_auth_seq_id 
+_struct_site.pdbx_auth_ins_code 
+_struct_site.pdbx_num_residues 
+_struct_site.details 
+AC1 Software ? ? ? ? 15 'BINDING SITE FOR RESIDUE EPE A 300' 
+AC2 Software ? ? ? ? 6  'BINDING SITE FOR RESIDUE GOL A 301' 
+AC3 Software ? ? ? ? 2  'BINDING SITE FOR RESIDUE GOL A 302' 
+# 
+loop_
+_struct_site_gen.id 
+_struct_site_gen.site_id 
+_struct_site_gen.pdbx_num_res 
+_struct_site_gen.label_comp_id 
+_struct_site_gen.label_asym_id 
+_struct_site_gen.label_seq_id 
+_struct_site_gen.pdbx_auth_ins_code 
+_struct_site_gen.auth_comp_id 
+_struct_site_gen.auth_asym_id 
+_struct_site_gen.auth_seq_id 
+_struct_site_gen.label_atom_id 
+_struct_site_gen.label_alt_id 
+_struct_site_gen.symmetry 
+_struct_site_gen.details 
+1  AC1 15 PRO A 26  ? PRO A 73  . ? 1_555 ? 
+2  AC1 15 SER A 28  ? SER A 75  . ? 1_555 ? 
+3  AC1 15 TRP A 29  ? TRP A 76  . ? 1_555 ? 
+4  AC1 15 GLY A 47  ? GLY A 94  . ? 1_555 ? 
+5  AC1 15 ARG A 48  ? ARG A 95  . ? 1_555 ? 
+6  AC1 15 VAL A 49  ? VAL A 96  . ? 1_555 ? 
+7  AC1 15 ARG A 90  ? ARG A 137 . ? 6_566 ? 
+8  AC1 15 TRP A 91  ? TRP A 138 . ? 6_566 ? 
+9  AC1 15 LYS A 119 ? LYS A 166 . ? 4_565 ? 
+10 AC1 15 LYS A 144 ? LYS A 191 . ? 4_565 ? 
+11 AC1 15 ALA A 148 ? ALA A 195 . ? 4_565 ? 
+12 AC1 15 HOH E .   ? HOH A 484 . ? 1_555 ? 
+13 AC1 15 HOH E .   ? HOH A 511 . ? 1_555 ? 
+14 AC1 15 HOH E .   ? HOH A 512 . ? 1_555 ? 
+15 AC1 15 HOH E .   ? HOH A 552 . ? 6_566 ? 
+16 AC2 6  VAL A 43  ? VAL A 90  . ? 1_555 ? 
+17 AC2 6  THR A 44  ? THR A 91  . ? 1_555 ? 
+18 AC2 6  THR A 60  ? THR A 107 . ? 7_556 ? 
+19 AC2 6  ALA A 143 ? ALA A 190 . ? 1_555 ? 
+20 AC2 6  HOH E .   ? HOH A 445 . ? 1_555 ? 
+21 AC2 6  HOH E .   ? HOH A 466 . ? 1_555 ? 
+22 AC3 2  HOH E .   ? HOH A 478 . ? 1_555 ? 
+23 AC3 2  HOH E .   ? HOH A 527 . ? 8_666 ? 
+# 
+_database_PDB_matrix.entry_id          1CXQ 
+_database_PDB_matrix.origx[1][1]       1.000000 
+_database_PDB_matrix.origx[1][2]       0.000000 
+_database_PDB_matrix.origx[1][3]       0.000000 
+_database_PDB_matrix.origx[2][1]       0.000000 
+_database_PDB_matrix.origx[2][2]       1.000000 
+_database_PDB_matrix.origx[2][3]       0.000000 
+_database_PDB_matrix.origx[3][1]       0.000000 
+_database_PDB_matrix.origx[3][2]       0.000000 
+_database_PDB_matrix.origx[3][3]       1.000000 
+_database_PDB_matrix.origx_vector[1]   0.000000 
+_database_PDB_matrix.origx_vector[2]   0.000000 
+_database_PDB_matrix.origx_vector[3]   0.000000 
+# 
+_atom_sites.entry_id                    1CXQ 
+_atom_sites.fract_transf_matrix[1][1]   0.015258 
+_atom_sites.fract_transf_matrix[1][2]   0.000000 
+_atom_sites.fract_transf_matrix[1][3]   0.000000 
+_atom_sites.fract_transf_matrix[2][1]   0.000000 
+_atom_sites.fract_transf_matrix[2][2]   0.015258 
+_atom_sites.fract_transf_matrix[2][3]   0.000000 
+_atom_sites.fract_transf_matrix[3][1]   0.000000 
+_atom_sites.fract_transf_matrix[3][2]   0.000000 
+_atom_sites.fract_transf_matrix[3][3]   0.012481 
+_atom_sites.fract_transf_vector[1]      0.000000 
+_atom_sites.fract_transf_vector[2]      0.000000 
+_atom_sites.fract_transf_vector[3]      0.000000 
+# 
+loop_
+_atom_type.symbol 
+C 
+N 
+O 
+S 
+# 
+loop_
+_atom_site.group_PDB 
+_atom_site.id 
+_atom_site.type_symbol 
+_atom_site.label_atom_id 
+_atom_site.label_alt_id 
+_atom_site.label_comp_id 
+_atom_site.label_asym_id 
+_atom_site.label_entity_id 
+_atom_site.label_seq_id 
+_atom_site.pdbx_PDB_ins_code 
+_atom_site.Cartn_x 
+_atom_site.Cartn_y 
+_atom_site.Cartn_z 
+_atom_site.occupancy 
+_atom_site.B_iso_or_equiv 
+_atom_site.pdbx_formal_charge 
+_atom_site.auth_seq_id 
+_atom_site.auth_comp_id 
+_atom_site.auth_asym_id 
+_atom_site.auth_atom_id 
+_atom_site.pdbx_PDB_model_num 
+ATOM   1    N N   . GLY A 1 5   ? 23.253 33.201 45.707 1.00 71.22 ? 52  GLY A N   1 
+ATOM   2    C CA  . GLY A 1 5   ? 22.810 32.813 47.065 1.00 59.96 ? 52  GLY A CA  1 
+ATOM   3    C C   . GLY A 1 5   ? 23.739 31.803 47.684 1.00 50.33 ? 52  GLY A C   1 
+ATOM   4    O O   . GLY A 1 5   ? 24.129 30.782 47.104 1.00 49.16 ? 52  GLY A O   1 
+ATOM   5    N N   . ARG A 1 6   ? 24.118 32.089 48.930 1.00 41.56 ? 53  ARG A N   1 
+ATOM   6    C CA  . ARG A 1 6   ? 25.045 31.154 49.576 1.00 33.54 ? 53  ARG A CA  1 
+ATOM   7    C C   . ARG A 1 6   ? 24.375 29.824 49.848 1.00 29.91 ? 53  ARG A C   1 
+ATOM   8    O O   . ARG A 1 6   ? 24.989 28.752 49.651 1.00 25.81 ? 53  ARG A O   1 
+ATOM   9    C CB  . ARG A 1 6   ? 25.604 31.761 50.882 1.00 27.50 ? 53  ARG A CB  1 
+ATOM   10   C CG  . ARG A 1 6   ? 26.649 30.829 51.521 1.00 21.62 ? 53  ARG A CG  1 
+ATOM   11   C CD  . ARG A 1 6   ? 27.214 31.463 52.809 1.00 17.75 ? 53  ARG A CD  1 
+ATOM   12   N NE  . ARG A 1 6   ? 26.145 31.633 53.787 1.00 17.72 ? 53  ARG A NE  1 
+ATOM   13   C CZ  . ARG A 1 6   ? 25.659 30.635 54.543 1.00 15.68 ? 53  ARG A CZ  1 
+ATOM   14   N NH1 . ARG A 1 6   ? 26.115 29.397 54.479 1.00 14.50 ? 53  ARG A NH1 1 
+ATOM   15   N NH2 . ARG A 1 6   ? 24.686 30.869 55.391 1.00 18.04 ? 53  ARG A NH2 1 
+ATOM   16   N N   . GLY A 1 7   ? 23.128 29.886 50.333 1.00 32.02 ? 54  GLY A N   1 
+ATOM   17   C CA  . GLY A 1 7   ? 22.439 28.696 50.796 1.00 28.04 ? 54  GLY A CA  1 
+ATOM   18   C C   . GLY A 1 7   ? 23.170 28.028 51.946 1.00 17.56 ? 54  GLY A C   1 
+ATOM   19   O O   . GLY A 1 7   ? 23.391 28.659 52.991 1.00 19.41 ? 54  GLY A O   1 
+ATOM   20   N N   . LEU A 1 8   ? 23.582 26.758 51.768 1.00 17.31 ? 55  LEU A N   1 
+ATOM   21   C CA  . LEU A 1 8   ? 24.388 26.066 52.772 1.00 13.55 ? 55  LEU A CA  1 
+ATOM   22   C C   . LEU A 1 8   ? 25.868 26.099 52.469 1.00 12.70 ? 55  LEU A C   1 
+ATOM   23   O O   . LEU A 1 8   ? 26.669 25.436 53.124 1.00 12.76 ? 55  LEU A O   1 
+ATOM   24   C CB  . LEU A 1 8   ? 23.955 24.598 52.878 1.00 15.60 ? 55  LEU A CB  1 
+ATOM   25   C CG  . LEU A 1 8   ? 22.466 24.451 53.353 1.00 17.62 ? 55  LEU A CG  1 
+ATOM   26   C CD1 . LEU A 1 8   ? 22.092 23.007 53.151 1.00 30.87 ? 55  LEU A CD1 1 
+ATOM   27   C CD2 . LEU A 1 8   ? 22.287 25.026 54.729 1.00 21.57 ? 55  LEU A CD2 1 
+ATOM   28   N N   . GLY A 1 9   ? 26.271 26.884 51.460 1.00 14.56 ? 56  GLY A N   1 
+ATOM   29   C CA  . GLY A 1 9   ? 27.649 26.899 51.035 1.00 15.04 ? 56  GLY A CA  1 
+ATOM   30   C C   . GLY A 1 9   ? 28.558 27.565 52.069 1.00 12.77 ? 56  GLY A C   1 
+ATOM   31   O O   . GLY A 1 9   ? 28.121 28.058 53.118 1.00 12.41 ? 56  GLY A O   1 
+ATOM   32   N N   . PRO A 1 10  ? 29.858 27.551 51.812 1.00 14.11 ? 57  PRO A N   1 
+ATOM   33   C CA  . PRO A 1 10  ? 30.850 28.040 52.764 1.00 12.93 ? 57  PRO A CA  1 
+ATOM   34   C C   . PRO A 1 10  ? 30.660 29.531 53.085 1.00 12.26 ? 57  PRO A C   1 
+ATOM   35   O O   . PRO A 1 10  ? 30.284 30.337 52.244 1.00 14.47 ? 57  PRO A O   1 
+ATOM   36   C CB  . PRO A 1 10  ? 32.154 27.799 52.054 1.00 16.92 ? 57  PRO A CB  1 
+ATOM   37   C CG  . PRO A 1 10  ? 31.796 27.508 50.622 1.00 25.07 ? 57  PRO A CG  1 
+ATOM   38   C CD  . PRO A 1 10  ? 30.409 27.025 50.554 1.00 17.96 ? 57  PRO A CD  1 
+ATOM   39   N N   . LEU A 1 11  ? 30.966 29.873 54.308 1.00 12.11 ? 58  LEU A N   1 
+ATOM   40   C CA  . LEU A 1 11  ? 30.878 31.249 54.767 1.00 12.91 ? 58  LEU A CA  1 
+ATOM   41   C C   . LEU A 1 11  ? 31.921 32.120 54.061 1.00 10.86 ? 58  LEU A C   1 
+ATOM   42   O O   . LEU A 1 11  ? 33.017 31.651 53.718 1.00 11.27 ? 58  LEU A O   1 
+ATOM   43   C CB  . LEU A 1 11  ? 31.133 31.339 56.265 1.00 13.79 ? 58  LEU A CB  1 
+ATOM   44   C CG  . LEU A 1 11  ? 30.177 30.525 57.166 1.00 14.41 ? 58  LEU A CG  1 
+ATOM   45   C CD1 . LEU A 1 11  ? 30.627 30.560 58.586 1.00 18.50 ? 58  LEU A CD1 1 
+ATOM   46   C CD2 . LEU A 1 11  ? 28.753 30.988 57.064 1.00 21.20 ? 58  LEU A CD2 1 
+ATOM   47   N N   . GLN A 1 12  ? 31.570 33.379 53.924 1.00 12.54 ? 59  GLN A N   1 
+ATOM   48   C CA  . GLN A 1 12  ? 32.362 34.345 53.111 1.00 13.51 ? 59  GLN A CA  1 
+ATOM   49   C C   . GLN A 1 12  ? 33.445 34.953 53.958 1.00 10.35 ? 59  GLN A C   1 
+ATOM   50   O O   . GLN A 1 12  ? 33.322 36.081 54.434 1.00 10.90 ? 59  GLN A O   1 
+ATOM   51   C CB  . GLN A 1 12  ? 31.391 35.371 52.531 1.00 17.27 ? 59  GLN A CB  1 
+ATOM   52   C CG  . GLN A 1 12  ? 30.449 34.777 51.447 1.00 25.11 ? 59  GLN A CG  1 
+ATOM   53   C CD  . GLN A 1 12  ? 29.248 35.655 51.190 1.00 40.56 ? 59  GLN A CD  1 
+ATOM   54   O OE1 . GLN A 1 12  ? 29.259 36.738 50.577 1.00 51.24 ? 59  GLN A OE1 1 
+ATOM   55   N NE2 . GLN A 1 12  ? 28.180 35.083 51.719 1.00 58.54 ? 59  GLN A NE2 1 
+ATOM   56   N N   . ILE A 1 13  ? 34.488 34.146 54.249 1.00 9.64  ? 60  ILE A N   1 
+ATOM   57   C CA  . ILE A 1 13  ? 35.565 34.502 55.165 1.00 8.57  ? 60  ILE A CA  1 
+ATOM   58   C C   . ILE A 1 13  ? 36.887 34.423 54.434 1.00 8.42  ? 60  ILE A C   1 
+ATOM   59   O O   . ILE A 1 13  ? 37.177 33.429 53.770 1.00 10.09 ? 60  ILE A O   1 
+ATOM   60   C CB  . ILE A 1 13  ? 35.597 33.584 56.407 1.00 9.02  ? 60  ILE A CB  1 
+ATOM   61   C CG1 . ILE A 1 13  ? 34.247 33.642 57.129 1.00 10.65 ? 60  ILE A CG1 1 
+ATOM   62   C CG2 . ILE A 1 13  ? 36.769 33.922 57.290 1.00 11.16 ? 60  ILE A CG2 1 
+ATOM   63   C CD1 . ILE A 1 13  ? 34.130 32.658 58.263 1.00 13.92 ? 60  ILE A CD1 1 
+ATOM   64   N N   . TRP A 1 14  ? 37.690 35.497 54.512 1.00 7.51  ? 61  TRP A N   1 
+ATOM   65   C CA  . TRP A 1 14  ? 39.014 35.522 53.940 1.00 7.54  ? 61  TRP A CA  1 
+ATOM   66   C C   . TRP A 1 14  ? 40.072 35.369 55.002 1.00 7.48  ? 61  TRP A C   1 
+ATOM   67   O O   . TRP A 1 14  ? 39.831 35.675 56.183 1.00 8.10  ? 61  TRP A O   1 
+ATOM   68   C CB  . TRP A 1 14  ? 39.274 36.884 53.261 1.00 7.96  ? 61  TRP A CB  1 
+ATOM   69   C CG  . TRP A 1 14  ? 38.408 37.221 52.115 1.00 7.55  ? 61  TRP A CG  1 
+ATOM   70   C CD1 . TRP A 1 14  ? 37.478 36.459 51.483 1.00 8.79  ? 61  TRP A CD1 1 
+ATOM   71   C CD2 . TRP A 1 14  ? 38.409 38.491 51.460 1.00 7.49  ? 61  TRP A CD2 1 
+ATOM   72   N NE1 . TRP A 1 14  ? 36.912 37.161 50.437 1.00 9.30  ? 61  TRP A NE1 1 
+ATOM   73   C CE2 . TRP A 1 14  ? 37.453 38.426 50.427 1.00 8.54  ? 61  TRP A CE2 1 
+ATOM   74   C CE3 . TRP A 1 14  ? 39.127 39.670 51.677 1.00 7.99  ? 61  TRP A CE3 1 
+ATOM   75   C CZ2 . TRP A 1 14  ? 37.211 39.520 49.600 1.00 9.66  ? 61  TRP A CZ2 1 
+ATOM   76   C CZ3 . TRP A 1 14  ? 38.870 40.754 50.855 1.00 8.60  ? 61  TRP A CZ3 1 
+ATOM   77   C CH2 . TRP A 1 14  ? 37.906 40.665 49.817 1.00 9.26  ? 61  TRP A CH2 1 
+ATOM   78   N N   . GLN A 1 15  ? 41.276 34.962 54.582 1.00 7.87  ? 62  GLN A N   1 
+ATOM   79   C CA  . GLN A 1 15  ? 42.488 35.102 55.361 1.00 8.38  ? 62  GLN A CA  1 
+ATOM   80   C C   . GLN A 1 15  ? 43.447 35.992 54.560 1.00 7.85  ? 62  GLN A C   1 
+ATOM   81   O O   . GLN A 1 15  ? 43.599 35.780 53.377 1.00 8.63  ? 62  GLN A O   1 
+ATOM   82   C CB  . GLN A 1 15  ? 43.183 33.793 55.654 1.00 9.09  ? 62  GLN A CB  1 
+ATOM   83   C CG  . GLN A 1 15  ? 42.319 32.857 56.500 1.00 10.81 ? 62  GLN A CG  1 
+ATOM   84   C CD  . GLN A 1 15  ? 42.906 31.470 56.600 1.00 11.69 ? 62  GLN A CD  1 
+ATOM   85   O OE1 . GLN A 1 15  ? 44.047 31.219 56.216 1.00 14.40 ? 62  GLN A OE1 1 
+ATOM   86   N NE2 . GLN A 1 15  ? 42.114 30.556 57.188 1.00 15.04 ? 62  GLN A NE2 1 
+ATOM   87   N N   . THR A 1 16  ? 44.095 36.944 55.237 1.00 7.73  ? 63  THR A N   1 
+ATOM   88   C CA  . THR A 1 16  ? 45.028 37.866 54.574 1.00 7.59  ? 63  THR A CA  1 
+ATOM   89   C C   . THR A 1 16  ? 46.328 37.925 55.344 1.00 8.07  ? 63  THR A C   1 
+ATOM   90   O O   . THR A 1 16  ? 46.331 37.931 56.555 1.00 9.18  ? 63  THR A O   1 
+ATOM   91   C CB  . THR A 1 16  ? 44.439 39.287 54.465 1.00 7.96  ? 63  THR A CB  1 
+ATOM   92   O OG1 . THR A 1 16  ? 43.192 39.201 53.735 1.00 7.64  ? 63  THR A OG1 1 
+ATOM   93   C CG2 . THR A 1 16  ? 45.372 40.279 53.828 1.00 8.37  ? 63  THR A CG2 1 
+ATOM   94   N N   . ASP A 1 17  ? 47.440 38.005 54.596 1.00 8.37  ? 64  ASP A N   1 
+ATOM   95   C CA  . ASP A 1 17  ? 48.765 38.124 55.180 1.00 8.66  ? 64  ASP A CA  1 
+ATOM   96   C C   . ASP A 1 17  ? 49.647 38.915 54.226 1.00 8.39  ? 64  ASP A C   1 
+ATOM   97   O O   . ASP A 1 17  ? 49.318 39.111 53.077 1.00 10.42 ? 64  ASP A O   1 
+ATOM   98   C CB  . ASP A 1 17  ? 49.350 36.734 55.432 1.00 10.17 ? 64  ASP A CB  1 
+ATOM   99   C CG  . ASP A 1 17  ? 50.500 36.638 56.332 1.00 11.47 ? 64  ASP A CG  1 
+ATOM   100  O OD1 . ASP A 1 17  ? 51.232 35.626 56.281 1.00 14.40 ? 64  ASP A OD1 1 
+ATOM   101  O OD2 . ASP A 1 17  ? 50.668 37.566 57.177 1.00 12.78 ? 64  ASP A OD2 1 
+ATOM   102  N N   . PHE A 1 18  ? 50.786 39.373 54.719 1.00 8.45  ? 65  PHE A N   1 
+ATOM   103  C CA  . PHE A 1 18  ? 51.866 39.892 53.917 1.00 8.06  ? 65  PHE A CA  1 
+ATOM   104  C C   . PHE A 1 18  ? 53.045 38.910 53.918 1.00 8.41  ? 65  PHE A C   1 
+ATOM   105  O O   . PHE A 1 18  ? 53.353 38.346 54.965 1.00 10.63 ? 65  PHE A O   1 
+ATOM   106  C CB  . PHE A 1 18  ? 52.380 41.233 54.489 1.00 9.21  ? 65  PHE A CB  1 
+ATOM   107  C CG  . PHE A 1 18  ? 51.576 42.415 54.134 1.00 9.28  ? 65  PHE A CG  1 
+ATOM   108  C CD1 . PHE A 1 18  ? 50.579 42.841 55.014 1.00 13.10 ? 65  PHE A CD1 1 
+ATOM   109  C CD2 . PHE A 1 18  ? 51.812 43.168 52.979 1.00 10.64 ? 65  PHE A CD2 1 
+ATOM   110  C CE1 . PHE A 1 18  ? 49.873 43.980 54.734 1.00 17.44 ? 65  PHE A CE1 1 
+ATOM   111  C CE2 . PHE A 1 18  ? 51.074 44.314 52.710 1.00 11.77 ? 65  PHE A CE2 1 
+ATOM   112  C CZ  . PHE A 1 18  ? 50.086 44.715 53.578 1.00 14.74 ? 65  PHE A CZ  1 
+ATOM   113  N N   . THR A 1 19  ? 53.689 38.768 52.771 1.00 8.13  ? 66  THR A N   1 
+ATOM   114  C CA  . THR A 1 19  ? 54.887 37.912 52.658 1.00 8.49  ? 66  THR A CA  1 
+ATOM   115  C C   . THR A 1 19  ? 55.901 38.627 51.800 1.00 7.59  ? 66  THR A C   1 
+ATOM   116  O O   . THR A 1 19  ? 55.571 39.218 50.753 1.00 8.26  ? 66  THR A O   1 
+ATOM   117  C CB  . THR A 1 19  ? 54.478 36.519 52.137 1.00 9.98  ? 66  THR A CB  1 
+ATOM   118  O OG1 . THR A 1 19  ? 55.599 35.629 52.307 1.00 12.04 ? 66  THR A OG1 1 
+ATOM   119  C CG2 . THR A 1 19  ? 54.090 36.481 50.682 1.00 12.09 ? 66  THR A CG2 1 
+ATOM   120  N N   . LEU A 1 20  ? 57.162 38.592 52.248 1.00 8.31  ? 67  LEU A N   1 
+ATOM   121  C CA  . LEU A 1 20  ? 58.230 39.338 51.596 1.00 7.87  ? 67  LEU A CA  1 
+ATOM   122  C C   . LEU A 1 20  ? 58.884 38.485 50.518 1.00 8.17  ? 67  LEU A C   1 
+ATOM   123  O O   . LEU A 1 20  ? 59.321 37.355 50.776 1.00 9.54  ? 67  LEU A O   1 
+ATOM   124  C CB  . LEU A 1 20  ? 59.282 39.753 52.648 1.00 9.17  ? 67  LEU A CB  1 
+ATOM   125  C CG  . LEU A 1 20  ? 60.449 40.569 52.211 1.00 9.10  ? 67  LEU A CG  1 
+ATOM   126  C CD1 . LEU A 1 20  ? 60.015 41.873 51.532 1.00 10.07 ? 67  LEU A CD1 1 
+ATOM   127  C CD2 . LEU A 1 20  ? 61.318 40.894 53.407 1.00 10.21 ? 67  LEU A CD2 1 
+ATOM   128  N N   . GLU A 1 21  ? 58.927 39.012 49.302 1.00 7.66  ? 68  GLU A N   1 
+ATOM   129  C CA  . GLU A 1 21  ? 59.436 38.303 48.108 1.00 7.70  ? 68  GLU A CA  1 
+ATOM   130  C C   . GLU A 1 21  ? 60.414 39.195 47.373 1.00 7.60  ? 68  GLU A C   1 
+ATOM   131  O O   . GLU A 1 21  ? 60.029 39.976 46.502 1.00 7.71  ? 68  GLU A O   1 
+ATOM   132  C CB  . GLU A 1 21  ? 58.251 37.911 47.221 1.00 8.64  ? 68  GLU A CB  1 
+ATOM   133  C CG  . GLU A 1 21  ? 58.697 37.206 45.920 1.00 10.50 ? 68  GLU A CG  1 
+ATOM   134  C CD  . GLU A 1 21  ? 59.718 36.140 46.189 1.00 10.83 ? 68  GLU A CD  1 
+ATOM   135  O OE1 . GLU A 1 21  ? 59.324 34.989 46.604 1.00 14.16 ? 68  GLU A OE1 1 
+ATOM   136  O OE2 . GLU A 1 21  ? 60.912 36.428 46.071 1.00 10.73 ? 68  GLU A OE2 1 
+ATOM   137  N N   . PRO A 1 22  ? 61.706 39.086 47.682 1.00 7.62  ? 69  PRO A N   1 
+ATOM   138  C CA  . PRO A 1 22  ? 62.715 39.907 47.010 1.00 8.00  ? 69  PRO A CA  1 
+ATOM   139  C C   . PRO A 1 22  ? 62.778 39.774 45.515 1.00 7.43  ? 69  PRO A C   1 
+ATOM   140  O O   . PRO A 1 22  ? 63.305 40.678 44.863 1.00 8.07  ? 69  PRO A O   1 
+ATOM   141  C CB  . PRO A 1 22  ? 64.024 39.494 47.695 1.00 9.08  ? 69  PRO A CB  1 
+ATOM   142  C CG  . PRO A 1 22  ? 63.586 39.090 49.070 1.00 9.83  ? 69  PRO A CG  1 
+ATOM   143  C CD  . PRO A 1 22  ? 62.285 38.309 48.798 1.00 8.34  ? 69  PRO A CD  1 
+ATOM   144  N N   . ARG A 1 23  ? 62.258 38.710 44.922 1.00 7.58  ? 70  ARG A N   1 
+ATOM   145  C CA  . ARG A 1 23  ? 62.225 38.659 43.473 1.00 8.25  ? 70  ARG A CA  1 
+ATOM   146  C C   . ARG A 1 23  ? 61.393 39.794 42.868 1.00 7.31  ? 70  ARG A C   1 
+ATOM   147  O O   . ARG A 1 23  ? 61.538 40.099 41.672 1.00 8.15  ? 70  ARG A O   1 
+ATOM   148  C CB  . ARG A 1 23  ? 61.696 37.305 42.947 1.00 9.79  ? 70  ARG A CB  1 
+ATOM   149  C CG  A ARG A 1 23  ? 62.652 36.165 43.343 0.56 12.66 ? 70  ARG A CG  1 
+ATOM   150  C CG  B ARG A 1 23  ? 62.665 36.096 43.151 0.44 9.92  ? 70  ARG A CG  1 
+ATOM   151  C CD  A ARG A 1 23  ? 62.064 34.808 42.901 0.56 13.72 ? 70  ARG A CD  1 
+ATOM   152  C CD  B ARG A 1 23  ? 61.937 34.848 42.559 0.44 13.09 ? 70  ARG A CD  1 
+ATOM   153  N NE  A ARG A 1 23  ? 62.631 33.720 43.647 0.56 17.27 ? 70  ARG A NE  1 
+ATOM   154  N NE  B ARG A 1 23  ? 62.881 33.769 42.421 0.44 14.44 ? 70  ARG A NE  1 
+ATOM   155  C CZ  A ARG A 1 23  ? 63.685 33.049 43.317 0.56 17.63 ? 70  ARG A CZ  1 
+ATOM   156  C CZ  B ARG A 1 23  ? 63.338 33.168 43.463 0.44 18.56 ? 70  ARG A CZ  1 
+ATOM   157  N NH1 A ARG A 1 23  ? 64.326 33.321 42.221 0.56 21.13 ? 70  ARG A NH1 1 
+ATOM   158  N NH1 B ARG A 1 23  ? 62.621 33.210 44.541 0.44 21.84 ? 70  ARG A NH1 1 
+ATOM   159  N NH2 A ARG A 1 23  ? 64.097 32.069 44.121 0.56 24.14 ? 70  ARG A NH2 1 
+ATOM   160  N NH2 B ARG A 1 23  ? 64.270 32.226 43.293 0.44 22.72 ? 70  ARG A NH2 1 
+ATOM   161  N N   . MET A 1 24  ? 60.493 40.367 43.668 1.00 7.18  ? 71  MET A N   1 
+ATOM   162  C CA  . MET A 1 24  ? 59.575 41.425 43.284 1.00 7.16  ? 71  MET A CA  1 
+ATOM   163  C C   . MET A 1 24  ? 59.999 42.827 43.777 1.00 7.02  ? 71  MET A C   1 
+ATOM   164  O O   . MET A 1 24  ? 59.233 43.760 43.664 1.00 7.52  ? 71  MET A O   1 
+ATOM   165  C CB  . MET A 1 24  ? 58.172 41.079 43.783 1.00 7.52  ? 71  MET A CB  1 
+ATOM   166  C CG  . MET A 1 24  ? 57.546 39.910 43.042 1.00 7.63  ? 71  MET A CG  1 
+ATOM   167  S SD  . MET A 1 24  ? 56.846 40.468 41.474 1.00 9.07  ? 71  MET A SD  1 
+ATOM   168  C CE  . MET A 1 24  ? 56.355 38.910 40.787 1.00 9.25  ? 71  MET A CE  1 
+ATOM   169  N N   . ALA A 1 25  ? 61.233 42.958 44.290 1.00 7.49  ? 72  ALA A N   1 
+ATOM   170  C CA  . ALA A 1 25  ? 61.722 44.259 44.719 1.00 7.10  ? 72  ALA A CA  1 
+ATOM   171  C C   . ALA A 1 25  ? 61.791 45.220 43.567 1.00 7.33  ? 72  ALA A C   1 
+ATOM   172  O O   . ALA A 1 25  ? 62.099 44.797 42.442 1.00 7.98  ? 72  ALA A O   1 
+ATOM   173  C CB  . ALA A 1 25  ? 63.072 44.113 45.371 1.00 8.03  ? 72  ALA A CB  1 
+ATOM   174  N N   . PRO A 1 26  ? 61.584 46.531 43.778 1.00 7.50  ? 73  PRO A N   1 
+ATOM   175  C CA  . PRO A 1 26  ? 61.408 47.194 45.085 1.00 7.75  ? 73  PRO A CA  1 
+ATOM   176  C C   . PRO A 1 26  ? 60.077 46.983 45.724 1.00 7.22  ? 73  PRO A C   1 
+ATOM   177  O O   . PRO A 1 26  ? 59.986 47.165 46.973 1.00 8.64  ? 73  PRO A O   1 
+ATOM   178  C CB  . PRO A 1 26  ? 61.635 48.672 44.762 1.00 8.63  ? 73  PRO A CB  1 
+ATOM   179  C CG  . PRO A 1 26  ? 61.259 48.781 43.299 1.00 9.18  ? 73  PRO A CG  1 
+ATOM   180  C CD  . PRO A 1 26  ? 61.760 47.501 42.701 1.00 8.47  ? 73  PRO A CD  1 
+ATOM   181  N N   . ARG A 1 27  ? 59.033 46.622 45.025 1.00 7.33  ? 74  ARG A N   1 
+ATOM   182  C CA  . ARG A 1 27  ? 57.727 46.359 45.656 1.00 7.65  ? 74  ARG A CA  1 
+ATOM   183  C C   . ARG A 1 27  ? 57.623 44.882 46.035 1.00 7.35  ? 74  ARG A C   1 
+ATOM   184  O O   . ARG A 1 27  ? 56.814 44.108 45.511 1.00 7.74  ? 74  ARG A O   1 
+ATOM   185  C CB  . ARG A 1 27  ? 56.581 46.847 44.753 1.00 8.86  ? 74  ARG A CB  1 
+ATOM   186  C CG  . ARG A 1 27  ? 56.596 48.362 44.553 1.00 10.78 ? 74  ARG A CG  1 
+ATOM   187  C CD  . ARG A 1 27  ? 55.305 48.848 43.933 1.00 16.60 ? 74  ARG A CD  1 
+ATOM   188  N NE  . ARG A 1 27  ? 55.043 48.358 42.658 1.00 21.83 ? 74  ARG A NE  1 
+ATOM   189  C CZ  . ARG A 1 27  ? 53.870 48.271 42.022 1.00 28.45 ? 74  ARG A CZ  1 
+ATOM   190  N NH1 . ARG A 1 27  ? 52.804 48.676 42.678 1.00 31.27 ? 74  ARG A NH1 1 
+ATOM   191  N NH2 . ARG A 1 27  ? 53.812 47.795 40.784 1.00 34.63 ? 74  ARG A NH2 1 
+ATOM   192  N N   . SER A 1 28  ? 58.483 44.517 46.987 1.00 7.33  ? 75  SER A N   1 
+ATOM   193  C CA  . SER A 1 28  ? 58.651 43.116 47.375 1.00 7.09  ? 75  SER A CA  1 
+ATOM   194  C C   . SER A 1 28  ? 57.692 42.644 48.418 1.00 6.97  ? 75  SER A C   1 
+ATOM   195  O O   . SER A 1 28  ? 57.662 41.447 48.708 1.00 7.98  ? 75  SER A O   1 
+ATOM   196  C CB  . SER A 1 28  ? 60.076 42.877 47.800 1.00 8.40  ? 75  SER A CB  1 
+ATOM   197  O OG  . SER A 1 28  ? 60.455 43.919 48.639 1.00 9.85  ? 75  SER A OG  1 
+ATOM   198  N N   . TRP A 1 29  ? 56.876 43.513 49.004 1.00 7.27  ? 76  TRP A N   1 
+ATOM   199  C CA  . TRP A 1 29  ? 55.861 43.047 49.960 1.00 7.86  ? 76  TRP A CA  1 
+ATOM   200  C C   . TRP A 1 29  ? 54.624 42.622 49.189 1.00 7.52  ? 76  TRP A C   1 
+ATOM   201  O O   . TRP A 1 29  ? 53.958 43.435 48.570 1.00 9.19  ? 76  TRP A O   1 
+ATOM   202  C CB  . TRP A 1 29  ? 55.551 44.144 50.956 1.00 8.57  ? 76  TRP A CB  1 
+ATOM   203  C CG  . TRP A 1 29  ? 56.484 44.162 52.135 1.00 9.08  ? 76  TRP A CG  1 
+ATOM   204  C CD1 . TRP A 1 29  ? 57.400 45.084 52.498 1.00 9.54  ? 76  TRP A CD1 1 
+ATOM   205  C CD2 . TRP A 1 29  ? 56.562 43.122 53.129 1.00 8.91  ? 76  TRP A CD2 1 
+ATOM   206  N NE1 . TRP A 1 29  ? 58.042 44.719 53.644 1.00 10.35 ? 76  TRP A NE1 1 
+ATOM   207  C CE2 . TRP A 1 29  ? 57.535 43.521 54.058 1.00 9.71  ? 76  TRP A CE2 1 
+ATOM   208  C CE3 . TRP A 1 29  ? 55.883 41.927 53.335 1.00 9.29  ? 76  TRP A CE3 1 
+ATOM   209  C CZ2 . TRP A 1 29  ? 57.867 42.750 55.185 1.00 10.64 ? 76  TRP A CZ2 1 
+ATOM   210  C CZ3 . TRP A 1 29  ? 56.177 41.149 54.439 1.00 9.76  ? 76  TRP A CZ3 1 
+ATOM   211  C CH2 . TRP A 1 29  ? 57.173 41.596 55.338 1.00 10.66 ? 76  TRP A CH2 1 
+ATOM   212  N N   . LEU A 1 30  ? 54.325 41.337 49.272 1.00 7.24  ? 77  LEU A N   1 
+ATOM   213  C CA  . LEU A 1 30  ? 53.145 40.782 48.638 1.00 7.25  ? 77  LEU A CA  1 
+ATOM   214  C C   . LEU A 1 30  ? 52.044 40.688 49.692 1.00 7.39  ? 77  LEU A C   1 
+ATOM   215  O O   . LEU A 1 30  ? 52.190 40.018 50.714 1.00 8.84  ? 77  LEU A O   1 
+ATOM   216  C CB  . LEU A 1 30  ? 53.417 39.411 48.042 1.00 7.79  ? 77  LEU A CB  1 
+ATOM   217  C CG  . LEU A 1 30  ? 54.558 39.381 47.048 1.00 8.68  ? 77  LEU A CG  1 
+ATOM   218  C CD1 . LEU A 1 30  ? 54.696 37.960 46.479 1.00 11.37 ? 77  LEU A CD1 1 
+ATOM   219  C CD2 . LEU A 1 30  ? 54.383 40.427 45.960 1.00 10.90 ? 77  LEU A CD2 1 
+ATOM   220  N N   . ALA A 1 31  ? 50.931 41.366 49.428 1.00 6.98  ? 78  ALA A N   1 
+ATOM   221  C CA  . ALA A 1 31  ? 49.712 41.224 50.210 1.00 7.04  ? 78  ALA A CA  1 
+ATOM   222  C C   . ALA A 1 31  ? 48.918 40.117 49.541 1.00 6.94  ? 78  ALA A C   1 
+ATOM   223  O O   . ALA A 1 31  ? 48.646 40.183 48.348 1.00 7.49  ? 78  ALA A O   1 
+ATOM   224  C CB  . ALA A 1 31  ? 48.935 42.509 50.254 1.00 7.94  ? 78  ALA A CB  1 
+ATOM   225  N N   . VAL A 1 32  ? 48.547 39.099 50.324 1.00 7.62  ? 79  VAL A N   1 
+ATOM   226  C CA  . VAL A 1 32  ? 47.921 37.896 49.846 1.00 7.32  ? 79  VAL A CA  1 
+ATOM   227  C C   . VAL A 1 32  ? 46.620 37.654 50.622 1.00 7.57  ? 79  VAL A C   1 
+ATOM   228  O O   . VAL A 1 32  ? 46.623 37.600 51.843 1.00 8.07  ? 79  VAL A O   1 
+ATOM   229  C CB  . VAL A 1 32  ? 48.832 36.675 50.043 1.00 8.75  ? 79  VAL A CB  1 
+ATOM   230  C CG1 . VAL A 1 32  ? 48.184 35.392 49.567 1.00 10.68 ? 79  VAL A CG1 1 
+ATOM   231  C CG2 . VAL A 1 32  ? 50.176 36.896 49.331 1.00 10.13 ? 79  VAL A CG2 1 
+ATOM   232  N N   . THR A 1 33  ? 45.526 37.536 49.894 1.00 7.60  ? 80  THR A N   1 
+ATOM   233  C CA  . THR A 1 33  ? 44.245 37.104 50.432 1.00 7.74  ? 80  THR A CA  1 
+ATOM   234  C C   . THR A 1 33  ? 43.875 35.783 49.796 1.00 7.92  ? 80  THR A C   1 
+ATOM   235  O O   . THR A 1 33  ? 43.965 35.610 48.598 1.00 8.89  ? 80  THR A O   1 
+ATOM   236  C CB  . THR A 1 33  ? 43.151 38.143 50.162 1.00 8.08  ? 80  THR A CB  1 
+ATOM   237  O OG1 . THR A 1 33  ? 43.367 39.273 51.026 1.00 8.25  ? 80  THR A OG1 1 
+ATOM   238  C CG2 . THR A 1 33  ? 41.766 37.627 50.374 1.00 9.56  ? 80  THR A CG2 1 
+ATOM   239  N N   . VAL A 1 34  ? 43.413 34.862 50.655 1.00 8.35  ? 81  VAL A N   1 
+ATOM   240  C CA  . VAL A 1 34  ? 42.756 33.644 50.203 1.00 8.71  ? 81  VAL A CA  1 
+ATOM   241  C C   . VAL A 1 34  ? 41.302 33.688 50.659 1.00 8.95  ? 81  VAL A C   1 
+ATOM   242  O O   . VAL A 1 34  ? 40.985 33.958 51.832 1.00 9.59  ? 81  VAL A O   1 
+ATOM   243  C CB  A VAL A 1 34  ? 43.534 32.385 50.645 0.77 10.08 ? 81  VAL A CB  1 
+ATOM   244  C CB  B VAL A 1 34  ? 43.145 32.374 50.862 0.23 10.35 ? 81  VAL A CB  1 
+ATOM   245  C CG1 A VAL A 1 34  ? 43.617 32.224 52.144 0.77 11.21 ? 81  VAL A CG1 1 
+ATOM   246  C CG1 B VAL A 1 34  ? 42.343 31.194 50.350 0.23 16.48 ? 81  VAL A CG1 1 
+ATOM   247  C CG2 A VAL A 1 34  ? 42.885 31.154 50.018 0.77 13.97 ? 81  VAL A CG2 1 
+ATOM   248  C CG2 B VAL A 1 34  ? 44.609 32.253 50.464 0.23 10.44 ? 81  VAL A CG2 1 
+ATOM   249  N N   . ASP A 1 35  ? 40.410 33.439 49.708 1.00 9.38  ? 82  ASP A N   1 
+ATOM   250  C CA  . ASP A 1 35  ? 39.001 33.260 50.043 1.00 10.29 ? 82  ASP A CA  1 
+ATOM   251  C C   . ASP A 1 35  ? 38.838 31.871 50.551 1.00 10.50 ? 82  ASP A C   1 
+ATOM   252  O O   . ASP A 1 35  ? 39.030 30.911 49.795 1.00 13.02 ? 82  ASP A O   1 
+ATOM   253  C CB  . ASP A 1 35  ? 38.178 33.520 48.773 1.00 12.08 ? 82  ASP A CB  1 
+ATOM   254  C CG  . ASP A 1 35  ? 36.717 33.151 48.944 1.00 15.43 ? 82  ASP A CG  1 
+ATOM   255  O OD1 . ASP A 1 35  ? 36.243 33.137 50.062 1.00 14.07 ? 82  ASP A OD1 1 
+ATOM   256  O OD2 . ASP A 1 35  ? 36.086 32.794 47.918 1.00 23.29 ? 82  ASP A OD2 1 
+ATOM   257  N N   . THR A 1 36  ? 38.485 31.687 51.802 1.00 10.41 ? 83  THR A N   1 
+ATOM   258  C CA  . THR A 1 36  ? 38.407 30.330 52.354 1.00 11.21 ? 83  THR A CA  1 
+ATOM   259  C C   . THR A 1 36  ? 37.224 29.570 51.738 1.00 12.33 ? 83  THR A C   1 
+ATOM   260  O O   . THR A 1 36  ? 37.219 28.356 51.854 1.00 15.83 ? 83  THR A O   1 
+ATOM   261  C CB  . THR A 1 36  ? 38.333 30.302 53.867 1.00 11.78 ? 83  THR A CB  1 
+ATOM   262  O OG1 . THR A 1 36  ? 37.051 30.819 54.330 1.00 12.09 ? 83  THR A OG1 1 
+ATOM   263  C CG2 . THR A 1 36  ? 39.445 31.090 54.527 1.00 13.60 ? 83  THR A CG2 1 
+ATOM   264  N N   . ALA A 1 37  ? 36.257 30.250 51.132 1.00 12.56 ? 84  ALA A N   1 
+ATOM   265  C CA  . ALA A 1 37  ? 35.129 29.542 50.525 1.00 14.05 ? 84  ALA A CA  1 
+ATOM   266  C C   . ALA A 1 37  ? 35.534 28.866 49.229 1.00 15.46 ? 84  ALA A C   1 
+ATOM   267  O O   . ALA A 1 37  ? 35.048 27.780 48.896 1.00 22.96 ? 84  ALA A O   1 
+ATOM   268  C CB  . ALA A 1 37  ? 33.994 30.540 50.286 1.00 15.52 ? 84  ALA A CB  1 
+ATOM   269  N N   . SER A 1 38  ? 36.373 29.468 48.434 1.00 17.90 ? 85  SER A N   1 
+ATOM   270  C CA  . SER A 1 38  ? 36.674 28.987 47.121 1.00 19.65 ? 85  SER A CA  1 
+ATOM   271  C C   . SER A 1 38  ? 38.117 28.601 46.928 1.00 18.35 ? 85  SER A C   1 
+ATOM   272  O O   . SER A 1 38  ? 38.474 27.972 45.892 1.00 21.05 ? 85  SER A O   1 
+ATOM   273  C CB  . SER A 1 38  ? 36.355 30.069 46.099 1.00 20.48 ? 85  SER A CB  1 
+ATOM   274  O OG  . SER A 1 38  ? 37.164 31.269 46.199 1.00 18.96 ? 85  SER A OG  1 
+ATOM   275  N N   . SER A 1 39  ? 38.993 29.028 47.790 1.00 16.11 ? 86  SER A N   1 
+ATOM   276  C CA  . SER A 1 39  ? 40.457 28.912 47.717 1.00 15.62 ? 86  SER A CA  1 
+ATOM   277  C C   . SER A 1 39  ? 41.085 29.846 46.687 1.00 13.38 ? 86  SER A C   1 
+ATOM   278  O O   . SER A 1 39  ? 42.301 29.811 46.509 1.00 14.84 ? 86  SER A O   1 
+ATOM   279  C CB  . SER A 1 39  ? 41.006 27.482 47.500 1.00 21.82 ? 86  SER A CB  1 
+ATOM   280  O OG  . SER A 1 39  ? 40.617 26.674 48.629 1.00 31.18 ? 86  SER A OG  1 
+ATOM   281  N N   . ALA A 1 40  ? 40.341 30.747 46.132 1.00 12.80 ? 87  ALA A N   1 
+ATOM   282  C CA  . ALA A 1 40  ? 40.858 31.776 45.205 1.00 11.78 ? 87  ALA A CA  1 
+ATOM   283  C C   . ALA A 1 40  ? 41.812 32.676 45.982 1.00 9.66  ? 87  ALA A C   1 
+ATOM   284  O O   . ALA A 1 40  ? 41.568 32.970 47.136 1.00 10.75 ? 87  ALA A O   1 
+ATOM   285  C CB  . ALA A 1 40  ? 39.750 32.609 44.589 1.00 15.49 ? 87  ALA A CB  1 
+ATOM   286  N N   . ILE A 1 41  ? 42.811 33.146 45.294 1.00 10.48 ? 88  ILE A N   1 
+ATOM   287  C CA  . ILE A 1 41  ? 43.800 34.073 45.847 1.00 10.67 ? 88  ILE A CA  1 
+ATOM   288  C C   . ILE A 1 41  ? 43.764 35.384 45.077 1.00 10.48 ? 88  ILE A C   1 
+ATOM   289  O O   . ILE A 1 41  ? 43.622 35.441 43.861 1.00 13.19 ? 88  ILE A O   1 
+ATOM   290  C CB  A ILE A 1 41  ? 45.182 33.364 45.743 0.66 14.49 ? 88  ILE A CB  1 
+ATOM   291  C CB  B ILE A 1 41  ? 45.116 33.640 45.887 0.34 15.17 ? 88  ILE A CB  1 
+ATOM   292  C CG1 A ILE A 1 41  ? 45.269 32.148 46.681 0.66 17.38 ? 88  ILE A CG1 1 
+ATOM   293  C CG1 B ILE A 1 41  ? 45.917 33.638 44.596 0.34 15.34 ? 88  ILE A CG1 1 
+ATOM   294  C CG2 A ILE A 1 41  ? 46.396 34.250 45.952 0.66 14.96 ? 88  ILE A CG2 1 
+ATOM   295  C CG2 B ILE A 1 41  ? 45.267 32.301 46.599 0.34 18.17 ? 88  ILE A CG2 1 
+ATOM   296  C CD1 A ILE A 1 41  ? 46.431 31.216 46.272 0.66 20.81 ? 88  ILE A CD1 1 
+ATOM   297  C CD1 B ILE A 1 41  ? 47.409 33.876 45.027 0.34 16.48 ? 88  ILE A CD1 1 
+ATOM   298  N N   . VAL A 1 42  ? 43.964 36.471 45.827 1.00 9.10  ? 89  VAL A N   1 
+ATOM   299  C CA  . VAL A 1 42  ? 44.279 37.773 45.257 1.00 8.68  ? 89  VAL A CA  1 
+ATOM   300  C C   . VAL A 1 42  ? 45.615 38.183 45.824 1.00 7.74  ? 89  VAL A C   1 
+ATOM   301  O O   . VAL A 1 42  ? 45.802 38.156 47.051 1.00 8.73  ? 89  VAL A O   1 
+ATOM   302  C CB  . VAL A 1 42  ? 43.201 38.818 45.579 1.00 9.52  ? 89  VAL A CB  1 
+ATOM   303  C CG1 . VAL A 1 42  ? 43.602 40.214 45.076 1.00 10.63 ? 89  VAL A CG1 1 
+ATOM   304  C CG2 . VAL A 1 42  ? 41.857 38.428 44.991 1.00 11.74 ? 89  VAL A CG2 1 
+ATOM   305  N N   . VAL A 1 43  ? 46.530 38.650 44.985 1.00 7.69  ? 90  VAL A N   1 
+ATOM   306  C CA  . VAL A 1 43  ? 47.834 39.160 45.425 1.00 7.47  ? 90  VAL A CA  1 
+ATOM   307  C C   . VAL A 1 43  ? 48.090 40.490 44.766 1.00 7.62  ? 90  VAL A C   1 
+ATOM   308  O O   . VAL A 1 43  ? 47.823 40.695 43.587 1.00 8.33  ? 90  VAL A O   1 
+ATOM   309  C CB  . VAL A 1 43  ? 48.963 38.167 45.137 1.00 8.38  ? 90  VAL A CB  1 
+ATOM   310  C CG1 . VAL A 1 43  ? 49.045 37.789 43.692 1.00 10.51 ? 90  VAL A CG1 1 
+ATOM   311  C CG2 . VAL A 1 43  ? 50.297 38.647 45.681 1.00 9.60  ? 90  VAL A CG2 1 
+ATOM   312  N N   . THR A 1 44  ? 48.620 41.415 45.589 1.00 7.71  ? 91  THR A N   1 
+ATOM   313  C CA  . THR A 1 44  ? 49.101 42.718 45.122 1.00 7.53  ? 91  THR A CA  1 
+ATOM   314  C C   . THR A 1 44  ? 50.487 42.967 45.688 1.00 7.39  ? 91  THR A C   1 
+ATOM   315  O O   . THR A 1 44  ? 50.870 42.419 46.725 1.00 8.71  ? 91  THR A O   1 
+ATOM   316  C CB  . THR A 1 44  ? 48.127 43.850 45.533 1.00 8.03  ? 91  THR A CB  1 
+ATOM   317  O OG1 . THR A 1 44  ? 47.915 43.812 46.945 1.00 8.39  ? 91  THR A OG1 1 
+ATOM   318  C CG2 . THR A 1 44  ? 46.785 43.708 44.840 1.00 9.28  ? 91  THR A CG2 1 
+ATOM   319  N N   . GLN A 1 45  ? 51.281 43.790 45.019 1.00 7.68  ? 92  GLN A N   1 
+ATOM   320  C CA  A GLN A 1 45  ? 52.622 44.076 45.551 0.65 8.45  ? 92  GLN A CA  1 
+ATOM   321  C CA  B GLN A 1 45  ? 52.644 44.224 45.345 0.35 7.62  ? 92  GLN A CA  1 
+ATOM   322  C C   . GLN A 1 45  ? 52.678 45.547 46.005 1.00 7.83  ? 92  GLN A C   1 
+ATOM   323  O O   . GLN A 1 45  ? 51.984 46.448 45.532 1.00 9.73  ? 92  GLN A O   1 
+ATOM   324  C CB  A GLN A 1 45  ? 53.715 43.663 44.501 0.65 8.19  ? 92  GLN A CB  1 
+ATOM   325  C CB  B GLN A 1 45  ? 53.486 44.694 44.061 0.35 8.17  ? 92  GLN A CB  1 
+ATOM   326  C CG  A GLN A 1 45  ? 53.670 44.534 43.275 0.65 8.67  ? 92  GLN A CG  1 
+ATOM   327  C CG  B GLN A 1 45  ? 54.053 43.444 43.442 0.35 8.34  ? 92  GLN A CG  1 
+ATOM   328  C CD  A GLN A 1 45  ? 54.700 44.119 42.228 0.65 8.87  ? 92  GLN A CD  1 
+ATOM   329  C CD  B GLN A 1 45  ? 55.039 43.787 42.318 0.35 9.26  ? 92  GLN A CD  1 
+ATOM   330  O OE1 A GLN A 1 45  ? 54.398 43.950 41.023 0.65 10.44 ? 92  GLN A OE1 1 
+ATOM   331  O OE1 B GLN A 1 45  ? 54.647 44.291 41.219 0.35 14.17 ? 92  GLN A OE1 1 
+ATOM   332  N NE2 A GLN A 1 45  ? 55.983 43.973 42.604 0.65 7.16  ? 92  GLN A NE2 1 
+ATOM   333  N NE2 B GLN A 1 45  ? 56.328 44.031 42.658 0.35 9.93  ? 92  GLN A NE2 1 
+ATOM   334  N N   . HIS A 1 46  ? 53.533 45.735 46.991 1.00 7.73  ? 93  HIS A N   1 
+ATOM   335  C CA  . HIS A 1 46  ? 53.636 46.958 47.748 1.00 8.19  ? 93  HIS A CA  1 
+ATOM   336  C C   . HIS A 1 46  ? 55.105 47.232 48.098 1.00 8.71  ? 93  HIS A C   1 
+ATOM   337  O O   . HIS A 1 46  ? 55.877 46.304 48.393 1.00 8.97  ? 93  HIS A O   1 
+ATOM   338  C CB  . HIS A 1 46  ? 52.839 46.849 49.059 1.00 8.45  ? 93  HIS A CB  1 
+ATOM   339  C CG  . HIS A 1 46  ? 51.412 46.525 48.764 1.00 7.95  ? 93  HIS A CG  1 
+ATOM   340  N ND1 . HIS A 1 46  ? 50.460 47.467 48.463 1.00 9.01  ? 93  HIS A ND1 1 
+ATOM   341  C CD2 . HIS A 1 46  ? 50.801 45.323 48.578 1.00 8.00  ? 93  HIS A CD2 1 
+ATOM   342  C CE1 . HIS A 1 46  ? 49.340 46.806 48.126 1.00 9.35  ? 93  HIS A CE1 1 
+ATOM   343  N NE2 . HIS A 1 46  ? 49.501 45.501 48.198 1.00 8.70  ? 93  HIS A NE2 1 
+ATOM   344  N N   . GLY A 1 47  ? 55.450 48.510 48.137 1.00 9.97  ? 94  GLY A N   1 
+ATOM   345  C CA  . GLY A 1 47  ? 56.808 48.883 48.547 1.00 11.24 ? 94  GLY A CA  1 
+ATOM   346  C C   . GLY A 1 47  ? 57.051 48.769 50.018 1.00 11.16 ? 94  GLY A C   1 
+ATOM   347  O O   . GLY A 1 47  ? 58.182 48.544 50.434 1.00 14.92 ? 94  GLY A O   1 
+ATOM   348  N N   . ARG A 1 48  ? 56.039 48.978 50.841 1.00 10.59 ? 95  ARG A N   1 
+ATOM   349  C CA  . ARG A 1 48  ? 56.180 48.982 52.299 1.00 11.52 ? 95  ARG A CA  1 
+ATOM   350  C C   . ARG A 1 48  ? 55.002 48.276 52.936 1.00 10.63 ? 95  ARG A C   1 
+ATOM   351  O O   . ARG A 1 48  ? 53.877 48.386 52.473 1.00 12.45 ? 95  ARG A O   1 
+ATOM   352  C CB  . ARG A 1 48  ? 56.214 50.424 52.821 1.00 13.67 ? 95  ARG A CB  1 
+ATOM   353  C CG  . ARG A 1 48  ? 57.220 51.308 52.123 1.00 16.88 ? 95  ARG A CG  1 
+ATOM   354  C CD  . ARG A 1 48  ? 58.617 50.928 52.437 1.00 17.99 ? 95  ARG A CD  1 
+ATOM   355  N NE  . ARG A 1 48  ? 58.952 50.913 53.861 1.00 17.67 ? 95  ARG A NE  1 
+ATOM   356  C CZ  . ARG A 1 48  ? 59.396 51.944 54.550 1.00 16.85 ? 95  ARG A CZ  1 
+ATOM   357  N NH1 . ARG A 1 48  ? 59.522 53.131 53.996 1.00 20.12 ? 95  ARG A NH1 1 
+ATOM   358  N NH2 . ARG A 1 48  ? 59.657 51.744 55.831 1.00 16.38 ? 95  ARG A NH2 1 
+ATOM   359  N N   . VAL A 1 49  ? 55.220 47.631 54.057 1.00 11.04 ? 96  VAL A N   1 
+ATOM   360  C CA  . VAL A 1 49  ? 54.158 46.982 54.810 1.00 12.01 ? 96  VAL A CA  1 
+ATOM   361  C C   . VAL A 1 49  ? 53.563 48.029 55.700 1.00 12.06 ? 96  VAL A C   1 
+ATOM   362  O O   . VAL A 1 49  ? 54.216 48.530 56.658 1.00 15.20 ? 96  VAL A O   1 
+ATOM   363  C CB  . VAL A 1 49  ? 54.724 45.691 55.464 1.00 16.31 ? 96  VAL A CB  1 
+ATOM   364  C CG1 . VAL A 1 49  ? 55.889 45.902 56.436 1.00 14.40 ? 96  VAL A CG1 1 
+ATOM   365  C CG2 . VAL A 1 49  ? 53.569 44.977 56.125 1.00 26.38 ? 96  VAL A CG2 1 
+ATOM   366  N N   . THR A 1 50  ? 52.392 48.510 55.404 1.00 11.21 ? 97  THR A N   1 
+ATOM   367  C CA  . THR A 1 50  ? 51.712 49.583 56.112 1.00 11.60 ? 97  THR A CA  1 
+ATOM   368  C C   . THR A 1 50  ? 50.196 49.271 56.173 1.00 10.55 ? 97  THR A C   1 
+ATOM   369  O O   . THR A 1 50  ? 49.677 48.469 55.419 1.00 10.17 ? 97  THR A O   1 
+ATOM   370  C CB  . THR A 1 50  ? 51.864 50.950 55.437 1.00 12.04 ? 97  THR A CB  1 
+ATOM   371  O OG1 . THR A 1 50  ? 51.189 50.890 54.208 1.00 12.35 ? 97  THR A OG1 1 
+ATOM   372  C CG2 . THR A 1 50  ? 53.332 51.340 55.238 1.00 13.51 ? 97  THR A CG2 1 
+ATOM   373  N N   . SER A 1 51  ? 49.533 49.981 57.068 1.00 11.36 ? 98  SER A N   1 
+ATOM   374  C CA  . SER A 1 51  ? 48.079 49.942 57.115 1.00 10.48 ? 98  SER A CA  1 
+ATOM   375  C C   . SER A 1 51  ? 47.446 50.303 55.782 1.00 9.58  ? 98  SER A C   1 
+ATOM   376  O O   . SER A 1 51  ? 46.513 49.615 55.317 1.00 9.63  ? 98  SER A O   1 
+ATOM   377  C CB  . SER A 1 51  ? 47.558 50.898 58.201 1.00 12.07 ? 98  SER A CB  1 
+ATOM   378  O OG  . SER A 1 51  ? 47.933 50.406 59.489 1.00 12.84 ? 98  SER A OG  1 
+ATOM   379  N N   . VAL A 1 52  ? 47.908 51.400 55.165 1.00 9.87  ? 99  VAL A N   1 
+ATOM   380  C CA  . VAL A 1 52  ? 47.287 51.802 53.914 1.00 10.08 ? 99  VAL A CA  1 
+ATOM   381  C C   . VAL A 1 52  ? 47.571 50.765 52.835 1.00 8.81  ? 99  VAL A C   1 
+ATOM   382  O O   . VAL A 1 52  ? 46.697 50.547 51.986 1.00 9.17  ? 99  VAL A O   1 
+ATOM   383  C CB  A VAL A 1 52  ? 47.808 53.170 53.537 0.83 11.04 ? 99  VAL A CB  1 
+ATOM   384  C CB  B VAL A 1 52  ? 47.405 53.685 53.311 0.17 13.07 ? 99  VAL A CB  1 
+ATOM   385  C CG1 A VAL A 1 52  ? 47.420 53.537 52.101 0.83 13.80 ? 99  VAL A CG1 1 
+ATOM   386  C CG1 B VAL A 1 52  ? 46.975 54.267 54.668 0.17 19.27 ? 99  VAL A CG1 1 
+ATOM   387  C CG2 A VAL A 1 52  ? 47.196 54.237 54.480 0.83 17.26 ? 99  VAL A CG2 1 
+ATOM   388  C CG2 B VAL A 1 52  ? 48.912 53.339 53.379 0.17 9.48  ? 99  VAL A CG2 1 
+ATOM   389  N N   . ALA A 1 53  ? 48.730 50.082 52.833 1.00 9.13  ? 100 ALA A N   1 
+ATOM   390  C CA  . ALA A 1 53  ? 48.959 49.037 51.836 1.00 8.79  ? 100 ALA A CA  1 
+ATOM   391  C C   . ALA A 1 53  ? 47.923 47.917 51.987 1.00 7.82  ? 100 ALA A C   1 
+ATOM   392  O O   . ALA A 1 53  ? 47.396 47.402 51.020 1.00 8.07  ? 100 ALA A O   1 
+ATOM   393  C CB  . ALA A 1 53  ? 50.336 48.434 51.954 1.00 10.42 ? 100 ALA A CB  1 
+ATOM   394  N N   . ALA A 1 54  ? 47.643 47.504 53.252 1.00 7.99  ? 101 ALA A N   1 
+ATOM   395  C CA  . ALA A 1 54  ? 46.628 46.495 53.480 1.00 8.28  ? 101 ALA A CA  1 
+ATOM   396  C C   . ALA A 1 54  ? 45.265 46.911 52.924 1.00 7.48  ? 101 ALA A C   1 
+ATOM   397  O O   . ALA A 1 54  ? 44.524 46.116 52.339 1.00 7.41  ? 101 ALA A O   1 
+ATOM   398  C CB  . ALA A 1 54  ? 46.515 46.198 54.966 1.00 9.60  ? 101 ALA A CB  1 
+ATOM   399  N N   . GLN A 1 55  ? 44.918 48.175 53.159 1.00 7.55  ? 102 GLN A N   1 
+ATOM   400  C CA  . GLN A 1 55  ? 43.646 48.733 52.690 1.00 7.50  ? 102 GLN A CA  1 
+ATOM   401  C C   . GLN A 1 55  ? 43.585 48.771 51.192 1.00 6.94  ? 102 GLN A C   1 
+ATOM   402  O O   . GLN A 1 55  ? 42.575 48.400 50.566 1.00 7.54  ? 102 GLN A O   1 
+ATOM   403  C CB  . GLN A 1 55  ? 43.441 50.112 53.313 1.00 7.92  ? 102 GLN A CB  1 
+ATOM   404  C CG  . GLN A 1 55  ? 43.337 50.035 54.853 1.00 8.42  ? 102 GLN A CG  1 
+ATOM   405  C CD  . GLN A 1 55  ? 43.611 51.373 55.526 1.00 9.80  ? 102 GLN A CD  1 
+ATOM   406  O OE1 . GLN A 1 55  ? 43.384 52.439 54.945 1.00 10.73 ? 102 GLN A OE1 1 
+ATOM   407  N NE2 . GLN A 1 55  ? 44.078 51.347 56.751 1.00 11.50 ? 102 GLN A NE2 1 
+ATOM   408  N N   . HIS A 1 56  ? 44.678 49.221 50.541 1.00 7.46  ? 103 HIS A N   1 
+ATOM   409  C CA  . HIS A 1 56  ? 44.710 49.187 49.082 1.00 7.52  ? 103 HIS A CA  1 
+ATOM   410  C C   . HIS A 1 56  ? 44.537 47.795 48.552 1.00 7.13  ? 103 HIS A C   1 
+ATOM   411  O O   . HIS A 1 56  ? 43.835 47.565 47.548 1.00 7.77  ? 103 HIS A O   1 
+ATOM   412  C CB  . HIS A 1 56  ? 46.022 49.769 48.583 1.00 8.80  ? 103 HIS A CB  1 
+ATOM   413  C CG  . HIS A 1 56  ? 46.193 51.249 48.755 1.00 9.74  ? 103 HIS A CG  1 
+ATOM   414  N ND1 . HIS A 1 56  ? 45.218 52.120 49.202 1.00 10.62 ? 103 HIS A ND1 1 
+ATOM   415  C CD2 . HIS A 1 56  ? 47.270 52.025 48.481 1.00 13.11 ? 103 HIS A CD2 1 
+ATOM   416  C CE1 . HIS A 1 56  ? 45.681 53.375 49.191 1.00 12.37 ? 103 HIS A CE1 1 
+ATOM   417  N NE2 . HIS A 1 56  ? 46.902 53.334 48.759 1.00 14.48 ? 103 HIS A NE2 1 
+ATOM   418  N N   . HIS A 1 57  ? 45.214 46.825 49.178 1.00 7.17  ? 104 HIS A N   1 
+ATOM   419  C CA  . HIS A 1 57  ? 45.094 45.431 48.807 1.00 6.97  ? 104 HIS A CA  1 
+ATOM   420  C C   . HIS A 1 57  ? 43.651 44.959 48.915 1.00 6.49  ? 104 HIS A C   1 
+ATOM   421  O O   . HIS A 1 57  ? 43.107 44.358 47.981 1.00 7.14  ? 104 HIS A O   1 
+ATOM   422  C CB  . HIS A 1 57  ? 45.984 44.577 49.703 1.00 7.28  ? 104 HIS A CB  1 
+ATOM   423  C CG  . HIS A 1 57  ? 45.690 43.128 49.593 1.00 7.03  ? 104 HIS A CG  1 
+ATOM   424  N ND1 . HIS A 1 57  ? 46.072 42.313 48.556 1.00 7.27  ? 104 HIS A ND1 1 
+ATOM   425  C CD2 . HIS A 1 57  ? 44.968 42.304 50.407 1.00 7.43  ? 104 HIS A CD2 1 
+ATOM   426  C CE1 . HIS A 1 57  ? 45.605 41.111 48.760 1.00 7.64  ? 104 HIS A CE1 1 
+ATOM   427  N NE2 . HIS A 1 57  ? 44.937 41.032 49.859 1.00 7.78  ? 104 HIS A NE2 1 
+ATOM   428  N N   . TRP A 1 58  ? 43.025 45.190 50.059 1.00 6.82  ? 105 TRP A N   1 
+ATOM   429  C CA  . TRP A 1 58  ? 41.641 44.717 50.232 1.00 6.59  ? 105 TRP A CA  1 
+ATOM   430  C C   . TRP A 1 58  ? 40.708 45.403 49.277 1.00 6.39  ? 105 TRP A C   1 
+ATOM   431  O O   . TRP A 1 58  ? 39.730 44.777 48.835 1.00 6.87  ? 105 TRP A O   1 
+ATOM   432  C CB  . TRP A 1 58  ? 41.188 44.905 51.690 1.00 6.93  ? 105 TRP A CB  1 
+ATOM   433  C CG  . TRP A 1 58  ? 41.707 43.891 52.645 1.00 6.75  ? 105 TRP A CG  1 
+ATOM   434  C CD1 . TRP A 1 58  ? 41.907 42.555 52.443 1.00 6.96  ? 105 TRP A CD1 1 
+ATOM   435  C CD2 . TRP A 1 58  ? 42.072 44.142 54.011 1.00 6.93  ? 105 TRP A CD2 1 
+ATOM   436  N NE1 . TRP A 1 58  ? 42.361 41.959 53.582 1.00 7.45  ? 105 TRP A NE1 1 
+ATOM   437  C CE2 . TRP A 1 58  ? 42.479 42.913 54.564 1.00 7.52  ? 105 TRP A CE2 1 
+ATOM   438  C CE3 . TRP A 1 58  ? 42.071 45.298 54.785 1.00 8.09  ? 105 TRP A CE3 1 
+ATOM   439  C CZ2 . TRP A 1 58  ? 42.896 42.822 55.872 1.00 8.90  ? 105 TRP A CZ2 1 
+ATOM   440  C CZ3 . TRP A 1 58  ? 42.488 45.183 56.100 1.00 10.34 ? 105 TRP A CZ3 1 
+ATOM   441  C CH2 . TRP A 1 58  ? 42.894 43.965 56.627 1.00 10.44 ? 105 TRP A CH2 1 
+ATOM   442  N N   . ALA A 1 59  ? 40.928 46.677 48.951 1.00 6.68  ? 106 ALA A N   1 
+ATOM   443  C CA  . ALA A 1 59  ? 40.060 47.327 47.978 1.00 7.20  ? 106 ALA A CA  1 
+ATOM   444  C C   . ALA A 1 59  ? 40.065 46.523 46.675 1.00 7.20  ? 106 ALA A C   1 
+ATOM   445  O O   . ALA A 1 59  ? 39.026 46.276 46.048 1.00 7.66  ? 106 ALA A O   1 
+ATOM   446  C CB  . ALA A 1 59  ? 40.504 48.755 47.751 1.00 8.48  ? 106 ALA A CB  1 
+ATOM   447  N N   . THR A 1 60  ? 41.262 46.145 46.238 1.00 7.44  ? 107 THR A N   1 
+ATOM   448  C CA  . THR A 1 60  ? 41.385 45.329 45.027 1.00 8.52  ? 107 THR A CA  1 
+ATOM   449  C C   . THR A 1 60  ? 40.759 43.957 45.204 1.00 7.08  ? 107 THR A C   1 
+ATOM   450  O O   . THR A 1 60  ? 40.063 43.447 44.325 1.00 7.90  ? 107 THR A O   1 
+ATOM   451  C CB  . THR A 1 60  ? 42.883 45.210 44.646 1.00 11.52 ? 107 THR A CB  1 
+ATOM   452  O OG1 . THR A 1 60  ? 43.305 46.521 44.301 1.00 22.05 ? 107 THR A OG1 1 
+ATOM   453  C CG2 . THR A 1 60  ? 43.100 44.255 43.523 1.00 13.81 ? 107 THR A CG2 1 
+ATOM   454  N N   . ALA A 1 61  ? 40.999 43.326 46.362 1.00 7.08  ? 108 ALA A N   1 
+ATOM   455  C CA  . ALA A 1 61  ? 40.408 42.002 46.602 1.00 7.29  ? 108 ALA A CA  1 
+ATOM   456  C C   . ALA A 1 61  ? 38.900 42.048 46.583 1.00 6.86  ? 108 ALA A C   1 
+ATOM   457  O O   . ALA A 1 61  ? 38.260 41.115 46.068 1.00 7.72  ? 108 ALA A O   1 
+ATOM   458  C CB  . ALA A 1 61  ? 40.919 41.408 47.903 1.00 8.43  ? 108 ALA A CB  1 
+ATOM   459  N N   . ILE A 1 62  ? 38.283 43.106 47.105 1.00 6.74  ? 109 ILE A N   1 
+ATOM   460  C CA  . ILE A 1 62  ? 36.820 43.253 47.067 1.00 6.63  ? 109 ILE A CA  1 
+ATOM   461  C C   . ILE A 1 62  ? 36.336 43.375 45.625 1.00 7.46  ? 109 ILE A C   1 
+ATOM   462  O O   . ILE A 1 62  ? 35.312 42.794 45.258 1.00 8.46  ? 109 ILE A O   1 
+ATOM   463  C CB  . ILE A 1 62  ? 36.382 44.445 47.928 1.00 6.77  ? 109 ILE A CB  1 
+ATOM   464  C CG1 . ILE A 1 62  ? 36.639 44.186 49.418 1.00 7.05  ? 109 ILE A CG1 1 
+ATOM   465  C CG2 . ILE A 1 62  ? 34.950 44.813 47.697 1.00 7.60  ? 109 ILE A CG2 1 
+ATOM   466  C CD1 . ILE A 1 62  ? 36.549 45.444 50.263 1.00 8.26  ? 109 ILE A CD1 1 
+ATOM   467  N N   . ALA A 1 63  ? 37.058 44.131 44.802 1.00 7.75  ? 110 ALA A N   1 
+ATOM   468  C CA  . ALA A 1 63  ? 36.702 44.244 43.370 1.00 8.64  ? 110 ALA A CA  1 
+ATOM   469  C C   . ALA A 1 63  ? 36.705 42.895 42.708 1.00 9.40  ? 110 ALA A C   1 
+ATOM   470  O O   . ALA A 1 63  ? 35.856 42.627 41.828 1.00 12.12 ? 110 ALA A O   1 
+ATOM   471  C CB  . ALA A 1 63  ? 37.630 45.200 42.692 1.00 8.73  ? 110 ALA A CB  1 
+ATOM   472  N N   . VAL A 1 64  ? 37.642 42.022 43.062 1.00 8.87  ? 111 VAL A N   1 
+ATOM   473  C CA  . VAL A 1 64  ? 37.770 40.718 42.448 1.00 10.06 ? 111 VAL A CA  1 
+ATOM   474  C C   . VAL A 1 64  ? 36.791 39.698 43.012 1.00 10.90 ? 111 VAL A C   1 
+ATOM   475  O O   . VAL A 1 64  ? 36.116 38.982 42.270 1.00 16.23 ? 111 VAL A O   1 
+ATOM   476  C CB  . VAL A 1 64  ? 39.204 40.211 42.593 1.00 10.33 ? 111 VAL A CB  1 
+ATOM   477  C CG1 . VAL A 1 64  ? 39.335 38.767 42.097 1.00 12.90 ? 111 VAL A CG1 1 
+ATOM   478  C CG2 . VAL A 1 64  ? 40.151 41.127 41.873 1.00 12.09 ? 111 VAL A CG2 1 
+ATOM   479  N N   . LEU A 1 65  ? 36.725 39.581 44.329 1.00 10.24 ? 112 LEU A N   1 
+ATOM   480  C CA  . LEU A 1 65  ? 36.028 38.524 45.029 1.00 11.53 ? 112 LEU A CA  1 
+ATOM   481  C C   . LEU A 1 65  ? 34.660 38.888 45.578 1.00 13.18 ? 112 LEU A C   1 
+ATOM   482  O O   . LEU A 1 65  ? 33.912 37.977 46.002 1.00 18.06 ? 112 LEU A O   1 
+ATOM   483  C CB  . LEU A 1 65  ? 36.900 38.052 46.202 1.00 11.12 ? 112 LEU A CB  1 
+ATOM   484  C CG  . LEU A 1 65  ? 38.265 37.478 45.858 1.00 11.71 ? 112 LEU A CG  1 
+ATOM   485  C CD1 . LEU A 1 65  ? 39.073 37.257 47.132 1.00 13.39 ? 112 LEU A CD1 1 
+ATOM   486  C CD2 . LEU A 1 65  ? 38.128 36.183 45.069 1.00 16.17 ? 112 LEU A CD2 1 
+ATOM   487  N N   . GLY A 1 66  ? 34.340 40.157 45.671 1.00 11.31 ? 113 GLY A N   1 
+ATOM   488  C CA  . GLY A 1 66  ? 33.153 40.611 46.357 1.00 11.45 ? 113 GLY A CA  1 
+ATOM   489  C C   . GLY A 1 66  ? 33.485 40.995 47.786 1.00 10.19 ? 113 GLY A C   1 
+ATOM   490  O O   . GLY A 1 66  ? 34.601 40.842 48.274 1.00 11.69 ? 113 GLY A O   1 
+ATOM   491  N N   . ARG A 1 67  ? 32.506 41.531 48.495 1.00 10.30 ? 114 ARG A N   1 
+ATOM   492  C CA  . ARG A 1 67  ? 32.694 41.947 49.830 1.00 10.49 ? 114 ARG A CA  1 
+ATOM   493  C C   . ARG A 1 67  ? 32.537 40.773 50.770 1.00 10.48 ? 114 ARG A C   1 
+ATOM   494  O O   . ARG A 1 67  ? 31.478 40.117 50.770 1.00 13.16 ? 114 ARG A O   1 
+ATOM   495  C CB  . ARG A 1 67  ? 31.675 43.048 50.153 1.00 11.59 ? 114 ARG A CB  1 
+ATOM   496  C CG  . ARG A 1 67  ? 31.937 43.639 51.490 1.00 13.39 ? 114 ARG A CG  1 
+ATOM   497  C CD  . ARG A 1 67  ? 30.977 44.670 51.967 1.00 16.52 ? 114 ARG A CD  1 
+ATOM   498  N NE  . ARG A 1 67  ? 29.656 44.535 51.563 1.00 29.48 ? 114 ARG A NE  1 
+ATOM   499  C CZ  . ARG A 1 67  ? 28.904 45.657 51.710 0.50 30.58 ? 114 ARG A CZ  1 
+ATOM   500  N NH1 . ARG A 1 67  ? 29.430 46.774 52.258 0.50 26.76 ? 114 ARG A NH1 1 
+ATOM   501  N NH2 . ARG A 1 67  ? 27.660 45.602 51.326 0.50 22.80 ? 114 ARG A NH2 1 
+ATOM   502  N N   . PRO A 1 68  ? 33.564 40.439 51.569 1.00 9.04  ? 115 PRO A N   1 
+ATOM   503  C CA  . PRO A 1 68  ? 33.466 39.298 52.477 1.00 9.39  ? 115 PRO A CA  1 
+ATOM   504  C C   . PRO A 1 68  ? 32.667 39.676 53.710 1.00 9.05  ? 115 PRO A C   1 
+ATOM   505  O O   . PRO A 1 68  ? 32.510 40.847 54.037 1.00 10.83 ? 115 PRO A O   1 
+ATOM   506  C CB  . PRO A 1 68  ? 34.929 39.039 52.821 1.00 9.31  ? 115 PRO A CB  1 
+ATOM   507  C CG  . PRO A 1 68  ? 35.532 40.415 52.837 1.00 8.98  ? 115 PRO A CG  1 
+ATOM   508  C CD  . PRO A 1 68  ? 34.840 41.167 51.723 1.00 8.72  ? 115 PRO A CD  1 
+ATOM   509  N N   . LYS A 1 69  ? 32.190 38.682 54.427 1.00 9.51  ? 116 LYS A N   1 
+ATOM   510  C CA  . LYS A 1 69  ? 31.593 38.901 55.727 1.00 10.50 ? 116 LYS A CA  1 
+ATOM   511  C C   . LYS A 1 69  ? 32.646 39.132 56.779 1.00 9.33  ? 116 LYS A C   1 
+ATOM   512  O O   . LYS A 1 69  ? 32.404 39.889 57.738 1.00 11.17 ? 116 LYS A O   1 
+ATOM   513  C CB  . LYS A 1 69  ? 30.688 37.722 56.158 1.00 13.08 ? 116 LYS A CB  1 
+ATOM   514  C CG  . LYS A 1 69  ? 29.469 37.567 55.263 1.00 16.96 ? 116 LYS A CG  1 
+ATOM   515  C CD  . LYS A 1 69  ? 28.522 38.733 55.225 1.00 27.12 ? 116 LYS A CD  1 
+ATOM   516  C CE  . LYS A 1 69  ? 27.186 38.469 54.562 0.50 26.97 ? 116 LYS A CE  1 
+ATOM   517  N NZ  . LYS A 1 69  ? 27.304 38.790 53.110 0.50 32.88 ? 116 LYS A NZ  1 
+ATOM   518  N N   . ALA A 1 70  ? 33.808 38.478 56.673 1.00 8.85  ? 117 ALA A N   1 
+ATOM   519  C CA  . ALA A 1 70  ? 34.836 38.617 57.689 1.00 8.19  ? 117 ALA A CA  1 
+ATOM   520  C C   . ALA A 1 70  ? 36.193 38.333 57.071 1.00 7.61  ? 117 ALA A C   1 
+ATOM   521  O O   . ALA A 1 70  ? 36.315 37.590 56.086 1.00 8.25  ? 117 ALA A O   1 
+ATOM   522  C CB  . ALA A 1 70  ? 34.642 37.624 58.844 1.00 9.96  ? 117 ALA A CB  1 
+ATOM   523  N N   . ILE A 1 71  ? 37.229 38.900 57.694 1.00 7.75  ? 118 ILE A N   1 
+ATOM   524  C CA  . ILE A 1 71  ? 38.619 38.678 57.345 1.00 7.64  ? 118 ILE A CA  1 
+ATOM   525  C C   . ILE A 1 71  ? 39.400 38.320 58.599 1.00 7.98  ? 118 ILE A C   1 
+ATOM   526  O O   . ILE A 1 71  ? 39.283 39.021 59.632 1.00 9.00  ? 118 ILE A O   1 
+ATOM   527  C CB  . ILE A 1 71  ? 39.245 39.922 56.669 1.00 7.84  ? 118 ILE A CB  1 
+ATOM   528  C CG1 . ILE A 1 71  ? 38.458 40.334 55.426 1.00 7.39  ? 118 ILE A CG1 1 
+ATOM   529  C CG2 . ILE A 1 71  ? 40.702 39.664 56.337 1.00 8.97  ? 118 ILE A CG2 1 
+ATOM   530  C CD1 . ILE A 1 71  ? 38.885 41.670 54.833 1.00 8.18  ? 118 ILE A CD1 1 
+ATOM   531  N N   . LYS A 1 72  ? 40.190 37.255 58.504 1.00 8.14  ? 119 LYS A N   1 
+ATOM   532  C CA  . LYS A 1 72  ? 41.125 36.800 59.497 1.00 8.44  ? 119 LYS A CA  1 
+ATOM   533  C C   . LYS A 1 72  ? 42.519 37.253 59.103 1.00 9.20  ? 119 LYS A C   1 
+ATOM   534  O O   . LYS A 1 72  ? 42.972 37.029 57.993 1.00 9.56  ? 119 LYS A O   1 
+ATOM   535  C CB  . LYS A 1 72  ? 41.096 35.260 59.586 1.00 9.78  ? 119 LYS A CB  1 
+ATOM   536  C CG  . LYS A 1 72  ? 42.222 34.569 60.307 1.00 12.93 ? 119 LYS A CG  1 
+ATOM   537  C CD  . LYS A 1 72  ? 42.207 34.770 61.772 1.00 14.44 ? 119 LYS A CD  1 
+ATOM   538  C CE  . LYS A 1 72  ? 43.289 34.010 62.536 1.00 16.34 ? 119 LYS A CE  1 
+ATOM   539  N NZ  . LYS A 1 72  ? 44.617 34.634 62.386 1.00 16.00 ? 119 LYS A NZ  1 
+ATOM   540  N N   . THR A 1 73  ? 43.233 37.852 60.065 1.00 9.76  ? 120 THR A N   1 
+ATOM   541  C CA  . THR A 1 73  ? 44.635 38.203 59.912 1.00 10.13 ? 120 THR A CA  1 
+ATOM   542  C C   . THR A 1 73  ? 45.382 37.839 61.194 1.00 11.12 ? 120 THR A C   1 
+ATOM   543  O O   . THR A 1 73  ? 44.760 37.484 62.204 1.00 11.90 ? 120 THR A O   1 
+ATOM   544  C CB  . THR A 1 73  ? 44.851 39.707 59.642 1.00 11.38 ? 120 THR A CB  1 
+ATOM   545  O OG1 . THR A 1 73  ? 44.531 40.484 60.826 1.00 11.51 ? 120 THR A OG1 1 
+ATOM   546  C CG2 . THR A 1 73  ? 43.960 40.241 58.523 1.00 11.28 ? 120 THR A CG2 1 
+ATOM   547  N N   . ASP A 1 74  ? 46.684 38.060 61.204 1.00 12.12 ? 121 ASP A N   1 
+ATOM   548  C CA  . ASP A 1 74  ? 47.434 38.036 62.459 1.00 12.92 ? 121 ASP A CA  1 
+ATOM   549  C C   . ASP A 1 74  ? 47.379 39.408 63.089 1.00 12.91 ? 121 ASP A C   1 
+ATOM   550  O O   . ASP A 1 74  ? 46.634 40.298 62.650 1.00 12.69 ? 121 ASP A O   1 
+ATOM   551  C CB  . ASP A 1 74  ? 48.846 37.519 62.208 1.00 15.66 ? 121 ASP A CB  1 
+ATOM   552  C CG  . ASP A 1 74  ? 49.791 38.458 61.508 1.00 17.09 ? 121 ASP A CG  1 
+ATOM   553  O OD1 . ASP A 1 74  ? 49.494 39.619 61.327 1.00 17.10 ? 121 ASP A OD1 1 
+ATOM   554  O OD2 . ASP A 1 74  ? 50.904 37.972 61.133 1.00 24.53 ? 121 ASP A OD2 1 
+ATOM   555  N N   . ASN A 1 75  ? 48.122 39.564 64.195 1.00 14.38 ? 122 ASN A N   1 
+ATOM   556  C CA  . ASN A 1 75  ? 48.106 40.783 64.963 1.00 15.49 ? 122 ASN A CA  1 
+ATOM   557  C C   . ASN A 1 75  ? 49.190 41.794 64.563 1.00 17.43 ? 122 ASN A C   1 
+ATOM   558  O O   . ASN A 1 75  ? 49.587 42.662 65.312 1.00 23.06 ? 122 ASN A O   1 
+ATOM   559  C CB  . ASN A 1 75  ? 48.209 40.576 66.504 1.00 18.20 ? 122 ASN A CB  1 
+ATOM   560  C CG  . ASN A 1 75  ? 46.911 40.017 67.002 1.00 19.31 ? 122 ASN A CG  1 
+ATOM   561  O OD1 . ASN A 1 75  ? 45.854 40.644 67.046 1.00 19.04 ? 122 ASN A OD1 1 
+ATOM   562  N ND2 . ASN A 1 75  ? 47.044 38.765 67.400 1.00 24.27 ? 122 ASN A ND2 1 
+ATOM   563  N N   . GLY A 1 76  ? 49.593 41.740 63.321 1.00 16.06 ? 123 GLY A N   1 
+ATOM   564  C CA  . GLY A 1 76  ? 50.567 42.741 62.846 1.00 17.80 ? 123 GLY A CA  1 
+ATOM   565  C C   . GLY A 1 76  ? 49.944 44.153 62.926 1.00 15.27 ? 123 GLY A C   1 
+ATOM   566  O O   . GLY A 1 76  ? 48.732 44.358 62.762 1.00 15.49 ? 123 GLY A O   1 
+ATOM   567  N N   . SER A 1 77  ? 50.820 45.139 63.096 1.00 16.61 ? 124 SER A N   1 
+ATOM   568  C CA  . SER A 1 77  ? 50.392 46.511 63.301 1.00 17.82 ? 124 SER A CA  1 
+ATOM   569  C C   . SER A 1 77  ? 49.603 47.066 62.115 1.00 15.57 ? 124 SER A C   1 
+ATOM   570  O O   . SER A 1 77  ? 48.718 47.912 62.299 1.00 18.43 ? 124 SER A O   1 
+ATOM   571  C CB  A SER A 1 77  ? 51.592 47.410 63.645 0.54 22.30 ? 124 SER A CB  1 
+ATOM   572  C CB  B SER A 1 77  ? 51.697 47.283 63.505 0.46 21.26 ? 124 SER A CB  1 
+ATOM   573  O OG  A SER A 1 77  ? 52.580 47.483 62.654 0.54 22.48 ? 124 SER A OG  1 
+ATOM   574  O OG  B SER A 1 77  ? 52.308 46.879 64.694 0.46 26.46 ? 124 SER A OG  1 
+ATOM   575  N N   . CYS A 1 78  ? 49.881 46.590 60.901 1.00 13.07 ? 125 CYS A N   1 
+ATOM   576  C CA  . CYS A 1 78  ? 49.127 47.066 59.732 1.00 12.76 ? 125 CYS A CA  1 
+ATOM   577  C C   . CYS A 1 78  ? 47.694 46.607 59.741 1.00 12.76 ? 125 CYS A C   1 
+ATOM   578  O O   . CYS A 1 78  ? 46.845 47.158 59.007 1.00 13.86 ? 125 CYS A O   1 
+ATOM   579  C CB  A CYS A 1 78  ? 49.823 46.602 58.452 0.69 14.10 ? 125 CYS A CB  1 
+ATOM   580  C CB  B CYS A 1 78  ? 49.535 46.636 58.057 0.31 15.51 ? 125 CYS A CB  1 
+ATOM   581  S SG  A CYS A 1 78  ? 49.922 44.822 58.208 0.69 16.73 ? 125 CYS A SG  1 
+ATOM   582  S SG  B CYS A 1 78  ? 51.352 46.762 58.072 0.31 21.59 ? 125 CYS A SG  1 
+ATOM   583  N N   . PHE A 1 79  ? 47.402 45.562 60.558 1.00 13.34 ? 126 PHE A N   1 
+ATOM   584  C CA  . PHE A 1 79  ? 46.047 45.037 60.636 1.00 14.94 ? 126 PHE A CA  1 
+ATOM   585  C C   . PHE A 1 79  ? 45.319 45.485 61.888 1.00 16.86 ? 126 PHE A C   1 
+ATOM   586  O O   . PHE A 1 79  ? 44.082 45.551 61.867 1.00 19.94 ? 126 PHE A O   1 
+ATOM   587  C CB  . PHE A 1 79  ? 46.118 43.506 60.652 1.00 14.11 ? 126 PHE A CB  1 
+ATOM   588  C CG  . PHE A 1 79  ? 46.675 42.902 59.383 1.00 12.00 ? 126 PHE A CG  1 
+ATOM   589  C CD1 . PHE A 1 79  ? 46.208 43.310 58.139 1.00 13.09 ? 126 PHE A CD1 1 
+ATOM   590  C CD2 . PHE A 1 79  ? 47.634 41.914 59.446 1.00 12.71 ? 126 PHE A CD2 1 
+ATOM   591  C CE1 . PHE A 1 79  ? 46.719 42.714 57.017 1.00 13.28 ? 126 PHE A CE1 1 
+ATOM   592  C CE2 . PHE A 1 79  ? 48.131 41.331 58.315 1.00 13.17 ? 126 PHE A CE2 1 
+ATOM   593  C CZ  . PHE A 1 79  ? 47.680 41.750 57.072 1.00 12.97 ? 126 PHE A CZ  1 
+ATOM   594  N N   . THR A 1 80  ? 46.044 45.853 62.946 1.00 16.96 ? 127 THR A N   1 
+ATOM   595  C CA  . THR A 1 80  ? 45.369 46.194 64.169 1.00 19.09 ? 127 THR A CA  1 
+ATOM   596  C C   . THR A 1 80  ? 45.355 47.700 64.458 1.00 15.44 ? 127 THR A C   1 
+ATOM   597  O O   . THR A 1 80  ? 44.892 48.156 65.495 1.00 16.10 ? 127 THR A O   1 
+ATOM   598  C CB  . THR A 1 80  ? 46.027 45.446 65.350 1.00 24.18 ? 127 THR A CB  1 
+ATOM   599  O OG1 . THR A 1 80  ? 47.400 45.870 65.429 1.00 23.16 ? 127 THR A OG1 1 
+ATOM   600  C CG2 . THR A 1 80  ? 45.891 43.967 65.062 1.00 35.48 ? 127 THR A CG2 1 
+ATOM   601  N N   . SER A 1 81  ? 45.867 48.487 63.540 1.00 12.35 ? 128 SER A N   1 
+ATOM   602  C CA  . SER A 1 81  ? 45.863 49.896 63.677 1.00 11.88 ? 128 SER A CA  1 
+ATOM   603  C C   . SER A 1 81  ? 44.459 50.495 63.711 1.00 11.31 ? 128 SER A C   1 
+ATOM   604  O O   . SER A 1 81  ? 43.498 49.921 63.201 1.00 11.80 ? 128 SER A O   1 
+ATOM   605  C CB  . SER A 1 81  ? 46.632 50.538 62.507 1.00 11.78 ? 128 SER A CB  1 
+ATOM   606  O OG  . SER A 1 81  ? 45.891 50.268 61.314 1.00 12.61 ? 128 SER A OG  1 
+ATOM   607  N N   . LYS A 1 82  ? 44.352 51.664 64.288 1.00 11.99 ? 129 LYS A N   1 
+ATOM   608  C CA  . LYS A 1 82  ? 43.086 52.391 64.250 1.00 12.45 ? 129 LYS A CA  1 
+ATOM   609  C C   . LYS A 1 82  ? 42.641 52.626 62.833 1.00 10.92 ? 129 LYS A C   1 
+ATOM   610  O O   . LYS A 1 82  ? 41.475 52.523 62.500 1.00 10.79 ? 129 LYS A O   1 
+ATOM   611  C CB  . LYS A 1 82  ? 43.243 53.759 64.967 1.00 16.00 ? 129 LYS A CB  1 
+ATOM   612  C CG  . LYS A 1 82  ? 42.021 54.658 64.992 0.50 17.20 ? 129 LYS A CG  1 
+ATOM   613  C CD  . LYS A 1 82  ? 42.462 55.997 65.611 0.50 23.18 ? 129 LYS A CD  1 
+ATOM   614  C CE  . LYS A 1 82  ? 41.334 56.860 66.116 0.50 32.86 ? 129 LYS A CE  1 
+ATOM   615  N NZ  . LYS A 1 82  ? 41.821 57.537 67.375 0.50 53.72 ? 129 LYS A NZ  1 
+ATOM   616  N N   . SER A 1 83  ? 43.560 52.978 61.948 1.00 11.40 ? 130 SER A N   1 
+ATOM   617  C CA  . SER A 1 83  ? 43.248 53.225 60.562 1.00 10.99 ? 130 SER A CA  1 
+ATOM   618  C C   . SER A 1 83  ? 42.604 52.007 59.897 1.00 9.45  ? 130 SER A C   1 
+ATOM   619  O O   . SER A 1 83  ? 41.562 52.117 59.235 1.00 9.63  ? 130 SER A O   1 
+ATOM   620  C CB  . SER A 1 83  ? 44.557 53.602 59.807 1.00 15.93 ? 130 SER A CB  1 
+ATOM   621  O OG  . SER A 1 83  ? 44.387 53.666 58.482 1.00 19.54 ? 130 SER A OG  1 
+ATOM   622  N N   . THR A 1 84  ? 43.242 50.860 60.070 1.00 9.71  ? 131 THR A N   1 
+ATOM   623  C CA  . THR A 1 84  ? 42.687 49.644 59.450 1.00 9.70  ? 131 THR A CA  1 
+ATOM   624  C C   . THR A 1 84  ? 41.377 49.253 60.055 1.00 9.34  ? 131 THR A C   1 
+ATOM   625  O O   . THR A 1 84  ? 40.441 48.835 59.334 1.00 9.73  ? 131 THR A O   1 
+ATOM   626  C CB  . THR A 1 84  ? 43.738 48.537 59.466 1.00 11.61 ? 131 THR A CB  1 
+ATOM   627  O OG1 . THR A 1 84  ? 44.792 49.001 58.589 1.00 13.68 ? 131 THR A OG1 1 
+ATOM   628  C CG2 . THR A 1 84  ? 43.092 47.239 59.013 1.00 16.86 ? 131 THR A CG2 1 
+ATOM   629  N N   . ARG A 1 85  ? 41.260 49.352 61.393 1.00 9.81  ? 132 ARG A N   1 
+ATOM   630  C CA  . ARG A 1 85  ? 39.994 49.038 62.010 1.00 10.46 ? 132 ARG A CA  1 
+ATOM   631  C C   . ARG A 1 85  ? 38.861 49.910 61.487 1.00 9.52  ? 132 ARG A C   1 
+ATOM   632  O O   . ARG A 1 85  ? 37.736 49.443 61.197 1.00 9.83  ? 132 ARG A O   1 
+ATOM   633  C CB  . ARG A 1 85  ? 40.185 49.059 63.512 1.00 15.75 ? 132 ARG A CB  1 
+ATOM   634  C CG  . ARG A 1 85  ? 41.191 47.845 63.767 0.50 14.20 ? 132 ARG A CG  1 
+ATOM   635  C CD  . ARG A 1 85  ? 41.355 47.516 65.255 0.50 13.41 ? 132 ARG A CD  1 
+ATOM   636  N NE  . ARG A 1 85  ? 40.136 46.909 65.773 0.50 13.63 ? 132 ARG A NE  1 
+ATOM   637  C CZ  . ARG A 1 85  ? 39.867 46.697 67.038 0.50 16.58 ? 132 ARG A CZ  1 
+ATOM   638  N NH1 . ARG A 1 85  ? 40.769 47.003 67.958 0.50 21.06 ? 132 ARG A NH1 1 
+ATOM   639  N NH2 . ARG A 1 85  ? 38.701 46.155 67.350 0.50 22.68 ? 132 ARG A NH2 1 
+ATOM   640  N N   . GLU A 1 86  ? 39.146 51.180 61.304 1.00 8.98  ? 133 GLU A N   1 
+ATOM   641  C CA  . GLU A 1 86  ? 38.143 52.104 60.767 1.00 8.82  ? 133 GLU A CA  1 
+ATOM   642  C C   . GLU A 1 86  ? 37.794 51.794 59.307 1.00 8.19  ? 133 GLU A C   1 
+ATOM   643  O O   . GLU A 1 86  ? 36.627 51.877 58.906 1.00 8.81  ? 133 GLU A O   1 
+ATOM   644  C CB  . GLU A 1 86  ? 38.614 53.543 60.934 1.00 9.74  ? 133 GLU A CB  1 
+ATOM   645  C CG  . GLU A 1 86  ? 37.705 54.543 60.254 1.00 11.42 ? 133 GLU A CG  1 
+ATOM   646  C CD  . GLU A 1 86  ? 36.282 54.612 60.641 1.00 12.26 ? 133 GLU A CD  1 
+ATOM   647  O OE1 . GLU A 1 86  ? 35.831 54.038 61.672 1.00 14.21 ? 133 GLU A OE1 1 
+ATOM   648  O OE2 . GLU A 1 86  ? 35.529 55.284 59.890 1.00 14.52 ? 133 GLU A OE2 1 
+ATOM   649  N N   . TRP A 1 87  ? 38.786 51.435 58.506 1.00 7.70  ? 134 TRP A N   1 
+ATOM   650  C CA  . TRP A 1 87  ? 38.545 51.106 57.093 1.00 7.57  ? 134 TRP A CA  1 
+ATOM   651  C C   . TRP A 1 87  ? 37.649 49.885 56.973 1.00 6.95  ? 134 TRP A C   1 
+ATOM   652  O O   . TRP A 1 87  ? 36.703 49.851 56.193 1.00 7.36  ? 134 TRP A O   1 
+ATOM   653  C CB  . TRP A 1 87  ? 39.906 50.897 56.410 1.00 7.88  ? 134 TRP A CB  1 
+ATOM   654  C CG  . TRP A 1 87  ? 39.866 50.740 54.935 1.00 7.32  ? 134 TRP A CG  1 
+ATOM   655  C CD1 . TRP A 1 87  ? 40.114 51.744 54.030 1.00 7.77  ? 134 TRP A CD1 1 
+ATOM   656  C CD2 . TRP A 1 87  ? 39.580 49.576 54.161 1.00 7.39  ? 134 TRP A CD2 1 
+ATOM   657  N NE1 . TRP A 1 87  ? 40.003 51.279 52.745 1.00 8.13  ? 134 TRP A NE1 1 
+ATOM   658  C CE2 . TRP A 1 87  ? 39.675 49.938 52.782 1.00 7.44  ? 134 TRP A CE2 1 
+ATOM   659  C CE3 . TRP A 1 87  ? 39.275 48.252 54.458 1.00 7.81  ? 134 TRP A CE3 1 
+ATOM   660  C CZ2 . TRP A 1 87  ? 39.467 49.021 51.761 1.00 7.97  ? 134 TRP A CZ2 1 
+ATOM   661  C CZ3 . TRP A 1 87  ? 39.057 47.353 53.441 1.00 8.31  ? 134 TRP A CZ3 1 
+ATOM   662  C CH2 . TRP A 1 87  ? 39.150 47.743 52.105 1.00 8.21  ? 134 TRP A CH2 1 
+ATOM   663  N N   . LEU A 1 88  ? 37.915 48.858 57.779 1.00 7.39  ? 135 LEU A N   1 
+ATOM   664  C CA  . LEU A 1 88  ? 37.075 47.663 57.746 1.00 7.55  ? 135 LEU A CA  1 
+ATOM   665  C C   . LEU A 1 88  ? 35.673 47.975 58.248 1.00 7.69  ? 135 LEU A C   1 
+ATOM   666  O O   . LEU A 1 88  ? 34.686 47.453 57.706 1.00 8.39  ? 135 LEU A O   1 
+ATOM   667  C CB  . LEU A 1 88  ? 37.708 46.542 58.575 1.00 8.02  ? 135 LEU A CB  1 
+ATOM   668  C CG  . LEU A 1 88  ? 38.984 45.942 57.928 1.00 8.03  ? 135 LEU A CG  1 
+ATOM   669  C CD1 . LEU A 1 88  ? 39.750 45.110 58.932 1.00 10.63 ? 135 LEU A CD1 1 
+ATOM   670  C CD2 . LEU A 1 88  ? 38.607 45.130 56.708 1.00 10.10 ? 135 LEU A CD2 1 
+ATOM   671  N N   . ALA A 1 89  ? 35.535 48.826 59.270 1.00 8.24  ? 136 ALA A N   1 
+ATOM   672  C CA  . ALA A 1 89  ? 34.212 49.215 59.754 1.00 8.49  ? 136 ALA A CA  1 
+ATOM   673  C C   . ALA A 1 89  ? 33.447 49.989 58.680 1.00 8.43  ? 136 ALA A C   1 
+ATOM   674  O O   . ALA A 1 89  ? 32.237 49.791 58.521 1.00 8.99  ? 136 ALA A O   1 
+ATOM   675  C CB  . ALA A 1 89  ? 34.337 50.030 61.036 1.00 9.92  ? 136 ALA A CB  1 
+ATOM   676  N N   . ARG A 1 90  ? 34.124 50.848 57.946 1.00 8.05  ? 137 ARG A N   1 
+ATOM   677  C CA  . ARG A 1 90  ? 33.512 51.592 56.825 1.00 7.84  ? 137 ARG A CA  1 
+ATOM   678  C C   . ARG A 1 90  ? 32.881 50.667 55.808 1.00 7.43  ? 137 ARG A C   1 
+ATOM   679  O O   . ARG A 1 90  ? 31.827 50.952 55.250 1.00 8.17  ? 137 ARG A O   1 
+ATOM   680  C CB  . ARG A 1 90  ? 34.612 52.444 56.183 1.00 8.66  ? 137 ARG A CB  1 
+ATOM   681  C CG  . ARG A 1 90  ? 34.156 53.235 54.989 1.00 8.38  ? 137 ARG A CG  1 
+ATOM   682  C CD  . ARG A 1 90  ? 35.302 53.617 54.061 1.00 9.75  ? 137 ARG A CD  1 
+ATOM   683  N NE  . ARG A 1 90  ? 36.372 54.277 54.796 1.00 10.55 ? 137 ARG A NE  1 
+ATOM   684  C CZ  . ARG A 1 90  ? 37.587 54.553 54.309 1.00 11.21 ? 137 ARG A CZ  1 
+ATOM   685  N NH1 . ARG A 1 90  ? 37.888 54.235 53.069 1.00 11.41 ? 137 ARG A NH1 1 
+ATOM   686  N NH2 . ARG A 1 90  ? 38.483 55.136 55.124 1.00 14.64 ? 137 ARG A NH2 1 
+ATOM   687  N N   . TRP A 1 91  ? 33.554 49.545 55.544 1.00 7.50  ? 138 TRP A N   1 
+ATOM   688  C CA  . TRP A 1 91  ? 33.088 48.530 54.621 1.00 7.73  ? 138 TRP A CA  1 
+ATOM   689  C C   . TRP A 1 91  ? 32.102 47.555 55.237 1.00 8.45  ? 138 TRP A C   1 
+ATOM   690  O O   . TRP A 1 91  ? 31.525 46.751 54.476 1.00 10.37 ? 138 TRP A O   1 
+ATOM   691  C CB  . TRP A 1 91  ? 34.279 47.771 54.043 1.00 8.03  ? 138 TRP A CB  1 
+ATOM   692  C CG  . TRP A 1 91  ? 34.913 48.459 52.853 1.00 7.71  ? 138 TRP A CG  1 
+ATOM   693  C CD1 . TRP A 1 91  ? 35.983 49.253 52.798 1.00 8.10  ? 138 TRP A CD1 1 
+ATOM   694  C CD2 . TRP A 1 91  ? 34.409 48.329 51.522 1.00 7.11  ? 138 TRP A CD2 1 
+ATOM   695  N NE1 . TRP A 1 91  ? 36.215 49.670 51.497 1.00 8.32  ? 138 TRP A NE1 1 
+ATOM   696  C CE2 . TRP A 1 91  ? 35.262 49.104 50.706 1.00 7.78  ? 138 TRP A CE2 1 
+ATOM   697  C CE3 . TRP A 1 91  ? 33.339 47.656 50.959 1.00 7.83  ? 138 TRP A CE3 1 
+ATOM   698  C CZ2 . TRP A 1 91  ? 35.055 49.193 49.327 1.00 8.19  ? 138 TRP A CZ2 1 
+ATOM   699  C CZ3 . TRP A 1 91  ? 33.138 47.740 49.590 1.00 8.38  ? 138 TRP A CZ3 1 
+ATOM   700  C CH2 . TRP A 1 91  ? 33.981 48.499 48.795 1.00 8.48  ? 138 TRP A CH2 1 
+ATOM   701  N N   . GLY A 1 92  ? 31.917 47.554 56.547 1.00 8.39  ? 139 GLY A N   1 
+ATOM   702  C CA  . GLY A 1 92  ? 31.056 46.586 57.211 1.00 10.04 ? 139 GLY A CA  1 
+ATOM   703  C C   . GLY A 1 92  ? 31.592 45.181 57.196 1.00 9.65  ? 139 GLY A C   1 
+ATOM   704  O O   . GLY A 1 92  ? 30.811 44.205 57.136 1.00 11.83 ? 139 GLY A O   1 
+ATOM   705  N N   . ILE A 1 93  ? 32.900 45.018 57.254 1.00 8.80  ? 140 ILE A N   1 
+ATOM   706  C CA  . ILE A 1 93  ? 33.565 43.728 57.257 1.00 8.55  ? 140 ILE A CA  1 
+ATOM   707  C C   . ILE A 1 93  ? 34.059 43.400 58.671 1.00 9.07  ? 140 ILE A C   1 
+ATOM   708  O O   . ILE A 1 93  ? 34.796 44.188 59.235 1.00 10.19 ? 140 ILE A O   1 
+ATOM   709  C CB  . ILE A 1 93  ? 34.740 43.723 56.249 1.00 8.48  ? 140 ILE A CB  1 
+ATOM   710  C CG1 . ILE A 1 93  ? 34.251 43.965 54.835 1.00 8.46  ? 140 ILE A CG1 1 
+ATOM   711  C CG2 . ILE A 1 93  ? 35.511 42.404 56.380 1.00 9.58  ? 140 ILE A CG2 1 
+ATOM   712  C CD1 . ILE A 1 93  ? 35.377 44.332 53.865 1.00 9.01  ? 140 ILE A CD1 1 
+ATOM   713  N N   . ALA A 1 94  ? 33.658 42.265 59.210 1.00 9.61  ? 141 ALA A N   1 
+ATOM   714  C CA  . ALA A 1 94  ? 34.146 41.836 60.506 1.00 9.98  ? 141 ALA A CA  1 
+ATOM   715  C C   . ALA A 1 94  ? 35.597 41.433 60.413 1.00 9.54  ? 141 ALA A C   1 
+ATOM   716  O O   . ALA A 1 94  ? 36.023 40.854 59.402 1.00 10.51 ? 141 ALA A O   1 
+ATOM   717  C CB  . ALA A 1 94  ? 33.289 40.664 61.017 1.00 11.88 ? 141 ALA A CB  1 
+ATOM   718  N N   . HIS A 1 95  ? 36.359 41.677 61.472 1.00 10.70 ? 142 HIS A N   1 
+ATOM   719  C CA  . HIS A 1 95  ? 37.789 41.390 61.495 1.00 10.00 ? 142 HIS A CA  1 
+ATOM   720  C C   . HIS A 1 95  ? 38.084 40.584 62.740 1.00 9.78  ? 142 HIS A C   1 
+ATOM   721  O O   . HIS A 1 95  ? 37.654 40.951 63.841 1.00 11.45 ? 142 HIS A O   1 
+ATOM   722  C CB  . HIS A 1 95  ? 38.544 42.693 61.516 1.00 11.97 ? 142 HIS A CB  1 
+ATOM   723  C CG  . HIS A 1 95  ? 40.042 42.572 61.490 1.00 12.21 ? 142 HIS A CG  1 
+ATOM   724  N ND1 . HIS A 1 95  ? 40.834 43.577 61.992 1.00 15.58 ? 142 HIS A ND1 1 
+ATOM   725  C CD2 . HIS A 1 95  ? 40.848 41.580 61.013 1.00 12.16 ? 142 HIS A CD2 1 
+ATOM   726  C CE1 . HIS A 1 95  ? 42.098 43.207 61.814 1.00 16.67 ? 142 HIS A CE1 1 
+ATOM   727  N NE2 . HIS A 1 95  ? 42.168 42.003 61.253 1.00 13.58 ? 142 HIS A NE2 1 
+ATOM   728  N N   . THR A 1 96  ? 38.842 39.492 62.571 1.00 9.41  ? 143 THR A N   1 
+ATOM   729  C CA  . THR A 1 96  ? 39.319 38.679 63.672 1.00 9.67  ? 143 THR A CA  1 
+ATOM   730  C C   . THR A 1 96  ? 40.818 38.456 63.486 1.00 9.38  ? 143 THR A C   1 
+ATOM   731  O O   . THR A 1 96  ? 41.296 38.285 62.394 1.00 10.04 ? 143 THR A O   1 
+ATOM   732  C CB  . THR A 1 96  ? 38.549 37.357 63.746 1.00 10.85 ? 143 THR A CB  1 
+ATOM   733  O OG1 . THR A 1 96  ? 39.012 36.595 64.859 1.00 13.46 ? 143 THR A OG1 1 
+ATOM   734  C CG2 . THR A 1 96  ? 38.725 36.497 62.524 1.00 12.38 ? 143 THR A CG2 1 
+ATOM   735  N N   . THR A 1 97  ? 41.500 38.406 64.632 1.00 11.20 ? 144 THR A N   1 
+ATOM   736  C CA  . THR A 1 97  ? 42.876 37.966 64.639 1.00 12.84 ? 144 THR A CA  1 
+ATOM   737  C C   . THR A 1 97  ? 43.017 36.635 65.370 1.00 15.06 ? 144 THR A C   1 
+ATOM   738  O O   . THR A 1 97  ? 44.126 36.180 65.588 1.00 18.23 ? 144 THR A O   1 
+ATOM   739  C CB  . THR A 1 97  ? 43.832 39.053 65.158 1.00 14.89 ? 144 THR A CB  1 
+ATOM   740  O OG1 . THR A 1 97  ? 43.532 39.344 66.532 1.00 17.02 ? 144 THR A OG1 1 
+ATOM   741  C CG2 . THR A 1 97  ? 43.743 40.303 64.317 1.00 15.79 ? 144 THR A CG2 1 
+ATOM   742  N N   . GLY A 1 98  ? 41.907 35.983 65.681 1.00 14.68 ? 145 GLY A N   1 
+ATOM   743  C CA  . GLY A 1 98  ? 41.854 34.651 66.228 1.00 18.96 ? 145 GLY A CA  1 
+ATOM   744  C C   . GLY A 1 98  ? 41.939 34.590 67.704 1.00 22.25 ? 145 GLY A C   1 
+ATOM   745  O O   . GLY A 1 98  ? 41.626 35.527 68.398 1.00 22.12 ? 145 GLY A O   1 
+ATOM   746  N N   . ILE A 1 99  ? 42.404 33.447 68.177 1.00 30.28 ? 146 ILE A N   1 
+ATOM   747  C CA  . ILE A 1 99  ? 42.403 33.148 69.596 1.00 34.26 ? 146 ILE A CA  1 
+ATOM   748  C C   . ILE A 1 99  ? 43.738 33.651 70.113 1.00 32.33 ? 146 ILE A C   1 
+ATOM   749  O O   . ILE A 1 99  ? 44.765 33.250 69.539 1.00 36.96 ? 146 ILE A O   1 
+ATOM   750  C CB  . ILE A 1 99  ? 42.235 31.628 69.794 1.00 38.66 ? 146 ILE A CB  1 
+ATOM   751  C CG1 . ILE A 1 99  ? 40.903 31.102 69.207 1.00 46.12 ? 146 ILE A CG1 1 
+ATOM   752  C CG2 . ILE A 1 99  ? 42.437 31.241 71.229 1.00 43.80 ? 146 ILE A CG2 1 
+ATOM   753  C CD1 . ILE A 1 99  ? 40.775 29.583 69.228 1.00 49.43 ? 146 ILE A CD1 1 
+ATOM   754  N N   . PRO A 1 100 ? 43.776 34.535 71.093 1.00 43.42 ? 147 PRO A N   1 
+ATOM   755  C CA  . PRO A 1 100 ? 45.043 35.009 71.664 1.00 49.55 ? 147 PRO A CA  1 
+ATOM   756  C C   . PRO A 1 100 ? 45.844 33.930 72.405 1.00 55.68 ? 147 PRO A C   1 
+ATOM   757  O O   . PRO A 1 100 ? 45.402 32.771 72.432 1.00 64.93 ? 147 PRO A O   1 
+ATOM   758  C CB  . PRO A 1 100 ? 44.582 36.088 72.656 1.00 50.16 ? 147 PRO A CB  1 
+ATOM   759  C CG  . PRO A 1 100 ? 43.196 36.464 72.266 1.00 49.29 ? 147 PRO A CG  1 
+ATOM   760  C CD  . PRO A 1 100 ? 42.592 35.209 71.671 1.00 49.39 ? 147 PRO A CD  1 
+ATOM   761  N N   . GLY A 1 105 ? 45.599 29.296 63.141 1.00 43.96 ? 152 GLY A N   1 
+ATOM   762  C CA  . GLY A 1 105 ? 44.332 29.639 62.550 1.00 30.49 ? 152 GLY A CA  1 
+ATOM   763  C C   . GLY A 1 105 ? 44.221 30.272 61.190 1.00 23.14 ? 152 GLY A C   1 
+ATOM   764  O O   . GLY A 1 105 ? 43.137 30.747 60.822 1.00 27.82 ? 152 GLY A O   1 
+ATOM   765  N N   . GLN A 1 106 ? 45.308 30.309 60.409 1.00 21.73 ? 153 GLN A N   1 
+ATOM   766  C CA  . GLN A 1 106 ? 45.291 30.762 59.049 1.00 18.39 ? 153 GLN A CA  1 
+ATOM   767  C C   . GLN A 1 106 ? 46.292 29.974 58.181 1.00 18.34 ? 153 GLN A C   1 
+ATOM   768  O O   . GLN A 1 106 ? 47.132 30.480 57.427 1.00 18.27 ? 153 GLN A O   1 
+ATOM   769  C CB  . GLN A 1 106 ? 45.494 32.270 58.975 1.00 17.33 ? 153 GLN A CB  1 
+ATOM   770  C CG  . GLN A 1 106 ? 46.760 32.820 59.643 1.00 17.70 ? 153 GLN A CG  1 
+ATOM   771  C CD  . GLN A 1 106 ? 46.757 34.373 59.547 1.00 16.60 ? 153 GLN A CD  1 
+ATOM   772  O OE1 . GLN A 1 106 ? 45.745 35.006 59.931 1.00 17.38 ? 153 GLN A OE1 1 
+ATOM   773  N NE2 . GLN A 1 106 ? 47.816 34.967 59.038 1.00 15.93 ? 153 GLN A NE2 1 
+ATOM   774  N N   . ALA A 1 107 ? 46.145 28.647 58.287 1.00 19.62 ? 154 ALA A N   1 
+ATOM   775  C CA  . ALA A 1 107 ? 46.893 27.732 57.491 1.00 19.19 ? 154 ALA A CA  1 
+ATOM   776  C C   . ALA A 1 107 ? 46.654 27.940 56.012 1.00 17.74 ? 154 ALA A C   1 
+ATOM   777  O O   . ALA A 1 107 ? 47.572 27.715 55.203 1.00 17.83 ? 154 ALA A O   1 
+ATOM   778  C CB  . ALA A 1 107 ? 46.493 26.299 57.931 1.00 24.84 ? 154 ALA A CB  1 
+ATOM   779  N N   . MET A 1 108 ? 45.445 28.326 55.621 1.00 16.23 ? 155 MET A N   1 
+ATOM   780  C CA  . MET A 1 108 ? 45.183 28.455 54.174 1.00 14.89 ? 155 MET A CA  1 
+ATOM   781  C C   . MET A 1 108 ? 46.016 29.580 53.566 1.00 12.89 ? 155 MET A C   1 
+ATOM   782  O O   . MET A 1 108 ? 46.568 29.425 52.475 1.00 13.53 ? 155 MET A O   1 
+ATOM   783  C CB  A MET A 1 108 ? 43.672 28.646 53.824 0.63 14.07 ? 155 MET A CB  1 
+ATOM   784  C CB  B MET A 1 108 ? 43.784 28.769 54.223 0.37 15.93 ? 155 MET A CB  1 
+ATOM   785  C CG  A MET A 1 108 ? 42.750 27.470 54.070 0.63 15.16 ? 155 MET A CG  1 
+ATOM   786  C CG  B MET A 1 108 ? 43.441 28.388 52.799 0.37 17.38 ? 155 MET A CG  1 
+ATOM   787  S SD  A MET A 1 108 ? 41.026 27.742 53.677 0.63 17.36 ? 155 MET A SD  1 
+ATOM   788  S SD  B MET A 1 108 ? 41.687 28.489 52.515 0.37 22.26 ? 155 MET A SD  1 
+ATOM   789  C CE  A MET A 1 108 ? 40.965 27.535 51.887 0.63 21.24 ? 155 MET A CE  1 
+ATOM   790  C CE  B MET A 1 108 ? 41.386 27.478 51.046 0.37 29.65 ? 155 MET A CE  1 
+ATOM   791  N N   . VAL A 1 109 ? 46.123 30.720 54.237 1.00 12.18 ? 156 VAL A N   1 
+ATOM   792  C CA  . VAL A 1 109 ? 46.937 31.808 53.653 1.00 11.03 ? 156 VAL A CA  1 
+ATOM   793  C C   . VAL A 1 109 ? 48.420 31.465 53.717 1.00 11.09 ? 156 VAL A C   1 
+ATOM   794  O O   . VAL A 1 109 ? 49.177 31.841 52.837 1.00 11.28 ? 156 VAL A O   1 
+ATOM   795  C CB  . VAL A 1 109 ? 46.625 33.196 54.262 1.00 11.22 ? 156 VAL A CB  1 
+ATOM   796  C CG1 . VAL A 1 109 ? 47.185 33.398 55.656 1.00 12.93 ? 156 VAL A CG1 1 
+ATOM   797  C CG2 . VAL A 1 109 ? 47.038 34.311 53.321 1.00 11.52 ? 156 VAL A CG2 1 
+ATOM   798  N N   . GLU A 1 110 ? 48.848 30.722 54.742 1.00 13.45 ? 157 GLU A N   1 
+ATOM   799  C CA  . GLU A 1 110 ? 50.252 30.300 54.777 1.00 15.04 ? 157 GLU A CA  1 
+ATOM   800  C C   . GLU A 1 110 ? 50.544 29.401 53.594 1.00 14.02 ? 157 GLU A C   1 
+ATOM   801  O O   . GLU A 1 110 ? 51.619 29.517 52.967 1.00 15.18 ? 157 GLU A O   1 
+ATOM   802  C CB  A GLU A 1 110 ? 50.542 29.710 56.158 0.67 19.82 ? 157 GLU A CB  1 
+ATOM   803  C CB  B GLU A 1 110 ? 50.637 29.448 55.922 0.33 19.70 ? 157 GLU A CB  1 
+ATOM   804  C CG  A GLU A 1 110 ? 50.598 30.849 57.167 0.67 21.22 ? 157 GLU A CG  1 
+ATOM   805  C CG  B GLU A 1 110 ? 50.572 30.140 57.269 0.33 20.53 ? 157 GLU A CG  1 
+ATOM   806  C CD  A GLU A 1 110 ? 50.882 30.275 58.547 0.67 26.34 ? 157 GLU A CD  1 
+ATOM   807  C CD  B GLU A 1 110 ? 51.821 30.999 57.437 0.33 21.72 ? 157 GLU A CD  1 
+ATOM   808  O OE1 A GLU A 1 110 ? 51.309 29.100 58.636 0.67 41.26 ? 157 GLU A OE1 1 
+ATOM   809  O OE1 B GLU A 1 110 ? 52.834 30.726 56.735 0.33 31.98 ? 157 GLU A OE1 1 
+ATOM   810  O OE2 A GLU A 1 110 ? 50.707 31.051 59.513 0.67 36.76 ? 157 GLU A OE2 1 
+ATOM   811  O OE2 B GLU A 1 110 ? 51.812 31.642 58.529 0.33 21.59 ? 157 GLU A OE2 1 
+ATOM   812  N N   . ARG A 1 111 ? 49.617 28.521 53.262 1.00 14.48 ? 158 ARG A N   1 
+ATOM   813  C CA  . ARG A 1 111 ? 49.777 27.685 52.060 1.00 15.50 ? 158 ARG A CA  1 
+ATOM   814  C C   . ARG A 1 111 ? 49.794 28.521 50.811 1.00 13.44 ? 158 ARG A C   1 
+ATOM   815  O O   . ARG A 1 111 ? 50.623 28.280 49.917 1.00 14.20 ? 158 ARG A O   1 
+ATOM   816  C CB  . ARG A 1 111 ? 48.651 26.598 51.966 1.00 17.21 ? 158 ARG A CB  1 
+ATOM   817  C CG  . ARG A 1 111 ? 48.626 25.785 50.668 1.00 22.78 ? 158 ARG A CG  1 
+ATOM   818  C CD  . ARG A 1 111 ? 47.600 24.677 50.705 1.00 28.67 ? 158 ARG A CD  1 
+ATOM   819  N NE  . ARG A 1 111 ? 47.556 23.826 49.508 1.00 33.29 ? 158 ARG A NE  1 
+ATOM   820  C CZ  . ARG A 1 111 ? 46.770 24.099 48.453 1.00 41.24 ? 158 ARG A CZ  1 
+ATOM   821  N NH1 . ARG A 1 111 ? 46.006 25.195 48.472 1.00 53.46 ? 158 ARG A NH1 1 
+ATOM   822  N NH2 . ARG A 1 111 ? 46.723 23.334 47.345 1.00 54.67 ? 158 ARG A NH2 1 
+ATOM   823  N N   . ALA A 1 112 ? 48.894 29.492 50.726 1.00 12.84 ? 159 ALA A N   1 
+ATOM   824  C CA  . ALA A 1 112 ? 48.873 30.368 49.569 1.00 11.73 ? 159 ALA A CA  1 
+ATOM   825  C C   . ALA A 1 112 ? 50.200 31.100 49.394 1.00 11.03 ? 159 ALA A C   1 
+ATOM   826  O O   . ALA A 1 112 ? 50.693 31.245 48.276 1.00 11.73 ? 159 ALA A O   1 
+ATOM   827  C CB  . ALA A 1 112 ? 47.712 31.334 49.701 1.00 13.16 ? 159 ALA A CB  1 
+ATOM   828  N N   . ASN A 1 113 ? 50.745 31.589 50.499 1.00 11.09 ? 160 ASN A N   1 
+ATOM   829  C CA  . ASN A 1 113 ? 52.036 32.304 50.416 1.00 11.15 ? 160 ASN A CA  1 
+ATOM   830  C C   . ASN A 1 113 ? 53.101 31.431 49.794 1.00 11.34 ? 160 ASN A C   1 
+ATOM   831  O O   . ASN A 1 113 ? 53.891 31.842 48.927 1.00 12.19 ? 160 ASN A O   1 
+ATOM   832  C CB  . ASN A 1 113 ? 52.490 32.742 51.794 1.00 11.21 ? 160 ASN A CB  1 
+ATOM   833  C CG  . ASN A 1 113 ? 51.686 33.854 52.453 1.00 11.99 ? 160 ASN A CG  1 
+ATOM   834  O OD1 . ASN A 1 113 ? 50.937 34.547 51.806 1.00 12.96 ? 160 ASN A OD1 1 
+ATOM   835  N ND2 . ASN A 1 113 ? 51.908 33.962 53.755 1.00 13.55 ? 160 ASN A ND2 1 
+ATOM   836  N N   . ARG A 1 114 ? 53.171 30.170 50.267 1.00 11.73 ? 161 ARG A N   1 
+ATOM   837  C CA  . ARG A 1 114 ? 54.194 29.251 49.768 1.00 13.04 ? 161 ARG A CA  1 
+ATOM   838  C C   . ARG A 1 114 ? 53.935 28.908 48.301 1.00 12.34 ? 161 ARG A C   1 
+ATOM   839  O O   . ARG A 1 114 ? 54.860 28.889 47.495 1.00 12.48 ? 161 ARG A O   1 
+ATOM   840  C CB  . ARG A 1 114 ? 54.214 28.016 50.632 1.00 16.69 ? 161 ARG A CB  1 
+ATOM   841  C CG  . ARG A 1 114 ? 54.969 26.819 50.038 0.50 17.59 ? 161 ARG A CG  1 
+ATOM   842  C CD  . ARG A 1 114 ? 55.119 25.685 51.051 0.50 28.19 ? 161 ARG A CD  1 
+ATOM   843  N NE  . ARG A 1 114 ? 53.846 25.152 51.501 0.50 33.61 ? 161 ARG A NE  1 
+ATOM   844  C CZ  . ARG A 1 114 ? 53.080 24.378 50.745 0.50 36.34 ? 161 ARG A CZ  1 
+ATOM   845  N NH1 . ARG A 1 114 ? 53.463 24.063 49.518 0.50 36.84 ? 161 ARG A NH1 1 
+ATOM   846  N NH2 . ARG A 1 114 ? 51.938 23.940 51.245 0.50 38.77 ? 161 ARG A NH2 1 
+ATOM   847  N N   . LEU A 1 115 ? 52.697 28.589 47.948 1.00 11.92 ? 162 LEU A N   1 
+ATOM   848  C CA  . LEU A 1 115 ? 52.398 28.251 46.538 1.00 12.07 ? 162 LEU A CA  1 
+ATOM   849  C C   . LEU A 1 115 ? 52.706 29.424 45.649 1.00 10.67 ? 162 LEU A C   1 
+ATOM   850  O O   . LEU A 1 115 ? 53.208 29.238 44.513 1.00 11.11 ? 162 LEU A O   1 
+ATOM   851  C CB  . LEU A 1 115 ? 50.894 27.886 46.416 1.00 15.37 ? 162 LEU A CB  1 
+ATOM   852  C CG  . LEU A 1 115 ? 50.432 26.581 47.037 1.00 18.67 ? 162 LEU A CG  1 
+ATOM   853  C CD1 . LEU A 1 115 ? 48.910 26.438 47.013 1.00 24.16 ? 162 LEU A CD1 1 
+ATOM   854  C CD2 . LEU A 1 115 ? 51.095 25.427 46.296 1.00 28.61 ? 162 LEU A CD2 1 
+ATOM   855  N N   . LEU A 1 116 ? 52.394 30.628 46.084 1.00 10.31 ? 163 LEU A N   1 
+ATOM   856  C CA  . LEU A 1 116 ? 52.653 31.806 45.268 1.00 10.60 ? 163 LEU A CA  1 
+ATOM   857  C C   . LEU A 1 116 ? 54.139 32.057 45.106 1.00 10.04 ? 163 LEU A C   1 
+ATOM   858  O O   . LEU A 1 116 ? 54.605 32.302 43.992 1.00 10.62 ? 163 LEU A O   1 
+ATOM   859  C CB  A LEU A 1 116 ? 51.950 32.942 46.005 0.55 11.01 ? 163 LEU A CB  1 
+ATOM   860  C CB  B LEU A 1 116 ? 52.155 33.212 45.818 0.45 11.75 ? 163 LEU A CB  1 
+ATOM   861  C CG  A LEU A 1 116 ? 52.122 34.257 45.263 0.55 12.99 ? 163 LEU A CG  1 
+ATOM   862  C CG  B LEU A 1 116 ? 50.685 33.501 45.582 0.45 10.84 ? 163 LEU A CG  1 
+ATOM   863  C CD1 A LEU A 1 116 ? 51.421 34.225 43.905 0.55 15.39 ? 163 LEU A CD1 1 
+ATOM   864  C CD1 B LEU A 1 116 ? 50.194 34.555 46.591 0.45 10.17 ? 163 LEU A CD1 1 
+ATOM   865  C CD2 A LEU A 1 116 ? 51.577 35.391 46.155 0.55 15.77 ? 163 LEU A CD2 1 
+ATOM   866  C CD2 B LEU A 1 116 ? 50.470 33.968 44.127 0.45 10.72 ? 163 LEU A CD2 1 
+ATOM   867  N N   . LYS A 1 117 ? 54.915 32.017 46.193 1.00 10.44 ? 164 LYS A N   1 
+ATOM   868  C CA  . LYS A 1 117 ? 56.364 32.264 46.028 1.00 10.84 ? 164 LYS A CA  1 
+ATOM   869  C C   . LYS A 1 117 ? 56.972 31.167 45.165 1.00 9.91  ? 164 LYS A C   1 
+ATOM   870  O O   . LYS A 1 117 ? 57.862 31.442 44.348 1.00 9.94  ? 164 LYS A O   1 
+ATOM   871  C CB  . LYS A 1 117 ? 57.008 32.468 47.380 1.00 13.33 ? 164 LYS A CB  1 
+ATOM   872  C CG  . LYS A 1 117 ? 56.599 33.773 48.060 1.00 14.48 ? 164 LYS A CG  1 
+ATOM   873  C CD  . LYS A 1 117 ? 57.271 34.055 49.399 1.00 18.10 ? 164 LYS A CD  1 
+ATOM   874  C CE  . LYS A 1 117 ? 56.911 33.051 50.445 1.00 20.39 ? 164 LYS A CE  1 
+ATOM   875  N NZ  . LYS A 1 117 ? 57.427 33.480 51.772 1.00 24.26 ? 164 LYS A NZ  1 
+ATOM   876  N N   . ASP A 1 118 ? 56.533 29.918 45.336 1.00 10.04 ? 165 ASP A N   1 
+ATOM   877  C CA  . ASP A 1 118 ? 57.096 28.864 44.466 1.00 10.66 ? 165 ASP A CA  1 
+ATOM   878  C C   . ASP A 1 118 ? 56.774 29.114 43.004 1.00 9.38  ? 165 ASP A C   1 
+ATOM   879  O O   . ASP A 1 118 ? 57.621 28.941 42.138 1.00 10.05 ? 165 ASP A O   1 
+ATOM   880  C CB  A ASP A 1 118 ? 56.496 27.557 44.946 0.57 10.29 ? 165 ASP A CB  1 
+ATOM   881  C CB  B ASP A 1 118 ? 56.615 27.271 44.654 0.43 15.17 ? 165 ASP A CB  1 
+ATOM   882  C CG  A ASP A 1 118 ? 56.989 27.018 46.267 0.57 12.54 ? 165 ASP A CG  1 
+ATOM   883  C CG  B ASP A 1 118 ? 57.424 26.149 44.029 0.43 16.08 ? 165 ASP A CG  1 
+ATOM   884  O OD1 A ASP A 1 118 ? 57.948 27.552 46.863 0.57 14.41 ? 165 ASP A OD1 1 
+ATOM   885  O OD1 B ASP A 1 118 ? 58.645 26.090 44.350 0.43 25.95 ? 165 ASP A OD1 1 
+ATOM   886  O OD2 A ASP A 1 118 ? 56.442 25.997 46.754 0.57 16.26 ? 165 ASP A OD2 1 
+ATOM   887  O OD2 B ASP A 1 118 ? 57.082 25.455 43.020 0.43 20.21 ? 165 ASP A OD2 1 
+ATOM   888  N N   . LYS A 1 119 ? 55.520 29.490 42.709 1.00 9.42  ? 166 LYS A N   1 
+ATOM   889  C CA  . LYS A 1 119 ? 55.107 29.755 41.347 1.00 8.80  ? 166 LYS A CA  1 
+ATOM   890  C C   . LYS A 1 119 ? 55.839 30.947 40.736 1.00 8.39  ? 166 LYS A C   1 
+ATOM   891  O O   . LYS A 1 119 ? 56.264 30.919 39.581 1.00 8.58  ? 166 LYS A O   1 
+ATOM   892  C CB  . LYS A 1 119 ? 53.597 29.918 41.266 1.00 9.51  ? 166 LYS A CB  1 
+ATOM   893  C CG  . LYS A 1 119 ? 53.035 30.025 39.842 1.00 9.31  ? 166 LYS A CG  1 
+ATOM   894  C CD  . LYS A 1 119 ? 53.182 28.814 38.964 1.00 11.30 ? 166 LYS A CD  1 
+ATOM   895  C CE  . LYS A 1 119 ? 52.298 27.635 39.376 1.00 12.19 ? 166 LYS A CE  1 
+ATOM   896  N NZ  . LYS A 1 119 ? 52.409 26.483 38.404 1.00 13.45 ? 166 LYS A NZ  1 
+ATOM   897  N N   . ILE A 1 120 ? 56.008 32.018 41.513 1.00 8.30  ? 167 ILE A N   1 
+ATOM   898  C CA  . ILE A 1 120 ? 56.776 33.168 41.065 1.00 7.99  ? 167 ILE A CA  1 
+ATOM   899  C C   . ILE A 1 120 ? 58.162 32.729 40.665 1.00 7.98  ? 167 ILE A C   1 
+ATOM   900  O O   . ILE A 1 120 ? 58.681 33.123 39.614 1.00 8.91  ? 167 ILE A O   1 
+ATOM   901  C CB  . ILE A 1 120 ? 56.784 34.276 42.118 1.00 8.20  ? 167 ILE A CB  1 
+ATOM   902  C CG1 . ILE A 1 120 ? 55.397 34.912 42.241 1.00 8.30  ? 167 ILE A CG1 1 
+ATOM   903  C CG2 . ILE A 1 120 ? 57.863 35.317 41.849 1.00 8.96  ? 167 ILE A CG2 1 
+ATOM   904  C CD1 . ILE A 1 120 ? 55.223 35.805 43.487 1.00 9.15  ? 167 ILE A CD1 1 
+ATOM   905  N N   . ARG A 1 121 ? 58.828 31.919 41.503 1.00 8.50  ? 168 ARG A N   1 
+ATOM   906  C CA  . ARG A 1 121 ? 60.158 31.454 41.192 1.00 9.03  ? 168 ARG A CA  1 
+ATOM   907  C C   . ARG A 1 121 ? 60.183 30.654 39.866 1.00 8.44  ? 168 ARG A C   1 
+ATOM   908  O O   . ARG A 1 121 ? 61.044 30.857 39.020 1.00 9.33  ? 168 ARG A O   1 
+ATOM   909  C CB  . ARG A 1 121 ? 60.718 30.620 42.331 1.00 11.44 ? 168 ARG A CB  1 
+ATOM   910  C CG  A ARG A 1 121 ? 62.146 30.167 41.928 0.52 13.71 ? 168 ARG A CG  1 
+ATOM   911  C CG  B ARG A 1 121 ? 62.124 29.912 41.993 0.48 12.98 ? 168 ARG A CG  1 
+ATOM   912  C CD  A ARG A 1 121 ? 62.913 29.668 43.177 0.52 14.89 ? 168 ARG A CD  1 
+ATOM   913  C CD  B ARG A 1 121 ? 62.538 28.934 43.134 0.48 15.22 ? 168 ARG A CD  1 
+ATOM   914  N NE  A ARG A 1 121 ? 64.178 29.059 42.753 0.52 16.91 ? 168 ARG A NE  1 
+ATOM   915  N NE  B ARG A 1 121 ? 61.690 27.734 43.096 0.48 15.74 ? 168 ARG A NE  1 
+ATOM   916  C CZ  A ARG A 1 121 ? 65.093 28.585 43.605 0.52 25.37 ? 168 ARG A CZ  1 
+ATOM   917  C CZ  B ARG A 1 121 ? 61.761 26.757 42.150 0.48 20.72 ? 168 ARG A CZ  1 
+ATOM   918  N NH1 A ARG A 1 121 ? 64.996 28.619 44.924 0.52 35.80 ? 168 ARG A NH1 1 
+ATOM   919  N NH1 B ARG A 1 121 ? 62.548 26.722 41.103 0.48 24.06 ? 168 ARG A NH1 1 
+ATOM   920  N NH2 A ARG A 1 121 ? 66.193 28.043 43.069 0.52 28.69 ? 168 ARG A NH2 1 
+ATOM   921  N NH2 B ARG A 1 121 ? 60.989 25.666 42.331 0.48 26.41 ? 168 ARG A NH2 1 
+ATOM   922  N N   . VAL A 1 122 ? 59.268 29.719 39.742 1.00 8.73  ? 169 VAL A N   1 
+ATOM   923  C CA  . VAL A 1 122 ? 59.218 28.876 38.543 1.00 9.04  ? 169 VAL A CA  1 
+ATOM   924  C C   . VAL A 1 122 ? 59.021 29.738 37.295 1.00 8.13  ? 169 VAL A C   1 
+ATOM   925  O O   . VAL A 1 122 ? 59.691 29.556 36.266 1.00 8.82  ? 169 VAL A O   1 
+ATOM   926  C CB  . VAL A 1 122 ? 58.111 27.813 38.684 1.00 9.82  ? 169 VAL A CB  1 
+ATOM   927  C CG1 . VAL A 1 122 ? 57.781 27.139 37.391 1.00 12.10 ? 169 VAL A CG1 1 
+ATOM   928  C CG2 . VAL A 1 122 ? 58.529 26.772 39.735 1.00 11.47 ? 169 VAL A CG2 1 
+ATOM   929  N N   . LEU A 1 123 ? 58.068 30.675 37.348 1.00 8.48  ? 170 LEU A N   1 
+ATOM   930  C CA  . LEU A 1 123 ? 57.778 31.520 36.181 1.00 8.06  ? 170 LEU A CA  1 
+ATOM   931  C C   . LEU A 1 123 ? 58.988 32.402 35.848 1.00 8.12  ? 170 LEU A C   1 
+ATOM   932  O O   . LEU A 1 123 ? 59.358 32.578 34.706 1.00 8.89  ? 170 LEU A O   1 
+ATOM   933  C CB  . LEU A 1 123 ? 56.522 32.338 36.393 1.00 8.58  ? 170 LEU A CB  1 
+ATOM   934  C CG  . LEU A 1 123 ? 55.230 31.537 36.556 1.00 8.75  ? 170 LEU A CG  1 
+ATOM   935  C CD1 . LEU A 1 123 ? 54.090 32.491 36.946 1.00 9.89  ? 170 LEU A CD1 1 
+ATOM   936  C CD2 . LEU A 1 123 ? 54.871 30.717 35.337 1.00 9.88  ? 170 LEU A CD2 1 
+ATOM   937  N N   . ALA A 1 124 ? 59.577 32.987 36.903 1.00 8.19  ? 171 ALA A N   1 
+ATOM   938  C CA  . ALA A 1 124 ? 60.724 33.860 36.705 1.00 8.90  ? 171 ALA A CA  1 
+ATOM   939  C C   . ALA A 1 124 ? 61.870 33.123 36.062 1.00 8.69  ? 171 ALA A C   1 
+ATOM   940  O O   . ALA A 1 124 ? 62.474 33.569 35.083 1.00 9.15  ? 171 ALA A O   1 
+ATOM   941  C CB  . ALA A 1 124 ? 61.164 34.471 38.042 1.00 9.91  ? 171 ALA A CB  1 
+ATOM   942  N N   . GLU A 1 125 ? 62.221 31.963 36.635 1.00 9.05  ? 172 GLU A N   1 
+ATOM   943  C CA  . GLU A 1 125 ? 63.312 31.166 36.095 1.00 9.76  ? 172 GLU A CA  1 
+ATOM   944  C C   . GLU A 1 125 ? 63.003 30.727 34.665 1.00 9.40  ? 172 GLU A C   1 
+ATOM   945  O O   . GLU A 1 125 ? 63.886 30.692 33.793 1.00 10.71 ? 172 GLU A O   1 
+ATOM   946  C CB  . GLU A 1 125 ? 63.642 29.996 36.987 1.00 10.46 ? 172 GLU A CB  1 
+ATOM   947  C CG  . GLU A 1 125 ? 64.236 30.421 38.325 1.00 11.61 ? 172 GLU A CG  1 
+ATOM   948  C CD  . GLU A 1 125 ? 64.699 29.303 39.198 1.00 14.47 ? 172 GLU A CD  1 
+ATOM   949  O OE1 . GLU A 1 125 ? 64.539 28.113 38.883 1.00 21.10 ? 172 GLU A OE1 1 
+ATOM   950  O OE2 . GLU A 1 125 ? 65.264 29.588 40.289 1.00 16.45 ? 172 GLU A OE2 1 
+ATOM   951  N N   . GLY A 1 126 ? 61.736 30.419 34.374 1.00 9.58  ? 173 GLY A N   1 
+ATOM   952  C CA  . GLY A 1 126 ? 61.342 30.099 33.010 1.00 9.81  ? 173 GLY A CA  1 
+ATOM   953  C C   . GLY A 1 126 ? 61.652 31.170 32.028 1.00 9.21  ? 173 GLY A C   1 
+ATOM   954  O O   . GLY A 1 126 ? 62.000 30.917 30.878 1.00 10.15 ? 173 GLY A O   1 
+ATOM   955  N N   . ASP A 1 127 ? 61.500 32.446 32.462 1.00 9.24  ? 174 ASP A N   1 
+ATOM   956  C CA  . ASP A 1 127 ? 61.799 33.622 31.663 1.00 10.31 ? 174 ASP A CA  1 
+ATOM   957  C C   . ASP A 1 127 ? 63.287 33.997 31.715 1.00 10.24 ? 174 ASP A C   1 
+ATOM   958  O O   . ASP A 1 127 ? 63.681 35.001 31.125 1.00 12.64 ? 174 ASP A O   1 
+ATOM   959  C CB  . ASP A 1 127 ? 60.934 34.793 32.135 1.00 10.28 ? 174 ASP A CB  1 
+ATOM   960  C CG  . ASP A 1 127 ? 59.493 34.721 31.737 1.00 10.33 ? 174 ASP A CG  1 
+ATOM   961  O OD1 . ASP A 1 127 ? 59.155 33.892 30.856 1.00 10.53 ? 174 ASP A OD1 1 
+ATOM   962  O OD2 . ASP A 1 127 ? 58.714 35.530 32.287 1.00 13.80 ? 174 ASP A OD2 1 
+ATOM   963  N N   . GLY A 1 128 ? 64.122 33.209 32.393 1.00 11.02 ? 175 GLY A N   1 
+ATOM   964  C CA  . GLY A 1 128 ? 65.546 33.459 32.474 1.00 11.59 ? 175 GLY A CA  1 
+ATOM   965  C C   . GLY A 1 128 ? 65.962 34.405 33.608 1.00 11.72 ? 175 GLY A C   1 
+ATOM   966  O O   . GLY A 1 128 ? 67.113 34.804 33.654 1.00 15.30 ? 175 GLY A O   1 
+ATOM   967  N N   . PHE A 1 129 ? 65.053 34.703 34.513 1.00 10.56 ? 176 PHE A N   1 
+ATOM   968  C CA  . PHE A 1 129 ? 65.349 35.588 35.650 1.00 10.59 ? 176 PHE A CA  1 
+ATOM   969  C C   . PHE A 1 129 ? 65.651 34.731 36.840 1.00 11.27 ? 176 PHE A C   1 
+ATOM   970  O O   . PHE A 1 129 ? 64.734 34.195 37.473 1.00 11.58 ? 176 PHE A O   1 
+ATOM   971  C CB  . PHE A 1 129 ? 64.168 36.523 35.904 1.00 10.65 ? 176 PHE A CB  1 
+ATOM   972  C CG  . PHE A 1 129 ? 63.675 37.310 34.703 1.00 11.70 ? 176 PHE A CG  1 
+ATOM   973  C CD1 . PHE A 1 129 ? 64.533 37.926 33.834 1.00 15.03 ? 176 PHE A CD1 1 
+ATOM   974  C CD2 . PHE A 1 129 ? 62.286 37.360 34.507 1.00 13.63 ? 176 PHE A CD2 1 
+ATOM   975  C CE1 . PHE A 1 129 ? 64.049 38.606 32.734 1.00 18.69 ? 176 PHE A CE1 1 
+ATOM   976  C CE2 . PHE A 1 129 ? 61.796 38.056 33.417 1.00 16.56 ? 176 PHE A CE2 1 
+ATOM   977  C CZ  . PHE A 1 129 ? 62.691 38.661 32.547 1.00 20.01 ? 176 PHE A CZ  1 
+ATOM   978  N N   . MET A 1 130 ? 66.934 34.584 37.163 1.00 12.15 ? 177 MET A N   1 
+ATOM   979  C CA  . MET A 1 130 ? 67.364 33.707 38.225 1.00 12.44 ? 177 MET A CA  1 
+ATOM   980  C C   . MET A 1 130 ? 67.460 34.425 39.574 1.00 13.23 ? 177 MET A C   1 
+ATOM   981  O O   . MET A 1 130 ? 67.607 33.760 40.601 1.00 16.84 ? 177 MET A O   1 
+ATOM   982  C CB  . MET A 1 130 ? 68.700 33.066 37.849 1.00 15.31 ? 177 MET A CB  1 
+ATOM   983  C CG  . MET A 1 130 ? 68.680 32.373 36.499 1.00 18.38 ? 177 MET A CG  1 
+ATOM   984  S SD  . MET A 1 130 ? 67.391 31.208 36.249 1.00 22.11 ? 177 MET A SD  1 
+ATOM   985  C CE  . MET A 1 130 ? 67.837 29.989 37.472 1.00 28.11 ? 177 MET A CE  1 
+ATOM   986  N N   . LYS A 1 131 ? 67.356 35.744 39.549 1.00 12.19 ? 178 LYS A N   1 
+ATOM   987  C CA  . LYS A 1 131 ? 67.438 36.527 40.788 1.00 12.19 ? 178 LYS A CA  1 
+ATOM   988  C C   . LYS A 1 131 ? 66.247 37.488 40.789 1.00 11.43 ? 178 LYS A C   1 
+ATOM   989  O O   . LYS A 1 131 ? 65.095 37.034 40.715 1.00 13.02 ? 178 LYS A O   1 
+ATOM   990  C CB  . LYS A 1 131 ? 68.801 37.199 40.924 1.00 16.21 ? 178 LYS A CB  1 
+ATOM   991  C CG  . LYS A 1 131 ? 69.946 36.175 41.130 1.00 20.23 ? 178 LYS A CG  1 
+ATOM   992  C CD  . LYS A 1 131 ? 71.271 36.848 41.296 1.00 28.45 ? 178 LYS A CD  1 
+ATOM   993  C CE  . LYS A 1 131 ? 72.418 35.834 41.373 0.50 29.11 ? 178 LYS A CE  1 
+ATOM   994  N NZ  . LYS A 1 131 ? 72.067 34.644 42.205 0.50 38.97 ? 178 LYS A NZ  1 
+ATOM   995  N N   . ARG A 1 132 ? 66.440 38.788 40.829 1.00 9.63  ? 179 ARG A N   1 
+ATOM   996  C CA  . ARG A 1 132 ? 65.293 39.705 40.863 1.00 9.10  ? 179 ARG A CA  1 
+ATOM   997  C C   . ARG A 1 132 ? 64.675 39.785 39.483 1.00 8.75  ? 179 ARG A C   1 
+ATOM   998  O O   . ARG A 1 132 ? 65.366 39.822 38.450 1.00 9.62  ? 179 ARG A O   1 
+ATOM   999  C CB  . ARG A 1 132 ? 65.752 41.079 41.340 1.00 9.60  ? 179 ARG A CB  1 
+ATOM   1000 C CG  . ARG A 1 132 ? 64.596 42.021 41.680 1.00 8.66  ? 179 ARG A CG  1 
+ATOM   1001 C CD  . ARG A 1 132 ? 65.147 43.432 42.035 1.00 8.84  ? 179 ARG A CD  1 
+ATOM   1002 N NE  . ARG A 1 132 ? 65.736 44.052 40.902 1.00 9.62  ? 179 ARG A NE  1 
+ATOM   1003 C CZ  . ARG A 1 132 ? 65.087 44.768 39.983 1.00 8.81  ? 179 ARG A CZ  1 
+ATOM   1004 N NH1 . ARG A 1 132 ? 63.827 45.152 40.181 1.00 9.53  ? 179 ARG A NH1 1 
+ATOM   1005 N NH2 . ARG A 1 132 ? 65.728 45.137 38.882 1.00 10.74 ? 179 ARG A NH2 1 
+ATOM   1006 N N   . ILE A 1 133 ? 63.339 39.847 39.434 1.00 8.15  ? 180 ILE A N   1 
+ATOM   1007 C CA  . ILE A 1 133 ? 62.647 40.035 38.160 1.00 7.97  ? 180 ILE A CA  1 
+ATOM   1008 C C   . ILE A 1 133 ? 62.763 41.481 37.753 1.00 7.95  ? 180 ILE A C   1 
+ATOM   1009 O O   . ILE A 1 133 ? 62.485 42.375 38.584 1.00 8.53  ? 180 ILE A O   1 
+ATOM   1010 C CB  . ILE A 1 133 ? 61.170 39.636 38.340 1.00 8.02  ? 180 ILE A CB  1 
+ATOM   1011 C CG1 . ILE A 1 133 ? 61.005 38.184 38.767 1.00 8.14  ? 180 ILE A CG1 1 
+ATOM   1012 C CG2 . ILE A 1 133 ? 60.346 39.929 37.086 1.00 8.60  ? 180 ILE A CG2 1 
+ATOM   1013 C CD1 . ILE A 1 133 ? 59.698 37.915 39.485 1.00 8.93  ? 180 ILE A CD1 1 
+ATOM   1014 N N   . PRO A 1 134 ? 63.145 41.808 36.515 1.00 9.08  ? 181 PRO A N   1 
+ATOM   1015 C CA  . PRO A 1 134 ? 63.171 43.212 36.094 1.00 9.60  ? 181 PRO A CA  1 
+ATOM   1016 C C   . PRO A 1 134 ? 61.847 43.889 36.384 1.00 9.03  ? 181 PRO A C   1 
+ATOM   1017 O O   . PRO A 1 134 ? 60.787 43.302 36.174 1.00 9.08  ? 181 PRO A O   1 
+ATOM   1018 C CB  . PRO A 1 134 ? 63.462 43.114 34.612 1.00 11.37 ? 181 PRO A CB  1 
+ATOM   1019 C CG  . PRO A 1 134 ? 64.247 41.851 34.482 1.00 12.40 ? 181 PRO A CG  1 
+ATOM   1020 C CD  . PRO A 1 134 ? 63.595 40.876 35.460 1.00 10.54 ? 181 PRO A CD  1 
+ATOM   1021 N N   . THR A 1 135 ? 61.921 45.122 36.853 1.00 9.54  ? 182 THR A N   1 
+ATOM   1022 C CA  . THR A 1 135 ? 60.732 45.817 37.318 1.00 9.35  ? 182 THR A CA  1 
+ATOM   1023 C C   . THR A 1 135 ? 59.641 45.852 36.272 1.00 9.24  ? 182 THR A C   1 
+ATOM   1024 O O   . THR A 1 135 ? 58.452 45.655 36.609 1.00 10.19 ? 182 THR A O   1 
+ATOM   1025 C CB  . THR A 1 135 ? 61.115 47.227 37.779 1.00 10.55 ? 182 THR A CB  1 
+ATOM   1026 O OG1 . THR A 1 135 ? 62.149 47.072 38.751 1.00 11.69 ? 182 THR A OG1 1 
+ATOM   1027 C CG2 . THR A 1 135 ? 59.898 47.888 38.415 1.00 14.15 ? 182 THR A CG2 1 
+ATOM   1028 N N   . SER A 1 136 ? 60.000 46.076 35.013 1.00 9.59  ? 183 SER A N   1 
+ATOM   1029 C CA  . SER A 1 136 ? 59.011 46.185 33.959 1.00 10.85 ? 183 SER A CA  1 
+ATOM   1030 C C   . SER A 1 136 ? 58.284 44.889 33.630 1.00 10.02 ? 183 SER A C   1 
+ATOM   1031 O O   . SER A 1 136 ? 57.308 44.911 32.885 1.00 11.90 ? 183 SER A O   1 
+ATOM   1032 C CB  . SER A 1 136 ? 59.707 46.695 32.666 1.00 13.68 ? 183 SER A CB  1 
+ATOM   1033 O OG  . SER A 1 136 ? 60.589 45.730 32.139 1.00 16.41 ? 183 SER A OG  1 
+ATOM   1034 N N   . LYS A 1 137 ? 58.779 43.778 34.157 1.00 9.13  ? 184 LYS A N   1 
+ATOM   1035 C CA  . LYS A 1 137 ? 58.202 42.444 33.873 1.00 9.07  ? 184 LYS A CA  1 
+ATOM   1036 C C   . LYS A 1 137 ? 57.387 41.932 35.064 1.00 7.87  ? 184 LYS A C   1 
+ATOM   1037 O O   . LYS A 1 137 ? 56.685 40.906 34.933 1.00 8.51  ? 184 LYS A O   1 
+ATOM   1038 C CB  . LYS A 1 137 ? 59.290 41.454 33.523 1.00 10.64 ? 184 LYS A CB  1 
+ATOM   1039 C CG  . LYS A 1 137 ? 60.087 41.835 32.287 1.00 14.04 ? 184 LYS A CG  1 
+ATOM   1040 C CD  . LYS A 1 137 ? 59.239 41.916 31.042 1.00 18.39 ? 184 LYS A CD  1 
+ATOM   1041 C CE  . LYS A 1 137 ? 60.080 42.365 29.850 1.00 38.49 ? 184 LYS A CE  1 
+ATOM   1042 N NZ  . LYS A 1 137 ? 59.127 42.305 28.656 1.00 59.67 ? 184 LYS A NZ  1 
+ATOM   1043 N N   . GLN A 1 138 ? 57.456 42.576 36.213 1.00 7.99  ? 185 GLN A N   1 
+ATOM   1044 C CA  . GLN A 1 138 ? 56.883 42.037 37.444 1.00 7.51  ? 185 GLN A CA  1 
+ATOM   1045 C C   . GLN A 1 138 ? 55.373 41.988 37.424 1.00 7.62  ? 185 GLN A C   1 
+ATOM   1046 O O   . GLN A 1 138 ? 54.806 41.012 37.914 1.00 7.91  ? 185 GLN A O   1 
+ATOM   1047 C CB  . GLN A 1 138 ? 57.325 42.896 38.637 1.00 7.87  ? 185 GLN A CB  1 
+ATOM   1048 C CG  . GLN A 1 138 ? 58.796 42.648 38.997 1.00 8.20  ? 185 GLN A CG  1 
+ATOM   1049 C CD  . GLN A 1 138 ? 59.245 43.603 40.073 1.00 8.11  ? 185 GLN A CD  1 
+ATOM   1050 O OE1 . GLN A 1 138 ? 58.441 44.347 40.660 1.00 9.43  ? 185 GLN A OE1 1 
+ATOM   1051 N NE2 . GLN A 1 138 ? 60.532 43.552 40.395 1.00 8.14  ? 185 GLN A NE2 1 
+ATOM   1052 N N   . GLY A 1 139 ? 54.705 43.036 36.953 1.00 7.70  ? 186 GLY A N   1 
+ATOM   1053 C CA  . GLY A 1 139 ? 53.275 43.036 37.054 1.00 8.18  ? 186 GLY A CA  1 
+ATOM   1054 C C   . GLY A 1 139 ? 52.631 41.883 36.321 1.00 7.12  ? 186 GLY A C   1 
+ATOM   1055 O O   . GLY A 1 139 ? 51.729 41.206 36.832 1.00 7.70  ? 186 GLY A O   1 
+ATOM   1056 N N   . GLU A 1 140 ? 53.083 41.650 35.071 1.00 7.36  ? 187 GLU A N   1 
+ATOM   1057 C CA  . GLU A 1 140 ? 52.499 40.541 34.331 1.00 7.37  ? 187 GLU A CA  1 
+ATOM   1058 C C   . GLU A 1 140 ? 52.901 39.210 34.928 1.00 6.90  ? 187 GLU A C   1 
+ATOM   1059 O O   . GLU A 1 140 ? 52.117 38.254 34.883 1.00 7.29  ? 187 GLU A O   1 
+ATOM   1060 C CB  . GLU A 1 140 ? 52.871 40.575 32.847 1.00 7.70  ? 187 GLU A CB  1 
+ATOM   1061 C CG  . GLU A 1 140 ? 52.226 41.709 32.092 1.00 8.01  ? 187 GLU A CG  1 
+ATOM   1062 C CD  . GLU A 1 140 ? 52.239 41.616 30.595 1.00 8.63  ? 187 GLU A CD  1 
+ATOM   1063 O OE1 . GLU A 1 140 ? 52.390 40.494 30.036 1.00 9.10  ? 187 GLU A OE1 1 
+ATOM   1064 O OE2 . GLU A 1 140 ? 52.009 42.641 29.938 1.00 11.33 ? 187 GLU A OE2 1 
+ATOM   1065 N N   . LEU A 1 141 ? 54.111 39.087 35.479 1.00 6.88  ? 188 LEU A N   1 
+ATOM   1066 C CA  . LEU A 1 141 ? 54.516 37.820 36.065 1.00 7.09  ? 188 LEU A CA  1 
+ATOM   1067 C C   . LEU A 1 141 ? 53.671 37.533 37.305 1.00 6.91  ? 188 LEU A C   1 
+ATOM   1068 O O   . LEU A 1 141 ? 53.226 36.391 37.506 1.00 7.60  ? 188 LEU A O   1 
+ATOM   1069 C CB  . LEU A 1 141 ? 56.015 37.780 36.328 1.00 7.50  ? 188 LEU A CB  1 
+ATOM   1070 C CG  . LEU A 1 141 ? 56.591 36.409 36.645 1.00 8.58  ? 188 LEU A CG  1 
+ATOM   1071 C CD1 . LEU A 1 141 ? 58.039 36.329 36.202 1.00 10.21 ? 188 LEU A CD1 1 
+ATOM   1072 C CD2 . LEU A 1 141 ? 56.447 36.045 38.114 1.00 9.52  ? 188 LEU A CD2 1 
+ATOM   1073 N N   . LEU A 1 142 ? 53.443 38.531 38.139 1.00 6.86  ? 189 LEU A N   1 
+ATOM   1074 C CA  . LEU A 1 142 ? 52.613 38.351 39.328 1.00 7.23  ? 189 LEU A CA  1 
+ATOM   1075 C C   . LEU A 1 142 ? 51.178 37.943 38.932 1.00 6.99  ? 189 LEU A C   1 
+ATOM   1076 O O   . LEU A 1 142 ? 50.585 37.047 39.521 1.00 7.53  ? 189 LEU A O   1 
+ATOM   1077 C CB  . LEU A 1 142 ? 52.613 39.625 40.158 1.00 7.50  ? 189 LEU A CB  1 
+ATOM   1078 C CG  . LEU A 1 142 ? 51.889 39.506 41.489 1.00 8.14  ? 189 LEU A CG  1 
+ATOM   1079 C CD1 . LEU A 1 142 ? 52.620 38.522 42.410 1.00 11.59 ? 189 LEU A CD1 1 
+ATOM   1080 C CD2 . LEU A 1 142 ? 51.809 40.873 42.156 1.00 11.53 ? 189 LEU A CD2 1 
+ATOM   1081 N N   . ALA A 1 143 ? 50.638 38.633 37.914 1.00 6.89  ? 190 ALA A N   1 
+ATOM   1082 C CA  . ALA A 1 143 ? 49.314 38.271 37.428 1.00 6.75  ? 190 ALA A CA  1 
+ATOM   1083 C C   . ALA A 1 143 ? 49.289 36.854 36.885 1.00 6.39  ? 190 ALA A C   1 
+ATOM   1084 O O   . ALA A 1 143 ? 48.287 36.135 37.057 1.00 7.56  ? 190 ALA A O   1 
+ATOM   1085 C CB  . ALA A 1 143 ? 48.871 39.259 36.348 1.00 7.68  ? 190 ALA A CB  1 
+ATOM   1086 N N   . LYS A 1 144 ? 50.345 36.431 36.229 1.00 6.78  ? 191 LYS A N   1 
+ATOM   1087 C CA  . LYS A 1 144 ? 50.440 35.052 35.713 1.00 6.81  ? 191 LYS A CA  1 
+ATOM   1088 C C   . LYS A 1 144 ? 50.442 34.046 36.839 1.00 6.71  ? 191 LYS A C   1 
+ATOM   1089 O O   . LYS A 1 144 ? 49.813 32.990 36.739 1.00 7.49  ? 191 LYS A O   1 
+ATOM   1090 C CB  . LYS A 1 144 ? 51.663 34.952 34.809 1.00 7.27  ? 191 LYS A CB  1 
+ATOM   1091 C CG  . LYS A 1 144 ? 51.785 33.613 34.093 1.00 8.16  ? 191 LYS A CG  1 
+ATOM   1092 C CD  . LYS A 1 144 ? 53.045 33.509 33.268 1.00 9.52  ? 191 LYS A CD  1 
+ATOM   1093 C CE  . LYS A 1 144 ? 53.125 34.444 32.122 1.00 9.90  ? 191 LYS A CE  1 
+ATOM   1094 N NZ  . LYS A 1 144 ? 54.496 34.382 31.499 1.00 11.88 ? 191 LYS A NZ  1 
+ATOM   1095 N N   . ALA A 1 145 ? 51.150 34.358 37.927 1.00 6.96  ? 192 ALA A N   1 
+ATOM   1096 C CA  . ALA A 1 145 ? 51.164 33.466 39.094 1.00 7.53  ? 192 ALA A CA  1 
+ATOM   1097 C C   . ALA A 1 145 ? 49.773 33.365 39.704 1.00 7.37  ? 192 ALA A C   1 
+ATOM   1098 O O   . ALA A 1 145 ? 49.343 32.259 40.092 1.00 8.27  ? 192 ALA A O   1 
+ATOM   1099 C CB  . ALA A 1 145 ? 52.178 33.941 40.100 1.00 8.26  ? 192 ALA A CB  1 
+ATOM   1100 N N   . MET A 1 146 ? 49.077 34.484 39.832 1.00 7.21  ? 193 MET A N   1 
+ATOM   1101 C CA  . MET A 1 146 ? 47.746 34.488 40.364 1.00 7.76  ? 193 MET A CA  1 
+ATOM   1102 C C   . MET A 1 146 ? 46.797 33.661 39.479 1.00 7.83  ? 193 MET A C   1 
+ATOM   1103 O O   . MET A 1 146 ? 46.006 32.852 39.956 1.00 9.34  ? 193 MET A O   1 
+ATOM   1104 C CB  . MET A 1 146 ? 47.244 35.915 40.504 1.00 8.18  ? 193 MET A CB  1 
+ATOM   1105 C CG  . MET A 1 146 ? 45.851 36.072 41.093 1.00 8.67  ? 193 MET A CG  1 
+ATOM   1106 S SD  . MET A 1 146 ? 45.500 37.791 41.421 1.00 8.80  ? 193 MET A SD  1 
+ATOM   1107 C CE  . MET A 1 146 ? 43.706 37.778 41.343 1.00 10.03 ? 193 MET A CE  1 
+ATOM   1108 N N   . TYR A 1 147 ? 46.873 33.893 38.152 1.00 7.76  ? 194 TYR A N   1 
+ATOM   1109 C CA  . TYR A 1 147 ? 46.125 33.070 37.212 1.00 8.26  ? 194 TYR A CA  1 
+ATOM   1110 C C   . TYR A 1 147 ? 46.399 31.598 37.399 1.00 8.72  ? 194 TYR A C   1 
+ATOM   1111 O O   . TYR A 1 147 ? 45.470 30.767 37.442 1.00 10.18 ? 194 TYR A O   1 
+ATOM   1112 C CB  . TYR A 1 147 ? 46.497 33.500 35.774 1.00 8.58  ? 194 TYR A CB  1 
+ATOM   1113 C CG  . TYR A 1 147 ? 46.317 32.413 34.745 1.00 7.95  ? 194 TYR A CG  1 
+ATOM   1114 C CD1 . TYR A 1 147 ? 45.088 32.015 34.274 1.00 9.00  ? 194 TYR A CD1 1 
+ATOM   1115 C CD2 . TYR A 1 147 ? 47.433 31.775 34.234 1.00 8.72  ? 194 TYR A CD2 1 
+ATOM   1116 C CE1 . TYR A 1 147 ? 44.977 30.992 33.323 1.00 9.67  ? 194 TYR A CE1 1 
+ATOM   1117 C CE2 . TYR A 1 147 ? 47.332 30.780 33.273 1.00 9.78  ? 194 TYR A CE2 1 
+ATOM   1118 C CZ  . TYR A 1 147 ? 46.102 30.406 32.825 1.00 9.91  ? 194 TYR A CZ  1 
+ATOM   1119 O OH  . TYR A 1 147 ? 45.946 29.420 31.866 1.00 11.97 ? 194 TYR A OH  1 
+ATOM   1120 N N   . ALA A 1 148 ? 47.681 31.224 37.511 1.00 8.35  ? 195 ALA A N   1 
+ATOM   1121 C CA  . ALA A 1 148 ? 48.084 29.850 37.569 1.00 9.59  ? 195 ALA A CA  1 
+ATOM   1122 C C   . ALA A 1 148 ? 47.480 29.138 38.767 1.00 9.63  ? 195 ALA A C   1 
+ATOM   1123 O O   . ALA A 1 148 ? 47.108 27.970 38.694 1.00 12.84 ? 195 ALA A O   1 
+ATOM   1124 C CB  . ALA A 1 148 ? 49.591 29.740 37.601 1.00 10.17 ? 195 ALA A CB  1 
+ATOM   1125 N N   . LEU A 1 149 ? 47.403 29.846 39.880 1.00 10.19 ? 196 LEU A N   1 
+ATOM   1126 C CA  . LEU A 1 149 ? 46.896 29.270 41.111 1.00 11.33 ? 196 LEU A CA  1 
+ATOM   1127 C C   . LEU A 1 149 ? 45.390 29.312 41.166 1.00 13.12 ? 196 LEU A C   1 
+ATOM   1128 O O   . LEU A 1 149 ? 44.810 28.533 41.915 1.00 25.93 ? 196 LEU A O   1 
+ATOM   1129 C CB  . LEU A 1 149 ? 47.510 29.974 42.311 1.00 12.43 ? 196 LEU A CB  1 
+ATOM   1130 C CG  . LEU A 1 149 ? 49.034 29.786 42.431 1.00 15.85 ? 196 LEU A CG  1 
+ATOM   1131 C CD1 . LEU A 1 149 ? 49.475 30.612 43.617 1.00 24.29 ? 196 LEU A CD1 1 
+ATOM   1132 C CD2 . LEU A 1 149 ? 49.482 28.298 42.473 1.00 18.70 ? 196 LEU A CD2 1 
+ATOM   1133 N N   . ASN A 1 150 ? 44.708 30.184 40.464 1.00 10.37 ? 197 ASN A N   1 
+ATOM   1134 C CA  . ASN A 1 150 ? 43.250 30.335 40.562 1.00 11.39 ? 197 ASN A CA  1 
+ATOM   1135 C C   . ASN A 1 150 ? 42.420 29.610 39.526 1.00 13.41 ? 197 ASN A C   1 
+ATOM   1136 O O   . ASN A 1 150 ? 41.268 29.283 39.779 1.00 15.63 ? 197 ASN A O   1 
+ATOM   1137 C CB  A ASN A 1 150 ? 43.055 31.845 40.250 0.47 11.66 ? 197 ASN A CB  1 
+ATOM   1138 C CB  B ASN A 1 150 ? 42.726 31.789 40.488 0.53 10.43 ? 197 ASN A CB  1 
+ATOM   1139 C CG  A ASN A 1 150 ? 42.876 32.709 41.484 0.47 11.53 ? 197 ASN A CG  1 
+ATOM   1140 C CG  B ASN A 1 150 ? 43.233 32.412 41.775 0.53 10.05 ? 197 ASN A CG  1 
+ATOM   1141 O OD1 A ASN A 1 150 ? 42.645 32.275 42.604 0.47 20.63 ? 197 ASN A OD1 1 
+ATOM   1142 O OD1 B ASN A 1 150 ? 43.577 31.879 42.815 0.53 11.87 ? 197 ASN A OD1 1 
+ATOM   1143 N ND2 A ASN A 1 150 ? 42.874 33.993 41.301 0.47 14.17 ? 197 ASN A ND2 1 
+ATOM   1144 N ND2 B ASN A 1 150 ? 43.313 33.684 41.781 0.53 18.60 ? 197 ASN A ND2 1 
+ATOM   1145 N N   . HIS A 1 151 ? 42.898 29.487 38.322 1.00 13.68 ? 198 HIS A N   1 
+ATOM   1146 C CA  . HIS A 1 151 ? 42.122 29.057 37.147 1.00 14.25 ? 198 HIS A CA  1 
+ATOM   1147 C C   . HIS A 1 151 ? 42.665 27.714 36.695 1.00 18.21 ? 198 HIS A C   1 
+ATOM   1148 O O   . HIS A 1 151 ? 43.830 27.614 36.286 1.00 23.91 ? 198 HIS A O   1 
+ATOM   1149 C CB  . HIS A 1 151 ? 42.217 30.207 36.120 1.00 19.53 ? 198 HIS A CB  1 
+ATOM   1150 C CG  . HIS A 1 151 ? 41.548 31.433 36.639 1.00 16.71 ? 198 HIS A CG  1 
+ATOM   1151 N ND1 . HIS A 1 151 ? 40.179 31.516 36.867 1.00 19.79 ? 198 HIS A ND1 1 
+ATOM   1152 C CD2 . HIS A 1 151 ? 42.166 32.632 37.004 1.00 17.16 ? 198 HIS A CD2 1 
+ATOM   1153 C CE1 . HIS A 1 151 ? 39.950 32.722 37.360 1.00 22.28 ? 198 HIS A CE1 1 
+ATOM   1154 N NE2 . HIS A 1 151 ? 41.120 33.360 37.437 1.00 18.82 ? 198 HIS A NE2 1 
+HETATM 1155 N N1  . EPE B 2 .   ? 61.652 47.337 51.616 1.00 10.39 ? 300 EPE A N1  1 
+HETATM 1156 C C2  . EPE B 2 .   ? 63.051 46.905 51.967 1.00 10.45 ? 300 EPE A C2  1 
+HETATM 1157 C C3  . EPE B 2 .   ? 63.962 47.257 50.796 1.00 10.26 ? 300 EPE A C3  1 
+HETATM 1158 N N4  . EPE B 2 .   ? 63.551 46.544 49.578 1.00 9.55  ? 300 EPE A N4  1 
+HETATM 1159 C C5  . EPE B 2 .   ? 62.151 46.910 49.248 1.00 10.60 ? 300 EPE A C5  1 
+HETATM 1160 C C6  . EPE B 2 .   ? 61.218 46.554 50.402 1.00 10.93 ? 300 EPE A C6  1 
+HETATM 1161 C C7  . EPE B 2 .   ? 64.368 46.893 48.385 1.00 9.77  ? 300 EPE A C7  1 
+HETATM 1162 C C8  . EPE B 2 .   ? 65.854 46.721 48.613 1.00 10.08 ? 300 EPE A C8  1 
+HETATM 1163 O O8  . EPE B 2 .   ? 66.240 45.400 48.979 1.00 9.74  ? 300 EPE A O8  1 
+HETATM 1164 C C9  . EPE B 2 .   ? 60.685 46.992 52.709 1.00 11.89 ? 300 EPE A C9  1 
+HETATM 1165 C C10 . EPE B 2 .   ? 60.870 47.974 53.893 1.00 11.61 ? 300 EPE A C10 1 
+HETATM 1166 S S   . EPE B 2 .   ? 59.559 47.692 55.090 1.00 12.14 ? 300 EPE A S   1 
+HETATM 1167 O O1S . EPE B 2 .   ? 59.732 48.694 56.115 1.00 14.62 ? 300 EPE A O1S 1 
+HETATM 1168 O O2S . EPE B 2 .   ? 59.737 46.327 55.596 1.00 12.65 ? 300 EPE A O2S 1 
+HETATM 1169 O O3S . EPE B 2 .   ? 58.331 47.863 54.358 1.00 12.66 ? 300 EPE A O3S 1 
+HETATM 1170 C C1  . GOL C 3 .   ? 47.201 41.007 39.524 0.50 31.48 ? 301 GOL A C1  1 
+HETATM 1171 O O1  . GOL C 3 .   ? 47.902 41.838 38.569 0.50 31.88 ? 301 GOL A O1  1 
+HETATM 1172 C C2  . GOL C 3 .   ? 46.621 42.071 40.443 0.50 22.32 ? 301 GOL A C2  1 
+HETATM 1173 O O2  . GOL C 3 .   ? 47.616 42.471 41.486 0.50 20.68 ? 301 GOL A O2  1 
+HETATM 1174 C C3  . GOL C 3 .   ? 45.228 41.910 40.982 0.50 28.49 ? 301 GOL A C3  1 
+HETATM 1175 O O3  . GOL C 3 .   ? 44.090 42.518 40.340 0.50 32.92 ? 301 GOL A O3  1 
+HETATM 1176 C C1  . GOL D 3 .   ? 30.075 38.814 62.227 0.50 23.28 ? 302 GOL A C1  1 
+HETATM 1177 O O1  . GOL D 3 .   ? 30.980 38.398 63.224 0.50 19.45 ? 302 GOL A O1  1 
+HETATM 1178 C C2  . GOL D 3 .   ? 29.586 37.660 61.308 0.50 22.70 ? 302 GOL A C2  1 
+HETATM 1179 O O2  . GOL D 3 .   ? 28.690 38.342 60.404 0.50 26.93 ? 302 GOL A O2  1 
+HETATM 1180 C C3  . GOL D 3 .   ? 30.737 36.978 60.581 0.50 19.97 ? 302 GOL A C3  1 
+HETATM 1181 O O3  . GOL D 3 .   ? 30.520 35.854 59.717 0.50 24.13 ? 302 GOL A O3  1 
+HETATM 1182 O O   . HOH E 4 .   ? 50.370 37.534 32.867 1.00 8.58  ? 401 HOH A O   1 
+HETATM 1183 O O   . HOH E 4 .   ? 51.450 37.894 30.393 1.00 9.23  ? 402 HOH A O   1 
+HETATM 1184 O O   . HOH E 4 .   ? 58.775 46.565 42.209 1.00 9.65  ? 403 HOH A O   1 
+HETATM 1185 O O   . HOH E 4 .   ? 36.733 47.870 46.348 1.00 9.69  ? 404 HOH A O   1 
+HETATM 1186 O O   . HOH E 4 .   ? 65.735 41.877 45.420 1.00 9.71  ? 405 HOH A O   1 
+HETATM 1187 O O   . HOH E 4 .   ? 54.650 43.673 33.672 1.00 10.57 ? 406 HOH A O   1 
+HETATM 1188 O O   . HOH E 4 .   ? 58.138 31.702 32.286 1.00 10.75 ? 407 HOH A O   1 
+HETATM 1189 O O   . HOH E 4 .   ? 56.774 34.360 29.505 1.00 11.28 ? 408 HOH A O   1 
+HETATM 1190 O O   . HOH E 4 .   ? 50.097 44.618 42.422 1.00 11.39 ? 409 HOH A O   1 
+HETATM 1191 O O   . HOH E 4 .   ? 42.895 53.532 52.446 1.00 11.98 ? 410 HOH A O   1 
+HETATM 1192 O O   . HOH E 4 .   ? 48.089 37.855 58.632 1.00 12.00 ? 411 HOH A O   1 
+HETATM 1193 O O   . HOH E 4 .   ? 55.451 31.713 31.646 1.00 12.02 ? 412 HOH A O   1 
+HETATM 1194 O O   . HOH E 4 .   ? 51.832 44.238 40.321 1.00 12.92 ? 413 HOH A O   1 
+HETATM 1195 O O   . HOH E 4 .   ? 57.459 37.678 55.073 1.00 13.10 ? 414 HOH A O   1 
+HETATM 1196 O O   . HOH E 4 .   ? 55.822 45.437 35.779 1.00 13.17 ? 415 HOH A O   1 
+HETATM 1197 O O   . HOH E 4 .   ? 67.091 37.802 37.603 1.00 13.38 ? 416 HOH A O   1 
+HETATM 1198 O O   . HOH E 4 .   ? 53.113 26.685 43.310 1.00 14.24 ? 417 HOH A O   1 
+HETATM 1199 O O   . HOH E 4 .   ? 56.425 39.233 32.681 1.00 14.54 ? 418 HOH A O   1 
+HETATM 1200 O O   . HOH E 4 .   ? 36.161 57.938 59.675 1.00 14.74 ? 419 HOH A O   1 
+HETATM 1201 O O   . HOH E 4 .   ? 43.333 49.703 45.665 1.00 15.22 ? 420 HOH A O   1 
+HETATM 1202 O O   . HOH E 4 .   ? 54.712 37.517 32.383 0.50 15.40 ? 421 HOH A O   1 
+HETATM 1203 O O   . HOH E 4 .   ? 36.175 55.614 57.238 1.00 15.96 ? 422 HOH A O   1 
+HETATM 1204 O O   . HOH E 4 .   ? 55.168 26.354 41.475 1.00 16.16 ? 423 HOH A O   1 
+HETATM 1205 O O   . HOH E 4 .   ? 49.576 53.420 56.666 1.00 16.16 ? 424 HOH A O   1 
+HETATM 1206 O O   . HOH E 4 .   ? 56.246 38.790 57.457 0.50 16.68 ? 425 HOH A O   1 
+HETATM 1207 O O   . HOH E 4 .   ? 66.794 42.003 37.419 1.00 16.74 ? 426 HOH A O   1 
+HETATM 1208 O O   . HOH E 4 .   ? 40.726 54.438 57.858 1.00 16.88 ? 427 HOH A O   1 
+HETATM 1209 O O   . HOH E 4 .   ? 36.716 47.179 62.404 1.00 17.67 ? 428 HOH A O   1 
+HETATM 1210 O O   . HOH E 4 .   ? 34.568 29.519 54.412 1.00 17.69 ? 429 HOH A O   1 
+HETATM 1211 O O   . HOH E 4 .   ? 59.998 33.008 45.015 1.00 17.75 ? 430 HOH A O   1 
+HETATM 1212 O O   . HOH E 4 .   ? 34.650 45.818 61.335 1.00 17.85 ? 431 HOH A O   1 
+HETATM 1213 O O   . HOH E 4 .   ? 58.737 38.185 31.698 1.00 17.91 ? 432 HOH A O   1 
+HETATM 1214 O O   . HOH E 4 .   ? 46.140 54.140 62.644 1.00 17.92 ? 433 HOH A O   1 
+HETATM 1215 O O   . HOH E 4 .   ? 49.688 47.094 44.286 0.50 18.17 ? 434 HOH A O   1 
+HETATM 1216 O O   . HOH E 4 .   ? 60.508 38.501 29.685 0.50 18.20 ? 435 HOH A O   1 
+HETATM 1217 O O   . HOH E 4 .   ? 53.797 32.309 55.282 0.50 18.38 ? 436 HOH A O   1 
+HETATM 1218 O O   . HOH E 4 .   ? 56.163 35.919 33.114 1.00 18.42 ? 437 HOH A O   1 
+HETATM 1219 O O   . HOH E 4 .   ? 30.412 42.411 54.839 1.00 18.52 ? 438 HOH A O   1 
+HETATM 1220 O O   . HOH E 4 .   ? 58.491 49.461 41.314 0.50 18.65 ? 439 HOH A O   1 
+HETATM 1221 O O   . HOH E 4 .   ? 35.214 43.575 63.398 1.00 18.90 ? 440 HOH A O   1 
+HETATM 1222 O O   . HOH E 4 .   ? 60.356 30.847 49.129 0.50 18.97 ? 441 HOH A O   1 
+HETATM 1223 O O   . HOH E 4 .   ? 54.855 25.514 38.963 1.00 18.98 ? 442 HOH A O   1 
+HETATM 1224 O O   . HOH E 4 .   ? 39.475 30.893 58.411 0.50 19.19 ? 443 HOH A O   1 
+HETATM 1225 O O   . HOH E 4 .   ? 56.123 35.324 55.044 1.00 19.33 ? 444 HOH A O   1 
+HETATM 1226 O O   . HOH E 4 .   ? 50.222 42.361 38.865 1.00 19.55 ? 445 HOH A O   1 
+HETATM 1227 O O   . HOH E 4 .   ? 46.627 52.749 65.539 0.50 19.56 ? 446 HOH A O   1 
+HETATM 1228 O O   . HOH E 4 .   ? 51.036 50.194 48.791 0.50 20.13 ? 447 HOH A O   1 
+HETATM 1229 O O   . HOH E 4 .   ? 51.862 52.904 52.535 0.50 20.25 ? 448 HOH A O   1 
+HETATM 1230 O O   . HOH E 4 .   ? 55.465 42.767 31.218 1.00 20.61 ? 449 HOH A O   1 
+HETATM 1231 O O   . HOH E 4 .   ? 55.951 46.069 39.573 0.50 20.79 ? 450 HOH A O   1 
+HETATM 1232 O O   . HOH E 4 .   ? 29.795 41.329 47.519 1.00 21.00 ? 451 HOH A O   1 
+HETATM 1233 O O   . HOH E 4 .   ? 64.000 34.626 40.134 1.00 21.11 ? 452 HOH A O   1 
+HETATM 1234 O O   . HOH E 4 .   ? 53.350 50.369 50.472 1.00 21.35 ? 453 HOH A O   1 
+HETATM 1235 O O   . HOH E 4 .   ? 45.451 55.930 57.262 0.50 21.63 ? 454 HOH A O   1 
+HETATM 1236 O O   . HOH E 4 .   ? 60.858 33.484 48.347 1.00 21.71 ? 455 HOH A O   1 
+HETATM 1237 O O   . HOH E 4 .   ? 42.641 54.857 55.849 1.00 22.05 ? 456 HOH A O   1 
+HETATM 1238 O O   . HOH E 4 .   ? 69.165 35.954 35.887 1.00 22.24 ? 457 HOH A O   1 
+HETATM 1239 O O   . HOH E 4 .   ? 59.689 45.033 29.703 0.50 22.51 ? 458 HOH A O   1 
+HETATM 1240 O O   . HOH E 4 .   ? 47.662 54.832 58.124 0.50 22.70 ? 459 HOH A O   1 
+HETATM 1241 O O   . HOH E 4 .   ? 45.916 47.065 43.579 0.50 23.28 ? 460 HOH A O   1 
+HETATM 1242 O O   . HOH E 4 .   ? 51.084 54.822 54.748 0.50 23.30 ? 461 HOH A O   1 
+HETATM 1243 O O   . HOH E 4 .   ? 60.452 27.997 45.606 1.00 24.55 ? 462 HOH A O   1 
+HETATM 1244 O O   . HOH E 4 .   ? 54.373 24.810 45.040 1.00 24.71 ? 463 HOH A O   1 
+HETATM 1245 O O   . HOH E 4 .   ? 60.411 34.259 28.367 1.00 25.16 ? 464 HOH A O   1 
+HETATM 1246 O O   . HOH E 4 .   ? 51.626 46.257 38.425 0.50 25.27 ? 465 HOH A O   1 
+HETATM 1247 O O   . HOH E 4 .   ? 47.579 44.911 41.315 0.50 25.47 ? 466 HOH A O   1 
+HETATM 1248 O O   . HOH E 4 .   ? 51.080 25.143 42.394 1.00 25.69 ? 467 HOH A O   1 
+HETATM 1249 O O   . HOH E 4 .   ? 36.616 52.685 63.896 1.00 25.77 ? 468 HOH A O   1 
+HETATM 1250 O O   . HOH E 4 .   ? 53.866 35.844 56.528 1.00 25.81 ? 469 HOH A O   1 
+HETATM 1251 O O   . HOH E 4 .   ? 40.551 54.997 52.452 1.00 26.07 ? 470 HOH A O   1 
+HETATM 1252 O O   . HOH E 4 .   ? 62.318 36.299 29.107 1.00 26.08 ? 471 HOH A O   1 
+HETATM 1253 O O   . HOH E 4 .   ? 56.155 46.994 31.574 1.00 26.25 ? 472 HOH A O   1 
+HETATM 1254 O O   . HOH E 4 .   ? 45.197 27.988 50.359 1.00 26.31 ? 473 HOH A O   1 
+HETATM 1255 O O   . HOH E 4 .   ? 65.965 36.535 30.619 1.00 26.76 ? 474 HOH A O   1 
+HETATM 1256 O O   . HOH E 4 .   ? 59.192 35.741 52.989 1.00 26.80 ? 475 HOH A O   1 
+HETATM 1257 O O   . HOH E 4 .   ? 49.516 25.843 55.666 1.00 26.96 ? 476 HOH A O   1 
+HETATM 1258 O O   . HOH E 4 .   ? 44.704 28.702 47.879 1.00 27.23 ? 477 HOH A O   1 
+HETATM 1259 O O   . HOH E 4 .   ? 29.929 40.501 58.646 1.00 27.24 ? 478 HOH A O   1 
+HETATM 1260 O O   . HOH E 4 .   ? 47.341 47.928 45.386 0.50 27.48 ? 479 HOH A O   1 
+HETATM 1261 O O   . HOH E 4 .   ? 62.600 26.642 37.903 1.00 29.77 ? 480 HOH A O   1 
+HETATM 1262 O O   . HOH E 4 .   ? 62.959 34.906 46.793 1.00 29.91 ? 481 HOH A O   1 
+HETATM 1263 O O   . HOH E 4 .   ? 43.039 27.641 57.884 1.00 30.91 ? 482 HOH A O   1 
+HETATM 1264 O O   . HOH E 4 .   ? 51.003 52.141 59.816 0.50 17.52 ? 483 HOH A O   1 
+HETATM 1265 O O   . HOH E 4 .   ? 63.177 43.776 49.341 1.00 10.32 ? 484 HOH A O   1 
+HETATM 1266 O O   . HOH E 4 .   ? 61.193 27.286 35.732 1.00 13.11 ? 485 HOH A O   1 
+HETATM 1267 O O   . HOH E 4 .   ? 60.090 49.600 48.289 1.00 13.47 ? 486 HOH A O   1 
+HETATM 1268 O O   . HOH E 4 .   ? 39.421 52.741 64.525 0.50 13.48 ? 487 HOH A O   1 
+HETATM 1269 O O   . HOH E 4 .   ? 44.880 52.059 45.812 1.00 16.22 ? 488 HOH A O   1 
+HETATM 1270 O O   . HOH E 4 .   ? 51.585 40.834 60.128 0.50 16.46 ? 489 HOH A O   1 
+HETATM 1271 O O   . HOH E 4 .   ? 40.281 45.924 62.677 0.50 16.46 ? 490 HOH A O   1 
+HETATM 1272 O O   . HOH E 4 .   ? 62.810 32.219 28.548 0.50 17.28 ? 491 HOH A O   1 
+HETATM 1273 O O   . HOH E 4 .   ? 53.831 50.410 46.882 0.50 17.57 ? 492 HOH A O   1 
+HETATM 1274 O O   . HOH E 4 .   ? 44.052 29.598 44.305 0.50 17.58 ? 493 HOH A O   1 
+HETATM 1275 O O   . HOH E 4 .   ? 61.163 30.808 46.463 0.50 17.93 ? 494 HOH A O   1 
+HETATM 1276 O O   . HOH E 4 .   ? 49.602 52.011 60.683 0.50 18.56 ? 495 HOH A O   1 
+HETATM 1277 O O   . HOH E 4 .   ? 61.058 51.038 40.367 1.00 20.05 ? 496 HOH A O   1 
+HETATM 1278 O O   . HOH E 4 .   ? 60.414 32.937 51.248 0.50 20.24 ? 497 HOH A O   1 
+HETATM 1279 O O   . HOH E 4 .   ? 56.203 41.613 58.835 0.50 20.37 ? 498 HOH A O   1 
+HETATM 1280 O O   . HOH E 4 .   ? 37.190 30.090 57.188 0.50 21.03 ? 499 HOH A O   1 
+HETATM 1281 O O   . HOH E 4 .   ? 50.504 34.042 58.302 0.50 21.18 ? 500 HOH A O   1 
+HETATM 1282 O O   . HOH E 4 .   ? 67.659 40.223 44.570 0.50 22.70 ? 501 HOH A O   1 
+HETATM 1283 O O   . HOH E 4 .   ? 61.209 35.115 50.260 1.00 23.45 ? 502 HOH A O   1 
+HETATM 1284 O O   . HOH E 4 .   ? 69.158 33.310 32.531 0.50 23.48 ? 503 HOH A O   1 
+HETATM 1285 O O   . HOH E 4 .   ? 40.522 56.578 59.375 0.50 24.13 ? 504 HOH A O   1 
+HETATM 1286 O O   . HOH E 4 .   ? 38.506 26.424 50.086 0.50 24.29 ? 505 HOH A O   1 
+HETATM 1287 O O   . HOH E 4 .   ? 48.037 53.761 60.651 0.50 24.98 ? 506 HOH A O   1 
+HETATM 1288 O O   . HOH E 4 .   ? 55.321 40.064 30.465 1.00 26.69 ? 507 HOH A O   1 
+HETATM 1289 O O   . HOH E 4 .   ? 41.742 56.179 62.106 0.50 29.41 ? 508 HOH A O   1 
+HETATM 1290 O O   . HOH E 4 .   ? 44.260 55.709 51.875 0.50 30.16 ? 509 HOH A O   1 
+HETATM 1291 O O   . HOH E 4 .   ? 59.042 51.352 46.565 0.50 29.97 ? 510 HOH A O   1 
+HETATM 1292 O O   . HOH E 4 .   ? 65.456 42.980 47.932 1.00 9.43  ? 511 HOH A O   1 
+HETATM 1293 O O   . HOH E 4 .   ? 68.956 44.955 49.357 1.00 12.15 ? 512 HOH A O   1 
+HETATM 1294 O O   . HOH E 4 .   ? 64.538 46.501 36.661 1.00 14.58 ? 513 HOH A O   1 
+HETATM 1295 O O   . HOH E 4 .   ? 21.405 28.640 55.103 0.50 16.52 ? 514 HOH A O   1 
+HETATM 1296 O O   . HOH E 4 .   ? 57.094 48.289 40.872 0.50 17.81 ? 515 HOH A O   1 
+HETATM 1297 O O   . HOH E 4 .   ? 51.182 51.596 58.740 0.50 18.42 ? 516 HOH A O   1 
+HETATM 1298 O O   . HOH E 4 .   ? 32.495 27.959 55.913 0.50 19.29 ? 517 HOH A O   1 
+HETATM 1299 O O   . HOH E 4 .   ? 64.109 49.428 37.044 0.50 19.52 ? 518 HOH A O   1 
+HETATM 1300 O O   . HOH E 4 .   ? 50.591 24.798 39.547 0.50 20.03 ? 519 HOH A O   1 
+HETATM 1301 O O   . HOH E 4 .   ? 50.260 52.049 50.340 0.50 21.43 ? 520 HOH A O   1 
+HETATM 1302 O O   . HOH E 4 .   ? 56.776 49.940 56.484 1.00 21.52 ? 521 HOH A O   1 
+HETATM 1303 O O   . HOH E 4 .   ? 43.780 47.205 67.916 0.50 22.12 ? 522 HOH A O   1 
+HETATM 1304 O O   . HOH E 4 .   ? 61.891 23.495 39.652 0.50 22.51 ? 523 HOH A O   1 
+HETATM 1305 O O   . HOH E 4 .   ? 48.904 49.110 64.952 0.50 22.63 ? 524 HOH A O   1 
+HETATM 1306 O O   . HOH E 4 .   ? 54.894 48.033 59.333 0.50 23.15 ? 525 HOH A O   1 
+HETATM 1307 O O   . HOH E 4 .   ? 33.725 34.101 50.256 1.00 23.25 ? 526 HOH A O   1 
+HETATM 1308 O O   . HOH E 4 .   ? 28.914 34.068 54.873 1.00 23.39 ? 527 HOH A O   1 
+HETATM 1309 O O   . HOH E 4 .   ? 66.119 31.703 41.550 0.50 23.66 ? 528 HOH A O   1 
+HETATM 1310 O O   . HOH E 4 .   ? 46.949 35.914 65.061 0.50 24.29 ? 529 HOH A O   1 
+HETATM 1311 O O   . HOH E 4 .   ? 58.257 23.281 41.109 0.50 24.40 ? 530 HOH A O   1 
+HETATM 1312 O O   . HOH E 4 .   ? 47.452 51.775 45.097 0.50 24.84 ? 531 HOH A O   1 
+HETATM 1313 O O   . HOH E 4 .   ? 53.867 39.682 57.651 0.50 25.57 ? 532 HOH A O   1 
+HETATM 1314 O O   . HOH E 4 .   ? 50.458 21.405 48.410 0.50 25.81 ? 533 HOH A O   1 
+HETATM 1315 O O   . HOH E 4 .   ? 45.818 42.866 68.770 0.50 26.32 ? 534 HOH A O   1 
+HETATM 1316 O O   . HOH E 4 .   ? 38.429 45.545 63.681 1.00 26.57 ? 535 HOH A O   1 
+HETATM 1317 O O   . HOH E 4 .   ? 62.591 47.136 34.170 1.00 26.66 ? 536 HOH A O   1 
+HETATM 1318 O O   . HOH E 4 .   ? 52.543 45.504 60.125 0.50 27.06 ? 537 HOH A O   1 
+HETATM 1319 O O   . HOH E 4 .   ? 53.658 44.251 63.141 0.50 27.15 ? 538 HOH A O   1 
+HETATM 1320 O O   . HOH E 4 .   ? 45.445 24.902 54.161 0.50 27.96 ? 539 HOH A O   1 
+HETATM 1321 O O   . HOH E 4 .   ? 34.329 36.712 48.904 1.00 28.54 ? 540 HOH A O   1 
+HETATM 1322 O O   . HOH E 4 .   ? 68.211 37.523 32.745 0.50 28.88 ? 541 HOH A O   1 
+HETATM 1323 O O   . HOH E 4 .   ? 56.953 46.499 29.011 0.50 29.63 ? 542 HOH A O   1 
+HETATM 1324 O O   . HOH E 4 .   ? 63.710 30.813 46.746 0.50 29.98 ? 543 HOH A O   1 
+HETATM 1325 O O   . HOH E 4 .   ? 42.276 28.186 43.667 0.50 30.17 ? 544 HOH A O   1 
+HETATM 1326 O O   . HOH E 4 .   ? 30.032 30.875 49.619 1.00 30.95 ? 545 HOH A O   1 
+HETATM 1327 O O   . HOH E 4 .   ? 27.738 45.699 57.303 0.50 34.09 ? 546 HOH A O   1 
+HETATM 1328 O O   . HOH E 4 .   ? 63.162 49.369 39.785 1.00 11.49 ? 547 HOH A O   1 
+HETATM 1329 O O   . HOH E 4 .   ? 59.749 27.221 43.035 0.50 15.73 ? 548 HOH A O   1 
+HETATM 1330 O O   . HOH E 4 .   ? 31.754 32.970 48.743 0.50 16.77 ? 549 HOH A O   1 
+HETATM 1331 O O   . HOH E 4 .   ? 60.150 34.840 54.580 0.50 18.18 ? 550 HOH A O   1 
+HETATM 1332 O O   . HOH E 4 .   ? 58.933 54.333 51.406 0.50 18.92 ? 551 HOH A O   1 
+HETATM 1333 O O   . HOH E 4 .   ? 28.725 48.278 49.363 1.00 19.60 ? 552 HOH A O   1 
+HETATM 1334 O O   . HOH E 4 .   ? 52.700 37.988 59.066 0.50 19.72 ? 553 HOH A O   1 
+HETATM 1335 O O   . HOH E 4 .   ? 53.949 29.853 54.113 0.50 19.90 ? 554 HOH A O   1 
+HETATM 1336 O O   . HOH E 4 .   ? 48.207 29.684 60.978 0.50 21.56 ? 555 HOH A O   1 
+HETATM 1337 O O   . HOH E 4 .   ? 28.828 45.639 54.643 0.50 21.99 ? 556 HOH A O   1 
+HETATM 1338 O O   . HOH E 4 .   ? 32.017 47.056 61.818 0.50 23.18 ? 557 HOH A O   1 
+HETATM 1339 O O   . HOH E 4 .   ? 31.585 37.633 49.701 0.50 23.44 ? 558 HOH A O   1 
+HETATM 1340 O O   . HOH E 4 .   ? 62.111 22.036 39.234 0.50 23.51 ? 559 HOH A O   1 
+HETATM 1341 O O   . HOH E 4 .   ? 59.762 32.702 56.420 0.50 23.73 ? 560 HOH A O   1 
+HETATM 1342 O O   . HOH E 4 .   ? 69.433 40.152 43.174 0.50 23.92 ? 561 HOH A O   1 
+HETATM 1343 O O   . HOH E 4 .   ? 67.775 31.088 40.722 0.50 24.12 ? 562 HOH A O   1 
+HETATM 1344 O O   . HOH E 4 .   ? 42.493 25.667 58.053 0.50 24.16 ? 563 HOH A O   1 
+HETATM 1345 O O   . HOH E 4 .   ? 41.732 39.344 70.881 0.50 24.24 ? 564 HOH A O   1 
+HETATM 1346 O O   . HOH E 4 .   ? 43.685 27.413 59.691 0.50 24.81 ? 565 HOH A O   1 
+HETATM 1347 O O   . HOH E 4 .   ? 57.698 29.261 48.805 0.50 24.86 ? 566 HOH A O   1 
+HETATM 1348 O O   . HOH E 4 .   ? 45.183 37.278 69.180 0.50 24.98 ? 567 HOH A O   1 
+HETATM 1349 O O   . HOH E 4 .   ? 63.200 45.876 32.128 0.50 25.10 ? 568 HOH A O   1 
+HETATM 1350 O O   . HOH E 4 .   ? 43.162 31.430 66.117 0.50 25.17 ? 569 HOH A O   1 
+HETATM 1351 O O   . HOH E 4 .   ? 44.320 25.535 51.030 0.50 25.77 ? 570 HOH A O   1 
+HETATM 1352 O O   . HOH E 4 .   ? 42.611 38.090 68.820 1.00 25.87 ? 571 HOH A O   1 
+HETATM 1353 O O   . HOH E 4 .   ? 21.752 30.504 53.536 0.50 25.88 ? 572 HOH A O   1 
+HETATM 1354 O O   . HOH E 4 .   ? 57.696 36.552 27.314 0.50 25.90 ? 573 HOH A O   1 
+HETATM 1355 O O   . HOH E 4 .   ? 52.077 25.677 54.092 0.50 26.18 ? 574 HOH A O   1 
+HETATM 1356 O O   . HOH E 4 .   ? 38.693 49.759 66.182 0.50 26.46 ? 575 HOH A O   1 
+HETATM 1357 O O   . HOH E 4 .   ? 23.306 25.296 49.364 0.50 26.81 ? 576 HOH A O   1 
+HETATM 1358 O O   . HOH E 4 .   ? 49.362 25.756 38.949 0.50 27.49 ? 577 HOH A O   1 
+HETATM 1359 O O   . HOH E 4 .   ? 50.025 37.033 65.980 0.50 27.51 ? 578 HOH A O   1 
+HETATM 1360 O O   . HOH E 4 .   ? 63.795 42.111 30.862 0.50 27.54 ? 579 HOH A O   1 
+HETATM 1361 O O   . HOH E 4 .   ? 47.364 34.204 63.555 0.50 27.62 ? 580 HOH A O   1 
+HETATM 1362 O O   . HOH E 4 .   ? 55.147 47.447 63.968 0.50 28.09 ? 581 HOH A O   1 
+HETATM 1363 O O   . HOH E 4 .   ? 34.228 28.826 58.059 0.50 28.42 ? 582 HOH A O   1 
+HETATM 1364 O O   . HOH E 4 .   ? 60.657 23.622 40.688 0.50 28.47 ? 583 HOH A O   1 
+HETATM 1365 O O   . HOH E 4 .   ? 49.573 54.516 48.852 0.50 28.76 ? 584 HOH A O   1 
+HETATM 1366 O O   . HOH E 4 .   ? 58.272 51.113 43.293 0.50 28.80 ? 585 HOH A O   1 
+HETATM 1367 O O   . HOH E 4 .   ? 40.075 29.175 42.344 0.50 29.10 ? 586 HOH A O   1 
+HETATM 1368 O O   . HOH E 4 .   ? 65.936 28.855 33.560 0.50 29.11 ? 587 HOH A O   1 
+HETATM 1369 O O   . HOH E 4 .   ? 60.269 55.153 51.630 0.50 29.41 ? 588 HOH A O   1 
+HETATM 1370 O O   . HOH E 4 .   ? 45.354 23.536 35.791 0.50 29.55 ? 589 HOH A O   1 
+HETATM 1371 O O   . HOH E 4 .   ? 44.375 49.293 42.829 0.50 31.73 ? 590 HOH A O   1 
+HETATM 1372 O O   . HOH E 4 .   ? 35.354 48.445 64.499 0.50 32.42 ? 591 HOH A O   1 
+HETATM 1373 O O   . HOH E 4 .   ? 45.777 32.701 64.167 0.50 33.75 ? 592 HOH A O   1 
+# 
+loop_
+_atom_site_anisotrop.id 
+_atom_site_anisotrop.type_symbol 
+_atom_site_anisotrop.pdbx_label_atom_id 
+_atom_site_anisotrop.pdbx_label_alt_id 
+_atom_site_anisotrop.pdbx_label_comp_id 
+_atom_site_anisotrop.pdbx_label_asym_id 
+_atom_site_anisotrop.pdbx_label_seq_id 
+_atom_site_anisotrop.pdbx_PDB_ins_code 
+_atom_site_anisotrop.U[1][1] 
+_atom_site_anisotrop.U[2][2] 
+_atom_site_anisotrop.U[3][3] 
+_atom_site_anisotrop.U[1][2] 
+_atom_site_anisotrop.U[1][3] 
+_atom_site_anisotrop.U[2][3] 
+_atom_site_anisotrop.pdbx_auth_seq_id 
+_atom_site_anisotrop.pdbx_auth_comp_id 
+_atom_site_anisotrop.pdbx_auth_asym_id 
+_atom_site_anisotrop.pdbx_auth_atom_id 
+1    N N   . GLY A 5   ? 1.8101 0.3988 0.4971 0.0131  -0.3571 0.2475  52  GLY A N   
+2    C CA  . GLY A 5   ? 1.2683 0.5499 0.4600 0.0229  -0.4798 0.2442  52  GLY A CA  
+3    C C   . GLY A 5   ? 0.9995 0.4761 0.4367 -0.0580 -0.3905 0.2089  52  GLY A C   
+4    O O   . GLY A 5   ? 0.8619 0.6709 0.3349 -0.0099 -0.2545 0.1672  52  GLY A O   
+5    N N   . ARG A 6   ? 0.7715 0.3752 0.4325 -0.0818 -0.3242 0.2021  53  ARG A N   
+6    C CA  . ARG A 6   ? 0.5821 0.3522 0.3401 -0.1150 -0.2099 0.1835  53  ARG A CA  
+7    C C   . ARG A 6   ? 0.4579 0.3576 0.3211 -0.0788 -0.1381 0.1664  53  ARG A C   
+8    O O   . ARG A 6   ? 0.4513 0.3444 0.1849 -0.1201 -0.0980 0.0997  53  ARG A O   
+9    C CB  . ARG A 6   ? 0.3976 0.3472 0.3003 -0.0337 -0.0967 0.1258  53  ARG A CB  
+10   C CG  . ARG A 6   ? 0.3105 0.3257 0.1855 -0.0336 -0.0126 0.0957  53  ARG A CG  
+11   C CD  . ARG A 6   ? 0.2203 0.2400 0.2141 -0.0166 0.0314  0.0560  53  ARG A CD  
+12   N NE  . ARG A 6   ? 0.1964 0.2359 0.2411 -0.0111 0.0254  0.0584  53  ARG A NE  
+13   C CZ  . ARG A 6   ? 0.1702 0.2470 0.1784 0.0033  0.0143  0.0426  53  ARG A CZ  
+14   N NH1 . ARG A 6   ? 0.1782 0.2289 0.1438 -0.0247 0.0102  0.0407  53  ARG A NH1 
+15   N NH2 . ARG A 6   ? 0.1898 0.2980 0.1978 0.0161  0.0254  0.0351  53  ARG A NH2 
+16   N N   . GLY A 7   ? 0.4531 0.4274 0.3362 -0.0068 -0.1518 0.1877  54  GLY A N   
+17   C CA  . GLY A 7   ? 0.3332 0.4254 0.3066 0.0058  -0.1172 0.1323  54  GLY A CA  
+18   C C   . GLY A 7   ? 0.2057 0.2769 0.1845 -0.0102 -0.0286 0.0432  54  GLY A C   
+19   O O   . GLY A 7   ? 0.2764 0.2169 0.2442 -0.0033 -0.0379 0.0207  54  GLY A O   
+20   N N   . LEU A 8   ? 0.2154 0.2635 0.1786 -0.0401 -0.0505 0.0039  55  LEU A N   
+21   C CA  . LEU A 8   ? 0.1852 0.2010 0.1286 -0.0565 -0.0155 0.0031  55  LEU A CA  
+22   C C   . LEU A 8   ? 0.1928 0.1940 0.0959 -0.0548 -0.0023 0.0024  55  LEU A C   
+23   O O   . LEU A 8   ? 0.1847 0.1878 0.1121 -0.0489 -0.0005 0.0097  55  LEU A O   
+24   C CB  . LEU A 8   ? 0.1707 0.2009 0.2213 -0.0533 0.0194  -0.0267 55  LEU A CB  
+25   C CG  . LEU A 8   ? 0.1726 0.2488 0.2481 -0.0559 0.0241  0.0026  55  LEU A CG  
+26   C CD1 . LEU A 8   ? 0.2894 0.2770 0.6065 -0.1362 0.1217  -0.0134 55  LEU A CD1 
+27   C CD2 . LEU A 8   ? 0.2079 0.4267 0.1849 -0.0021 0.0377  0.0576  55  LEU A CD2 
+28   N N   . GLY A 9   ? 0.2170 0.2233 0.1129 -0.0506 -0.0029 0.0286  56  GLY A N   
+29   C CA  . GLY A 9   ? 0.2284 0.2261 0.1169 -0.0893 0.0157  -0.0015 56  GLY A CA  
+30   C C   . GLY A 9   ? 0.2038 0.1802 0.1011 -0.0558 0.0274  0.0045  56  GLY A C   
+31   O O   . GLY A 9   ? 0.1825 0.1730 0.1161 -0.0472 0.0266  0.0039  56  GLY A O   
+32   N N   . PRO A 10  ? 0.2153 0.1952 0.1256 -0.0825 0.0520  -0.0189 57  PRO A N   
+33   C CA  . PRO A 10  ? 0.1740 0.1613 0.1561 -0.0461 0.0491  -0.0111 57  PRO A CA  
+34   C C   . PRO A 10  ? 0.1561 0.1494 0.1602 -0.0590 0.0210  -0.0003 57  PRO A C   
+35   O O   . PRO A 10  ? 0.1913 0.1764 0.1823 -0.0506 0.0166  0.0152  57  PRO A O   
+36   C CB  . PRO A 10  ? 0.1984 0.2353 0.2092 -0.0396 0.0926  -0.0197 57  PRO A CB  
+37   C CG  . PRO A 10  ? 0.2633 0.4228 0.2666 -0.1173 0.1185  -0.1950 57  PRO A CG  
+38   C CD  . PRO A 10  ? 0.2842 0.2287 0.1696 -0.1113 0.1143  -0.0619 57  PRO A CD  
+39   N N   . LEU A 11  ? 0.1530 0.1367 0.1706 -0.0552 0.0384  -0.0019 58  LEU A N   
+40   C CA  . LEU A 11  ? 0.1539 0.1403 0.1965 -0.0548 0.0433  -0.0199 58  LEU A CA  
+41   C C   . LEU A 11  ? 0.1233 0.1281 0.1615 -0.0385 0.0222  -0.0081 58  LEU A C   
+42   O O   . LEU A 11  ? 0.1467 0.1320 0.1496 -0.0318 0.0408  -0.0074 58  LEU A O   
+43   C CB  . LEU A 11  ? 0.1614 0.1825 0.1800 -0.0566 0.0749  -0.0248 58  LEU A CB  
+44   C CG  . LEU A 11  ? 0.1854 0.1614 0.2008 -0.0714 0.0786  -0.0354 58  LEU A CG  
+45   C CD1 . LEU A 11  ? 0.2918 0.2293 0.1819 -0.1107 0.1035  -0.0364 58  LEU A CD1 
+46   C CD2 . LEU A 11  ? 0.1766 0.3026 0.3262 -0.0486 0.1220  -0.0709 58  LEU A CD2 
+47   N N   . GLN A 12  ? 0.1193 0.1341 0.2231 -0.0332 -0.0066 0.0002  59  GLN A N   
+48   C CA  . GLN A 12  ? 0.1890 0.1566 0.1678 -0.0496 -0.0537 0.0390  59  GLN A CA  
+49   C C   . GLN A 12  ? 0.1339 0.1194 0.1399 -0.0387 -0.0014 0.0396  59  GLN A C   
+50   O O   . GLN A 12  ? 0.1368 0.1216 0.1558 -0.0211 -0.0092 0.0362  59  GLN A O   
+51   C CB  . GLN A 12  ? 0.2067 0.1733 0.2760 -0.0353 -0.1042 0.0294  59  GLN A CB  
+52   C CG  . GLN A 12  ? 0.3363 0.2501 0.3677 0.0116  -0.2227 -0.0433 59  GLN A CG  
+53   C CD  . GLN A 12  ? 0.3149 0.4498 0.7762 0.0118  -0.3040 0.1694  59  GLN A CD  
+54   O OE1 . GLN A 12  ? 0.6342 0.7322 0.5806 0.3699  0.0789  0.3262  59  GLN A OE1 
+55   N NE2 . GLN A 12  ? 0.2740 0.3500 1.6002 -0.0253 -0.2208 0.3157  59  GLN A NE2 
+56   N N   . ILE A 13  ? 0.1239 0.1160 0.1265 -0.0341 0.0056  0.0044  60  ILE A N   
+57   C CA  . ILE A 13  ? 0.1125 0.1053 0.1080 -0.0231 0.0180  0.0067  60  ILE A CA  
+58   C C   . ILE A 13  ? 0.1163 0.0980 0.1054 -0.0242 0.0176  0.0096  60  ILE A C   
+59   O O   . ILE A 13  ? 0.1489 0.1040 0.1304 -0.0309 0.0482  -0.0134 60  ILE A O   
+60   C CB  . ILE A 13  ? 0.1194 0.1121 0.1111 -0.0182 0.0227  0.0170  60  ILE A CB  
+61   C CG1 . ILE A 13  ? 0.1335 0.1524 0.1188 -0.0289 0.0343  0.0076  60  ILE A CG1 
+62   C CG2 . ILE A 13  ? 0.1358 0.1732 0.1149 -0.0252 0.0105  0.0387  60  ILE A CG2 
+63   C CD1 . ILE A 13  ? 0.1420 0.2251 0.1617 -0.0496 0.0334  0.0603  60  ILE A CD1 
+64   N N   . TRP A 14  ? 0.1032 0.0864 0.0959 -0.0051 0.0149  0.0093  61  TRP A N   
+65   C CA  . TRP A 14  ? 0.0984 0.0969 0.0911 -0.0180 0.0119  0.0166  61  TRP A CA  
+66   C C   . TRP A 14  ? 0.1063 0.0924 0.0856 -0.0118 0.0144  0.0101  61  TRP A C   
+67   O O   . TRP A 14  ? 0.0995 0.1102 0.0983 -0.0102 0.0112  0.0064  61  TRP A O   
+68   C CB  . TRP A 14  ? 0.1096 0.0993 0.0936 -0.0048 0.0135  0.0146  61  TRP A CB  
+69   C CG  . TRP A 14  ? 0.0975 0.1052 0.0842 0.0026  0.0144  0.0089  61  TRP A CG  
+70   C CD1 . TRP A 14  ? 0.1334 0.1085 0.0922 -0.0144 0.0039  0.0070  61  TRP A CD1 
+71   C CD2 . TRP A 14  ? 0.0986 0.1050 0.0808 0.0032  0.0138  0.0110  61  TRP A CD2 
+72   N NE1 . TRP A 14  ? 0.1241 0.1284 0.1008 -0.0085 -0.0091 0.0064  61  TRP A NE1 
+73   C CE2 . TRP A 14  ? 0.1127 0.1169 0.0948 0.0064  0.0098  0.0098  61  TRP A CE2 
+74   C CE3 . TRP A 14  ? 0.1039 0.1072 0.0926 0.0023  0.0225  0.0161  61  TRP A CE3 
+75   C CZ2 . TRP A 14  ? 0.1251 0.1478 0.0942 0.0137  -0.0020 0.0261  61  TRP A CZ2 
+76   C CZ3 . TRP A 14  ? 0.1083 0.1066 0.1119 0.0089  0.0300  0.0231  61  TRP A CZ3 
+77   C CH2 . TRP A 14  ? 0.1219 0.1238 0.1060 0.0205  0.0311  0.0273  61  TRP A CH2 
+78   N N   . GLN A 15  ? 0.1050 0.1004 0.0936 -0.0096 0.0165  0.0089  62  GLN A N   
+79   C CA  . GLN A 15  ? 0.1077 0.1181 0.0927 -0.0049 0.0158  0.0174  62  GLN A CA  
+80   C C   . GLN A 15  ? 0.0923 0.1162 0.0898 -0.0030 0.0121  0.0077  62  GLN A C   
+81   O O   . GLN A 15  ? 0.1125 0.1190 0.0966 -0.0240 0.0204  0.0033  62  GLN A O   
+82   C CB  . GLN A 15  ? 0.1105 0.1222 0.1128 -0.0057 0.0199  0.0239  62  GLN A CB  
+83   C CG  . GLN A 15  ? 0.1501 0.1295 0.1314 0.0019  0.0342  0.0359  62  GLN A CG  
+84   C CD  . GLN A 15  ? 0.1601 0.1263 0.1579 0.0087  0.0363  0.0369  62  GLN A CD  
+85   O OE1 . GLN A 15  ? 0.1938 0.1392 0.2143 0.0345  0.0735  0.0596  62  GLN A OE1 
+86   N NE2 . GLN A 15  ? 0.2052 0.1455 0.2208 0.0005  0.0613  0.0638  62  GLN A NE2 
+87   N N   . THR A 16  ? 0.0959 0.1143 0.0832 -0.0001 0.0092  0.0127  63  THR A N   
+88   C CA  . THR A 16  ? 0.0863 0.1089 0.0931 0.0002  0.0090  0.0076  63  THR A CA  
+89   C C   . THR A 16  ? 0.0969 0.1271 0.0826 -0.0007 0.0053  0.0201  63  THR A C   
+90   O O   . THR A 16  ? 0.0999 0.1535 0.0954 -0.0027 -0.0007 0.0149  63  THR A O   
+91   C CB  . THR A 16  ? 0.0964 0.1049 0.1011 -0.0014 -0.0042 0.0032  63  THR A CB  
+92   O OG1 . THR A 16  ? 0.0907 0.0993 0.1004 -0.0012 0.0056  0.0116  63  THR A OG1 
+93   C CG2 . THR A 16  ? 0.0999 0.1096 0.1084 -0.0017 0.0090  0.0077  63  THR A CG2 
+94   N N   . ASP A 17  ? 0.0933 0.1299 0.0949 -0.0074 0.0004  0.0050  64  ASP A N   
+95   C CA  . ASP A 17  ? 0.0939 0.1346 0.1005 -0.0013 -0.0023 0.0045  64  ASP A CA  
+96   C C   . ASP A 17  ? 0.0885 0.1413 0.0888 -0.0017 0.0012  0.0006  64  ASP A C   
+97   O O   . ASP A 17  ? 0.1020 0.1892 0.1046 -0.0394 -0.0093 0.0123  64  ASP A O   
+98   C CB  . ASP A 17  ? 0.1166 0.1459 0.1238 0.0088  -0.0026 0.0244  64  ASP A CB  
+99   C CG  . ASP A 17  ? 0.1304 0.1813 0.1242 0.0137  -0.0061 0.0355  64  ASP A CG  
+100  O OD1 . ASP A 17  ? 0.1442 0.2071 0.1959 0.0376  -0.0096 0.0382  64  ASP A OD1 
+101  O OD2 . ASP A 17  ? 0.1330 0.2297 0.1227 -0.0029 -0.0229 0.0111  64  ASP A OD2 
+102  N N   . PHE A 18  ? 0.0880 0.1458 0.0872 -0.0009 -0.0029 0.0045  65  PHE A N   
+103  C CA  . PHE A 18  ? 0.0835 0.1252 0.0975 0.0000  0.0003  0.0065  65  PHE A CA  
+104  C C   . PHE A 18  ? 0.0887 0.1299 0.1011 0.0007  -0.0072 0.0155  65  PHE A C   
+105  O O   . PHE A 18  ? 0.1026 0.1921 0.1093 0.0240  -0.0032 0.0231  65  PHE A O   
+106  C CB  . PHE A 18  ? 0.0851 0.1432 0.1216 -0.0040 -0.0034 -0.0006 65  PHE A CB  
+107  C CG  . PHE A 18  ? 0.0855 0.1277 0.1396 -0.0023 -0.0051 -0.0187 65  PHE A CG  
+108  C CD1 . PHE A 18  ? 0.1294 0.1777 0.1907 0.0249  0.0310  -0.0189 65  PHE A CD1 
+109  C CD2 . PHE A 18  ? 0.1050 0.1503 0.1489 -0.0050 -0.0191 0.0047  65  PHE A CD2 
+110  C CE1 . PHE A 18  ? 0.1730 0.2073 0.2824 0.0674  0.0737  0.0078  65  PHE A CE1 
+111  C CE2 . PHE A 18  ? 0.1206 0.1508 0.1760 -0.0185 -0.0382 0.0141  65  PHE A CE2 
+112  C CZ  . PHE A 18  ? 0.1181 0.1635 0.2784 0.0147  -0.0090 0.0011  65  PHE A CZ  
+113  N N   . THR A 19  ? 0.0852 0.1231 0.1007 0.0073  -0.0009 0.0044  66  THR A N   
+114  C CA  . THR A 19  ? 0.0819 0.1234 0.1171 0.0034  -0.0059 0.0098  66  THR A CA  
+115  C C   . THR A 19  ? 0.0768 0.1145 0.0972 0.0111  -0.0014 -0.0073 66  THR A C   
+116  O O   . THR A 19  ? 0.0798 0.1278 0.1063 0.0008  -0.0059 0.0049  66  THR A O   
+117  C CB  . THR A 19  ? 0.1005 0.1266 0.1521 0.0066  -0.0185 -0.0085 66  THR A CB  
+118  O OG1 . THR A 19  ? 0.1370 0.1342 0.1860 0.0211  -0.0164 -0.0068 66  THR A OG1 
+119  C CG2 . THR A 19  ? 0.1606 0.1470 0.1517 -0.0120 -0.0180 0.0055  66  THR A CG2 
+120  N N   . LEU A 20  ? 0.0832 0.1346 0.0978 0.0005  -0.0068 0.0003  67  LEU A N   
+121  C CA  . LEU A 20  ? 0.0841 0.1235 0.0912 -0.0053 -0.0121 0.0038  67  LEU A CA  
+122  C C   . LEU A 20  ? 0.0871 0.1203 0.1029 0.0132  -0.0095 -0.0002 67  LEU A C   
+123  O O   . LEU A 20  ? 0.1162 0.1282 0.1179 0.0184  0.0010  0.0092  67  LEU A O   
+124  C CB  . LEU A 20  ? 0.0944 0.1458 0.1081 -0.0078 -0.0206 0.0001  67  LEU A CB  
+125  C CG  . LEU A 20  ? 0.0864 0.1445 0.1148 -0.0106 -0.0134 -0.0179 67  LEU A CG  
+126  C CD1 . LEU A 20  ? 0.1152 0.1442 0.1233 -0.0181 -0.0200 -0.0038 67  LEU A CD1 
+127  C CD2 . LEU A 20  ? 0.0973 0.1734 0.1175 -0.0104 -0.0255 -0.0175 67  LEU A CD2 
+128  N N   . GLU A 21  ? 0.0899 0.1071 0.0941 -0.0035 -0.0082 -0.0033 68  GLU A N   
+129  C CA  . GLU A 21  ? 0.0850 0.1087 0.0989 0.0006  -0.0041 -0.0059 68  GLU A CA  
+130  C C   . GLU A 21  ? 0.0815 0.1075 0.0997 0.0071  -0.0106 -0.0089 68  GLU A C   
+131  O O   . GLU A 21  ? 0.0824 0.1121 0.0983 0.0065  -0.0061 -0.0112 68  GLU A O   
+132  C CB  . GLU A 21  ? 0.0969 0.1245 0.1069 -0.0119 -0.0087 -0.0137 68  GLU A CB  
+133  C CG  . GLU A 21  ? 0.1318 0.1458 0.1213 -0.0230 -0.0040 -0.0362 68  GLU A CG  
+134  C CD  . GLU A 21  ? 0.1440 0.1141 0.1533 -0.0257 0.0198  -0.0396 68  GLU A CD  
+135  O OE1 . GLU A 21  ? 0.1867 0.1211 0.2301 -0.0300 0.0584  -0.0308 68  GLU A OE1 
+136  O OE2 . GLU A 21  ? 0.1409 0.1197 0.1472 -0.0175 0.0138  -0.0129 68  GLU A OE2 
+137  N N   . PRO A 22  ? 0.0850 0.1057 0.0986 0.0028  -0.0078 -0.0054 69  PRO A N   
+138  C CA  . PRO A 22  ? 0.0894 0.1021 0.1126 -0.0042 -0.0182 -0.0051 69  PRO A CA  
+139  C C   . PRO A 22  ? 0.0693 0.1056 0.1073 -0.0030 -0.0069 -0.0100 69  PRO A C   
+140  O O   . PRO A 22  ? 0.0792 0.1156 0.1119 -0.0078 -0.0069 -0.0132 69  PRO A O   
+141  C CB  . PRO A 22  ? 0.0934 0.1280 0.1236 -0.0118 -0.0252 0.0128  69  PRO A CB  
+142  C CG  . PRO A 22  ? 0.0926 0.1534 0.1275 -0.0148 -0.0179 0.0100  69  PRO A CG  
+143  C CD  . PRO A 22  ? 0.0841 0.1205 0.1123 -0.0037 -0.0165 0.0020  69  PRO A CD  
+144  N N   . ARG A 23  ? 0.0840 0.0981 0.1061 0.0036  -0.0026 -0.0030 70  ARG A N   
+145  C CA  . ARG A 23  ? 0.0920 0.1125 0.1089 0.0045  -0.0027 -0.0237 70  ARG A CA  
+146  C C   . ARG A 23  ? 0.0801 0.1016 0.0961 -0.0095 -0.0050 -0.0212 70  ARG A C   
+147  O O   . ARG A 23  ? 0.0934 0.1167 0.0994 -0.0009 -0.0018 -0.0193 70  ARG A O   
+148  C CB  . ARG A 23  ? 0.1336 0.1023 0.1361 0.0024  -0.0140 -0.0173 70  ARG A CB  
+149  C CG  A ARG A 23  ? 0.1510 0.1160 0.2139 0.0352  0.0041  -0.0279 70  ARG A CG  
+150  C CG  B ARG A 23  ? 0.1472 0.1076 0.1221 0.0144  -0.0068 -0.0072 70  ARG A CG  
+151  C CD  A ARG A 23  ? 0.2398 0.1065 0.1751 0.0284  0.0308  -0.0189 70  ARG A CD  
+152  C CD  B ARG A 23  ? 0.1585 0.1140 0.2250 0.0189  -0.0156 -0.0382 70  ARG A CD  
+153  N NE  A ARG A 23  ? 0.3158 0.1275 0.2128 0.0658  0.0487  0.0069  70  ARG A NE  
+154  N NE  B ARG A 23  ? 0.2281 0.1256 0.1948 0.0524  -0.0140 -0.0417 70  ARG A NE  
+155  C CZ  A ARG A 23  ? 0.2900 0.1769 0.2029 0.0743  0.0281  0.0361  70  ARG A CZ  
+156  C CZ  B ARG A 23  ? 0.2913 0.1728 0.2410 0.0846  -0.0367 -0.0121 70  ARG A CZ  
+157  N NH1 A ARG A 23  ? 0.3108 0.2209 0.2712 0.0169  0.0903  0.0308  70  ARG A NH1 
+158  N NH1 B ARG A 23  ? 0.3260 0.2714 0.2323 0.1196  -0.0298 0.0726  70  ARG A NH1 
+159  N NH2 A ARG A 23  ? 0.4301 0.2157 0.2715 0.1374  -0.0055 0.0625  70  ARG A NH2 
+160  N NH2 B ARG A 23  ? 0.3017 0.1958 0.3657 0.1087  -0.0444 0.0088  70  ARG A NH2 
+161  N N   . MET A 24  ? 0.0844 0.0965 0.0920 -0.0042 -0.0093 -0.0156 71  MET A N   
+162  C CA  . MET A 24  ? 0.0815 0.0993 0.0913 -0.0046 -0.0083 -0.0193 71  MET A CA  
+163  C C   . MET A 24  ? 0.0802 0.1024 0.0841 -0.0046 -0.0112 -0.0142 71  MET A C   
+164  O O   . MET A 24  ? 0.0818 0.1002 0.1037 0.0007  -0.0120 -0.0162 71  MET A O   
+165  C CB  . MET A 24  ? 0.0853 0.1011 0.0995 -0.0069 -0.0110 -0.0152 71  MET A CB  
+166  C CG  . MET A 24  ? 0.0789 0.1074 0.1035 -0.0088 -0.0080 -0.0212 71  MET A CG  
+167  S SD  . MET A 24  ? 0.1208 0.1121 0.1116 -0.0149 -0.0262 -0.0085 71  MET A SD  
+168  C CE  . MET A 24  ? 0.0953 0.1356 0.1205 -0.0018 -0.0227 -0.0394 71  MET A CE  
+169  N N   . ALA A 25  ? 0.0857 0.1002 0.0987 -0.0080 -0.0133 -0.0162 72  ALA A N   
+170  C CA  . ALA A 25  ? 0.0801 0.0944 0.0950 -0.0039 -0.0117 -0.0157 72  ALA A CA  
+171  C C   . ALA A 25  ? 0.0779 0.1071 0.0935 -0.0108 -0.0127 -0.0163 72  ALA A C   
+172  O O   . ALA A 25  ? 0.0885 0.1213 0.0933 -0.0118 -0.0133 -0.0125 72  ALA A O   
+173  C CB  . ALA A 25  ? 0.0844 0.1138 0.1070 -0.0061 -0.0203 -0.0122 72  ALA A CB  
+174  N N   . PRO A 26  ? 0.0863 0.1051 0.0937 -0.0145 -0.0130 -0.0052 73  PRO A N   
+175  C CA  . PRO A 26  ? 0.0850 0.1028 0.1068 -0.0065 -0.0177 -0.0150 73  PRO A CA  
+176  C C   . PRO A 26  ? 0.0909 0.0832 0.1002 -0.0016 -0.0106 -0.0180 73  PRO A C   
+177  O O   . PRO A 26  ? 0.1043 0.1221 0.1019 -0.0143 -0.0102 -0.0141 73  PRO A O   
+178  C CB  . PRO A 26  ? 0.0940 0.0979 0.1360 -0.0020 -0.0003 -0.0076 73  PRO A CB  
+179  C CG  . PRO A 26  ? 0.0968 0.1123 0.1399 -0.0043 -0.0143 0.0003  73  PRO A CG  
+180  C CD  . PRO A 26  ? 0.0961 0.1197 0.1059 -0.0129 -0.0104 0.0039  73  PRO A CD  
+181  N N   . ARG A 27  ? 0.0830 0.1044 0.0912 0.0005  -0.0098 -0.0123 74  ARG A N   
+182  C CA  . ARG A 27  ? 0.0837 0.1059 0.1010 0.0038  -0.0022 -0.0101 74  ARG A CA  
+183  C C   . ARG A 27  ? 0.0747 0.1103 0.0943 0.0026  0.0009  -0.0117 74  ARG A C   
+184  O O   . ARG A 27  ? 0.0849 0.1062 0.1031 0.0003  -0.0081 -0.0168 74  ARG A O   
+185  C CB  . ARG A 27  ? 0.0870 0.1189 0.1307 0.0094  -0.0092 -0.0023 74  ARG A CB  
+186  C CG  . ARG A 27  ? 0.1443 0.1211 0.1442 0.0163  -0.0070 0.0123  74  ARG A CG  
+187  C CD  . ARG A 27  ? 0.2345 0.1578 0.2384 0.0483  -0.0741 0.0306  74  ARG A CD  
+188  N NE  . ARG A 27  ? 0.3202 0.2218 0.2875 0.0083  -0.1408 0.0235  74  ARG A NE  
+189  C CZ  . ARG A 27  ? 0.3715 0.2651 0.4443 0.1107  -0.2374 -0.0999 74  ARG A CZ  
+190  N NH1 . ARG A 27  ? 0.2996 0.3197 0.5688 -0.0482 -0.1080 0.0163  74  ARG A NH1 
+191  N NH2 . ARG A 27  ? 0.5921 0.2833 0.4402 0.0799  -0.3138 -0.0925 74  ARG A NH2 
+192  N N   . SER A 28  ? 0.0791 0.1010 0.0984 -0.0055 -0.0062 -0.0050 75  SER A N   
+193  C CA  . SER A 28  ? 0.0775 0.0971 0.0947 -0.0023 -0.0080 -0.0108 75  SER A CA  
+194  C C   . SER A 28  ? 0.0719 0.0966 0.0963 -0.0019 -0.0109 -0.0105 75  SER A C   
+195  O O   . SER A 28  ? 0.0803 0.1023 0.1206 -0.0025 -0.0036 -0.0094 75  SER A O   
+196  C CB  . SER A 28  ? 0.0781 0.1124 0.1286 -0.0069 -0.0132 -0.0028 75  SER A CB  
+197  O OG  . SER A 28  ? 0.1035 0.1285 0.1423 -0.0054 -0.0248 -0.0186 75  SER A OG  
+198  N N   . TRP A 29  ? 0.0822 0.0985 0.0955 -0.0063 -0.0020 -0.0173 76  TRP A N   
+199  C CA  . TRP A 29  ? 0.0806 0.1141 0.1040 -0.0032 -0.0055 -0.0033 76  TRP A CA  
+200  C C   . TRP A 29  ? 0.0739 0.1123 0.0994 -0.0033 -0.0036 -0.0036 76  TRP A C   
+201  O O   . TRP A 29  ? 0.0908 0.1133 0.1451 -0.0058 -0.0257 0.0165  76  TRP A O   
+202  C CB  . TRP A 29  ? 0.0931 0.1266 0.1060 -0.0002 0.0054  -0.0144 76  TRP A CB  
+203  C CG  . TRP A 29  ? 0.0946 0.1354 0.1149 0.0031  -0.0001 -0.0276 76  TRP A CG  
+204  C CD1 . TRP A 29  ? 0.0996 0.1372 0.1256 -0.0053 0.0038  -0.0302 76  TRP A CD1 
+205  C CD2 . TRP A 29  ? 0.0951 0.1394 0.1041 -0.0029 -0.0089 -0.0275 76  TRP A CD2 
+206  N NE1 . TRP A 29  ? 0.1041 0.1610 0.1281 -0.0143 -0.0090 -0.0372 76  TRP A NE1 
+207  C CE2 . TRP A 29  ? 0.0944 0.1596 0.1150 0.0087  -0.0063 -0.0331 76  TRP A CE2 
+208  C CE3 . TRP A 29  ? 0.0995 0.1546 0.0990 0.0029  -0.0031 -0.0134 76  TRP A CE3 
+209  C CZ2 . TRP A 29  ? 0.1003 0.1844 0.1197 -0.0064 -0.0203 -0.0211 76  TRP A CZ2 
+210  C CZ3 . TRP A 29  ? 0.1068 0.1509 0.1130 0.0056  -0.0104 -0.0165 76  TRP A CZ3 
+211  C CH2 . TRP A 29  ? 0.1146 0.1759 0.1146 0.0065  -0.0177 -0.0160 76  TRP A CH2 
+212  N N   . LEU A 30  ? 0.0745 0.1061 0.0945 0.0004  -0.0071 -0.0002 77  LEU A N   
+213  C CA  . LEU A 30  ? 0.0682 0.1087 0.0986 -0.0027 -0.0040 -0.0087 77  LEU A CA  
+214  C C   . LEU A 30  ? 0.0805 0.1047 0.0956 -0.0012 -0.0070 0.0016  77  LEU A C   
+215  O O   . LEU A 30  ? 0.0817 0.1496 0.1047 0.0096  0.0001  0.0186  77  LEU A O   
+216  C CB  . LEU A 30  ? 0.0791 0.1142 0.1026 0.0040  -0.0092 -0.0123 77  LEU A CB  
+217  C CG  . LEU A 30  ? 0.0885 0.1334 0.1079 0.0044  -0.0018 -0.0254 77  LEU A CG  
+218  C CD1 . LEU A 30  ? 0.1020 0.1664 0.1635 0.0110  -0.0080 -0.0669 77  LEU A CD1 
+219  C CD2 . LEU A 30  ? 0.1322 0.1821 0.0999 0.0029  0.0145  -0.0074 77  LEU A CD2 
+220  N N   . ALA A 31  ? 0.0713 0.0970 0.0968 -0.0006 0.0032  0.0031  78  ALA A N   
+221  C CA  . ALA A 31  ? 0.0772 0.1050 0.0854 0.0025  -0.0005 0.0035  78  ALA A CA  
+222  C C   . ALA A 31  ? 0.0730 0.1024 0.0882 -0.0014 0.0078  0.0046  78  ALA A C   
+223  O O   . ALA A 31  ? 0.0905 0.1066 0.0876 -0.0062 0.0029  0.0030  78  ALA A O   
+224  C CB  . ALA A 31  ? 0.0778 0.1079 0.1160 0.0029  0.0027  -0.0142 78  ALA A CB  
+225  N N   . VAL A 32  ? 0.0898 0.1102 0.0896 0.0010  0.0063  0.0021  79  VAL A N   
+226  C CA  . VAL A 32  ? 0.0847 0.1012 0.0921 -0.0028 0.0094  0.0014  79  VAL A CA  
+227  C C   . VAL A 32  ? 0.0928 0.1022 0.0927 -0.0007 0.0105  0.0018  79  VAL A C   
+228  O O   . VAL A 32  ? 0.0893 0.1300 0.0872 -0.0063 0.0056  0.0100  79  VAL A O   
+229  C CB  . VAL A 32  ? 0.0987 0.1102 0.1235 0.0056  0.0201  0.0038  79  VAL A CB  
+230  C CG1 . VAL A 32  ? 0.1248 0.1063 0.1747 -0.0014 0.0308  0.0021  79  VAL A CG1 
+231  C CG2 . VAL A 32  ? 0.1006 0.1193 0.1651 0.0145  0.0362  0.0042  79  VAL A CG2 
+232  N N   . THR A 33  ? 0.0894 0.1150 0.0844 -0.0126 0.0091  0.0043  80  THR A N   
+233  C CA  . THR A 33  ? 0.0924 0.1076 0.0941 -0.0139 0.0240  0.0029  80  THR A CA  
+234  C C   . THR A 33  ? 0.0951 0.1072 0.0987 -0.0086 0.0199  -0.0038 80  THR A C   
+235  O O   . THR A 33  ? 0.1249 0.1159 0.0968 -0.0216 0.0244  -0.0083 80  THR A O   
+236  C CB  . THR A 33  ? 0.1001 0.1016 0.1052 -0.0159 0.0132  -0.0091 80  THR A CB  
+237  O OG1 . THR A 33  ? 0.0939 0.1142 0.1055 -0.0068 0.0109  -0.0083 80  THR A OG1 
+238  C CG2 . THR A 33  ? 0.0988 0.1266 0.1377 -0.0137 0.0116  -0.0037 80  THR A CG2 
+239  N N   . VAL A 34  ? 0.1093 0.1146 0.0935 -0.0176 0.0136  -0.0003 81  VAL A N   
+240  C CA  . VAL A 34  ? 0.1157 0.0968 0.1184 -0.0143 0.0243  -0.0045 81  VAL A CA  
+241  C C   . VAL A 34  ? 0.1237 0.1070 0.1093 -0.0242 0.0245  -0.0109 81  VAL A C   
+242  O O   . VAL A 34  ? 0.1317 0.1310 0.1017 -0.0327 0.0280  -0.0110 81  VAL A O   
+243  C CB  A VAL A 34  ? 0.1507 0.1024 0.1299 -0.0017 0.0288  -0.0002 81  VAL A CB  
+244  C CB  B VAL A 34  ? 0.1221 0.1123 0.1587 -0.0212 0.0113  0.0131  81  VAL A CB  
+245  C CG1 A VAL A 34  ? 0.1903 0.1052 0.1304 -0.0067 0.0195  0.0086  81  VAL A CG1 
+246  C CG1 B VAL A 34  ? 0.2056 0.0929 0.3277 -0.0037 -0.0909 -0.0030 81  VAL A CG1 
+247  C CG2 A VAL A 34  ? 0.2372 0.1022 0.1912 -0.0044 -0.0245 -0.0160 81  VAL A CG2 
+248  C CG2 B VAL A 34  ? 0.1348 0.1549 0.1071 0.0161  0.0330  0.0426  81  VAL A CG2 
+249  N N   . ASP A 35  ? 0.1187 0.1286 0.1093 -0.0310 0.0246  -0.0164 82  ASP A N   
+250  C CA  . ASP A 35  ? 0.1260 0.1325 0.1326 -0.0457 0.0312  -0.0199 82  ASP A CA  
+251  C C   . ASP A 35  ? 0.1358 0.1272 0.1359 -0.0399 0.0433  -0.0280 82  ASP A C   
+252  O O   . ASP A 35  ? 0.1786 0.1383 0.1779 -0.0550 0.0816  -0.0504 82  ASP A O   
+253  C CB  . ASP A 35  ? 0.1413 0.1775 0.1404 -0.0261 0.0098  -0.0181 82  ASP A CB  
+254  C CG  . ASP A 35  ? 0.1438 0.2548 0.1877 -0.0553 0.0099  -0.0331 82  ASP A CG  
+255  O OD1 . ASP A 35  ? 0.1264 0.2026 0.2056 -0.0288 0.0164  0.0180  82  ASP A OD1 
+256  O OD2 . ASP A 35  ? 0.1864 0.4629 0.2355 -0.1036 -0.0197 -0.0527 82  ASP A OD2 
+257  N N   . THR A 36  ? 0.1306 0.1177 0.1470 -0.0311 0.0410  -0.0094 83  THR A N   
+258  C CA  . THR A 36  ? 0.1465 0.1216 0.1578 -0.0235 0.0361  -0.0053 83  THR A CA  
+259  C C   . THR A 36  ? 0.1510 0.1247 0.1927 -0.0454 0.0529  -0.0205 83  THR A C   
+260  O O   . THR A 36  ? 0.2514 0.1307 0.2194 -0.0505 0.0325  -0.0085 83  THR A O   
+261  C CB  . THR A 36  ? 0.1532 0.1278 0.1665 -0.0174 0.0411  0.0116  83  THR A CB  
+262  O OG1 . THR A 36  ? 0.1647 0.1334 0.1613 -0.0284 0.0614  0.0014  83  THR A OG1 
+263  C CG2 . THR A 36  ? 0.1742 0.1918 0.1508 -0.0261 0.0166  0.0091  83  THR A CG2 
+264  N N   . ALA A 37  ? 0.1418 0.1617 0.1737 -0.0485 0.0366  -0.0303 84  ALA A N   
+265  C CA  . ALA A 37  ? 0.1612 0.1976 0.1751 -0.0584 0.0325  -0.0272 84  ALA A CA  
+266  C C   . ALA A 37  ? 0.2015 0.2019 0.1841 -0.1004 0.0512  -0.0401 84  ALA A C   
+267  O O   . ALA A 37  ? 0.3608 0.2690 0.2425 -0.2054 0.1209  -0.0894 84  ALA A O   
+268  C CB  . ALA A 37  ? 0.1563 0.2134 0.2200 -0.0593 0.0158  0.0053  84  ALA A CB  
+269  N N   . SER A 38  ? 0.2409 0.2420 0.1972 -0.1631 0.0767  -0.0834 85  SER A N   
+270  C CA  . SER A 38  ? 0.2797 0.2704 0.1964 -0.1753 0.0881  -0.0981 85  SER A CA  
+271  C C   . SER A 38  ? 0.3040 0.2033 0.1897 -0.1498 0.0934  -0.0834 85  SER A C   
+272  O O   . SER A 38  ? 0.3608 0.2354 0.2037 -0.1531 0.1157  -0.1004 85  SER A O   
+273  C CB  . SER A 38  ? 0.2448 0.3314 0.2019 -0.1679 0.0278  -0.0832 85  SER A CB  
+274  O OG  . SER A 38  ? 0.2237 0.2961 0.2004 -0.1276 0.0250  -0.0506 85  SER A OG  
+275  N N   . SER A 39  ? 0.2880 0.1550 0.1691 -0.1029 0.0775  -0.0443 86  SER A N   
+276  C CA  . SER A 39  ? 0.2909 0.1248 0.1777 -0.0683 0.0813  -0.0301 86  SER A CA  
+277  C C   . SER A 39  ? 0.2557 0.1129 0.1397 -0.0480 0.0640  -0.0346 86  SER A C   
+278  O O   . SER A 39  ? 0.2523 0.1419 0.1698 -0.0213 0.0734  -0.0071 86  SER A O   
+279  C CB  . SER A 39  ? 0.4012 0.1207 0.3073 -0.0510 0.1660  0.0039  86  SER A CB  
+280  O OG  . SER A 39  ? 0.6439 0.1891 0.3517 -0.0018 0.2107  0.0690  86  SER A OG  
+281  N N   . ALA A 40  ? 0.2089 0.1368 0.1404 -0.0668 0.0465  -0.0265 87  ALA A N   
+282  C CA  . ALA A 40  ? 0.1855 0.1281 0.1341 -0.0697 0.0380  -0.0238 87  ALA A CA  
+283  C C   . ALA A 40  ? 0.1439 0.1050 0.1180 -0.0197 0.0357  -0.0170 87  ALA A C   
+284  O O   . ALA A 40  ? 0.1510 0.1389 0.1188 -0.0474 0.0411  -0.0276 87  ALA A O   
+285  C CB  . ALA A 40  ? 0.2041 0.1953 0.1890 -0.1016 -0.0243 0.0242  87  ALA A CB  
+286  N N   . ILE A 41  ? 0.1560 0.1308 0.1113 -0.0440 0.0316  -0.0175 88  ILE A N   
+287  C CA  . ILE A 41  ? 0.1428 0.1513 0.1111 -0.0426 0.0203  0.0015  88  ILE A CA  
+288  C C   . ILE A 41  ? 0.1557 0.1436 0.0990 -0.0593 0.0246  -0.0118 88  ILE A C   
+289  O O   . ILE A 41  ? 0.2413 0.1585 0.1014 -0.0882 0.0146  -0.0044 88  ILE A O   
+290  C CB  A ILE A 41  ? 0.1458 0.2454 0.1596 -0.0122 0.0134  0.0393  88  ILE A CB  
+291  C CB  B ILE A 41  ? 0.1385 0.2750 0.1631 -0.0351 0.0144  0.1036  88  ILE A CB  
+292  C CG1 A ILE A 41  ? 0.2016 0.2553 0.2034 0.0258  0.0167  0.0554  88  ILE A CG1 
+293  C CG1 B ILE A 41  ? 0.1191 0.2836 0.1801 0.0331  0.0210  0.0978  88  ILE A CG1 
+294  C CG2 A ILE A 41  ? 0.1412 0.2400 0.1872 -0.0036 0.0284  -0.0457 88  ILE A CG2 
+295  C CG2 B ILE A 41  ? 0.2575 0.2432 0.1898 0.0711  0.1058  0.0692  88  ILE A CG2 
+296  C CD1 A ILE A 41  ? 0.2673 0.3078 0.2156 0.0807  0.0292  0.0606  88  ILE A CD1 
+297  C CD1 B ILE A 41  ? 0.1246 0.2434 0.2581 -0.0004 0.0335  -0.0205 88  ILE A CD1 
+298  N N   . VAL A 42  ? 0.1066 0.1427 0.0965 -0.0287 0.0176  -0.0060 89  VAL A N   
+299  C CA  . VAL A 42  ? 0.1034 0.1323 0.0939 -0.0310 0.0164  -0.0165 89  VAL A CA  
+300  C C   . VAL A 42  ? 0.0941 0.1130 0.0870 -0.0094 0.0126  -0.0051 89  VAL A C   
+301  O O   . VAL A 42  ? 0.1066 0.1349 0.0902 -0.0233 0.0142  -0.0001 89  VAL A O   
+302  C CB  . VAL A 42  ? 0.0916 0.1571 0.1130 -0.0094 0.0187  -0.0085 89  VAL A CB  
+303  C CG1 . VAL A 42  ? 0.1017 0.1611 0.1410 -0.0013 0.0191  0.0078  89  VAL A CG1 
+304  C CG2 . VAL A 42  ? 0.1039 0.2017 0.1404 -0.0256 0.0072  -0.0202 89  VAL A CG2 
+305  N N   . VAL A 43  ? 0.0875 0.1203 0.0844 -0.0075 0.0071  -0.0024 90  VAL A N   
+306  C CA  . VAL A 43  ? 0.0847 0.1119 0.0873 -0.0099 0.0012  -0.0039 90  VAL A CA  
+307  C C   . VAL A 43  ? 0.0772 0.1167 0.0955 -0.0043 0.0035  0.0051  90  VAL A C   
+308  O O   . VAL A 43  ? 0.0947 0.1225 0.0991 -0.0151 -0.0039 0.0065  90  VAL A O   
+309  C CB  . VAL A 43  ? 0.0939 0.1132 0.1111 -0.0019 0.0047  0.0049  90  VAL A CB  
+310  C CG1 . VAL A 43  ? 0.1186 0.1623 0.1184 0.0202  0.0087  -0.0138 90  VAL A CG1 
+311  C CG2 . VAL A 43  ? 0.0845 0.1593 0.1208 -0.0018 0.0057  0.0077  90  VAL A CG2 
+312  N N   . THR A 44  ? 0.0914 0.1123 0.0892 -0.0097 0.0076  0.0055  91  THR A N   
+313  C CA  . THR A 44  ? 0.0810 0.1074 0.0976 -0.0067 0.0010  0.0073  91  THR A CA  
+314  C C   . THR A 44  ? 0.0883 0.1040 0.0884 -0.0017 0.0049  0.0021  91  THR A C   
+315  O O   . THR A 44  ? 0.0895 0.1371 0.1045 -0.0039 -0.0049 0.0127  91  THR A O   
+316  C CB  . THR A 44  ? 0.0873 0.1152 0.1024 -0.0005 0.0040  0.0153  91  THR A CB  
+317  O OG1 . THR A 44  ? 0.0804 0.1302 0.1080 -0.0102 0.0136  0.0068  91  THR A OG1 
+318  C CG2 . THR A 44  ? 0.0877 0.1507 0.1143 0.0089  -0.0012 0.0097  91  THR A CG2 
+319  N N   . GLN A 45  ? 0.0798 0.1143 0.0978 -0.0089 0.0008  -0.0057 92  GLN A N   
+320  C CA  A GLN A 45  ? 0.0781 0.1294 0.1136 -0.0110 0.0104  -0.0352 92  GLN A CA  
+321  C CA  B GLN A 45  ? 0.0889 0.1250 0.0754 -0.0187 -0.0016 0.0009  92  GLN A CA  
+322  C C   . GLN A 45  ? 0.0791 0.1187 0.0998 -0.0136 0.0052  0.0006  92  GLN A C   
+323  O O   . GLN A 45  ? 0.1099 0.1184 0.1413 -0.0189 -0.0139 0.0166  92  GLN A O   
+324  C CB  A GLN A 45  ? 0.0803 0.1369 0.0940 0.0048  -0.0018 -0.0076 92  GLN A CB  
+325  C CB  B GLN A 45  ? 0.0907 0.1193 0.1004 0.0043  0.0237  0.0062  92  GLN A CB  
+326  C CG  A GLN A 45  ? 0.1005 0.1134 0.1157 0.0084  0.0134  0.0018  92  GLN A CG  
+327  C CG  B GLN A 45  ? 0.1018 0.1190 0.0960 -0.0002 -0.0053 -0.0182 92  GLN A CG  
+328  C CD  A GLN A 45  ? 0.0831 0.1630 0.0911 -0.0009 -0.0022 -0.0048 92  GLN A CD  
+329  C CD  B GLN A 45  ? 0.0667 0.2047 0.0806 0.0073  -0.0109 -0.0360 92  GLN A CD  
+330  O OE1 A GLN A 45  ? 0.0836 0.2096 0.1036 -0.0132 -0.0128 -0.0378 92  GLN A OE1 
+331  O OE1 B GLN A 45  ? 0.0898 0.3720 0.0764 0.0137  -0.0087 0.0012  92  GLN A OE1 
+332  N NE2 A GLN A 45  ? 0.0788 0.1135 0.0797 -0.0147 -0.0027 -0.0104 92  GLN A NE2 
+333  N NE2 B GLN A 45  ? 0.0675 0.1052 0.2048 0.0074  -0.0457 0.0108  92  GLN A NE2 
+334  N N   . HIS A 46  ? 0.0817 0.1011 0.1109 -0.0141 0.0064  -0.0103 93  HIS A N   
+335  C CA  . HIS A 46  ? 0.0954 0.0992 0.1166 -0.0035 0.0002  -0.0101 93  HIS A CA  
+336  C C   . HIS A 46  ? 0.0971 0.1131 0.1207 -0.0216 0.0065  -0.0220 93  HIS A C   
+337  O O   . HIS A 46  ? 0.0854 0.1240 0.1314 -0.0081 0.0030  -0.0274 93  HIS A O   
+338  C CB  . HIS A 46  ? 0.0927 0.1023 0.1262 -0.0035 0.0053  -0.0091 93  HIS A CB  
+339  C CG  . HIS A 46  ? 0.0906 0.1088 0.1026 0.0026  0.0030  -0.0087 93  HIS A CG  
+340  N ND1 . HIS A 46  ? 0.1029 0.1067 0.1327 0.0041  -0.0024 -0.0021 93  HIS A ND1 
+341  C CD2 . HIS A 46  ? 0.0815 0.1146 0.1079 -0.0070 0.0102  0.0029  93  HIS A CD2 
+342  C CE1 . HIS A 46  ? 0.0899 0.1326 0.1328 0.0057  0.0035  -0.0047 93  HIS A CE1 
+343  N NE2 . HIS A 46  ? 0.0861 0.1283 0.1163 -0.0037 0.0065  -0.0076 93  HIS A NE2 
+344  N N   . GLY A 47  ? 0.1184 0.1129 0.1474 -0.0249 0.0164  -0.0255 94  GLY A N   
+345  C CA  . GLY A 47  ? 0.1084 0.1483 0.1703 -0.0400 0.0270  -0.0590 94  GLY A CA  
+346  C C   . GLY A 47  ? 0.1006 0.1467 0.1767 -0.0248 0.0150  -0.0525 94  GLY A C   
+347  O O   . GLY A 47  ? 0.1063 0.2479 0.2127 0.0024  -0.0081 -0.1080 94  GLY A O   
+348  N N   . ARG A 48  ? 0.1011 0.1571 0.1441 -0.0057 0.0009  -0.0459 95  ARG A N   
+349  C CA  . ARG A 48  ? 0.0970 0.1821 0.1584 0.0047  -0.0067 -0.0625 95  ARG A CA  
+350  C C   . ARG A 48  ? 0.0911 0.1807 0.1322 0.0098  -0.0196 -0.0382 95  ARG A C   
+351  O O   . ARG A 48  ? 0.0899 0.2398 0.1435 0.0180  -0.0146 -0.0105 95  ARG A O   
+352  C CB  . ARG A 48  ? 0.1286 0.2034 0.1873 -0.0199 0.0058  -0.1017 95  ARG A CB  
+353  C CG  . ARG A 48  ? 0.1728 0.2308 0.2379 -0.0473 0.0125  -0.0779 95  ARG A CG  
+354  C CD  . ARG A 48  ? 0.1635 0.2939 0.2260 -0.0322 0.0129  -0.1117 95  ARG A CD  
+355  N NE  . ARG A 48  ? 0.1831 0.2538 0.2344 -0.0141 -0.0019 -0.1098 95  ARG A NE  
+356  C CZ  . ARG A 48  ? 0.1631 0.2544 0.2227 -0.0329 0.0097  -0.0960 95  ARG A CZ  
+357  N NH1 . ARG A 48  ? 0.2469 0.2520 0.2656 -0.0362 0.0103  -0.0871 95  ARG A NH1 
+358  N NH2 . ARG A 48  ? 0.1389 0.2252 0.2583 0.0430  -0.0705 -0.1147 95  ARG A NH2 
+359  N N   . VAL A 49  ? 0.1057 0.1717 0.1422 0.0103  -0.0366 -0.0387 96  VAL A N   
+360  C CA  . VAL A 49  ? 0.1375 0.1812 0.1375 0.0025  -0.0285 -0.0155 96  VAL A CA  
+361  C C   . VAL A 49  ? 0.1134 0.2161 0.1286 0.0012  -0.0348 -0.0169 96  VAL A C   
+362  O O   . VAL A 49  ? 0.1400 0.2767 0.1610 0.0191  -0.0480 -0.0605 96  VAL A O   
+363  C CB  . VAL A 49  ? 0.1640 0.2318 0.2238 0.0154  -0.0689 0.0410  96  VAL A CB  
+364  C CG1 . VAL A 49  ? 0.1800 0.1982 0.1690 0.0222  -0.0425 -0.0058 96  VAL A CG1 
+365  C CG2 . VAL A 49  ? 0.3079 0.3608 0.3335 -0.1621 -0.1597 0.1698  96  VAL A CG2 
+366  N N   . THR A 50  ? 0.0975 0.2019 0.1266 -0.0165 -0.0131 -0.0257 97  THR A N   
+367  C CA  . THR A 50  ? 0.0937 0.2126 0.1343 -0.0120 -0.0054 -0.0300 97  THR A CA  
+368  C C   . THR A 50  ? 0.1002 0.1958 0.1050 -0.0129 -0.0082 -0.0264 97  THR A C   
+369  O O   . THR A 50  ? 0.0980 0.1727 0.1157 -0.0074 -0.0024 -0.0111 97  THR A O   
+370  C CB  . THR A 50  ? 0.1105 0.1983 0.1488 -0.0264 -0.0040 -0.0507 97  THR A CB  
+371  O OG1 . THR A 50  ? 0.1200 0.1782 0.1710 -0.0301 -0.0252 -0.0138 97  THR A OG1 
+372  C CG2 . THR A 50  ? 0.1095 0.1953 0.2084 -0.0267 -0.0024 -0.0534 97  THR A CG2 
+373  N N   . SER A 51  ? 0.1015 0.2112 0.1190 -0.0153 -0.0062 -0.0302 98  SER A N   
+374  C CA  . SER A 51  ? 0.1071 0.1819 0.1092 -0.0063 0.0023  -0.0259 98  SER A CA  
+375  C C   . SER A 51  ? 0.0946 0.1555 0.1140 0.0052  0.0040  -0.0232 98  SER A C   
+376  O O   . SER A 51  ? 0.1006 0.1576 0.1076 -0.0145 0.0048  -0.0254 98  SER A O   
+377  C CB  . SER A 51  ? 0.1287 0.2181 0.1118 0.0082  -0.0063 -0.0416 98  SER A CB  
+378  O OG  . SER A 51  ? 0.1325 0.2351 0.1201 -0.0109 0.0129  -0.0243 98  SER A OG  
+379  N N   . VAL A 52  ? 0.1084 0.1543 0.1123 -0.0173 -0.0078 -0.0345 99  VAL A N   
+380  C CA  . VAL A 52  ? 0.1247 0.1335 0.1246 -0.0099 -0.0069 -0.0247 99  VAL A CA  
+381  C C   . VAL A 52  ? 0.1016 0.1207 0.1122 -0.0186 -0.0007 -0.0108 99  VAL A C   
+382  O O   . VAL A 52  ? 0.0987 0.1304 0.1194 -0.0165 -0.0050 -0.0142 99  VAL A O   
+383  C CB  A VAL A 52  ? 0.1442 0.1182 0.1572 0.0029  -0.0310 -0.0264 99  VAL A CB  
+384  C CB  B VAL A 52  ? 0.1554 0.1251 0.2161 0.0023  0.0147  -0.0123 99  VAL A CB  
+385  C CG1 A VAL A 52  ? 0.2284 0.1354 0.1605 -0.0364 -0.0558 -0.0027 99  VAL A CG1 
+386  C CG1 B VAL A 52  ? 0.2528 0.1686 0.3108 -0.0118 0.0632  -0.1058 99  VAL A CG1 
+387  C CG2 A VAL A 52  ? 0.2934 0.1536 0.2087 0.0371  -0.0492 -0.0743 99  VAL A CG2 
+388  C CG2 B VAL A 52  ? 0.1569 0.0701 0.1333 -0.0034 -0.0391 0.0022  99  VAL A CG2 
+389  N N   . ALA A 53  ? 0.0896 0.1348 0.1226 -0.0218 0.0012  -0.0202 100 ALA A N   
+390  C CA  . ALA A 53  ? 0.0898 0.1404 0.1039 -0.0175 0.0041  -0.0154 100 ALA A CA  
+391  C C   . ALA A 53  ? 0.0762 0.1180 0.1031 -0.0036 0.0003  -0.0114 100 ALA A C   
+392  O O   . ALA A 53  ? 0.0853 0.1226 0.0988 -0.0090 0.0042  -0.0130 100 ALA A O   
+393  C CB  . ALA A 53  ? 0.0829 0.1660 0.1469 -0.0209 0.0069  -0.0302 100 ALA A CB  
+394  N N   . ALA A 54  ? 0.0848 0.1178 0.1012 -0.0028 -0.0028 -0.0159 101 ALA A N   
+395  C CA  . ALA A 54  ? 0.0884 0.1140 0.1121 0.0003  -0.0030 0.0009  101 ALA A CA  
+396  C C   . ALA A 54  ? 0.0862 0.1084 0.0895 0.0023  0.0063  -0.0062 101 ALA A C   
+397  O O   . ALA A 54  ? 0.0871 0.1036 0.0907 -0.0044 0.0004  -0.0031 101 ALA A O   
+398  C CB  . ALA A 54  ? 0.1043 0.1509 0.1096 -0.0008 -0.0052 0.0136  101 ALA A CB  
+399  N N   . GLN A 55  ? 0.0788 0.1132 0.0947 -0.0067 0.0016  -0.0043 102 GLN A N   
+400  C CA  . GLN A 55  ? 0.0820 0.1063 0.0964 0.0008  0.0024  0.0006  102 GLN A CA  
+401  C C   . GLN A 55  ? 0.0834 0.0826 0.0976 -0.0005 0.0045  -0.0029 102 GLN A C   
+402  O O   . GLN A 55  ? 0.0867 0.1020 0.0978 -0.0074 0.0056  -0.0086 102 GLN A O   
+403  C CB  . GLN A 55  ? 0.0831 0.1223 0.0955 0.0004  0.0003  -0.0089 102 GLN A CB  
+404  C CG  . GLN A 55  ? 0.0883 0.1395 0.0920 0.0062  0.0086  -0.0108 102 GLN A CG  
+405  C CD  . GLN A 55  ? 0.1131 0.1641 0.0951 -0.0116 0.0124  -0.0210 102 GLN A CD  
+406  O OE1 . GLN A 55  ? 0.1511 0.1522 0.1043 -0.0254 0.0065  -0.0237 102 GLN A OE1 
+407  N NE2 . GLN A 55  ? 0.1307 0.2037 0.1024 0.0170  -0.0051 -0.0412 102 GLN A NE2 
+408  N N   . HIS A 56  ? 0.0879 0.1067 0.0890 -0.0112 0.0008  0.0002  103 HIS A N   
+409  C CA  . HIS A 56  ? 0.0890 0.1024 0.0943 -0.0132 0.0004  0.0018  103 HIS A CA  
+410  C C   . HIS A 56  ? 0.0769 0.1045 0.0894 -0.0112 0.0137  -0.0009 103 HIS A C   
+411  O O   . HIS A 56  ? 0.0916 0.1109 0.0927 -0.0111 0.0042  0.0001  103 HIS A O   
+412  C CB  . HIS A 56  ? 0.1087 0.1182 0.1073 -0.0265 0.0169  -0.0094 103 HIS A CB  
+413  C CG  . HIS A 56  ? 0.1230 0.1294 0.1177 -0.0314 0.0140  0.0050  103 HIS A CG  
+414  N ND1 . HIS A 56  ? 0.1573 0.1105 0.1355 -0.0192 0.0075  0.0032  103 HIS A ND1 
+415  C CD2 . HIS A 56  ? 0.1572 0.1505 0.1904 -0.0667 0.0145  -0.0098 103 HIS A CD2 
+416  C CE1 . HIS A 56  ? 0.1937 0.1191 0.1574 -0.0335 -0.0261 0.0022  103 HIS A CE1 
+417  N NE2 . HIS A 56  ? 0.1916 0.1448 0.2140 -0.0619 -0.0085 -0.0047 103 HIS A NE2 
+418  N N   . HIS A 57  ? 0.0769 0.1041 0.0914 -0.0147 0.0029  -0.0091 104 HIS A N   
+419  C CA  . HIS A 57  ? 0.0833 0.0954 0.0861 -0.0131 0.0076  -0.0008 104 HIS A CA  
+420  C C   . HIS A 57  ? 0.0746 0.0932 0.0790 -0.0016 0.0072  0.0028  104 HIS A C   
+421  O O   . HIS A 57  ? 0.0779 0.1066 0.0869 -0.0032 0.0044  -0.0072 104 HIS A O   
+422  C CB  . HIS A 57  ? 0.0673 0.1088 0.1003 -0.0086 0.0059  -0.0119 104 HIS A CB  
+423  C CG  . HIS A 57  ? 0.0762 0.0988 0.0920 -0.0029 -0.0013 -0.0056 104 HIS A CG  
+424  N ND1 . HIS A 57  ? 0.0799 0.1062 0.0901 -0.0015 0.0016  -0.0053 104 HIS A ND1 
+425  C CD2 . HIS A 57  ? 0.0813 0.1046 0.0963 -0.0054 0.0047  0.0005  104 HIS A CD2 
+426  C CE1 . HIS A 57  ? 0.0914 0.0928 0.1059 -0.0070 0.0046  -0.0041 104 HIS A CE1 
+427  N NE2 . HIS A 57  ? 0.0849 0.1070 0.1039 -0.0061 0.0097  -0.0030 104 HIS A NE2 
+428  N N   . TRP A 58  ? 0.0707 0.0986 0.0897 -0.0058 0.0043  -0.0002 105 TRP A N   
+429  C CA  . TRP A 58  ? 0.0692 0.0974 0.0837 0.0022  0.0065  0.0003  105 TRP A CA  
+430  C C   . TRP A 58  ? 0.0736 0.0927 0.0765 0.0023  0.0105  0.0001  105 TRP A C   
+431  O O   . TRP A 58  ? 0.0762 0.1017 0.0830 -0.0071 0.0028  0.0041  105 TRP A O   
+432  C CB  . TRP A 58  ? 0.0842 0.0993 0.0800 0.0009  0.0096  0.0026  105 TRP A CB  
+433  C CG  . TRP A 58  ? 0.0811 0.0958 0.0796 -0.0009 0.0085  0.0015  105 TRP A CG  
+434  C CD1 . TRP A 58  ? 0.0888 0.0965 0.0789 0.0016  0.0079  0.0037  105 TRP A CD1 
+435  C CD2 . TRP A 58  ? 0.0827 0.0993 0.0815 -0.0010 0.0045  0.0008  105 TRP A CD2 
+436  N NE1 . TRP A 58  ? 0.0955 0.0943 0.0934 0.0005  0.0076  0.0122  105 TRP A NE1 
+437  C CE2 . TRP A 58  ? 0.0927 0.1072 0.0858 -0.0035 0.0058  0.0075  105 TRP A CE2 
+438  C CE3 . TRP A 58  ? 0.1027 0.1064 0.0982 -0.0041 -0.0066 -0.0068 105 TRP A CE3 
+439  C CZ2 . TRP A 58  ? 0.1206 0.1328 0.0847 0.0066  0.0022  0.0138  105 TRP A CZ2 
+440  C CZ3 . TRP A 58  ? 0.1505 0.1444 0.0980 0.0075  -0.0097 -0.0225 105 TRP A CZ3 
+441  C CH2 . TRP A 58  ? 0.1481 0.1571 0.0914 0.0063  -0.0126 -0.0013 105 TRP A CH2 
+442  N N   . ALA A 59  ? 0.0772 0.0954 0.0811 -0.0056 0.0015  0.0003  106 ALA A N   
+443  C CA  . ALA A 59  ? 0.0910 0.0948 0.0880 -0.0011 0.0004  0.0043  106 ALA A CA  
+444  C C   . ALA A 59  ? 0.0892 0.1018 0.0827 -0.0164 -0.0015 0.0133  106 ALA A C   
+445  O O   . ALA A 59  ? 0.1017 0.1000 0.0895 -0.0056 -0.0034 0.0066  106 ALA A O   
+446  C CB  . ALA A 59  ? 0.1190 0.0946 0.1087 -0.0073 -0.0031 0.0068  106 ALA A CB  
+447  N N   . THR A 60  ? 0.0987 0.1051 0.0790 -0.0145 0.0091  0.0000  107 THR A N   
+448  C CA  . THR A 60  ? 0.1094 0.1277 0.0866 -0.0213 0.0146  -0.0004 107 THR A CA  
+449  C C   . THR A 60  ? 0.0861 0.1070 0.0757 0.0050  0.0127  -0.0011 107 THR A C   
+450  O O   . THR A 60  ? 0.0981 0.1196 0.0826 -0.0010 0.0071  -0.0063 107 THR A O   
+451  C CB  . THR A 60  ? 0.1374 0.1734 0.1268 -0.0412 0.0683  -0.0122 107 THR A CB  
+452  O OG1 . THR A 60  ? 0.2963 0.2166 0.3247 -0.1228 0.2086  -0.0350 107 THR A OG1 
+453  C CG2 . THR A 60  ? 0.1480 0.2497 0.1271 -0.0201 0.0524  -0.0451 107 THR A CG2 
+454  N N   . ALA A 61  ? 0.0750 0.1105 0.0834 -0.0040 0.0073  -0.0025 108 ALA A N   
+455  C CA  . ALA A 61  ? 0.0837 0.0976 0.0957 0.0018  0.0088  -0.0018 108 ALA A CA  
+456  C C   . ALA A 61  ? 0.0855 0.0951 0.0802 -0.0082 0.0037  -0.0033 108 ALA A C   
+457  O O   . ALA A 61  ? 0.0948 0.0992 0.0995 -0.0073 0.0021  -0.0019 108 ALA A O   
+458  C CB  . ALA A 61  ? 0.0972 0.1194 0.1037 -0.0060 -0.0052 0.0012  108 ALA A CB  
+459  N N   . ILE A 62  ? 0.0797 0.0964 0.0801 -0.0101 0.0111  0.0045  109 ILE A N   
+460  C CA  . ILE A 62  ? 0.0827 0.0884 0.0810 -0.0046 0.0005  0.0084  109 ILE A CA  
+461  C C   . ILE A 62  ? 0.0839 0.1086 0.0911 -0.0039 -0.0019 -0.0003 109 ILE A C   
+462  O O   . ILE A 62  ? 0.0923 0.1306 0.0986 -0.0167 -0.0066 -0.0072 109 ILE A O   
+463  C CB  . ILE A 62  ? 0.0872 0.0878 0.0822 -0.0041 0.0055  0.0062  109 ILE A CB  
+464  C CG1 . ILE A 62  ? 0.0859 0.0999 0.0820 -0.0056 0.0172  0.0153  109 ILE A CG1 
+465  C CG2 . ILE A 62  ? 0.0915 0.1062 0.0910 -0.0007 0.0058  0.0034  109 ILE A CG2 
+466  C CD1 . ILE A 62  ? 0.1082 0.1110 0.0945 0.0026  0.0147  0.0032  109 ILE A CD1 
+467  N N   . ALA A 63  ? 0.0991 0.1143 0.0809 -0.0009 -0.0029 0.0081  110 ALA A N   
+468  C CA  . ALA A 63  ? 0.1185 0.1286 0.0812 0.0096  -0.0028 0.0002  110 ALA A CA  
+469  C C   . ALA A 63  ? 0.1313 0.1344 0.0913 -0.0017 -0.0086 -0.0028 110 ALA A C   
+470  O O   . ALA A 63  ? 0.1802 0.1529 0.1273 -0.0059 -0.0564 -0.0027 110 ALA A O   
+471  C CB  . ALA A 63  ? 0.1332 0.1184 0.0802 0.0087  0.0045  0.0099  110 ALA A CB  
+472  N N   . VAL A 64  ? 0.1254 0.1174 0.0943 -0.0069 -0.0008 -0.0152 111 VAL A N   
+473  C CA  . VAL A 64  ? 0.1560 0.1339 0.0926 0.0047  0.0027  -0.0179 111 VAL A CA  
+474  C C   . VAL A 64  ? 0.1644 0.1270 0.1227 -0.0160 -0.0269 -0.0194 111 VAL A C   
+475  O O   . VAL A 64  ? 0.2799 0.1754 0.1614 -0.0642 -0.0737 -0.0247 111 VAL A O   
+476  C CB  . VAL A 64  ? 0.1646 0.1356 0.0922 0.0105  0.0100  -0.0240 111 VAL A CB  
+477  C CG1 . VAL A 64  ? 0.2365 0.1485 0.1050 0.0440  -0.0104 -0.0286 111 VAL A CG1 
+478  C CG2 . VAL A 64  ? 0.1603 0.1858 0.1131 0.0021  0.0379  -0.0377 111 VAL A CG2 
+479  N N   . LEU A 65  ? 0.1397 0.1232 0.1260 -0.0341 -0.0085 -0.0093 112 LEU A N   
+480  C CA  . LEU A 65  ? 0.1498 0.1161 0.1722 -0.0406 0.0039  -0.0067 112 LEU A CA  
+481  C C   . LEU A 65  ? 0.1316 0.1560 0.2131 -0.0394 0.0005  0.0043  112 LEU A C   
+482  O O   . LEU A 65  ? 0.1549 0.1725 0.3588 -0.0630 0.0409  0.0102  112 LEU A O   
+483  C CB  . LEU A 65  ? 0.1372 0.1294 0.1557 -0.0299 0.0234  0.0087  112 LEU A CB  
+484  C CG  . LEU A 65  ? 0.1652 0.1263 0.1534 -0.0083 0.0246  0.0056  112 LEU A CG  
+485  C CD1 . LEU A 65  ? 0.1546 0.2014 0.1528 0.0131  0.0354  0.0420  112 LEU A CD1 
+486  C CD2 . LEU A 65  ? 0.2561 0.1477 0.2108 -0.0021 0.0467  -0.0265 112 LEU A CD2 
+487  N N   . GLY A 66  ? 0.1122 0.1621 0.1553 -0.0194 -0.0139 0.0163  113 GLY A N   
+488  C CA  . GLY A 66  ? 0.1139 0.1654 0.1559 -0.0241 -0.0110 0.0252  113 GLY A CA  
+489  C C   . GLY A 66  ? 0.0949 0.1518 0.1402 -0.0196 -0.0148 0.0457  113 GLY A C   
+490  O O   . GLY A 66  ? 0.0994 0.2194 0.1252 -0.0141 0.0012  0.0412  113 GLY A O   
+491  N N   . ARG A 67  ? 0.1012 0.1427 0.1475 -0.0157 -0.0228 0.0341  114 ARG A N   
+492  C CA  . ARG A 67  ? 0.1086 0.1319 0.1583 -0.0107 -0.0193 0.0349  114 ARG A CA  
+493  C C   . ARG A 67  ? 0.1123 0.1405 0.1456 -0.0273 -0.0109 0.0361  114 ARG A C   
+494  O O   . ARG A 67  ? 0.1204 0.1681 0.2116 -0.0411 -0.0243 0.0567  114 ARG A O   
+495  C CB  . ARG A 67  ? 0.1194 0.1466 0.1745 -0.0038 -0.0180 0.0252  114 ARG A CB  
+496  C CG  . ARG A 67  ? 0.1680 0.1714 0.1694 -0.0155 -0.0037 0.0077  114 ARG A CG  
+497  C CD  . ARG A 67  ? 0.1775 0.1785 0.2718 -0.0355 0.0479  -0.0264 114 ARG A CD  
+498  N NE  . ARG A 67  ? 0.1993 0.5027 0.4183 0.0756  -0.0171 -0.2466 114 ARG A NE  
+499  C CZ  . ARG A 67  ? 0.2002 0.4992 0.4624 0.0836  0.0758  -0.1730 114 ARG A CZ  
+500  N NH1 . ARG A 67  ? 0.2066 0.4414 0.3686 0.2024  -0.1364 -0.1046 114 ARG A NH1 
+501  N NH2 . ARG A 67  ? 0.2333 0.2766 0.3564 0.0354  0.0426  -0.0053 114 ARG A NH2 
+502  N N   . PRO A 68  ? 0.1024 0.1175 0.1236 -0.0115 0.0108  0.0231  115 PRO A N   
+503  C CA  . PRO A 68  ? 0.1176 0.1257 0.1133 -0.0024 0.0137  0.0249  115 PRO A CA  
+504  C C   . PRO A 68  ? 0.0947 0.1216 0.1274 -0.0007 0.0143  0.0222  115 PRO A C   
+505  O O   . PRO A 68  ? 0.1145 0.1346 0.1624 0.0041  0.0396  0.0123  115 PRO A O   
+506  C CB  . PRO A 68  ? 0.1095 0.1340 0.1103 0.0074  0.0208  0.0236  115 PRO A CB  
+507  C CG  . PRO A 68  ? 0.1077 0.1342 0.0994 0.0018  0.0154  0.0141  115 PRO A CG  
+508  C CD  . PRO A 68  ? 0.0984 0.1121 0.1206 -0.0089 0.0028  0.0097  115 PRO A CD  
+509  N N   . LYS A 69  ? 0.0995 0.1408 0.1211 -0.0132 0.0120  0.0287  116 LYS A N   
+510  C CA  . LYS A 69  ? 0.1058 0.1637 0.1293 -0.0120 0.0209  0.0240  116 LYS A CA  
+511  C C   . LYS A 69  ? 0.0933 0.1421 0.1191 -0.0094 0.0333  0.0211  116 LYS A C   
+512  O O   . LYS A 69  ? 0.1182 0.1714 0.1350 0.0039  0.0376  0.0041  116 LYS A O   
+513  C CB  . LYS A 69  ? 0.1363 0.2095 0.1514 -0.0540 0.0293  0.0346  116 LYS A CB  
+514  C CG  . LYS A 69  ? 0.1520 0.2765 0.2158 -0.0867 0.0199  0.0068  116 LYS A CG  
+515  C CD  . LYS A 69  ? 0.2038 0.4251 0.4016 0.0122  -0.0928 0.0361  116 LYS A CD  
+516  C CE  . LYS A 69  ? 0.2092 0.4283 0.3872 -0.0302 -0.0728 -0.0028 116 LYS A CE  
+517  N NZ  . LYS A 69  ? 0.2496 0.6475 0.3522 -0.0985 -0.0776 -0.0435 116 LYS A NZ  
+518  N N   . ALA A 70  ? 0.1048 0.1305 0.1010 -0.0089 0.0202  0.0128  117 ALA A N   
+519  C CA  . ALA A 70  ? 0.1059 0.1112 0.0940 -0.0079 0.0224  0.0125  117 ALA A CA  
+520  C C   . ALA A 70  ? 0.1031 0.0981 0.0879 -0.0089 0.0168  0.0167  117 ALA A C   
+521  O O   . ALA A 70  ? 0.1063 0.1031 0.1041 -0.0030 0.0114  0.0056  117 ALA A O   
+522  C CB  . ALA A 70  ? 0.1241 0.1465 0.1077 -0.0173 0.0281  0.0351  117 ALA A CB  
+523  N N   . ILE A 71  ? 0.1072 0.1054 0.0819 -0.0049 0.0193  0.0083  118 ILE A N   
+524  C CA  . ILE A 71  ? 0.1028 0.1066 0.0808 -0.0032 0.0203  0.0085  118 ILE A CA  
+525  C C   . ILE A 71  ? 0.1060 0.1129 0.0842 -0.0120 0.0155  0.0042  118 ILE A C   
+526  O O   . ILE A 71  ? 0.1264 0.1332 0.0825 -0.0062 0.0088  -0.0010 118 ILE A O   
+527  C CB  . ILE A 71  ? 0.1012 0.1095 0.0873 -0.0075 0.0101  0.0100  118 ILE A CB  
+528  C CG1 . ILE A 71  ? 0.1048 0.0930 0.0831 0.0043  0.0149  0.0015  118 ILE A CG1 
+529  C CG2 . ILE A 71  ? 0.0991 0.1364 0.1055 -0.0099 0.0098  0.0324  118 ILE A CG2 
+530  C CD1 . ILE A 71  ? 0.1102 0.1013 0.0993 -0.0010 0.0251  0.0076  118 ILE A CD1 
+531  N N   . LYS A 72  ? 0.1103 0.1181 0.0809 -0.0037 0.0045  0.0082  119 LYS A N   
+532  C CA  . LYS A 72  ? 0.1118 0.1233 0.0855 -0.0122 0.0070  0.0106  119 LYS A CA  
+533  C C   . LYS A 72  ? 0.1178 0.1455 0.0864 -0.0177 0.0012  0.0222  119 LYS A C   
+534  O O   . LYS A 72  ? 0.1150 0.1544 0.0937 -0.0068 0.0063  0.0136  119 LYS A O   
+535  C CB  . LYS A 72  ? 0.1275 0.1264 0.1178 -0.0121 0.0091  0.0202  119 LYS A CB  
+536  C CG  . LYS A 72  ? 0.1878 0.1628 0.1405 -0.0015 -0.0165 0.0540  119 LYS A CG  
+537  C CD  . LYS A 72  ? 0.2003 0.2176 0.1309 0.0220  0.0167  0.0614  119 LYS A CD  
+538  C CE  . LYS A 72  ? 0.1807 0.3018 0.1385 0.0113  -0.0070 0.0686  119 LYS A CE  
+539  N NZ  . LYS A 72  ? 0.2045 0.2159 0.1875 0.0036  0.0003  0.0612  119 LYS A NZ  
+540  N N   . THR A 73  ? 0.1171 0.1612 0.0927 -0.0259 0.0017  0.0190  120 THR A N   
+541  C CA  . THR A 73  ? 0.1122 0.1783 0.0943 -0.0180 -0.0074 0.0335  120 THR A CA  
+542  C C   . THR A 73  ? 0.1338 0.1923 0.0963 -0.0261 -0.0153 0.0291  120 THR A C   
+543  O O   . THR A 73  ? 0.1516 0.2016 0.0991 -0.0238 -0.0069 0.0412  120 THR A O   
+544  C CB  . THR A 73  ? 0.1510 0.1931 0.0882 -0.0530 -0.0189 0.0341  120 THR A CB  
+545  O OG1 . THR A 73  ? 0.1607 0.1676 0.1089 -0.0429 -0.0293 0.0320  120 THR A OG1 
+546  C CG2 . THR A 73  ? 0.1440 0.1756 0.1091 -0.0369 -0.0218 0.0384  120 THR A CG2 
+547  N N   . ASP A 74  ? 0.1259 0.2283 0.1062 -0.0197 -0.0203 0.0166  121 ASP A N   
+548  C CA  . ASP A 74  ? 0.1438 0.2259 0.1213 -0.0163 -0.0335 0.0325  121 ASP A CA  
+549  C C   . ASP A 74  ? 0.1464 0.2345 0.1096 -0.0183 -0.0328 0.0225  121 ASP A C   
+550  O O   . ASP A 74  ? 0.1478 0.2166 0.1180 -0.0306 -0.0301 0.0143  121 ASP A O   
+551  C CB  . ASP A 74  ? 0.1507 0.2771 0.1670 0.0186  -0.0478 0.0115  121 ASP A CB  
+552  C CG  . ASP A 74  ? 0.1197 0.3303 0.1992 -0.0003 -0.0331 0.0010  121 ASP A CG  
+553  O OD1 . ASP A 74  ? 0.1393 0.3440 0.1664 -0.0074 -0.0150 0.0625  121 ASP A OD1 
+554  O OD2 . ASP A 74  ? 0.1559 0.4212 0.3547 0.0271  0.0195  -0.0108 121 ASP A OD2 
+555  N N   . ASN A 75  ? 0.1690 0.2550 0.1223 -0.0433 -0.0469 0.0300  122 ASN A N   
+556  C CA  . ASN A 75  ? 0.2092 0.2542 0.1251 -0.0580 -0.0582 0.0311  122 ASN A CA  
+557  C C   . ASN A 75  ? 0.2130 0.2797 0.1695 -0.0725 -0.0517 0.0103  122 ASN A C   
+558  O O   . ASN A 75  ? 0.3408 0.3481 0.1872 -0.1621 -0.0611 -0.0069 122 ASN A O   
+559  C CB  . ASN A 75  ? 0.2430 0.3214 0.1272 -0.0364 -0.0518 0.0227  122 ASN A CB  
+560  C CG  . ASN A 75  ? 0.2671 0.3062 0.1603 -0.0256 -0.0248 0.0675  122 ASN A CG  
+561  O OD1 . ASN A 75  ? 0.2419 0.2824 0.1992 -0.0469 -0.0522 0.0259  122 ASN A OD1 
+562  N ND2 . ASN A 75  ? 0.3175 0.3147 0.2899 -0.0129 -0.0336 0.0995  122 ASN A ND2 
+563  N N   . GLY A 76  ? 0.1793 0.2570 0.1740 -0.0505 -0.0383 0.0330  123 GLY A N   
+564  C CA  . GLY A 76  ? 0.1694 0.2362 0.2706 -0.0355 -0.0304 0.0432  123 GLY A CA  
+565  C C   . GLY A 76  ? 0.1694 0.2368 0.1740 -0.0408 0.0086  -0.0160 123 GLY A C   
+566  O O   . GLY A 76  ? 0.1708 0.2402 0.1776 -0.0268 0.0054  -0.0198 123 GLY A O   
+567  N N   . SER A 77  ? 0.1899 0.2614 0.1798 -0.0533 -0.0371 -0.0158 124 SER A N   
+568  C CA  . SER A 77  ? 0.2341 0.2576 0.1853 -0.0783 -0.0204 -0.0407 124 SER A CA  
+569  C C   . SER A 77  ? 0.1747 0.2137 0.2033 -0.0549 -0.0019 -0.0473 124 SER A C   
+570  O O   . SER A 77  ? 0.2330 0.2308 0.2366 -0.0258 0.0373  -0.0673 124 SER A O   
+571  C CB  A SER A 77  ? 0.2641 0.3129 0.2702 -0.1008 -0.0698 -0.0642 124 SER A CB  
+572  C CB  B SER A 77  ? 0.2372 0.2968 0.2737 -0.0785 -0.0653 -0.0742 124 SER A CB  
+573  O OG  A SER A 77  ? 0.2372 0.3051 0.3118 -0.1237 -0.0707 0.0112  124 SER A OG  
+574  O OG  B SER A 77  ? 0.2835 0.3946 0.3273 0.0006  -0.1227 -0.0918 124 SER A OG  
+575  N N   . CYS A 78  ? 0.1321 0.1802 0.1842 -0.0303 0.0089  -0.0199 125 CYS A N   
+576  C CA  . CYS A 78  ? 0.1274 0.1569 0.2007 -0.0169 0.0156  -0.0063 125 CYS A CA  
+577  C C   . CYS A 78  ? 0.1220 0.1537 0.2090 -0.0212 0.0148  -0.0297 125 CYS A C   
+578  O O   . CYS A 78  ? 0.1286 0.1681 0.2298 -0.0026 0.0192  -0.0244 125 CYS A O   
+579  C CB  A CYS A 78  ? 0.1249 0.2308 0.1799 0.0530  0.0139  0.0474  125 CYS A CB  
+580  C CB  B CYS A 78  ? 0.1644 0.2407 0.1844 -0.0382 0.0288  0.0133  125 CYS A CB  
+581  S SG  A CYS A 78  ? 0.1552 0.2513 0.2290 -0.0400 0.0357  -0.0805 125 CYS A SG  
+582  S SG  B CYS A 78  ? 0.1435 0.3926 0.2841 0.0773  0.0627  0.0982  125 CYS A SG  
+583  N N   . PHE A 79  ? 0.1318 0.1639 0.2112 -0.0356 0.0191  -0.0267 126 PHE A N   
+584  C CA  . PHE A 79  ? 0.1402 0.1596 0.2676 -0.0415 0.0346  -0.0426 126 PHE A CA  
+585  C C   . PHE A 79  ? 0.1636 0.1781 0.2988 -0.0591 0.0662  -0.0661 126 PHE A C   
+586  O O   . PHE A 79  ? 0.1633 0.2308 0.3636 -0.0708 0.0816  -0.1097 126 PHE A O   
+587  C CB  . PHE A 79  ? 0.1531 0.1577 0.2253 -0.0337 0.0320  -0.0187 126 PHE A CB  
+588  C CG  . PHE A 79  ? 0.1201 0.1455 0.1905 -0.0326 0.0018  -0.0122 126 PHE A CG  
+589  C CD1 . PHE A 79  ? 0.1385 0.1404 0.2184 -0.0119 -0.0245 -0.0007 126 PHE A CD1 
+590  C CD2 . PHE A 79  ? 0.1317 0.1760 0.1754 -0.0115 -0.0067 0.0085  126 PHE A CD2 
+591  C CE1 . PHE A 79  ? 0.1726 0.1430 0.1889 -0.0265 -0.0313 0.0074  126 PHE A CE1 
+592  C CE2 . PHE A 79  ? 0.1457 0.1692 0.1855 0.0020  -0.0050 0.0008  126 PHE A CE2 
+593  C CZ  . PHE A 79  ? 0.1589 0.1569 0.1768 -0.0270 0.0090  0.0042  126 PHE A CZ  
+594  N N   . THR A 80  ? 0.1741 0.1966 0.2738 -0.0570 0.0826  -0.0688 127 THR A N   
+595  C CA  . THR A 80  ? 0.2313 0.2109 0.2830 -0.0489 0.1093  -0.0555 127 THR A CA  
+596  C C   . THR A 80  ? 0.1790 0.2045 0.2031 -0.0210 0.0582  -0.0334 127 THR A C   
+597  O O   . THR A 80  ? 0.2261 0.2178 0.1678 -0.0153 0.0566  -0.0197 127 THR A O   
+598  C CB  . THR A 80  ? 0.3869 0.2241 0.3079 0.0449  0.1960  0.0257  127 THR A CB  
+599  O OG1 . THR A 80  ? 0.3735 0.3031 0.2033 0.0745  0.0741  0.0704  127 THR A OG1 
+600  C CG2 . THR A 80  ? 0.5877 0.2031 0.5573 -0.0071 0.3793  0.0599  127 THR A CG2 
+601  N N   . SER A 81  ? 0.1336 0.2060 0.1296 -0.0151 -0.0040 -0.0389 128 SER A N   
+602  C CA  . SER A 81  ? 0.1396 0.1981 0.1137 -0.0105 -0.0175 -0.0386 128 SER A CA  
+603  C C   . SER A 81  ? 0.1365 0.1972 0.0959 -0.0224 -0.0082 -0.0434 128 SER A C   
+604  O O   . SER A 81  ? 0.1342 0.1936 0.1206 -0.0117 -0.0093 -0.0497 128 SER A O   
+605  C CB  . SER A 81  ? 0.1312 0.1918 0.1245 -0.0159 -0.0228 -0.0331 128 SER A CB  
+606  O OG  . SER A 81  ? 0.1244 0.2477 0.1070 -0.0233 -0.0130 -0.0421 128 SER A OG  
+607  N N   . LYS A 82  ? 0.1491 0.1979 0.1084 -0.0149 -0.0093 -0.0449 129 LYS A N   
+608  C CA  . LYS A 82  ? 0.1653 0.2034 0.1043 -0.0066 -0.0089 -0.0560 129 LYS A CA  
+609  C C   . LYS A 82  ? 0.1372 0.1626 0.1150 -0.0182 0.0034  -0.0449 129 LYS A C   
+610  O O   . LYS A 82  ? 0.1432 0.1576 0.1091 -0.0049 0.0030  -0.0378 129 LYS A O   
+611  C CB  . LYS A 82  ? 0.2551 0.2101 0.1428 0.0230  -0.0420 -0.0758 129 LYS A CB  
+612  C CG  . LYS A 82  ? 0.2757 0.2137 0.1640 0.0405  -0.0575 -0.0663 129 LYS A CG  
+613  C CD  . LYS A 82  ? 0.4430 0.2005 0.2370 0.0591  -0.0956 -0.0845 129 LYS A CD  
+614  C CE  . LYS A 82  ? 0.5501 0.2271 0.4714 0.1611  -0.0902 -0.1171 129 LYS A CE  
+615  N NZ  . LYS A 82  ? 0.7471 0.5065 0.7874 0.2337  -0.1285 -0.4833 129 LYS A NZ  
+616  N N   . SER A 83  ? 0.1514 0.1624 0.1194 -0.0341 -0.0016 -0.0418 130 SER A N   
+617  C CA  . SER A 83  ? 0.1523 0.1439 0.1213 -0.0177 -0.0094 -0.0288 130 SER A CA  
+618  C C   . SER A 83  ? 0.1205 0.1358 0.1029 -0.0115 0.0097  -0.0208 130 SER A C   
+619  O O   . SER A 83  ? 0.1182 0.1340 0.1137 -0.0051 -0.0013 -0.0158 130 SER A O   
+620  C CB  . SER A 83  ? 0.2243 0.2252 0.1556 -0.1135 0.0202  -0.0256 130 SER A CB  
+621  O OG  . SER A 83  ? 0.2960 0.2841 0.1624 -0.1354 0.0522  -0.0620 130 SER A OG  
+622  N N   . THR A 84  ? 0.1088 0.1489 0.1113 0.0007  -0.0106 -0.0360 131 THR A N   
+623  C CA  . THR A 84  ? 0.1161 0.1430 0.1096 0.0089  -0.0140 -0.0357 131 THR A CA  
+624  C C   . THR A 84  ? 0.1224 0.1170 0.1157 0.0071  -0.0181 -0.0193 131 THR A C   
+625  O O   . THR A 84  ? 0.1240 0.1098 0.1358 0.0107  -0.0307 -0.0208 131 THR A O   
+626  C CB  . THR A 84  ? 0.1307 0.1706 0.1398 0.0301  -0.0314 -0.0677 131 THR A CB  
+627  O OG1 . THR A 84  ? 0.1463 0.2552 0.1184 0.0648  -0.0078 -0.0494 131 THR A OG1 
+628  C CG2 . THR A 84  ? 0.1399 0.1878 0.3130 0.0576  -0.0926 -0.1399 131 THR A CG2 
+629  N N   . ARG A 85  ? 0.1277 0.1298 0.1151 -0.0100 -0.0221 0.0116  132 ARG A N   
+630  C CA  . ARG A 85  ? 0.1348 0.1349 0.1276 -0.0181 -0.0167 0.0037  132 ARG A CA  
+631  C C   . ARG A 85  ? 0.1258 0.1388 0.0970 -0.0140 -0.0010 0.0047  132 ARG A C   
+632  O O   . ARG A 85  ? 0.1267 0.1418 0.1051 -0.0097 -0.0011 0.0026  132 ARG A O   
+633  C CB  . ARG A 85  ? 0.1492 0.3202 0.1288 -0.0551 -0.0266 0.1025  132 ARG A CB  
+634  C CG  . ARG A 85  ? 0.2287 0.2250 0.0860 -0.0576 -0.0314 0.0359  132 ARG A CG  
+635  C CD  . ARG A 85  ? 0.1912 0.2241 0.0940 -0.0340 -0.0267 0.0179  132 ARG A CD  
+636  N NE  . ARG A 85  ? 0.2281 0.1744 0.1154 -0.0213 0.0258  0.0138  132 ARG A NE  
+637  C CZ  . ARG A 85  ? 0.3028 0.1799 0.1474 0.0328  0.0759  0.0283  132 ARG A CZ  
+638  N NH1 . ARG A 85  ? 0.5167 0.1935 0.0900 -0.0167 0.0275  -0.0032 132 ARG A NH1 
+639  N NH2 . ARG A 85  ? 0.3765 0.2094 0.2759 0.0048  0.1958  0.0317  132 ARG A NH2 
+640  N N   . GLU A 86  ? 0.1152 0.1343 0.0918 0.0062  0.0087  -0.0051 133 GLU A N   
+641  C CA  . GLU A 86  ? 0.1030 0.1376 0.0944 0.0045  0.0088  -0.0256 133 GLU A CA  
+642  C C   . GLU A 86  ? 0.1046 0.1151 0.0914 0.0081  0.0076  -0.0126 133 GLU A C   
+643  O O   . GLU A 86  ? 0.1033 0.1365 0.0950 0.0135  0.0050  -0.0138 133 GLU A O   
+644  C CB  . GLU A 86  ? 0.1314 0.1313 0.1073 0.0121  0.0002  -0.0289 133 GLU A CB  
+645  C CG  . GLU A 86  ? 0.1292 0.1497 0.1549 0.0120  -0.0060 -0.0303 133 GLU A CG  
+646  C CD  . GLU A 86  ? 0.1291 0.1724 0.1643 0.0216  -0.0009 -0.0295 133 GLU A CD  
+647  O OE1 . GLU A 86  ? 0.1331 0.2596 0.1474 0.0025  -0.0037 -0.0284 133 GLU A OE1 
+648  O OE2 . GLU A 86  ? 0.1294 0.1924 0.2298 0.0011  -0.0258 0.0089  133 GLU A OE2 
+649  N N   . TRP A 87  ? 0.1025 0.1033 0.0869 0.0026  0.0058  -0.0080 134 TRP A N   
+650  C CA  . TRP A 87  ? 0.1037 0.1062 0.0778 0.0029  0.0068  -0.0052 134 TRP A CA  
+651  C C   . TRP A 87  ? 0.0903 0.1009 0.0727 0.0123  0.0122  -0.0064 134 TRP A C   
+652  O O   . TRP A 87  ? 0.0923 0.1034 0.0838 0.0073  0.0079  -0.0047 134 TRP A O   
+653  C CB  . TRP A 87  ? 0.1011 0.1100 0.0884 0.0015  0.0100  -0.0051 134 TRP A CB  
+654  C CG  . TRP A 87  ? 0.0842 0.1085 0.0855 -0.0038 0.0063  -0.0007 134 TRP A CG  
+655  C CD1 . TRP A 87  ? 0.0954 0.1053 0.0946 -0.0015 0.0121  -0.0018 134 TRP A CD1 
+656  C CD2 . TRP A 87  ? 0.0890 0.1026 0.0893 0.0079  0.0037  -0.0003 134 TRP A CD2 
+657  N NE1 . TRP A 87  ? 0.1053 0.1175 0.0859 0.0057  0.0103  0.0059  134 TRP A NE1 
+658  C CE2 . TRP A 87  ? 0.0825 0.1100 0.0900 0.0085  0.0074  0.0014  134 TRP A CE2 
+659  C CE3 . TRP A 87  ? 0.0979 0.1052 0.0937 0.0079  0.0051  0.0043  134 TRP A CE3 
+660  C CZ2 . TRP A 87  ? 0.0904 0.1209 0.0914 0.0107  0.0035  0.0020  134 TRP A CZ2 
+661  C CZ3 . TRP A 87  ? 0.1129 0.1022 0.1008 0.0180  0.0084  -0.0036 134 TRP A CZ3 
+662  C CH2 . TRP A 87  ? 0.0999 0.1138 0.0984 0.0156  0.0036  -0.0155 134 TRP A CH2 
+663  N N   . LEU A 88  ? 0.0919 0.1031 0.0857 0.0017  0.0041  -0.0015 135 LEU A N   
+664  C CA  . LEU A 88  ? 0.0998 0.1029 0.0842 0.0009  0.0090  0.0009  135 LEU A CA  
+665  C C   . LEU A 88  ? 0.0915 0.1024 0.0984 0.0002  0.0068  0.0010  135 LEU A C   
+666  O O   . LEU A 88  ? 0.0988 0.1098 0.1102 -0.0021 0.0120  -0.0002 135 LEU A O   
+667  C CB  . LEU A 88  ? 0.0962 0.1020 0.1067 0.0040  0.0138  0.0045  135 LEU A CB  
+668  C CG  . LEU A 88  ? 0.1057 0.1005 0.0990 0.0111  0.0190  0.0084  135 LEU A CG  
+669  C CD1 . LEU A 88  ? 0.1209 0.1382 0.1450 0.0306  0.0123  0.0335  135 LEU A CD1 
+670  C CD2 . LEU A 88  ? 0.1157 0.1247 0.1435 -0.0037 0.0152  -0.0300 135 LEU A CD2 
+671  N N   . ALA A 89  ? 0.0932 0.1267 0.0932 0.0030  0.0161  -0.0066 136 ALA A N   
+672  C CA  . ALA A 89  ? 0.1034 0.1178 0.1012 0.0067  0.0216  -0.0024 136 ALA A CA  
+673  C C   . ALA A 89  ? 0.1042 0.1189 0.0973 0.0103  0.0287  -0.0055 136 ALA A C   
+674  O O   . ALA A 89  ? 0.0907 0.1339 0.1171 0.0088  0.0294  -0.0027 136 ALA A O   
+675  C CB  . ALA A 89  ? 0.1164 0.1573 0.1034 0.0110  0.0260  -0.0163 136 ALA A CB  
+676  N N   . ARG A 90  ? 0.0949 0.1106 0.1002 -0.0017 0.0062  -0.0099 137 ARG A N   
+677  C CA  . ARG A 90  ? 0.0934 0.1000 0.1045 0.0072  0.0134  -0.0103 137 ARG A CA  
+678  C C   . ARG A 90  ? 0.0890 0.0941 0.0995 0.0080  0.0194  -0.0013 137 ARG A C   
+679  O O   . ARG A 90  ? 0.0893 0.1024 0.1185 0.0102  0.0023  -0.0016 137 ARG A O   
+680  C CB  . ARG A 90  ? 0.1072 0.1110 0.1107 -0.0035 0.0166  -0.0116 137 ARG A CB  
+681  C CG  . ARG A 90  ? 0.0969 0.1064 0.1152 0.0063  0.0103  -0.0052 137 ARG A CG  
+682  C CD  . ARG A 90  ? 0.1084 0.1394 0.1227 -0.0043 0.0056  0.0134  137 ARG A CD  
+683  N NE  . ARG A 90  ? 0.1171 0.1352 0.1485 -0.0144 0.0102  -0.0004 137 ARG A NE  
+684  C CZ  . ARG A 90  ? 0.1281 0.1454 0.1523 -0.0268 0.0110  0.0040  137 ARG A CZ  
+685  N NH1 . ARG A 90  ? 0.1156 0.1572 0.1607 0.0034  0.0244  0.0058  137 ARG A NH1 
+686  N NH2 . ARG A 90  ? 0.1324 0.2345 0.1894 -0.0495 -0.0068 -0.0165 137 ARG A NH2 
+687  N N   . TRP A 91  ? 0.0930 0.0968 0.0953 0.0155  0.0042  -0.0066 138 TRP A N   
+688  C CA  . TRP A 91  ? 0.0999 0.0946 0.0994 0.0137  0.0029  -0.0028 138 TRP A CA  
+689  C C   . TRP A 91  ? 0.0936 0.1048 0.1226 0.0125  0.0081  -0.0083 138 TRP A C   
+690  O O   . TRP A 91  ? 0.1281 0.1243 0.1418 -0.0128 0.0014  -0.0086 138 TRP A O   
+691  C CB  . TRP A 91  ? 0.1036 0.1018 0.0998 0.0064  0.0151  -0.0034 138 TRP A CB  
+692  C CG  . TRP A 91  ? 0.0930 0.1029 0.0972 0.0055  0.0120  -0.0068 138 TRP A CG  
+693  C CD1 . TRP A 91  ? 0.0933 0.1111 0.1033 0.0079  0.0030  -0.0034 138 TRP A CD1 
+694  C CD2 . TRP A 91  ? 0.0855 0.0847 0.1001 0.0095  0.0102  -0.0019 138 TRP A CD2 
+695  N NE1 . TRP A 91  ? 0.0947 0.1146 0.1069 -0.0077 0.0051  -0.0029 138 TRP A NE1 
+696  C CE2 . TRP A 91  ? 0.0884 0.1101 0.0972 0.0045  0.0111  -0.0055 138 TRP A CE2 
+697  C CE3 . TRP A 91  ? 0.0982 0.0907 0.1087 0.0072  0.0064  -0.0065 138 TRP A CE3 
+698  C CZ2 . TRP A 91  ? 0.0983 0.1166 0.0961 0.0086  0.0119  -0.0012 138 TRP A CZ2 
+699  C CZ3 . TRP A 91  ? 0.0983 0.1100 0.1101 0.0037  -0.0002 -0.0106 138 TRP A CZ3 
+700  C CH2 . TRP A 91  ? 0.1118 0.1127 0.0977 0.0119  0.0060  -0.0110 138 TRP A CH2 
+701  N N   . GLY A 92  ? 0.0898 0.1013 0.1279 0.0010  0.0201  -0.0034 139 GLY A N   
+702  C CA  . GLY A 92  ? 0.1091 0.1114 0.1611 0.0040  0.0420  0.0027  139 GLY A CA  
+703  C C   . GLY A 92  ? 0.1008 0.1082 0.1578 0.0085  0.0433  0.0131  139 GLY A C   
+704  O O   . GLY A 92  ? 0.1064 0.1134 0.2297 -0.0039 0.0376  0.0104  139 GLY A O   
+705  N N   . ILE A 93  ? 0.1029 0.1032 0.1283 -0.0003 0.0342  0.0050  140 ILE A N   
+706  C CA  . ILE A 93  ? 0.0998 0.1009 0.1241 0.0022  0.0259  0.0027  140 ILE A CA  
+707  C C   . ILE A 93  ? 0.1219 0.1078 0.1149 0.0036  0.0280  0.0016  140 ILE A C   
+708  O O   . ILE A 93  ? 0.1341 0.1342 0.1190 -0.0045 0.0175  0.0033  140 ILE A O   
+709  C CB  . ILE A 93  ? 0.1092 0.0989 0.1142 0.0030  0.0314  -0.0006 140 ILE A CB  
+710  C CG1 . ILE A 93  ? 0.0991 0.1027 0.1197 0.0051  0.0183  0.0052  140 ILE A CG1 
+711  C CG2 . ILE A 93  ? 0.1139 0.1179 0.1323 0.0193  0.0385  0.0189  140 ILE A CG2 
+712  C CD1 . ILE A 93  ? 0.1153 0.1049 0.1223 0.0055  0.0347  0.0065  140 ILE A CD1 
+713  N N   . ALA A 94  ? 0.1280 0.1235 0.1135 0.0061  0.0388  0.0109  141 ALA A N   
+714  C CA  . ALA A 94  ? 0.1524 0.1267 0.0999 0.0059  0.0306  0.0016  141 ALA A CA  
+715  C C   . ALA A 94  ? 0.1427 0.1209 0.0987 -0.0027 0.0324  0.0110  141 ALA A C   
+716  O O   . ALA A 94  ? 0.1314 0.1508 0.1171 0.0036  0.0259  -0.0190 141 ALA A O   
+717  C CB  . ALA A 94  ? 0.1499 0.1657 0.1358 0.0061  0.0495  0.0423  141 ALA A CB  
+718  N N   . HIS A 95  ? 0.1671 0.1473 0.0923 0.0113  0.0260  0.0086  142 HIS A N   
+719  C CA  . HIS A 95  ? 0.1552 0.1291 0.0958 -0.0071 0.0108  0.0104  142 HIS A CA  
+720  C C   . HIS A 95  ? 0.1573 0.1249 0.0895 -0.0216 0.0198  0.0060  142 HIS A C   
+721  O O   . HIS A 95  ? 0.1927 0.1494 0.0931 -0.0102 0.0245  -0.0040 142 HIS A O   
+722  C CB  . HIS A 95  ? 0.2048 0.1384 0.1115 -0.0222 0.0205  0.0165  142 HIS A CB  
+723  C CG  . HIS A 95  ? 0.1976 0.1564 0.1100 -0.0514 -0.0014 0.0307  142 HIS A CG  
+724  N ND1 . HIS A 95  ? 0.2655 0.1721 0.1545 -0.0686 -0.0460 0.0300  142 HIS A ND1 
+725  C CD2 . HIS A 95  ? 0.1581 0.1898 0.1143 -0.0457 0.0022  0.0260  142 HIS A CD2 
+726  C CE1 . HIS A 95  ? 0.2325 0.2002 0.2005 -0.0841 -0.0667 0.0518  142 HIS A CE1 
+727  N NE2 . HIS A 95  ? 0.1784 0.2249 0.1125 -0.0913 -0.0121 0.0359  142 HIS A NE2 
+728  N N   . THR A 96  ? 0.1454 0.1299 0.0822 -0.0114 0.0067  0.0087  143 THR A N   
+729  C CA  . THR A 96  ? 0.1437 0.1323 0.0915 -0.0294 0.0096  0.0142  143 THR A CA  
+730  C C   . THR A 96  ? 0.1434 0.1268 0.0861 -0.0234 0.0032  0.0262  143 THR A C   
+731  O O   . THR A 96  ? 0.1362 0.1520 0.0934 -0.0214 0.0057  0.0272  143 THR A O   
+732  C CB  . THR A 96  ? 0.1613 0.1356 0.1153 -0.0356 0.0131  0.0237  143 THR A CB  
+733  O OG1 . THR A 96  ? 0.1973 0.1652 0.1489 -0.0286 0.0196  0.0485  143 THR A OG1 
+734  C CG2 . THR A 96  ? 0.1691 0.1471 0.1542 -0.0536 0.0206  -0.0112 143 THR A CG2 
+735  N N   . THR A 97  ? 0.1550 0.1762 0.0942 -0.0153 0.0005  0.0176  144 THR A N   
+736  C CA  . THR A 97  ? 0.1432 0.2240 0.1204 -0.0144 -0.0111 0.0394  144 THR A CA  
+737  C C   . THR A 97  ? 0.1771 0.2579 0.1372 0.0155  0.0025  0.0691  144 THR A C   
+738  O O   . THR A 97  ? 0.1963 0.3094 0.1868 0.0511  -0.0063 0.0672  144 THR A O   
+739  C CB  . THR A 97  ? 0.1700 0.2864 0.1096 -0.0411 -0.0157 0.0162  144 THR A CB  
+740  O OG1 . THR A 97  ? 0.1781 0.3422 0.1266 -0.0373 -0.0225 0.0043  144 THR A OG1 
+741  C CG2 . THR A 97  ? 0.1784 0.2406 0.1808 -0.0503 0.0217  0.0127  144 THR A CG2 
+742  N N   . GLY A 98  ? 0.2049 0.1970 0.1560 0.0049  0.0111  0.0435  145 GLY A N   
+743  C CA  . GLY A 98  ? 0.2908 0.2254 0.2042 0.0189  0.0107  0.0836  145 GLY A CA  
+744  C C   . GLY A 98  ? 0.3312 0.3049 0.2093 0.0872  0.0856  0.1307  145 GLY A C   
+745  O O   . GLY A 98  ? 0.2683 0.3769 0.1954 0.0476  0.0339  0.0637  145 GLY A O   
+746  N N   . ILE A 99  ? 0.4561 0.3783 0.3161 0.1247  0.0388  0.2180  146 ILE A N   
+747  C CA  . ILE A 99  ? 0.5076 0.4789 0.3154 0.0357  -0.0192 0.2436  146 ILE A CA  
+748  C C   . ILE A 99  ? 0.5027 0.3444 0.3814 0.1001  -0.0002 0.0715  146 ILE A C   
+749  O O   . ILE A 99  ? 0.4859 0.6524 0.2661 0.2225  -0.0891 0.0736  146 ILE A O   
+750  C CB  . ILE A 99  ? 0.5707 0.5178 0.3803 -0.0868 -0.0954 0.3131  146 ILE A CB  
+751  C CG1 . ILE A 99  ? 0.4787 0.6798 0.5937 -0.1231 -0.0576 0.3555  146 ILE A CG1 
+752  C CG2 . ILE A 99  ? 0.6301 0.6676 0.3666 0.0566  0.0243  0.3647  146 ILE A CG2 
+753  C CD1 . ILE A 99  ? 0.2920 0.6811 0.9050 -0.1175 -0.1915 0.3567  146 ILE A CD1 
+754  N N   . PRO A 100 ? 0.7165 0.6188 0.3144 0.3189  -0.1814 -0.0125 147 PRO A N   
+755  C CA  . PRO A 100 ? 0.7997 0.6535 0.4297 0.3434  -0.2809 -0.1437 147 PRO A CA  
+756  C C   . PRO A 100 ? 0.9736 0.7235 0.4183 0.3674  -0.4513 -0.1826 147 PRO A C   
+757  O O   . PRO A 100 ? 1.2696 0.6401 0.5574 0.4244  -0.2760 -0.1576 147 PRO A O   
+758  C CB  . PRO A 100 ? 0.8424 0.7320 0.3315 0.3215  -0.1557 -0.1106 147 PRO A CB  
+759  C CG  . PRO A 100 ? 0.7713 0.7453 0.3561 0.2809  -0.0722 -0.1216 147 PRO A CG  
+760  C CD  . PRO A 100 ? 0.7904 0.7204 0.3659 0.2792  -0.0646 -0.1019 147 PRO A CD  
+761  N N   . GLY A 105 ? 0.7420 0.6106 0.3176 0.1131  0.0612  0.2909  152 GLY A N   
+762  C CA  . GLY A 105 ? 0.5653 0.3313 0.2617 -0.1008 0.1222  0.1347  152 GLY A CA  
+763  C C   . GLY A 105 ? 0.3964 0.2606 0.2222 -0.0087 0.0935  0.0658  152 GLY A C   
+764  O O   . GLY A 105 ? 0.3469 0.2937 0.4164 -0.0557 0.0612  0.0682  152 GLY A O   
+765  N N   . GLN A 106 ? 0.3926 0.2498 0.1832 0.0258  0.0728  0.0653  153 GLN A N   
+766  C CA  . GLN A 106 ? 0.3082 0.1962 0.1942 0.0234  0.0508  0.0632  153 GLN A CA  
+767  C C   . GLN A 106 ? 0.2907 0.2061 0.2002 0.0339  0.0605  0.0704  153 GLN A C   
+768  O O   . GLN A 106 ? 0.3253 0.1917 0.1773 0.0227  0.0546  0.0650  153 GLN A O   
+769  C CB  . GLN A 106 ? 0.2279 0.2031 0.2274 0.0139  0.0303  0.0552  153 GLN A CB  
+770  C CG  . GLN A 106 ? 0.2209 0.2398 0.2119 0.0158  0.0192  0.0812  153 GLN A CG  
+771  C CD  . GLN A 106 ? 0.1845 0.2424 0.2038 0.0068  0.0204  0.0394  153 GLN A CD  
+772  O OE1 . GLN A 106 ? 0.1990 0.2595 0.2019 0.0229  0.0326  0.0349  153 GLN A OE1 
+773  N NE2 . GLN A 106 ? 0.1638 0.2207 0.2207 0.0166  0.0002  0.0583  153 GLN A NE2 
+774  N N   . ALA A 107 ? 0.2972 0.2115 0.2369 0.0481  0.0937  0.0931  154 ALA A N   
+775  C CA  . ALA A 107 ? 0.2839 0.1893 0.2561 0.0500  0.0717  0.0994  154 ALA A CA  
+776  C C   . ALA A 107 ? 0.2435 0.1895 0.2408 0.0369  0.0940  0.0954  154 ALA A C   
+777  O O   . ALA A 107 ? 0.2290 0.1705 0.2777 0.0457  0.0892  0.0842  154 ALA A O   
+778  C CB  . ALA A 107 ? 0.4386 0.1984 0.3069 0.0516  0.1277  0.1320  154 ALA A CB  
+779  N N   . MET A 108 ? 0.2268 0.1459 0.2440 0.0068  0.0739  0.0512  155 MET A N   
+780  C CA  . MET A 108 ? 0.1950 0.1332 0.2377 -0.0072 0.0768  0.0169  155 MET A CA  
+781  C C   . MET A 108 ? 0.1722 0.1185 0.1989 -0.0001 0.0528  0.0097  155 MET A C   
+782  O O   . MET A 108 ? 0.1705 0.1354 0.2081 0.0103  0.0615  0.0036  155 MET A O   
+783  C CB  A MET A 108 ? 0.1904 0.1144 0.2297 -0.0293 0.0725  -0.0349 155 MET A CB  
+784  C CB  B MET A 108 ? 0.1901 0.1520 0.2632 -0.0221 0.0782  0.0204  155 MET A CB  
+785  C CG  A MET A 108 ? 0.1942 0.1306 0.2512 -0.0220 0.0736  0.0191  155 MET A CG  
+786  C CG  B MET A 108 ? 0.2179 0.1574 0.2851 0.0310  0.0451  -0.0102 155 MET A CG  
+787  S SD  A MET A 108 ? 0.1848 0.1410 0.3340 -0.0283 0.0835  0.0060  155 MET A SD  
+788  S SD  B MET A 108 ? 0.2270 0.2376 0.3814 -0.0005 0.0167  -0.0266 155 MET A SD  
+789  C CE  A MET A 108 ? 0.2700 0.1824 0.3546 -0.0050 -0.0263 -0.0782 155 MET A CE  
+790  C CE  B MET A 108 ? 0.3109 0.5450 0.2707 0.0701  -0.0565 -0.1013 155 MET A CE  
+791  N N   . VAL A 109 ? 0.1639 0.1280 0.1710 -0.0024 0.0502  0.0186  156 VAL A N   
+792  C CA  . VAL A 109 ? 0.1404 0.1256 0.1529 0.0022  0.0344  0.0164  156 VAL A CA  
+793  C C   . VAL A 109 ? 0.1464 0.1327 0.1425 0.0135  0.0312  0.0201  156 VAL A C   
+794  O O   . VAL A 109 ? 0.1396 0.1484 0.1405 0.0112  0.0303  0.0219  156 VAL A O   
+795  C CB  . VAL A 109 ? 0.1445 0.1274 0.1543 0.0039  0.0327  0.0121  156 VAL A CB  
+796  C CG1 . VAL A 109 ? 0.1949 0.1649 0.1314 -0.0043 0.0390  0.0106  156 VAL A CG1 
+797  C CG2 . VAL A 109 ? 0.1659 0.1282 0.1435 0.0037  0.0166  0.0219  156 VAL A CG2 
+798  N N   . GLU A 110 ? 0.1763 0.1698 0.1650 0.0370  0.0414  0.0482  157 GLU A N   
+799  C CA  . GLU A 110 ? 0.1870 0.2148 0.1696 0.0546  0.0185  0.0453  157 GLU A CA  
+800  C C   . GLU A 110 ? 0.1952 0.1630 0.1747 0.0448  0.0566  0.0591  157 GLU A C   
+801  O O   . GLU A 110 ? 0.1731 0.1969 0.2067 0.0464  0.0444  0.0681  157 GLU A O   
+802  C CB  A GLU A 110 ? 0.2540 0.3295 0.1697 0.1160  0.0316  0.0791  157 GLU A CB  
+803  C CB  B GLU A 110 ? 0.2682 0.3078 0.1724 0.1466  0.0540  0.0745  157 GLU A CB  
+804  C CG  A GLU A 110 ? 0.2019 0.4225 0.1818 0.0799  -0.0033 0.0246  157 GLU A CG  
+805  C CG  B GLU A 110 ? 0.2286 0.3685 0.1829 0.0950  -0.0143 0.0399  157 GLU A CG  
+806  C CD  A GLU A 110 ? 0.3242 0.4900 0.1867 0.0757  0.0068  0.0531  157 GLU A CD  
+807  C CD  B GLU A 110 ? 0.1925 0.4335 0.1992 0.0856  -0.0046 0.1201  157 GLU A CD  
+808  O OE1 A GLU A 110 ? 0.8114 0.4333 0.3231 0.0577  0.0073  0.1693  157 GLU A OE1 
+809  O OE1 B GLU A 110 ? 0.2074 0.6114 0.3963 0.0997  0.0332  -0.0626 157 GLU A OE1 
+810  O OE2 A GLU A 110 ? 0.4459 0.7581 0.1929 0.1991  0.0073  -0.0393 157 GLU A OE2 
+811  O OE2 B GLU A 110 ? 0.1682 0.3117 0.3402 0.0372  0.0384  0.0541  157 GLU A OE2 
+812  N N   . ARG A 111 ? 0.2016 0.1617 0.1870 0.0372  0.0727  0.0586  158 ARG A N   
+813  C CA  . ARG A 111 ? 0.2334 0.1472 0.2082 0.0429  0.0649  0.0422  158 ARG A CA  
+814  C C   . ARG A 111 ? 0.1927 0.1243 0.1938 0.0206  0.0568  0.0268  158 ARG A C   
+815  O O   . ARG A 111 ? 0.1989 0.1396 0.2009 0.0308  0.0682  0.0135  158 ARG A O   
+816  C CB  . ARG A 111 ? 0.2689 0.1481 0.2370 0.0158  0.0940  0.0503  158 ARG A CB  
+817  C CG  . ARG A 111 ? 0.3674 0.1547 0.3435 -0.0220 0.1469  -0.0333 158 ARG A CG  
+818  C CD  . ARG A 111 ? 0.4271 0.2102 0.4519 -0.0839 0.1930  -0.0758 158 ARG A CD  
+819  N NE  . ARG A 111 ? 0.5906 0.2512 0.4229 -0.1922 0.2214  -0.0642 158 ARG A NE  
+820  C CZ  . ARG A 111 ? 0.5836 0.4534 0.5300 -0.0889 0.1227  -0.1975 158 ARG A CZ  
+821  N NH1 . ARG A 111 ? 0.4977 0.7014 0.8321 0.0654  -0.0025 -0.3135 158 ARG A NH1 
+822  N NH2 . ARG A 111 ? 0.9195 0.6330 0.5247 -0.0504 0.0874  -0.2601 158 ARG A NH2 
+823  N N   . ALA A 112 ? 0.1699 0.1287 0.1891 0.0211  0.0586  0.0256  159 ALA A N   
+824  C CA  . ALA A 112 ? 0.1606 0.1272 0.1578 0.0075  0.0221  0.0117  159 ALA A CA  
+825  C C   . ALA A 112 ? 0.1419 0.1466 0.1306 0.0145  0.0193  0.0187  159 ALA A C   
+826  O O   . ALA A 112 ? 0.1520 0.1587 0.1350 0.0103  0.0227  0.0187  159 ALA A O   
+827  C CB  . ALA A 112 ? 0.1385 0.1679 0.1936 0.0115  0.0135  0.0313  159 ALA A CB  
+828  N N   . ASN A 113 ? 0.1373 0.1531 0.1309 0.0188  0.0215  0.0226  160 ASN A N   
+829  C CA  . ASN A 113 ? 0.1417 0.1560 0.1260 0.0116  0.0188  0.0197  160 ASN A CA  
+830  C C   . ASN A 113 ? 0.1289 0.1711 0.1310 0.0219  0.0071  0.0213  160 ASN A C   
+831  O O   . ASN A 113 ? 0.1310 0.2107 0.1215 0.0099  0.0147  0.0260  160 ASN A O   
+832  C CB  . ASN A 113 ? 0.1509 0.1617 0.1134 0.0150  0.0224  0.0197  160 ASN A CB  
+833  C CG  . ASN A 113 ? 0.1632 0.1418 0.1506 0.0157  0.0283  0.0272  160 ASN A CG  
+834  O OD1 . ASN A 113 ? 0.1471 0.1431 0.2022 0.0098  0.0168  0.0308  160 ASN A OD1 
+835  N ND2 . ASN A 113 ? 0.1940 0.1779 0.1430 0.0207  0.0382  -0.0092 160 ASN A ND2 
+836  N N   . ARG A 114 ? 0.1509 0.1740 0.1209 0.0429  0.0201  0.0251  161 ARG A N   
+837  C CA  . ARG A 114 ? 0.1695 0.1908 0.1352 0.0592  0.0138  0.0186  161 ARG A CA  
+838  C C   . ARG A 114 ? 0.1563 0.1762 0.1364 0.0531  0.0242  0.0094  161 ARG A C   
+839  O O   . ARG A 114 ? 0.1634 0.1620 0.1490 0.0378  0.0374  0.0150  161 ARG A O   
+840  C CB  . ARG A 114 ? 0.2355 0.2278 0.1708 0.1120  0.0319  0.0597  161 ARG A CB  
+841  C CG  . ARG A 114 ? 0.2270 0.2597 0.1818 0.1574  0.0540  0.0968  161 ARG A CG  
+842  C CD  . ARG A 114 ? 0.3582 0.2786 0.4343 0.1359  0.0367  0.2187  161 ARG A CD  
+843  N NE  . ARG A 114 ? 0.3852 0.3719 0.5200 0.1039  0.0248  0.3270  161 ARG A NE  
+844  C CZ  . ARG A 114 ? 0.4029 0.3636 0.6144 0.0558  0.0181  0.3336  161 ARG A CZ  
+845  N NH1 . ARG A 114 ? 0.4640 0.2473 0.6884 0.0267  0.0436  0.2091  161 ARG A NH1 
+846  N NH2 . ARG A 114 ? 0.3816 0.2138 0.8778 0.1403  0.1186  0.2923  161 ARG A NH2 
+847  N N   . LEU A 115 ? 0.1682 0.1503 0.1345 0.0264  0.0325  0.0136  162 LEU A N   
+848  C CA  . LEU A 115 ? 0.1775 0.1441 0.1369 0.0115  0.0310  0.0013  162 LEU A CA  
+849  C C   . LEU A 115 ? 0.1386 0.1291 0.1376 0.0206  0.0080  0.0036  162 LEU A C   
+850  O O   . LEU A 115 ? 0.1412 0.1437 0.1374 0.0051  0.0173  0.0035  162 LEU A O   
+851  C CB  . LEU A 115 ? 0.1934 0.2177 0.1727 -0.0405 0.0302  0.0091  162 LEU A CB  
+852  C CG  . LEU A 115 ? 0.2663 0.2185 0.2245 -0.0766 0.0380  -0.0026 162 LEU A CG  
+853  C CD1 . LEU A 115 ? 0.2781 0.3868 0.2532 -0.1584 0.0159  0.0386  162 LEU A CD1 
+854  C CD2 . LEU A 115 ? 0.5059 0.2091 0.3721 -0.1060 0.2201  -0.0257 162 LEU A CD2 
+855  N N   . LEU A 116 ? 0.1327 0.1406 0.1186 0.0120  0.0055  -0.0043 163 LEU A N   
+856  C CA  . LEU A 116 ? 0.1468 0.1256 0.1305 0.0315  0.0052  -0.0055 163 LEU A CA  
+857  C C   . LEU A 116 ? 0.1519 0.1147 0.1149 0.0165  0.0044  -0.0115 163 LEU A C   
+858  O O   . LEU A 116 ? 0.1748 0.1166 0.1121 0.0264  0.0133  -0.0097 163 LEU A O   
+859  C CB  A LEU A 116 ? 0.1716 0.1258 0.1208 0.0318  0.0260  0.0109  163 LEU A CB  
+860  C CB  B LEU A 116 ? 0.1597 0.1464 0.1404 0.0407  -0.0077 -0.0266 163 LEU A CB  
+861  C CG  A LEU A 116 ? 0.2089 0.1213 0.1635 0.0480  0.0589  0.0215  163 LEU A CG  
+862  C CG  B LEU A 116 ? 0.1395 0.1305 0.1419 0.0273  0.0269  0.0278  163 LEU A CG  
+863  C CD1 A LEU A 116 ? 0.2401 0.2033 0.1412 0.0639  0.0753  0.0688  163 LEU A CD1 
+864  C CD1 B LEU A 116 ? 0.1084 0.1486 0.1294 0.0035  -0.0053 -0.0042 163 LEU A CD1 
+865  C CD2 A LEU A 116 ? 0.2400 0.1145 0.2445 0.0222  0.0867  -0.0102 163 LEU A CD2 
+866  C CD2 B LEU A 116 ? 0.1439 0.1334 0.1300 0.0063  0.0117  0.0154  163 LEU A CD2 
+867  N N   . LYS A 117 ? 0.1518 0.1382 0.1067 0.0025  0.0040  -0.0149 164 LYS A N   
+868  C CA  . LYS A 117 ? 0.1484 0.1535 0.1100 0.0041  0.0079  -0.0141 164 LYS A CA  
+869  C C   . LYS A 117 ? 0.1313 0.1330 0.1122 -0.0001 -0.0081 -0.0034 164 LYS A C   
+870  O O   . LYS A 117 ? 0.1331 0.1317 0.1130 0.0009  0.0015  -0.0102 164 LYS A O   
+871  C CB  . LYS A 117 ? 0.1466 0.2326 0.1274 0.0073  0.0066  -0.0377 164 LYS A CB  
+872  C CG  . LYS A 117 ? 0.1636 0.2446 0.1421 -0.0271 0.0400  -0.0689 164 LYS A CG  
+873  C CD  . LYS A 117 ? 0.1913 0.3292 0.1671 -0.0338 0.0268  -0.0827 164 LYS A CD  
+874  C CE  . LYS A 117 ? 0.2244 0.3606 0.1898 0.0148  -0.0288 -0.0146 164 LYS A CE  
+875  N NZ  . LYS A 117 ? 0.3014 0.4102 0.2101 0.0400  -0.0814 -0.0193 164 LYS A NZ  
+876  N N   . ASP A 118 ? 0.1220 0.1399 0.1195 0.0125  0.0087  0.0037  165 ASP A N   
+877  C CA  . ASP A 118 ? 0.1541 0.1183 0.1328 0.0168  -0.0002 0.0125  165 ASP A CA  
+878  C C   . ASP A 118 ? 0.1370 0.0956 0.1238 0.0192  0.0018  0.0018  165 ASP A C   
+879  O O   . ASP A 118 ? 0.1363 0.1078 0.1379 0.0188  0.0086  -0.0041 165 ASP A O   
+880  C CB  A ASP A 118 ? 0.1478 0.1224 0.1209 0.0194  0.0206  0.0065  165 ASP A CB  
+881  C CB  B ASP A 118 ? 0.2485 0.1171 0.2108 -0.0001 -0.0565 0.0588  165 ASP A CB  
+882  C CG  A ASP A 118 ? 0.1872 0.1401 0.1493 0.0438  0.0132  0.0265  165 ASP A CG  
+883  C CG  B ASP A 118 ? 0.3092 0.1121 0.1896 0.0278  -0.0902 0.0411  165 ASP A CG  
+884  O OD1 A ASP A 118 ? 0.2010 0.1999 0.1467 0.0413  -0.0198 0.0572  165 ASP A OD1 
+885  O OD1 B ASP A 118 ? 0.3205 0.4245 0.2409 0.1359  -0.1161 -0.0999 165 ASP A OD1 
+886  O OD2 A ASP A 118 ? 0.2450 0.1576 0.2151 0.0401  0.0327  0.0722  165 ASP A OD2 
+887  O OD2 B ASP A 118 ? 0.3534 0.2459 0.1687 -0.0564 -0.0374 0.0054  165 ASP A OD2 
+888  N N   . LYS A 119 ? 0.1343 0.1132 0.1103 0.0220  0.0084  -0.0069 166 LYS A N   
+889  C CA  . LYS A 119 ? 0.1286 0.1013 0.1045 0.0041  0.0016  -0.0094 166 LYS A CA  
+890  C C   . LYS A 119 ? 0.1178 0.0947 0.1062 0.0187  0.0055  -0.0137 166 LYS A C   
+891  O O   . LYS A 119 ? 0.1170 0.1060 0.1029 0.0094  0.0029  -0.0124 166 LYS A O   
+892  C CB  . LYS A 119 ? 0.1233 0.1180 0.1201 0.0121  0.0078  0.0044  166 LYS A CB  
+893  C CG  . LYS A 119 ? 0.1230 0.1198 0.1109 0.0065  0.0089  0.0116  166 LYS A CG  
+894  C CD  . LYS A 119 ? 0.1719 0.1278 0.1296 -0.0010 0.0006  0.0005  166 LYS A CD  
+895  C CE  . LYS A 119 ? 0.1935 0.1366 0.1331 -0.0071 0.0036  -0.0022 166 LYS A CE  
+896  N NZ  . LYS A 119 ? 0.2089 0.1498 0.1525 -0.0300 0.0230  -0.0263 166 LYS A NZ  
+897  N N   . ILE A 120 ? 0.1161 0.0999 0.0995 0.0090  0.0080  -0.0082 167 ILE A N   
+898  C CA  . ILE A 120 ? 0.1159 0.0999 0.0879 0.0110  -0.0037 -0.0091 167 ILE A CA  
+899  C C   . ILE A 120 ? 0.1165 0.0877 0.0989 0.0052  0.0019  -0.0124 167 ILE A C   
+900  O O   . ILE A 120 ? 0.1251 0.1084 0.1050 0.0111  0.0058  -0.0183 167 ILE A O   
+901  C CB  . ILE A 120 ? 0.1146 0.0998 0.0972 0.0117  0.0005  -0.0068 167 ILE A CB  
+902  C CG1 . ILE A 120 ? 0.1170 0.1001 0.0983 0.0166  -0.0087 -0.0113 167 ILE A CG1 
+903  C CG2 . ILE A 120 ? 0.1283 0.1022 0.1099 0.0025  0.0000  -0.0143 167 ILE A CG2 
+904  C CD1 . ILE A 120 ? 0.1247 0.1095 0.1135 0.0237  0.0029  -0.0176 167 ILE A CD1 
+905  N N   . ARG A 121 ? 0.1170 0.1013 0.1046 0.0131  -0.0044 -0.0204 168 ARG A N   
+906  C CA  . ARG A 121 ? 0.1241 0.0988 0.1201 0.0204  -0.0004 -0.0140 168 ARG A CA  
+907  C C   . ARG A 121 ? 0.1076 0.1020 0.1111 0.0198  -0.0070 -0.0128 168 ARG A C   
+908  O O   . ARG A 121 ? 0.1188 0.1175 0.1181 0.0154  0.0017  -0.0194 168 ARG A O   
+909  C CB  . ARG A 121 ? 0.1448 0.1756 0.1142 0.0523  -0.0197 -0.0082 168 ARG A CB  
+910  C CG  A ARG A 121 ? 0.1647 0.2132 0.1429 0.0774  0.0019  0.0375  168 ARG A CG  
+911  C CG  B ARG A 121 ? 0.1525 0.1830 0.1578 0.0657  -0.0441 -0.0345 168 ARG A CG  
+912  C CD  A ARG A 121 ? 0.1820 0.2110 0.1725 0.0949  -0.0272 0.0274  168 ARG A CD  
+913  C CD  B ARG A 121 ? 0.2083 0.1798 0.1901 0.1025  -0.0417 -0.0223 168 ARG A CD  
+914  N NE  A ARG A 121 ? 0.1758 0.2554 0.2113 0.0904  -0.0281 -0.0045 168 ARG A NE  
+915  N NE  B ARG A 121 ? 0.2260 0.1917 0.1804 0.0884  -0.0393 -0.0114 168 ARG A NE  
+916  C CZ  A ARG A 121 ? 0.2123 0.4385 0.3132 0.1731  -0.0500 0.0483  168 ARG A CZ  
+917  C CZ  B ARG A 121 ? 0.3046 0.1683 0.3144 0.1497  -0.0813 -0.0685 168 ARG A CZ  
+918  N NH1 A ARG A 121 ? 0.3466 0.7113 0.3023 0.2752  -0.1282 0.0596  168 ARG A NH1 
+919  N NH1 B ARG A 121 ? 0.5273 0.1834 0.2037 0.2052  -0.0605 -0.0613 168 ARG A NH1 
+920  N NH2 A ARG A 121 ? 0.2125 0.3534 0.5240 0.1505  -0.0060 0.0285  168 ARG A NH2 
+921  N NH2 B ARG A 121 ? 0.3759 0.1836 0.4440 0.1059  -0.1664 -0.0506 168 ARG A NH2 
+922  N N   . VAL A 122 ? 0.1266 0.0972 0.1081 0.0159  -0.0031 -0.0095 169 VAL A N   
+923  C CA  . VAL A 122 ? 0.1250 0.0931 0.1254 0.0210  -0.0037 -0.0211 169 VAL A CA  
+924  C C   . VAL A 122 ? 0.1006 0.0947 0.1137 0.0072  0.0004  -0.0201 169 VAL A C   
+925  O O   . VAL A 122 ? 0.1119 0.0971 0.1262 0.0072  0.0069  -0.0299 169 VAL A O   
+926  C CB  . VAL A 122 ? 0.1443 0.1024 0.1265 0.0024  0.0130  -0.0113 169 VAL A CB  
+927  C CG1 . VAL A 122 ? 0.1915 0.1207 0.1477 -0.0286 0.0124  -0.0345 169 VAL A CG1 
+928  C CG2 . VAL A 122 ? 0.1677 0.1026 0.1655 0.0054  0.0011  -0.0034 169 VAL A CG2 
+929  N N   . LEU A 123 ? 0.1190 0.0996 0.1036 0.0166  0.0014  -0.0166 170 LEU A N   
+930  C CA  . LEU A 123 ? 0.1140 0.0987 0.0936 0.0123  -0.0026 -0.0140 170 LEU A CA  
+931  C C   . LEU A 123 ? 0.1106 0.0972 0.1007 0.0136  -0.0006 -0.0171 170 LEU A C   
+932  O O   . LEU A 123 ? 0.1128 0.1229 0.1019 0.0059  0.0093  -0.0141 170 LEU A O   
+933  C CB  . LEU A 123 ? 0.1134 0.1109 0.1015 0.0243  0.0033  -0.0183 170 LEU A CB  
+934  C CG  . LEU A 123 ? 0.1155 0.1218 0.0952 0.0226  0.0046  -0.0070 170 LEU A CG  
+935  C CD1 . LEU A 123 ? 0.1264 0.1472 0.1022 0.0380  0.0105  -0.0090 170 LEU A CD1 
+936  C CD2 . LEU A 123 ? 0.1282 0.1318 0.1154 0.0110  0.0004  -0.0177 170 LEU A CD2 
+937  N N   . ALA A 124 ? 0.1082 0.1010 0.1022 0.0119  -0.0004 -0.0154 171 ALA A N   
+938  C CA  . ALA A 124 ? 0.1153 0.1059 0.1171 0.0000  0.0010  -0.0169 171 ALA A CA  
+939  C C   . ALA A 124 ? 0.1054 0.1101 0.1145 0.0001  -0.0021 -0.0253 171 ALA A C   
+940  O O   . ALA A 124 ? 0.1145 0.1166 0.1166 -0.0098 0.0031  -0.0219 171 ALA A O   
+941  C CB  . ALA A 124 ? 0.1398 0.1141 0.1226 0.0016  0.0114  -0.0337 171 ALA A CB  
+942  N N   . GLU A 125 ? 0.1061 0.1213 0.1165 0.0040  0.0097  -0.0139 172 GLU A N   
+943  C CA  . GLU A 125 ? 0.1127 0.1228 0.1354 0.0141  0.0058  -0.0222 172 GLU A CA  
+944  C C   . GLU A 125 ? 0.1153 0.1076 0.1344 0.0119  0.0041  -0.0240 172 GLU A C   
+945  O O   . GLU A 125 ? 0.1243 0.1403 0.1424 0.0141  0.0128  -0.0283 172 GLU A O   
+946  C CB  . GLU A 125 ? 0.1195 0.1397 0.1380 0.0264  -0.0054 -0.0208 172 GLU A CB  
+947  C CG  . GLU A 125 ? 0.1396 0.1527 0.1489 0.0128  -0.0164 -0.0199 172 GLU A CG  
+948  C CD  . GLU A 125 ? 0.1829 0.1662 0.2008 0.0341  -0.0675 -0.0195 172 GLU A CD  
+949  O OE1 . GLU A 125 ? 0.3439 0.1640 0.2937 0.0138  -0.1441 -0.0111 172 GLU A OE1 
+950  O OE2 . GLU A 125 ? 0.2147 0.2309 0.1796 0.0284  -0.0615 -0.0105 172 GLU A OE2 
+951  N N   . GLY A 126 ? 0.1190 0.1143 0.1306 0.0103  0.0076  -0.0299 173 GLY A N   
+952  C CA  . GLY A 126 ? 0.1249 0.1152 0.1326 -0.0008 0.0118  -0.0357 173 GLY A CA  
+953  C C   . GLY A 126 ? 0.1103 0.1131 0.1267 -0.0071 0.0071  -0.0373 173 GLY A C   
+954  O O   . GLY A 126 ? 0.1282 0.1301 0.1274 -0.0028 0.0113  -0.0350 173 GLY A O   
+955  N N   . ASP A 127 ? 0.1118 0.1187 0.1205 -0.0019 0.0037  -0.0278 174 ASP A N   
+956  C CA  . ASP A 127 ? 0.1391 0.1129 0.1399 -0.0065 0.0086  -0.0223 174 ASP A CA  
+957  C C   . ASP A 127 ? 0.1386 0.1260 0.1245 -0.0181 0.0160  -0.0270 174 ASP A C   
+958  O O   . ASP A 127 ? 0.1667 0.1521 0.1614 -0.0318 0.0209  -0.0028 174 ASP A O   
+959  C CB  . ASP A 127 ? 0.1465 0.1176 0.1265 0.0022  -0.0106 -0.0326 174 ASP A CB  
+960  C CG  . ASP A 127 ? 0.1430 0.1077 0.1417 0.0001  -0.0006 -0.0273 174 ASP A CG  
+961  O OD1 . ASP A 127 ? 0.1498 0.1180 0.1321 0.0016  -0.0118 -0.0201 174 ASP A OD1 
+962  O OD2 . ASP A 127 ? 0.1653 0.1567 0.2024 0.0202  -0.0087 -0.0614 174 ASP A OD2 
+963  N N   . GLY A 128 ? 0.1296 0.1450 0.1440 -0.0097 0.0091  -0.0378 175 GLY A N   
+964  C CA  . GLY A 128 ? 0.1166 0.1629 0.1610 -0.0185 0.0317  -0.0544 175 GLY A CA  
+965  C C   . GLY A 128 ? 0.1194 0.1566 0.1694 -0.0164 0.0226  -0.0501 175 GLY A C   
+966  O O   . GLY A 128 ? 0.1225 0.2522 0.2068 -0.0512 0.0313  -0.0901 175 GLY A O   
+967  N N   . PHE A 129 ? 0.1084 0.1388 0.1539 -0.0093 0.0105  -0.0518 176 PHE A N   
+968  C CA  . PHE A 129 ? 0.1161 0.1332 0.1529 -0.0155 0.0008  -0.0406 176 PHE A CA  
+969  C C   . PHE A 129 ? 0.1165 0.1553 0.1564 0.0079  0.0039  -0.0403 176 PHE A C   
+970  O O   . PHE A 129 ? 0.1279 0.1671 0.1451 -0.0084 -0.0080 -0.0208 176 PHE A O   
+971  C CB  . PHE A 129 ? 0.1307 0.1362 0.1378 -0.0056 0.0085  -0.0393 176 PHE A CB  
+972  C CG  . PHE A 129 ? 0.1747 0.1296 0.1404 0.0063  0.0044  -0.0410 176 PHE A CG  
+973  C CD1 . PHE A 129 ? 0.2562 0.1555 0.1593 0.0340  0.0631  -0.0143 176 PHE A CD1 
+974  C CD2 . PHE A 129 ? 0.1937 0.1289 0.1952 0.0033  -0.0551 -0.0510 176 PHE A CD2 
+975  C CE1 . PHE A 129 ? 0.3637 0.1918 0.1545 0.0753  0.0596  -0.0115 176 PHE A CE1 
+976  C CE2 . PHE A 129 ? 0.2788 0.1359 0.2144 0.0299  -0.0943 -0.0606 176 PHE A CE2 
+977  C CZ  . PHE A 129 ? 0.3955 0.2020 0.1628 0.0500  -0.0482 -0.0349 176 PHE A CZ  
+978  N N   . MET A 130 ? 0.1159 0.1718 0.1741 0.0073  -0.0004 -0.0384 177 MET A N   
+979  C CA  . MET A 130 ? 0.1305 0.1393 0.2028 0.0133  -0.0246 -0.0463 177 MET A CA  
+980  C C   . MET A 130 ? 0.1637 0.1387 0.2005 0.0187  -0.0497 -0.0357 177 MET A C   
+981  O O   . MET A 130 ? 0.2792 0.1579 0.2029 0.0533  -0.0701 -0.0381 177 MET A O   
+982  C CB  . MET A 130 ? 0.1394 0.1690 0.2731 0.0318  -0.0170 -0.0520 177 MET A CB  
+983  C CG  . MET A 130 ? 0.1600 0.1986 0.3398 0.0361  0.0024  -0.1269 177 MET A CG  
+984  S SD  . MET A 130 ? 0.1971 0.2651 0.3776 -0.0111 0.0471  -0.1773 177 MET A SD  
+985  C CE  . MET A 130 ? 0.2152 0.2843 0.5686 0.0108  0.1377  -0.0447 177 MET A CE  
+986  N N   . LYS A 131 ? 0.1248 0.1356 0.2029 0.0159  -0.0339 -0.0483 178 LYS A N   
+987  C CA  . LYS A 131 ? 0.1486 0.1470 0.1675 0.0235  -0.0375 -0.0332 178 LYS A CA  
+988  C C   . LYS A 131 ? 0.1231 0.1348 0.1763 0.0030  -0.0322 -0.0406 178 LYS A C   
+989  O O   . LYS A 131 ? 0.1268 0.1373 0.2305 -0.0153 -0.0024 -0.0364 178 LYS A O   
+990  C CB  . LYS A 131 ? 0.1396 0.2009 0.2753 0.0406  -0.0879 -0.0928 178 LYS A CB  
+991  C CG  . LYS A 131 ? 0.1761 0.2356 0.3570 0.0796  -0.0799 -0.0826 178 LYS A CG  
+992  C CD  . LYS A 131 ? 0.1753 0.3282 0.5777 0.0803  -0.1633 -0.1151 178 LYS A CD  
+993  C CE  . LYS A 131 ? 0.1989 0.3106 0.5966 0.0814  -0.2038 -0.0314 178 LYS A CE  
+994  N NZ  . LYS A 131 ? 0.4583 0.4957 0.5265 0.2259  0.0282  0.0535  178 LYS A NZ  
+995  N N   . ARG A 132 ? 0.0917 0.1314 0.1429 0.0041  -0.0194 -0.0296 179 ARG A N   
+996  C CA  . ARG A 132 ? 0.0945 0.1257 0.1255 -0.0045 -0.0077 -0.0221 179 ARG A CA  
+997  C C   . ARG A 132 ? 0.0819 0.1295 0.1209 -0.0066 -0.0010 -0.0250 179 ARG A C   
+998  O O   . ARG A 132 ? 0.0875 0.1509 0.1273 -0.0020 0.0063  -0.0182 179 ARG A O   
+999  C CB  . ARG A 132 ? 0.1011 0.1295 0.1340 0.0018  -0.0130 -0.0281 179 ARG A CB  
+1000 C CG  . ARG A 132 ? 0.0884 0.1273 0.1134 0.0016  -0.0059 -0.0182 179 ARG A CG  
+1001 C CD  . ARG A 132 ? 0.0936 0.1369 0.1053 -0.0130 0.0025  -0.0302 179 ARG A CD  
+1002 N NE  . ARG A 132 ? 0.1036 0.1452 0.1167 -0.0204 -0.0029 -0.0250 179 ARG A NE  
+1003 C CZ  . ARG A 132 ? 0.1044 0.1171 0.1132 -0.0214 -0.0015 -0.0311 179 ARG A CZ  
+1004 N NH1 . ARG A 132 ? 0.1139 0.1290 0.1193 -0.0085 0.0037  -0.0129 179 ARG A NH1 
+1005 N NH2 . ARG A 132 ? 0.1287 0.1518 0.1276 -0.0192 0.0141  -0.0155 179 ARG A NH2 
+1006 N N   . ILE A 133 ? 0.0869 0.1205 0.1023 -0.0062 -0.0038 -0.0228 180 ILE A N   
+1007 C CA  . ILE A 133 ? 0.0873 0.1152 0.1003 -0.0015 0.0026  -0.0191 180 ILE A CA  
+1008 C C   . ILE A 133 ? 0.0797 0.1134 0.1089 -0.0033 -0.0037 -0.0222 180 ILE A C   
+1009 O O   . ILE A 133 ? 0.0959 0.1205 0.1076 -0.0109 -0.0020 -0.0266 180 ILE A O   
+1010 C CB  . ILE A 133 ? 0.0894 0.1097 0.1057 -0.0069 -0.0001 -0.0228 180 ILE A CB  
+1011 C CG1 . ILE A 133 ? 0.0954 0.1046 0.1091 -0.0061 -0.0052 -0.0284 180 ILE A CG1 
+1012 C CG2 . ILE A 133 ? 0.1008 0.1234 0.1026 -0.0066 -0.0119 -0.0304 180 ILE A CG2 
+1013 C CD1 . ILE A 133 ? 0.1016 0.1263 0.1114 -0.0210 -0.0057 -0.0209 180 ILE A CD1 
+1014 N N   . PRO A 134 ? 0.1124 0.1252 0.1074 -0.0135 0.0121  -0.0158 181 PRO A N   
+1015 C CA  . PRO A 134 ? 0.1173 0.1245 0.1231 -0.0301 0.0163  -0.0146 181 PRO A CA  
+1016 C C   . PRO A 134 ? 0.1163 0.1132 0.1135 -0.0235 -0.0035 -0.0103 181 PRO A C   
+1017 O O   . PRO A 134 ? 0.1050 0.1214 0.1187 -0.0177 -0.0107 -0.0117 181 PRO A O   
+1018 C CB  . PRO A 134 ? 0.1573 0.1565 0.1184 -0.0292 0.0145  -0.0059 181 PRO A CB  
+1019 C CG  . PRO A 134 ? 0.1891 0.1521 0.1299 -0.0255 0.0459  -0.0201 181 PRO A CG  
+1020 C CD  . PRO A 134 ? 0.1409 0.1402 0.1196 -0.0163 0.0194  -0.0303 181 PRO A CD  
+1021 N N   . THR A 135 ? 0.1118 0.1267 0.1240 -0.0233 -0.0030 -0.0151 182 THR A N   
+1022 C CA  . THR A 135 ? 0.1239 0.1154 0.1159 -0.0144 -0.0102 -0.0140 182 THR A CA  
+1023 C C   . THR A 135 ? 0.1204 0.1139 0.1169 -0.0194 -0.0053 -0.0088 182 THR A C   
+1024 O O   . THR A 135 ? 0.1205 0.1362 0.1305 -0.0264 -0.0041 -0.0154 182 THR A O   
+1025 C CB  . THR A 135 ? 0.1452 0.1180 0.1377 0.0012  -0.0391 -0.0134 182 THR A CB  
+1026 O OG1 . THR A 135 ? 0.1521 0.1401 0.1521 0.0135  -0.0528 -0.0275 182 THR A OG1 
+1027 C CG2 . THR A 135 ? 0.1424 0.1603 0.2351 0.0076  -0.0392 -0.0816 182 THR A CG2 
+1028 N N   . SER A 136 ? 0.1223 0.1238 0.1183 -0.0236 -0.0136 0.0006  183 SER A N   
+1029 C CA  . SER A 136 ? 0.1415 0.1419 0.1290 -0.0498 -0.0216 0.0131  183 SER A CA  
+1030 C C   . SER A 136 ? 0.1406 0.1259 0.1142 -0.0326 -0.0183 0.0065  183 SER A C   
+1031 O O   . SER A 136 ? 0.1502 0.1481 0.1540 -0.0338 -0.0458 0.0143  183 SER A O   
+1032 C CB  . SER A 136 ? 0.1930 0.1970 0.1299 -0.0694 -0.0223 0.0494  183 SER A CB  
+1033 O OG  . SER A 136 ? 0.2044 0.2671 0.1521 -0.0706 0.0187  0.0046  183 SER A OG  
+1034 N N   . LYS A 137 ? 0.1169 0.1308 0.0993 -0.0214 -0.0021 -0.0071 184 LYS A N   
+1035 C CA  . LYS A 137 ? 0.1201 0.1226 0.1020 -0.0212 0.0008  -0.0109 184 LYS A CA  
+1036 C C   . LYS A 137 ? 0.1061 0.1076 0.0852 -0.0109 -0.0162 -0.0108 184 LYS A C   
+1037 O O   . LYS A 137 ? 0.1231 0.1066 0.0936 -0.0196 -0.0072 -0.0156 184 LYS A O   
+1038 C CB  . LYS A 137 ? 0.1299 0.1470 0.1273 -0.0151 0.0168  -0.0234 184 LYS A CB  
+1039 C CG  . LYS A 137 ? 0.1816 0.1973 0.1544 -0.0381 0.0601  -0.0322 184 LYS A CG  
+1040 C CD  . LYS A 137 ? 0.2923 0.2704 0.1359 -0.0416 0.0384  -0.0198 184 LYS A CD  
+1041 C CE  . LYS A 137 ? 0.5962 0.7367 0.1297 -0.0693 0.1611  -0.0268 184 LYS A CE  
+1042 N NZ  . LYS A 137 ? 0.6093 1.4930 0.1650 0.2896  0.1313  0.1304  184 LYS A NZ  
+1043 N N   . GLN A 138 ? 0.1015 0.1070 0.0949 -0.0209 -0.0066 -0.0138 185 GLN A N   
+1044 C CA  . GLN A 138 ? 0.0959 0.0993 0.0902 -0.0134 -0.0107 -0.0141 185 GLN A CA  
+1045 C C   . GLN A 138 ? 0.1034 0.0935 0.0926 -0.0182 -0.0070 -0.0191 185 GLN A C   
+1046 O O   . GLN A 138 ? 0.1017 0.1046 0.0942 -0.0184 -0.0160 -0.0120 185 GLN A O   
+1047 C CB  . GLN A 138 ? 0.0896 0.1115 0.0978 -0.0109 -0.0068 -0.0206 185 GLN A CB  
+1048 C CG  . GLN A 138 ? 0.0989 0.1204 0.0921 -0.0072 -0.0158 -0.0177 185 GLN A CG  
+1049 C CD  . GLN A 138 ? 0.0899 0.1260 0.0923 -0.0033 -0.0039 -0.0228 185 GLN A CD  
+1050 O OE1 . GLN A 138 ? 0.0931 0.1542 0.1111 -0.0028 -0.0120 -0.0441 185 GLN A OE1 
+1051 N NE2 . GLN A 138 ? 0.0878 0.1222 0.0991 -0.0115 -0.0106 -0.0211 185 GLN A NE2 
+1052 N N   . GLY A 139 ? 0.0937 0.1064 0.0926 -0.0115 -0.0073 -0.0111 186 GLY A N   
+1053 C CA  . GLY A 139 ? 0.1044 0.1037 0.1028 -0.0076 -0.0139 -0.0197 186 GLY A CA  
+1054 C C   . GLY A 139 ? 0.1000 0.0786 0.0920 -0.0040 -0.0124 -0.0025 186 GLY A C   
+1055 O O   . GLY A 139 ? 0.0974 0.0989 0.0963 -0.0111 -0.0030 -0.0101 186 GLY A O   
+1056 N N   . GLU A 140 ? 0.0990 0.0905 0.0902 -0.0063 -0.0121 -0.0096 187 GLU A N   
+1057 C CA  . GLU A 140 ? 0.1032 0.0896 0.0871 -0.0043 -0.0080 -0.0072 187 GLU A CA  
+1058 C C   . GLU A 140 ? 0.0948 0.0916 0.0759 -0.0077 -0.0155 -0.0100 187 GLU A C   
+1059 O O   . GLU A 140 ? 0.0966 0.0940 0.0864 -0.0121 -0.0078 -0.0065 187 GLU A O   
+1060 C CB  . GLU A 140 ? 0.1103 0.1011 0.0813 -0.0088 -0.0116 -0.0044 187 GLU A CB  
+1061 C CG  . GLU A 140 ? 0.1159 0.0913 0.0971 -0.0064 -0.0160 -0.0073 187 GLU A CG  
+1062 C CD  . GLU A 140 ? 0.1348 0.1006 0.0925 -0.0227 -0.0160 0.0048  187 GLU A CD  
+1063 O OE1 . GLU A 140 ? 0.1421 0.1117 0.0920 -0.0131 -0.0072 -0.0042 187 GLU A OE1 
+1064 O OE2 . GLU A 140 ? 0.2059 0.1206 0.1039 0.0036  -0.0084 0.0081  187 GLU A OE2 
+1065 N N   . LEU A 141 ? 0.0945 0.0863 0.0807 -0.0091 -0.0064 -0.0084 188 LEU A N   
+1066 C CA  . LEU A 141 ? 0.0955 0.0859 0.0881 -0.0032 -0.0076 -0.0121 188 LEU A CA  
+1067 C C   . LEU A 141 ? 0.0876 0.0852 0.0899 -0.0048 -0.0083 -0.0078 188 LEU A C   
+1068 O O   . LEU A 141 ? 0.1020 0.0913 0.0955 -0.0035 -0.0048 -0.0083 188 LEU A O   
+1069 C CB  . LEU A 141 ? 0.0875 0.0954 0.1020 -0.0077 -0.0038 -0.0104 188 LEU A CB  
+1070 C CG  . LEU A 141 ? 0.1041 0.1056 0.1164 0.0057  -0.0136 -0.0203 188 LEU A CG  
+1071 C CD1 . LEU A 141 ? 0.1131 0.1326 0.1421 0.0202  -0.0090 -0.0277 188 LEU A CD1 
+1072 C CD2 . LEU A 141 ? 0.1275 0.1161 0.1182 -0.0053 -0.0125 -0.0110 188 LEU A CD2 
+1073 N N   . LEU A 142 ? 0.0884 0.0902 0.0821 -0.0036 -0.0098 -0.0098 189 LEU A N   
+1074 C CA  . LEU A 142 ? 0.0905 0.1020 0.0822 0.0009  -0.0112 -0.0117 189 LEU A CA  
+1075 C C   . LEU A 142 ? 0.0986 0.0901 0.0769 0.0014  -0.0016 -0.0051 189 LEU A C   
+1076 O O   . LEU A 142 ? 0.1028 0.0966 0.0869 -0.0094 -0.0024 -0.0071 189 LEU A O   
+1077 C CB  . LEU A 142 ? 0.1017 0.1017 0.0815 -0.0036 -0.0072 -0.0106 189 LEU A CB  
+1078 C CG  . LEU A 142 ? 0.0996 0.1270 0.0827 -0.0014 -0.0045 -0.0180 189 LEU A CG  
+1079 C CD1 . LEU A 142 ? 0.1500 0.2046 0.0857 0.0385  0.0143  0.0144  189 LEU A CD1 
+1080 C CD2 . LEU A 142 ? 0.1916 0.1503 0.0960 -0.0137 0.0215  -0.0373 189 LEU A CD2 
+1081 N N   . ALA A 143 ? 0.0891 0.0881 0.0844 -0.0061 -0.0097 -0.0107 190 ALA A N   
+1082 C CA  . ALA A 143 ? 0.0858 0.0886 0.0819 0.0006  0.0020  -0.0130 190 ALA A CA  
+1083 C C   . ALA A 143 ? 0.0842 0.0817 0.0768 -0.0014 -0.0030 -0.0026 190 ALA A C   
+1084 O O   . ALA A 143 ? 0.0969 0.0943 0.0960 -0.0040 0.0036  -0.0094 190 ALA A O   
+1085 C CB  . ALA A 143 ? 0.0975 0.0829 0.1113 0.0060  -0.0155 -0.0099 190 ALA A CB  
+1086 N N   . LYS A 144 ? 0.0901 0.0808 0.0867 -0.0029 -0.0031 -0.0142 191 LYS A N   
+1087 C CA  . LYS A 144 ? 0.0925 0.0828 0.0834 -0.0018 -0.0036 -0.0125 191 LYS A CA  
+1088 C C   . LYS A 144 ? 0.0889 0.0808 0.0852 0.0022  0.0033  -0.0154 191 LYS A C   
+1089 O O   . LYS A 144 ? 0.1109 0.0801 0.0936 -0.0084 0.0025  -0.0078 191 LYS A O   
+1090 C CB  . LYS A 144 ? 0.1019 0.0841 0.0901 -0.0032 -0.0002 -0.0104 191 LYS A CB  
+1091 C CG  . LYS A 144 ? 0.1108 0.1014 0.0978 0.0056  0.0030  -0.0245 191 LYS A CG  
+1092 C CD  . LYS A 144 ? 0.1193 0.1153 0.1270 0.0008  0.0168  -0.0282 191 LYS A CD  
+1093 C CE  . LYS A 144 ? 0.1269 0.1348 0.1143 0.0062  0.0080  -0.0230 191 LYS A CE  
+1094 N NZ  . LYS A 144 ? 0.1528 0.1808 0.1178 0.0038  0.0446  -0.0293 191 LYS A NZ  
+1095 N N   . ALA A 145 ? 0.0978 0.0821 0.0847 -0.0012 -0.0062 -0.0041 192 ALA A N   
+1096 C CA  . ALA A 145 ? 0.1058 0.0910 0.0892 0.0078  0.0004  -0.0007 192 ALA A CA  
+1097 C C   . ALA A 145 ? 0.1113 0.0928 0.0761 -0.0013 -0.0014 -0.0071 192 ALA A C   
+1098 O O   . ALA A 145 ? 0.1178 0.0924 0.1041 -0.0055 0.0057  -0.0036 192 ALA A O   
+1099 C CB  . ALA A 145 ? 0.1086 0.1211 0.0841 0.0066  -0.0032 -0.0075 192 ALA A CB  
+1100 N N   . MET A 146 ? 0.0993 0.0901 0.0845 -0.0016 0.0040  -0.0060 193 MET A N   
+1101 C CA  . MET A 146 ? 0.1108 0.0989 0.0853 0.0018  0.0095  0.0024  193 MET A CA  
+1102 C C   . MET A 146 ? 0.0977 0.0951 0.1046 0.0002  0.0130  -0.0042 193 MET A C   
+1103 O O   . MET A 146 ? 0.1208 0.1224 0.1116 -0.0177 0.0110  0.0071  193 MET A O   
+1104 C CB  . MET A 146 ? 0.1115 0.1029 0.0966 0.0085  0.0087  -0.0031 193 MET A CB  
+1105 C CG  . MET A 146 ? 0.1102 0.1155 0.1038 0.0018  0.0090  0.0007  193 MET A CG  
+1106 S SD  . MET A 146 ? 0.1264 0.1105 0.0974 0.0037  0.0108  -0.0093 193 MET A SD  
+1107 C CE  . MET A 146 ? 0.1118 0.1473 0.1219 0.0152  0.0064  -0.0046 193 MET A CE  
+1108 N N   . TYR A 147 ? 0.0962 0.0989 0.0999 -0.0104 -0.0007 -0.0005 194 TYR A N   
+1109 C CA  . TYR A 147 ? 0.1017 0.1070 0.1052 -0.0175 -0.0021 0.0041  194 TYR A CA  
+1110 C C   . TYR A 147 ? 0.1213 0.1033 0.1067 -0.0252 -0.0110 -0.0025 194 TYR A C   
+1111 O O   . TYR A 147 ? 0.1360 0.1200 0.1306 -0.0369 -0.0174 0.0154  194 TYR A O   
+1112 C CB  . TYR A 147 ? 0.1174 0.1055 0.1031 -0.0147 -0.0067 -0.0006 194 TYR A CB  
+1113 C CG  . TYR A 147 ? 0.1110 0.0933 0.0979 -0.0097 -0.0131 0.0070  194 TYR A CG  
+1114 C CD1 . TYR A 147 ? 0.1152 0.1039 0.1228 -0.0135 -0.0192 0.0052  194 TYR A CD1 
+1115 C CD2 . TYR A 147 ? 0.1201 0.1132 0.0982 -0.0108 -0.0030 0.0010  194 TYR A CD2 
+1116 C CE1 . TYR A 147 ? 0.1284 0.1231 0.1158 -0.0256 -0.0239 0.0034  194 TYR A CE1 
+1117 C CE2 . TYR A 147 ? 0.1382 0.1248 0.1086 -0.0062 -0.0051 -0.0111 194 TYR A CE2 
+1118 C CZ  . TYR A 147 ? 0.1588 0.1019 0.1159 -0.0226 -0.0077 -0.0068 194 TYR A CZ  
+1119 O OH  . TYR A 147 ? 0.1803 0.1343 0.1401 -0.0195 -0.0200 -0.0320 194 TYR A OH  
+1120 N N   . ALA A 148 ? 0.1319 0.0775 0.1080 -0.0161 -0.0027 0.0016  195 ALA A N   
+1121 C CA  . ALA A 148 ? 0.1539 0.0905 0.1198 -0.0097 -0.0008 -0.0066 195 ALA A CA  
+1122 C C   . ALA A 148 ? 0.1507 0.0921 0.1230 -0.0099 -0.0089 0.0044  195 ALA A C   
+1123 O O   . ALA A 148 ? 0.2147 0.0992 0.1741 -0.0253 -0.0119 0.0160  195 ALA A O   
+1124 C CB  . ALA A 148 ? 0.1539 0.0962 0.1362 0.0133  0.0134  -0.0097 195 ALA A CB  
+1125 N N   . LEU A 149 ? 0.1547 0.1088 0.1235 -0.0236 0.0089  0.0108  196 LEU A N   
+1126 C CA  . LEU A 149 ? 0.1697 0.1418 0.1190 -0.0222 -0.0014 0.0297  196 LEU A CA  
+1127 C C   . LEU A 149 ? 0.1700 0.1778 0.1508 -0.0555 0.0093  0.0506  196 LEU A C   
+1128 O O   . LEU A 149 ? 0.2190 0.3921 0.3743 -0.0800 0.0053  0.2658  196 LEU A O   
+1129 C CB  . LEU A 149 ? 0.1901 0.1594 0.1227 -0.0187 -0.0066 0.0311  196 LEU A CB  
+1130 C CG  . LEU A 149 ? 0.2172 0.1568 0.2282 -0.0186 -0.0807 0.0116  196 LEU A CG  
+1131 C CD1 . LEU A 149 ? 0.3315 0.2328 0.3584 0.0383  -0.1900 -0.0723 196 LEU A CD1 
+1132 C CD2 . LEU A 149 ? 0.2917 0.1974 0.2213 0.0463  -0.0310 0.0011  196 LEU A CD2 
+1133 N N   . ASN A 150 ? 0.1462 0.1397 0.1079 -0.0399 0.0105  -0.0031 197 ASN A N   
+1134 C CA  . ASN A 150 ? 0.1337 0.1730 0.1259 -0.0597 0.0210  -0.0204 197 ASN A CA  
+1135 C C   . ASN A 150 ? 0.1721 0.1850 0.1524 -0.0883 0.0167  -0.0244 197 ASN A C   
+1136 O O   . ASN A 150 ? 0.1714 0.2488 0.1737 -0.0884 0.0099  -0.0389 197 ASN A O   
+1137 C CB  A ASN A 150 ? 0.1134 0.1784 0.1513 -0.0383 -0.0314 -0.0348 197 ASN A CB  
+1138 C CB  B ASN A 150 ? 0.1111 0.1758 0.1093 -0.0538 0.0172  -0.0235 197 ASN A CB  
+1139 C CG  A ASN A 150 ? 0.1069 0.1784 0.1530 0.0304  -0.0064 -0.0155 197 ASN A CG  
+1140 C CG  B ASN A 150 ? 0.0668 0.1908 0.1243 -0.0317 -0.0052 -0.0312 197 ASN A CG  
+1141 O OD1 A ASN A 150 ? 0.4507 0.1803 0.1528 -0.0128 0.0299  -0.0397 197 ASN A OD1 
+1142 O OD1 B ASN A 150 ? 0.1444 0.2045 0.1022 -0.0156 0.0224  -0.0295 197 ASN A OD1 
+1143 N ND2 A ASN A 150 ? 0.1660 0.1649 0.2075 -0.0080 -0.0723 -0.0341 197 ASN A ND2 
+1144 N ND2 B ASN A 150 ? 0.3776 0.2160 0.1131 -0.1709 -0.0684 0.0122  197 ASN A ND2 
+1145 N N   . HIS A 151 ? 0.1672 0.1926 0.1601 -0.0314 0.0089  -0.0539 198 HIS A N   
+1146 C CA  . HIS A 151 ? 0.1923 0.1709 0.1784 -0.0112 -0.0271 -0.0448 198 HIS A CA  
+1147 C C   . HIS A 151 ? 0.1976 0.1887 0.3056 0.0054  -0.0141 -0.1018 198 HIS A C   
+1148 O O   . HIS A 151 ? 0.2483 0.3609 0.2994 0.0412  0.0503  -0.1091 198 HIS A O   
+1149 C CB  . HIS A 151 ? 0.2688 0.2689 0.2045 0.0771  0.0382  0.0418  198 HIS A CB  
+1150 C CG  . HIS A 151 ? 0.2086 0.2361 0.1901 0.0262  0.0253  0.0394  198 HIS A CG  
+1151 N ND1 . HIS A 151 ? 0.2083 0.2246 0.3189 0.0286  0.0269  0.0514  198 HIS A ND1 
+1152 C CD2 . HIS A 151 ? 0.2119 0.2976 0.1427 0.0282  -0.0471 -0.0033 198 HIS A CD2 
+1153 C CE1 . HIS A 151 ? 0.2285 0.1995 0.4186 0.0543  0.0382  0.0773  198 HIS A CE1 
+1154 N NE2 . HIS A 151 ? 0.2527 0.2187 0.2438 0.0300  0.0081  0.0547  198 HIS A NE2 
+1155 N N1  . EPE B .   ? 0.1101 0.1387 0.1458 -0.0030 -0.0297 -0.0243 300 EPE A N1  
+1156 C C2  . EPE B .   ? 0.0952 0.1562 0.1456 -0.0026 -0.0184 -0.0160 300 EPE A C2  
+1157 C C3  . EPE B .   ? 0.1160 0.1447 0.1291 -0.0250 -0.0258 -0.0140 300 EPE A C3  
+1158 N N4  . EPE B .   ? 0.0995 0.1300 0.1333 -0.0085 -0.0287 -0.0110 300 EPE A N4  
+1159 C C5  . EPE B .   ? 0.1001 0.1607 0.1418 0.0069  -0.0308 0.0025  300 EPE A C5  
+1160 C C6  . EPE B .   ? 0.1101 0.1782 0.1272 -0.0080 -0.0160 -0.0399 300 EPE A C6  
+1161 C C7  . EPE B .   ? 0.1131 0.1290 0.1291 -0.0156 -0.0188 0.0092  300 EPE A C7  
+1162 C C8  . EPE B .   ? 0.1205 0.1282 0.1343 0.0009  -0.0193 0.0009  300 EPE A C8  
+1163 O O8  . EPE B .   ? 0.1146 0.1193 0.1359 -0.0072 -0.0268 -0.0008 300 EPE A O8  
+1164 C C9  . EPE B .   ? 0.1191 0.1878 0.1447 -0.0123 -0.0068 -0.0464 300 EPE A C9  
+1165 C C10 . EPE B .   ? 0.1141 0.1730 0.1541 -0.0011 -0.0214 -0.0443 300 EPE A C10 
+1166 S S   . EPE B .   ? 0.1123 0.1863 0.1628 0.0109  -0.0313 -0.0598 300 EPE A S   
+1167 O O1S . EPE B .   ? 0.1614 0.2205 0.1736 0.0021  -0.0390 -0.0894 300 EPE A O1S 
+1168 O O2S . EPE B .   ? 0.1121 0.1869 0.1816 0.0009  -0.0126 -0.0152 300 EPE A O2S 
+1169 O O3S . EPE B .   ? 0.1134 0.2157 0.1518 0.0234  -0.0389 -0.0477 300 EPE A O3S 
+1170 C C1  . GOL C .   ? 0.7146 0.1592 0.3224 0.0304  0.0983  -0.0912 301 GOL A C1  
+1171 O O1  . GOL C .   ? 0.6061 0.3736 0.2316 0.2577  0.1578  0.0793  301 GOL A O1  
+1172 C C2  . GOL C .   ? 0.5312 0.1929 0.1237 -0.0393 0.0632  -0.0420 301 GOL A C2  
+1173 O O2  . GOL C .   ? 0.4411 0.1901 0.1545 0.0217  0.0292  0.0532  301 GOL A O2  
+1174 C C3  . GOL C .   ? 0.5343 0.2531 0.2952 -0.1675 0.0693  -0.1113 301 GOL A C3  
+1175 O O3  . GOL C .   ? 0.4682 0.6710 0.1117 -0.2111 0.0252  -0.1341 301 GOL A O3  
+1176 C C1  . GOL D .   ? 0.1632 0.3985 0.3229 -0.0356 0.0671  0.0819  302 GOL A C1  
+1177 O O1  . GOL D .   ? 0.2489 0.2297 0.2605 -0.0209 0.0703  0.0405  302 GOL A O1  
+1178 C C2  . GOL D .   ? 0.1716 0.3846 0.3065 -0.0956 0.0233  0.1457  302 GOL A C2  
+1179 O O2  . GOL D .   ? 0.5464 0.1670 0.3100 0.1075  -0.0647 -0.0139 302 GOL A O2  
+1180 C C3  . GOL D .   ? 0.1863 0.2756 0.2967 -0.1208 0.0014  0.0976  302 GOL A C3  
+1181 O O3  . GOL D .   ? 0.3729 0.2576 0.2862 -0.1277 -0.1174 0.1188  302 GOL A O3  
+1182 O O   . HOH E .   ? 0.1158 0.1167 0.0934 -0.0020 -0.0190 -0.0060 401 HOH A O   
+1183 O O   . HOH E .   ? 0.1460 0.0988 0.1058 -0.0004 0.0029  -0.0129 402 HOH A O   
+1184 O O   . HOH E .   ? 0.1169 0.1360 0.1138 -0.0157 -0.0142 -0.0187 403 HOH A O   
+1185 O O   . HOH E .   ? 0.1078 0.1024 0.1580 -0.0067 0.0033  0.0333  404 HOH A O   
+1186 O O   . HOH E .   ? 0.1167 0.1201 0.1321 -0.0138 -0.0173 -0.0037 405 HOH A O   
+1187 O O   . HOH E .   ? 0.1266 0.1399 0.1350 -0.0338 -0.0132 0.0152  406 HOH A O   
+1188 O O   . HOH E .   ? 0.1449 0.1299 0.1338 -0.0098 0.0009  -0.0205 407 HOH A O   
+1189 O O   . HOH E .   ? 0.1483 0.1474 0.1327 -0.0155 -0.0067 -0.0127 408 HOH A O   
+1190 O O   . HOH E .   ? 0.1332 0.1904 0.1090 -0.0021 -0.0118 0.0146  409 HOH A O   
+1191 O O   . HOH E .   ? 0.1771 0.1441 0.1341 -0.0115 0.0165  -0.0042 410 HOH A O   
+1192 O O   . HOH E .   ? 0.1280 0.2113 0.1167 0.0029  -0.0130 0.0301  411 HOH A O   
+1193 O O   . HOH E .   ? 0.1492 0.1857 0.1219 0.0201  0.0076  -0.0291 412 HOH A O   
+1194 O O   . HOH E .   ? 0.1154 0.2514 0.1242 0.0021  -0.0152 -0.0374 413 HOH A O   
+1195 O O   . HOH E .   ? 0.1196 0.2144 0.1638 -0.0303 -0.0273 0.0493  414 HOH A O   
+1196 O O   . HOH E .   ? 0.1406 0.1181 0.2416 -0.0262 -0.0098 0.0225  415 HOH A O   
+1197 O O   . HOH E .   ? 0.1712 0.1468 0.1905 0.0151  0.0236  -0.0425 416 HOH A O   
+1198 O O   . HOH E .   ? 0.2318 0.1302 0.1791 -0.0004 0.0409  -0.0179 417 HOH A O   
+1199 O O   . HOH E .   ? 0.1537 0.2695 0.1291 0.0141  -0.0157 -0.0727 418 HOH A O   
+1200 O O   . HOH E .   ? 0.1247 0.1842 0.2512 0.0131  -0.0048 -0.0383 419 HOH A O   
+1201 O O   . HOH E .   ? 0.2237 0.1894 0.1650 0.0313  0.0085  0.0361  420 HOH A O   
+1202 O O   . HOH E .   ? 0.1765 0.1833 0.2253 -0.0187 0.0297  -0.0543 421 HOH A O   
+1203 O O   . HOH E .   ? 0.2324 0.2012 0.1729 0.0129  0.0048  -0.0470 422 HOH A O   
+1204 O O   . HOH E .   ? 0.2615 0.1579 0.1944 0.0016  0.0302  -0.0417 423 HOH A O   
+1205 O O   . HOH E .   ? 0.1701 0.2312 0.2126 -0.0305 -0.0131 -0.0659 424 HOH A O   
+1206 O O   . HOH E .   ? 0.1680 0.2458 0.2199 -0.0173 0.0556  0.0163  425 HOH A O   
+1207 O O   . HOH E .   ? 0.2206 0.1995 0.2162 -0.0642 -0.0169 -0.0138 426 HOH A O   
+1208 O O   . HOH E .   ? 0.2764 0.1509 0.2142 -0.0058 0.0156  0.0092  427 HOH A O   
+1209 O O   . HOH E .   ? 0.3164 0.2259 0.1292 -0.1244 -0.0322 0.0360  428 HOH A O   
+1210 O O   . HOH E .   ? 0.1609 0.1594 0.3519 -0.0103 0.0384  0.0555  429 HOH A O   
+1211 O O   . HOH E .   ? 0.2128 0.2194 0.2420 -0.0433 0.0597  -0.0909 430 HOH A O   
+1212 O O   . HOH E .   ? 0.2764 0.2220 0.1798 -0.0926 0.0675  -0.0349 431 HOH A O   
+1213 O O   . HOH E .   ? 0.2027 0.1728 0.3050 0.0072  0.0427  -0.0487 432 HOH A O   
+1214 O O   . HOH E .   ? 0.1827 0.2690 0.2294 -0.0612 -0.0342 -0.0610 433 HOH A O   
+1215 O O   . HOH E .   ? 0.1530 0.2829 0.2545 -0.0393 -0.0797 0.1169  434 HOH A O   
+1216 O O   . HOH E .   ? 0.2973 0.2055 0.1886 0.0135  -0.0168 -0.0408 435 HOH A O   
+1217 O O   . HOH E .   ? 0.2114 0.2857 0.2012 0.0626  -0.0284 0.1145  436 HOH A O   
+1218 O O   . HOH E .   ? 0.1709 0.3749 0.1542 0.0079  -0.0141 -0.0716 437 HOH A O   
+1219 O O   . HOH E .   ? 0.1819 0.2503 0.2714 0.0383  0.0389  -0.0250 438 HOH A O   
+1220 O O   . HOH E .   ? 0.2534 0.2350 0.2200 0.0661  0.0387  -0.0246 439 HOH A O   
+1221 O O   . HOH E .   ? 0.3623 0.1829 0.1730 0.0099  0.0948  -0.0288 440 HOH A O   
+1222 O O   . HOH E .   ? 0.2751 0.1803 0.2652 -0.0028 -0.0249 -0.0021 441 HOH A O   
+1223 O O   . HOH E .   ? 0.2521 0.2592 0.2100 0.0496  -0.0082 -0.0429 442 HOH A O   
+1224 O O   . HOH E .   ? 0.1754 0.3547 0.1989 -0.0421 0.0605  0.0328  443 HOH A O   
+1225 O O   . HOH E .   ? 0.2185 0.2763 0.2397 0.0255  -0.0071 0.0506  444 HOH A O   
+1226 O O   . HOH E .   ? 0.2259 0.2755 0.2413 -0.0216 0.0256  -0.0721 445 HOH A O   
+1227 O O   . HOH E .   ? 0.1484 0.2743 0.3203 0.0055  -0.0791 -0.1878 446 HOH A O   
+1228 O O   . HOH E .   ? 0.4708 0.1107 0.1836 -0.0146 -0.0083 -0.0317 447 HOH A O   
+1229 O O   . HOH E .   ? 0.2328 0.2475 0.2889 -0.0950 -0.0067 0.1062  448 HOH A O   
+1230 O O   . HOH E .   ? 0.1648 0.4819 0.1365 -0.0496 -0.0006 -0.0620 449 HOH A O   
+1231 O O   . HOH E .   ? 0.4446 0.2051 0.1401 0.0349  0.0894  -0.0222 450 HOH A O   
+1232 O O   . HOH E .   ? 0.1731 0.3684 0.2565 0.0009  -0.0568 -0.0069 451 HOH A O   
+1233 O O   . HOH E .   ? 0.3730 0.2833 0.1456 -0.1909 0.0122  -0.0530 452 HOH A O   
+1234 O O   . HOH E .   ? 0.1948 0.2418 0.3745 0.0081  -0.0270 0.0021  453 HOH A O   
+1235 O O   . HOH E .   ? 0.3007 0.2213 0.2998 -0.1093 0.0577  -0.0770 454 HOH A O   
+1236 O O   . HOH E .   ? 0.2964 0.2370 0.2915 0.0224  -0.0187 0.0244  455 HOH A O   
+1237 O O   . HOH E .   ? 0.4682 0.1754 0.1942 -0.0021 0.0933  -0.0203 456 HOH A O   
+1238 O O   . HOH E .   ? 0.1948 0.3860 0.2641 -0.0997 0.0317  -0.0776 457 HOH A O   
+1239 O O   . HOH E .   ? 0.3113 0.3516 0.1923 -0.0905 0.0105  -0.1015 458 HOH A O   
+1240 O O   . HOH E .   ? 0.3736 0.2521 0.2367 0.1277  0.0555  -0.0212 459 HOH A O   
+1241 O O   . HOH E .   ? 0.2259 0.3245 0.3340 -0.0679 0.0358  0.1485  460 HOH A O   
+1242 O O   . HOH E .   ? 0.2949 0.2779 0.3125 -0.0143 0.0697  -0.0537 461 HOH A O   
+1243 O O   . HOH E .   ? 0.2818 0.4077 0.2431 0.0321  -0.0665 0.0335  462 HOH A O   
+1244 O O   . HOH E .   ? 0.2944 0.2363 0.4081 0.0250  0.0229  0.0556  463 HOH A O   
+1245 O O   . HOH E .   ? 0.4790 0.2958 0.1809 -0.1539 0.0291  -0.0213 464 HOH A O   
+1246 O O   . HOH E .   ? 0.4615 0.2736 0.2250 0.0604  0.0139  0.0546  465 HOH A O   
+1247 O O   . HOH E .   ? 0.1808 0.4002 0.3869 -0.0517 -0.0930 0.1801  466 HOH A O   
+1248 O O   . HOH E .   ? 0.4041 0.2751 0.2969 -0.0913 -0.0128 -0.0684 467 HOH A O   
+1249 O O   . HOH E .   ? 0.3076 0.4764 0.1953 0.1040  0.0293  -0.0190 468 HOH A O   
+1250 O O   . HOH E .   ? 0.1869 0.4851 0.3087 0.0468  0.0137  0.0661  469 HOH A O   
+1251 O O   . HOH E .   ? 0.1802 0.2443 0.5661 0.0425  0.1741  0.1313  470 HOH A O   
+1252 O O   . HOH E .   ? 0.3348 0.4248 0.2314 -0.0449 -0.0055 0.1282  471 HOH A O   
+1253 O O   . HOH E .   ? 0.1796 0.3190 0.4986 -0.0785 -0.1106 0.1852  472 HOH A O   
+1254 O O   . HOH E .   ? 0.4214 0.2497 0.3285 -0.0540 -0.0007 0.0589  473 HOH A O   
+1255 O O   . HOH E .   ? 0.3000 0.3305 0.3864 -0.0987 0.1564  -0.0861 474 HOH A O   
+1256 O O   . HOH E .   ? 0.4267 0.2734 0.3180 0.1259  0.1255  0.1072  475 HOH A O   
+1257 O O   . HOH E .   ? 0.3757 0.2891 0.3598 0.1337  0.0381  0.1011  476 HOH A O   
+1258 O O   . HOH E .   ? 0.4215 0.3065 0.3065 0.1142  -0.0058 0.0043  477 HOH A O   
+1259 O O   . HOH E .   ? 0.1884 0.4823 0.3644 0.0810  0.0872  0.0440  478 HOH A O   
+1260 O O   . HOH E .   ? 0.3967 0.4642 0.1834 0.2085  -0.0196 0.0531  479 HOH A O   
+1261 O O   . HOH E .   ? 0.3198 0.1978 0.6135 -0.0571 -0.2505 0.1042  480 HOH A O   
+1262 O O   . HOH E .   ? 0.4620 0.3928 0.2818 0.2205  -0.1493 -0.0684 481 HOH A O   
+1263 O O   . HOH E .   ? 0.3456 0.3045 0.5242 0.1941  -0.1211 -0.2104 482 HOH A O   
+1264 O O   . HOH E .   ? 0.1232 0.3651 0.1776 -0.0575 -0.0647 -0.0807 483 HOH A O   
+1265 O O   . HOH E .   ? 0.1017 0.1523 0.1380 -0.0050 -0.0332 0.0105  484 HOH A O   
+1266 O O   . HOH E .   ? 0.1506 0.1049 0.2427 0.0195  0.0052  -0.0405 485 HOH A O   
+1267 O O   . HOH E .   ? 0.1297 0.1635 0.2186 0.0023  -0.0258 -0.0479 486 HOH A O   
+1268 O O   . HOH E .   ? 0.1498 0.2727 0.0897 -0.0204 0.0191  -0.0183 487 HOH A O   
+1269 O O   . HOH E .   ? 0.2020 0.2479 0.1662 0.0241  -0.0027 0.0283  488 HOH A O   
+1270 O O   . HOH E .   ? 0.1445 0.2809 0.2000 -0.0398 0.0318  0.0039  489 HOH A O   
+1271 O O   . HOH E .   ? 0.2264 0.1590 0.2398 0.0080  0.0229  0.0356  490 HOH A O   
+1272 O O   . HOH E .   ? 0.2822 0.1934 0.1811 -0.0815 0.0467  -0.0151 491 HOH A O   
+1273 O O   . HOH E .   ? 0.2773 0.1555 0.2349 0.0457  0.0146  0.0592  492 HOH A O   
+1274 O O   . HOH E .   ? 0.2662 0.2489 0.1530 0.0231  0.0567  0.0102  493 HOH A O   
+1275 O O   . HOH E .   ? 0.2906 0.1961 0.1946 0.0275  -0.0126 -0.0011 494 HOH A O   
+1276 O O   . HOH E .   ? 0.2000 0.3284 0.1767 -0.0801 -0.0576 -0.0486 495 HOH A O   
+1277 O O   . HOH E .   ? 0.2792 0.2249 0.2576 0.0826  -0.0593 -0.0161 496 HOH A O   
+1278 O O   . HOH E .   ? 0.2438 0.2914 0.2339 0.0453  -0.0269 -0.0342 497 HOH A O   
+1279 O O   . HOH E .   ? 0.1934 0.3709 0.2095 -0.1066 -0.0242 0.0734  498 HOH A O   
+1280 O O   . HOH E .   ? 0.3131 0.3449 0.1412 -0.0040 0.0386  0.0382  499 HOH A O   
+1281 O O   . HOH E .   ? 0.1531 0.2367 0.4148 0.0549  0.0496  0.0649  500 HOH A O   
+1282 O O   . HOH E .   ? 0.2520 0.3809 0.2296 0.1794  -0.0648 -0.0967 501 HOH A O   
+1283 O O   . HOH E .   ? 0.2474 0.3880 0.2554 -0.0235 -0.0002 -0.0353 502 HOH A O   
+1284 O O   . HOH E .   ? 0.1462 0.4210 0.3250 0.0307  0.0745  -0.1086 503 HOH A O   
+1285 O O   . HOH E .   ? 0.3803 0.1907 0.3457 -0.0012 0.1492  -0.0986 504 HOH A O   
+1286 O O   . HOH E .   ? 0.3545 0.2120 0.3565 0.0351  0.1484  0.0150  505 HOH A O   
+1287 O O   . HOH E .   ? 0.3167 0.4471 0.1855 -0.0671 0.1126  -0.0117 506 HOH A O   
+1288 O O   . HOH E .   ? 0.4059 0.4419 0.1664 0.1849  -0.0124 -0.0393 507 HOH A O   
+1289 O O   . HOH E .   ? 0.4751 0.3923 0.2501 0.1269  0.0145  0.0123  508 HOH A O   
+1290 O O   . HOH E .   ? 0.2665 0.1659 0.7138 -0.0189 0.1843  0.1186  509 HOH A O   
+1291 O O   . HOH E .   ? 0.3504 0.2323 0.5561 0.0778  0.0769  0.2199  510 HOH A O   
+1292 O O   . HOH E .   ? 0.1114 0.1199 0.1270 -0.0059 -0.0221 -0.0073 511 HOH A O   
+1293 O O   . HOH E .   ? 0.1426 0.1518 0.1673 0.0054  -0.0229 -0.0221 512 HOH A O   
+1294 O O   . HOH E .   ? 0.1569 0.1959 0.2012 -0.0509 -0.0458 0.0140  513 HOH A O   
+1295 O O   . HOH E .   ? 0.1869 0.2444 0.1964 -0.0044 0.0308  0.0080  514 HOH A O   
+1296 O O   . HOH E .   ? 0.1921 0.2969 0.1879 0.1091  0.0129  0.0149  515 HOH A O   
+1297 O O   . HOH E .   ? 0.1542 0.4097 0.1362 -0.0528 -0.0229 -0.1277 516 HOH A O   
+1298 O O   . HOH E .   ? 0.3182 0.2617 0.1531 0.1220  -0.0005 0.0456  517 HOH A O   
+1299 O O   . HOH E .   ? 0.2858 0.2015 0.2546 -0.0564 -0.0797 0.0404  518 HOH A O   
+1300 O O   . HOH E .   ? 0.3250 0.1709 0.2652 -0.0879 0.1040  -0.0370 519 HOH A O   
+1301 O O   . HOH E .   ? 0.1865 0.2983 0.3293 -0.0053 -0.0164 0.0646  520 HOH A O   
+1302 O O   . HOH E .   ? 0.2134 0.3284 0.2757 -0.0501 0.0105  -0.0398 521 HOH A O   
+1303 O O   . HOH E .   ? 0.2084 0.4604 0.1716 -0.0653 0.0208  -0.0595 522 HOH A O   
+1304 O O   . HOH E .   ? 0.3264 0.2545 0.2745 -0.0432 0.1217  -0.1335 523 HOH A O   
+1305 O O   . HOH E .   ? 0.2520 0.3358 0.2722 0.1074  -0.1431 -0.0869 524 HOH A O   
+1306 O O   . HOH E .   ? 0.1982 0.4878 0.1936 0.0797  -0.0500 -0.1331 525 HOH A O   
+1307 O O   . HOH E .   ? 0.2493 0.3887 0.2455 -0.0293 0.0589  -0.0361 526 HOH A O   
+1308 O O   . HOH E .   ? 0.2012 0.2318 0.4556 0.0213  0.0777  0.0153  527 HOH A O   
+1309 O O   . HOH E .   ? 0.4195 0.3065 0.1731 -0.0966 -0.0457 -0.0724 528 HOH A O   
+1310 O O   . HOH E .   ? 0.2628 0.3207 0.3393 0.0107  0.0338  0.0999  529 HOH A O   
+1311 O O   . HOH E .   ? 0.4204 0.1817 0.3250 -0.0882 -0.0744 0.0805  530 HOH A O   
+1312 O O   . HOH E .   ? 0.2278 0.4460 0.2701 0.0333  0.1258  0.0019  531 HOH A O   
+1313 O O   . HOH E .   ? 0.2948 0.4963 0.1804 0.1940  -0.0559 0.0013  532 HOH A O   
+1314 O O   . HOH E .   ? 0.4066 0.1019 0.4720 0.0195  0.1653  0.0089  533 HOH A O   
+1315 O O   . HOH E .   ? 0.3317 0.4431 0.2255 0.0564  -0.0606 -0.1298 534 HOH A O   
+1316 O O   . HOH E .   ? 0.6681 0.1591 0.1825 -0.0607 -0.0986 0.0000  535 HOH A O   
+1317 O O   . HOH E .   ? 0.2787 0.3402 0.3939 -0.0496 -0.1358 0.0874  536 HOH A O   
+1318 O O   . HOH E .   ? 0.1352 0.4463 0.4467 0.0291  0.0475  0.1667  537 HOH A O   
+1319 O O   . HOH E .   ? 0.1915 0.3455 0.4948 -0.0930 -0.1131 0.1027  538 HOH A O   
+1320 O O   . HOH E .   ? 0.4765 0.1524 0.4337 0.0072  0.1282  -0.0361 539 HOH A O   
+1321 O O   . HOH E .   ? 0.3241 0.5356 0.2248 -0.1868 -0.0904 0.1278  540 HOH A O   
+1322 O O   . HOH E .   ? 0.3047 0.3914 0.4013 -0.1480 0.1582  -0.1618 541 HOH A O   
+1323 O O   . HOH E .   ? 0.3656 0.4762 0.2838 0.0133  -0.0430 -0.0415 542 HOH A O   
+1324 O O   . HOH E .   ? 0.3378 0.5394 0.2620 0.0320  -0.0271 0.0641  543 HOH A O   
+1325 O O   . HOH E .   ? 0.3833 0.5711 0.1920 0.0289  0.1550  0.0555  544 HOH A O   
+1326 O O   . HOH E .   ? 0.3841 0.6138 0.1778 -0.1932 0.0265  0.0747  545 HOH A O   
+1327 O O   . HOH E .   ? 0.2678 0.4218 0.6058 -0.0818 0.1895  -0.1655 546 HOH A O   
+1328 O O   . HOH E .   ? 0.1534 0.1269 0.1562 -0.0045 -0.0589 -0.0068 547 HOH A O   
+1329 O O   . HOH E .   ? 0.2324 0.1915 0.1737 0.0600  0.0379  0.0146  548 HOH A O   
+1330 O O   . HOH E .   ? 0.1931 0.2542 0.1897 0.0008  0.0153  0.0509  549 HOH A O   
+1331 O O   . HOH E .   ? 0.2246 0.2295 0.2367 -0.0508 -0.0144 -0.0029 550 HOH A O   
+1332 O O   . HOH E .   ? 0.2887 0.2369 0.1932 -0.0572 -0.0015 0.0361  551 HOH A O   
+1333 O O   . HOH E .   ? 0.3182 0.1907 0.2358 -0.0617 0.1373  -0.0470 552 HOH A O   
+1334 O O   . HOH E .   ? 0.1524 0.4081 0.1886 0.0224  -0.0227 -0.0767 553 HOH A O   
+1335 O O   . HOH E .   ? 0.2037 0.3793 0.1730 -0.0031 -0.0068 0.0634  554 HOH A O   
+1336 O O   . HOH E .   ? 0.2471 0.2700 0.3021 0.0171  -0.0594 0.0865  555 HOH A O   
+1337 O O   . HOH E .   ? 0.2165 0.2692 0.3497 -0.0961 -0.0894 0.0077  556 HOH A O   
+1338 O O   . HOH E .   ? 0.2516 0.3275 0.3015 -0.0608 0.0033  0.1325  557 HOH A O   
+1339 O O   . HOH E .   ? 0.3870 0.2341 0.2697 -0.0308 -0.0796 -0.0182 558 HOH A O   
+1340 O O   . HOH E .   ? 0.4087 0.2195 0.2649 -0.0154 0.0009  -0.0256 559 HOH A O   
+1341 O O   . HOH E .   ? 0.2219 0.2140 0.4656 -0.0279 -0.1143 0.0081  560 HOH A O   
+1342 O O   . HOH E .   ? 0.3659 0.3245 0.2185 0.0469  0.0011  -0.0293 561 HOH A O   
+1343 O O   . HOH E .   ? 0.4264 0.1867 0.3033 0.0253  -0.0604 -0.0200 562 HOH A O   
+1344 O O   . HOH E .   ? 0.3926 0.1921 0.3335 0.0243  0.1111  0.0380  563 HOH A O   
+1345 O O   . HOH E .   ? 0.3123 0.4273 0.1814 -0.0072 -0.0359 -0.0541 564 HOH A O   
+1346 O O   . HOH E .   ? 0.4164 0.1172 0.4091 0.0212  0.3207  0.1133  565 HOH A O   
+1347 O O   . HOH E .   ? 0.2232 0.4372 0.2840 0.1600  0.0568  0.1587  566 HOH A O   
+1348 O O   . HOH E .   ? 0.2104 0.4142 0.3244 -0.0060 -0.0073 0.2035  567 HOH A O   
+1349 O O   . HOH E .   ? 0.2848 0.3400 0.3287 0.0139  0.0530  0.1284  568 HOH A O   
+1350 O O   . HOH E .   ? 0.4441 0.2263 0.2858 0.0893  0.0709  0.0726  569 HOH A O   
+1351 O O   . HOH E .   ? 0.3695 0.2374 0.3721 0.0435  0.0749  -0.0841 570 HOH A O   
+1352 O O   . HOH E .   ? 0.3491 0.4672 0.1665 -0.0876 -0.0380 0.0912  571 HOH A O   
+1353 O O   . HOH E .   ? 0.2454 0.3125 0.4254 0.0473  -0.0613 -0.0447 572 HOH A O   
+1354 O O   . HOH E .   ? 0.1769 0.4890 0.3181 0.0179  -0.0733 -0.1499 573 HOH A O   
+1355 O O   . HOH E .   ? 0.3671 0.3796 0.2478 0.1461  0.0090  0.0921  574 HOH A O   
+1356 O O   . HOH E .   ? 0.4609 0.4126 0.1319 0.1488  -0.0533 0.0056  575 HOH A O   
+1357 O O   . HOH E .   ? 0.5297 0.3515 0.1373 -0.0816 -0.1003 -0.0156 576 HOH A O   
+1358 O O   . HOH E .   ? 0.4424 0.2098 0.3922 0.0069  -0.0254 0.0504  577 HOH A O   
+1359 O O   . HOH E .   ? 0.3925 0.4692 0.1835 0.1100  -0.0161 -0.0836 578 HOH A O   
+1360 O O   . HOH E .   ? 0.3613 0.4518 0.2335 -0.0899 -0.0127 0.1198  579 HOH A O   
+1361 O O   . HOH E .   ? 0.2568 0.4977 0.2950 0.0303  -0.0926 0.0822  580 HOH A O   
+1362 O O   . HOH E .   ? 0.2334 0.3838 0.4501 0.0437  -0.0235 0.0228  581 HOH A O   
+1363 O O   . HOH E .   ? 0.3747 0.3147 0.3905 0.1609  -0.0530 -0.0922 582 HOH A O   
+1364 O O   . HOH E .   ? 0.4624 0.2187 0.4004 0.0072  0.0100  -0.0202 583 HOH A O   
+1365 O O   . HOH E .   ? 0.3185 0.2388 0.5354 -0.0821 0.0399  0.0384  584 HOH A O   
+1366 O O   . HOH E .   ? 0.4834 0.1981 0.4130 0.0056  0.0808  0.0449  585 HOH A O   
+1367 O O   . HOH E .   ? 0.2136 0.5831 0.3088 -0.0873 0.0670  -0.1262 586 HOH A O   
+1368 O O   . HOH E .   ? 0.2800 0.3633 0.4627 0.1803  0.0181  -0.1606 587 HOH A O   
+1369 O O   . HOH E .   ? 0.4145 0.3350 0.3680 -0.0869 0.0425  0.0634  588 HOH A O   
+1370 O O   . HOH E .   ? 0.3045 0.2258 0.5923 0.1197  0.2506  0.0355  589 HOH A O   
+1371 O O   . HOH E .   ? 0.5360 0.2693 0.4002 -0.0004 0.0769  -0.0551 590 HOH A O   
+1372 O O   . HOH E .   ? 0.5610 0.4756 0.1950 -0.2300 0.1940  -0.0632 591 HOH A O   
+1373 O O   . HOH E .   ? 0.4819 0.4568 0.3435 0.2236  -0.2282 0.0063  592 HOH A O   
+# 
+loop_
+_pdbx_poly_seq_scheme.asym_id 
+_pdbx_poly_seq_scheme.entity_id 
+_pdbx_poly_seq_scheme.seq_id 
+_pdbx_poly_seq_scheme.mon_id 
+_pdbx_poly_seq_scheme.ndb_seq_num 
+_pdbx_poly_seq_scheme.pdb_seq_num 
+_pdbx_poly_seq_scheme.auth_seq_num 
+_pdbx_poly_seq_scheme.pdb_mon_id 
+_pdbx_poly_seq_scheme.auth_mon_id 
+_pdbx_poly_seq_scheme.pdb_strand_id 
+_pdbx_poly_seq_scheme.pdb_ins_code 
+_pdbx_poly_seq_scheme.hetero 
+A 1 1   PRO 1   48  ?   ?   ?   A . n 
+A 1 2   LEU 2   49  ?   ?   ?   A . n 
+A 1 3   ARG 3   50  ?   ?   ?   A . n 
+A 1 4   GLU 4   51  ?   ?   ?   A . n 
+A 1 5   GLY 5   52  52  GLY GLY A . n 
+A 1 6   ARG 6   53  53  ARG ARG A . n 
+A 1 7   GLY 7   54  54  GLY GLY A . n 
+A 1 8   LEU 8   55  55  LEU LEU A . n 
+A 1 9   GLY 9   56  56  GLY GLY A . n 
+A 1 10  PRO 10  57  57  PRO PRO A . n 
+A 1 11  LEU 11  58  58  LEU LEU A . n 
+A 1 12  GLN 12  59  59  GLN GLN A . n 
+A 1 13  ILE 13  60  60  ILE ILE A . n 
+A 1 14  TRP 14  61  61  TRP TRP A . n 
+A 1 15  GLN 15  62  62  GLN GLN A . n 
+A 1 16  THR 16  63  63  THR THR A . n 
+A 1 17  ASP 17  64  64  ASP ASP A . n 
+A 1 18  PHE 18  65  65  PHE PHE A . n 
+A 1 19  THR 19  66  66  THR THR A . n 
+A 1 20  LEU 20  67  67  LEU LEU A . n 
+A 1 21  GLU 21  68  68  GLU GLU A . n 
+A 1 22  PRO 22  69  69  PRO PRO A . n 
+A 1 23  ARG 23  70  70  ARG ARG A . n 
+A 1 24  MET 24  71  71  MET MET A . n 
+A 1 25  ALA 25  72  72  ALA ALA A . n 
+A 1 26  PRO 26  73  73  PRO PRO A . n 
+A 1 27  ARG 27  74  74  ARG ARG A . n 
+A 1 28  SER 28  75  75  SER SER A . n 
+A 1 29  TRP 29  76  76  TRP TRP A . n 
+A 1 30  LEU 30  77  77  LEU LEU A . n 
+A 1 31  ALA 31  78  78  ALA ALA A . n 
+A 1 32  VAL 32  79  79  VAL VAL A . n 
+A 1 33  THR 33  80  80  THR THR A . n 
+A 1 34  VAL 34  81  81  VAL VAL A . n 
+A 1 35  ASP 35  82  82  ASP ASP A . n 
+A 1 36  THR 36  83  83  THR THR A . n 
+A 1 37  ALA 37  84  84  ALA ALA A . n 
+A 1 38  SER 38  85  85  SER SER A . n 
+A 1 39  SER 39  86  86  SER SER A . n 
+A 1 40  ALA 40  87  87  ALA ALA A . n 
+A 1 41  ILE 41  88  88  ILE ILE A . n 
+A 1 42  VAL 42  89  89  VAL VAL A . n 
+A 1 43  VAL 43  90  90  VAL VAL A . n 
+A 1 44  THR 44  91  91  THR THR A . n 
+A 1 45  GLN 45  92  92  GLN GLN A . n 
+A 1 46  HIS 46  93  93  HIS HIS A . n 
+A 1 47  GLY 47  94  94  GLY GLY A . n 
+A 1 48  ARG 48  95  95  ARG ARG A . n 
+A 1 49  VAL 49  96  96  VAL VAL A . n 
+A 1 50  THR 50  97  97  THR THR A . n 
+A 1 51  SER 51  98  98  SER SER A . n 
+A 1 52  VAL 52  99  99  VAL VAL A . n 
+A 1 53  ALA 53  100 100 ALA ALA A . n 
+A 1 54  ALA 54  101 101 ALA ALA A . n 
+A 1 55  GLN 55  102 102 GLN GLN A . n 
+A 1 56  HIS 56  103 103 HIS HIS A . n 
+A 1 57  HIS 57  104 104 HIS HIS A . n 
+A 1 58  TRP 58  105 105 TRP TRP A . n 
+A 1 59  ALA 59  106 106 ALA ALA A . n 
+A 1 60  THR 60  107 107 THR THR A . n 
+A 1 61  ALA 61  108 108 ALA ALA A . n 
+A 1 62  ILE 62  109 109 ILE ILE A . n 
+A 1 63  ALA 63  110 110 ALA ALA A . n 
+A 1 64  VAL 64  111 111 VAL VAL A . n 
+A 1 65  LEU 65  112 112 LEU LEU A . n 
+A 1 66  GLY 66  113 113 GLY GLY A . n 
+A 1 67  ARG 67  114 114 ARG ARG A . n 
+A 1 68  PRO 68  115 115 PRO PRO A . n 
+A 1 69  LYS 69  116 116 LYS LYS A . n 
+A 1 70  ALA 70  117 117 ALA ALA A . n 
+A 1 71  ILE 71  118 118 ILE ILE A . n 
+A 1 72  LYS 72  119 119 LYS LYS A . n 
+A 1 73  THR 73  120 120 THR THR A . n 
+A 1 74  ASP 74  121 121 ASP ASP A . n 
+A 1 75  ASN 75  122 122 ASN ASN A . n 
+A 1 76  GLY 76  123 123 GLY GLY A . n 
+A 1 77  SER 77  124 124 SER SER A . n 
+A 1 78  CYS 78  125 125 CYS CYS A . n 
+A 1 79  PHE 79  126 126 PHE PHE A . n 
+A 1 80  THR 80  127 127 THR THR A . n 
+A 1 81  SER 81  128 128 SER SER A . n 
+A 1 82  LYS 82  129 129 LYS LYS A . n 
+A 1 83  SER 83  130 130 SER SER A . n 
+A 1 84  THR 84  131 131 THR THR A . n 
+A 1 85  ARG 85  132 132 ARG ARG A . n 
+A 1 86  GLU 86  133 133 GLU GLU A . n 
+A 1 87  TRP 87  134 134 TRP TRP A . n 
+A 1 88  LEU 88  135 135 LEU LEU A . n 
+A 1 89  ALA 89  136 136 ALA ALA A . n 
+A 1 90  ARG 90  137 137 ARG ARG A . n 
+A 1 91  TRP 91  138 138 TRP TRP A . n 
+A 1 92  GLY 92  139 139 GLY GLY A . n 
+A 1 93  ILE 93  140 140 ILE ILE A . n 
+A 1 94  ALA 94  141 141 ALA ALA A . n 
+A 1 95  HIS 95  142 142 HIS HIS A . n 
+A 1 96  THR 96  143 143 THR THR A . n 
+A 1 97  THR 97  144 144 THR THR A . n 
+A 1 98  GLY 98  145 145 GLY GLY A . n 
+A 1 99  ILE 99  146 146 ILE ILE A . n 
+A 1 100 PRO 100 147 147 PRO PRO A . n 
+A 1 101 GLY 101 148 ?   ?   ?   A . n 
+A 1 102 ASN 102 149 ?   ?   ?   A . n 
+A 1 103 SER 103 150 ?   ?   ?   A . n 
+A 1 104 GLN 104 151 ?   ?   ?   A . n 
+A 1 105 GLY 105 152 152 GLY GLY A . n 
+A 1 106 GLN 106 153 153 GLN GLN A . n 
+A 1 107 ALA 107 154 154 ALA ALA A . n 
+A 1 108 MET 108 155 155 MET MET A . n 
+A 1 109 VAL 109 156 156 VAL VAL A . n 
+A 1 110 GLU 110 157 157 GLU GLU A . n 
+A 1 111 ARG 111 158 158 ARG ARG A . n 
+A 1 112 ALA 112 159 159 ALA ALA A . n 
+A 1 113 ASN 113 160 160 ASN ASN A . n 
+A 1 114 ARG 114 161 161 ARG ARG A . n 
+A 1 115 LEU 115 162 162 LEU LEU A . n 
+A 1 116 LEU 116 163 163 LEU LEU A . n 
+A 1 117 LYS 117 164 164 LYS LYS A . n 
+A 1 118 ASP 118 165 165 ASP ASP A . n 
+A 1 119 LYS 119 166 166 LYS LYS A . n 
+A 1 120 ILE 120 167 167 ILE ILE A . n 
+A 1 121 ARG 121 168 168 ARG ARG A . n 
+A 1 122 VAL 122 169 169 VAL VAL A . n 
+A 1 123 LEU 123 170 170 LEU LEU A . n 
+A 1 124 ALA 124 171 171 ALA ALA A . n 
+A 1 125 GLU 125 172 172 GLU GLU A . n 
+A 1 126 GLY 126 173 173 GLY GLY A . n 
+A 1 127 ASP 127 174 174 ASP ASP A . n 
+A 1 128 GLY 128 175 175 GLY GLY A . n 
+A 1 129 PHE 129 176 176 PHE PHE A . n 
+A 1 130 MET 130 177 177 MET MET A . n 
+A 1 131 LYS 131 178 178 LYS LYS A . n 
+A 1 132 ARG 132 179 179 ARG ARG A . n 
+A 1 133 ILE 133 180 180 ILE ILE A . n 
+A 1 134 PRO 134 181 181 PRO PRO A . n 
+A 1 135 THR 135 182 182 THR THR A . n 
+A 1 136 SER 136 183 183 SER SER A . n 
+A 1 137 LYS 137 184 184 LYS LYS A . n 
+A 1 138 GLN 138 185 185 GLN GLN A . n 
+A 1 139 GLY 139 186 186 GLY GLY A . n 
+A 1 140 GLU 140 187 187 GLU GLU A . n 
+A 1 141 LEU 141 188 188 LEU LEU A . n 
+A 1 142 LEU 142 189 189 LEU LEU A . n 
+A 1 143 ALA 143 190 190 ALA ALA A . n 
+A 1 144 LYS 144 191 191 LYS LYS A . n 
+A 1 145 ALA 145 192 192 ALA ALA A . n 
+A 1 146 MET 146 193 193 MET MET A . n 
+A 1 147 TYR 147 194 194 TYR TYR A . n 
+A 1 148 ALA 148 195 195 ALA ALA A . n 
+A 1 149 LEU 149 196 196 LEU LEU A . n 
+A 1 150 ASN 150 197 197 ASN ASN A . n 
+A 1 151 HIS 151 198 198 HIS HIS A . n 
+A 1 152 PHE 152 199 ?   ?   ?   A . n 
+A 1 153 GLU 153 200 ?   ?   ?   A . n 
+A 1 154 ARG 154 201 ?   ?   ?   A . n 
+A 1 155 GLY 155 202 ?   ?   ?   A . n 
+A 1 156 GLU 156 203 ?   ?   ?   A . n 
+A 1 157 ASN 157 204 ?   ?   ?   A . n 
+A 1 158 THR 158 205 ?   ?   ?   A . n 
+A 1 159 LYS 159 206 ?   ?   ?   A . n 
+A 1 160 THR 160 207 ?   ?   ?   A . n 
+A 1 161 ASN 161 208 ?   ?   ?   A . n 
+A 1 162 LEU 162 209 ?   ?   ?   A . n 
+# 
+loop_
+_pdbx_nonpoly_scheme.asym_id 
+_pdbx_nonpoly_scheme.entity_id 
+_pdbx_nonpoly_scheme.mon_id 
+_pdbx_nonpoly_scheme.ndb_seq_num 
+_pdbx_nonpoly_scheme.pdb_seq_num 
+_pdbx_nonpoly_scheme.auth_seq_num 
+_pdbx_nonpoly_scheme.pdb_mon_id 
+_pdbx_nonpoly_scheme.auth_mon_id 
+_pdbx_nonpoly_scheme.pdb_strand_id 
+_pdbx_nonpoly_scheme.pdb_ins_code 
+B 2 EPE 1   300 300 EPE EPE A . 
+C 3 GOL 1   301 301 GOL GLL A . 
+D 3 GOL 1   302 302 GOL GLL A . 
+E 4 HOH 1   401 401 HOH HOH A . 
+E 4 HOH 2   402 402 HOH HOH A . 
+E 4 HOH 3   403 403 HOH HOH A . 
+E 4 HOH 4   404 404 HOH HOH A . 
+E 4 HOH 5   405 405 HOH HOH A . 
+E 4 HOH 6   406 406 HOH HOH A . 
+E 4 HOH 7   407 407 HOH HOH A . 
+E 4 HOH 8   408 408 HOH HOH A . 
+E 4 HOH 9   409 409 HOH HOH A . 
+E 4 HOH 10  410 410 HOH HOH A . 
+E 4 HOH 11  411 411 HOH HOH A . 
+E 4 HOH 12  412 412 HOH HOH A . 
+E 4 HOH 13  413 413 HOH HOH A . 
+E 4 HOH 14  414 414 HOH HOH A . 
+E 4 HOH 15  415 415 HOH HOH A . 
+E 4 HOH 16  416 416 HOH HOH A . 
+E 4 HOH 17  417 417 HOH HOH A . 
+E 4 HOH 18  418 418 HOH HOH A . 
+E 4 HOH 19  419 419 HOH HOH A . 
+E 4 HOH 20  420 420 HOH HOH A . 
+E 4 HOH 21  421 421 HOH HOH A . 
+E 4 HOH 22  422 422 HOH HOH A . 
+E 4 HOH 23  423 423 HOH HOH A . 
+E 4 HOH 24  424 424 HOH HOH A . 
+E 4 HOH 25  425 425 HOH HOH A . 
+E 4 HOH 26  426 426 HOH HOH A . 
+E 4 HOH 27  427 427 HOH HOH A . 
+E 4 HOH 28  428 428 HOH HOH A . 
+E 4 HOH 29  429 429 HOH HOH A . 
+E 4 HOH 30  430 430 HOH HOH A . 
+E 4 HOH 31  431 431 HOH HOH A . 
+E 4 HOH 32  432 432 HOH HOH A . 
+E 4 HOH 33  433 433 HOH HOH A . 
+E 4 HOH 34  434 434 HOH HOH A . 
+E 4 HOH 35  435 435 HOH HOH A . 
+E 4 HOH 36  436 436 HOH HOH A . 
+E 4 HOH 37  437 437 HOH HOH A . 
+E 4 HOH 38  438 438 HOH HOH A . 
+E 4 HOH 39  439 439 HOH HOH A . 
+E 4 HOH 40  440 440 HOH HOH A . 
+E 4 HOH 41  441 441 HOH HOH A . 
+E 4 HOH 42  442 442 HOH HOH A . 
+E 4 HOH 43  443 443 HOH HOH A . 
+E 4 HOH 44  444 444 HOH HOH A . 
+E 4 HOH 45  445 445 HOH HOH A . 
+E 4 HOH 46  446 446 HOH HOH A . 
+E 4 HOH 47  447 447 HOH HOH A . 
+E 4 HOH 48  448 448 HOH HOH A . 
+E 4 HOH 49  449 449 HOH HOH A . 
+E 4 HOH 50  450 450 HOH HOH A . 
+E 4 HOH 51  451 451 HOH HOH A . 
+E 4 HOH 52  452 452 HOH HOH A . 
+E 4 HOH 53  453 453 HOH HOH A . 
+E 4 HOH 54  454 454 HOH HOH A . 
+E 4 HOH 55  455 455 HOH HOH A . 
+E 4 HOH 56  456 456 HOH HOH A . 
+E 4 HOH 57  457 457 HOH HOH A . 
+E 4 HOH 58  458 458 HOH HOH A . 
+E 4 HOH 59  459 459 HOH HOH A . 
+E 4 HOH 60  460 460 HOH HOH A . 
+E 4 HOH 61  461 461 HOH HOH A . 
+E 4 HOH 62  462 462 HOH HOH A . 
+E 4 HOH 63  463 463 HOH HOH A . 
+E 4 HOH 64  464 464 HOH HOH A . 
+E 4 HOH 65  465 465 HOH HOH A . 
+E 4 HOH 66  466 466 HOH HOH A . 
+E 4 HOH 67  467 467 HOH HOH A . 
+E 4 HOH 68  468 468 HOH HOH A . 
+E 4 HOH 69  469 469 HOH HOH A . 
+E 4 HOH 70  470 470 HOH HOH A . 
+E 4 HOH 71  471 471 HOH HOH A . 
+E 4 HOH 72  472 472 HOH HOH A . 
+E 4 HOH 73  473 473 HOH HOH A . 
+E 4 HOH 74  474 474 HOH HOH A . 
+E 4 HOH 75  475 475 HOH HOH A . 
+E 4 HOH 76  476 476 HOH HOH A . 
+E 4 HOH 77  477 477 HOH HOH A . 
+E 4 HOH 78  478 478 HOH HOH A . 
+E 4 HOH 79  479 479 HOH HOH A . 
+E 4 HOH 80  480 480 HOH HOH A . 
+E 4 HOH 81  481 481 HOH HOH A . 
+E 4 HOH 82  482 482 HOH HOH A . 
+E 4 HOH 83  483 483 HOH HOH A . 
+E 4 HOH 84  484 484 HOH HOH A . 
+E 4 HOH 85  485 485 HOH HOH A . 
+E 4 HOH 86  486 486 HOH HOH A . 
+E 4 HOH 87  487 487 HOH HOH A . 
+E 4 HOH 88  488 488 HOH HOH A . 
+E 4 HOH 89  489 489 HOH HOH A . 
+E 4 HOH 90  490 490 HOH HOH A . 
+E 4 HOH 91  491 491 HOH HOH A . 
+E 4 HOH 92  492 492 HOH HOH A . 
+E 4 HOH 93  493 493 HOH HOH A . 
+E 4 HOH 94  494 494 HOH HOH A . 
+E 4 HOH 95  495 495 HOH HOH A . 
+E 4 HOH 96  496 496 HOH HOH A . 
+E 4 HOH 97  497 497 HOH HOH A . 
+E 4 HOH 98  498 498 HOH HOH A . 
+E 4 HOH 99  499 499 HOH HOH A . 
+E 4 HOH 100 500 500 HOH HOH A . 
+E 4 HOH 101 501 501 HOH HOH A . 
+E 4 HOH 102 502 502 HOH HOH A . 
+E 4 HOH 103 503 503 HOH HOH A . 
+E 4 HOH 104 504 504 HOH HOH A . 
+E 4 HOH 105 505 505 HOH HOH A . 
+E 4 HOH 106 506 506 HOH HOH A . 
+E 4 HOH 107 507 507 HOH HOH A . 
+E 4 HOH 108 508 508 HOH HOH A . 
+E 4 HOH 109 509 509 HOH HOH A . 
+E 4 HOH 110 510 510 HOH HOH A . 
+E 4 HOH 111 511 511 HOH HOH A . 
+E 4 HOH 112 512 512 HOH HOH A . 
+E 4 HOH 113 513 513 HOH HOH A . 
+E 4 HOH 114 514 514 HOH HOH A . 
+E 4 HOH 115 515 515 HOH HOH A . 
+E 4 HOH 116 516 516 HOH HOH A . 
+E 4 HOH 117 517 517 HOH HOH A . 
+E 4 HOH 118 518 518 HOH HOH A . 
+E 4 HOH 119 519 519 HOH HOH A . 
+E 4 HOH 120 520 520 HOH HOH A . 
+E 4 HOH 121 521 521 HOH HOH A . 
+E 4 HOH 122 522 522 HOH HOH A . 
+E 4 HOH 123 523 523 HOH HOH A . 
+E 4 HOH 124 524 524 HOH HOH A . 
+E 4 HOH 125 525 525 HOH HOH A . 
+E 4 HOH 126 526 526 HOH HOH A . 
+E 4 HOH 127 527 527 HOH HOH A . 
+E 4 HOH 128 528 528 HOH HOH A . 
+E 4 HOH 129 529 529 HOH HOH A . 
+E 4 HOH 130 530 530 HOH HOH A . 
+E 4 HOH 131 531 531 HOH HOH A . 
+E 4 HOH 132 532 532 HOH HOH A . 
+E 4 HOH 133 533 533 HOH HOH A . 
+E 4 HOH 134 534 534 HOH HOH A . 
+E 4 HOH 135 535 535 HOH HOH A . 
+E 4 HOH 136 536 536 HOH HOH A . 
+E 4 HOH 137 537 537 HOH HOH A . 
+E 4 HOH 138 538 538 HOH HOH A . 
+E 4 HOH 139 539 539 HOH HOH A . 
+E 4 HOH 140 540 540 HOH HOH A . 
+E 4 HOH 141 541 541 HOH HOH A . 
+E 4 HOH 142 542 542 HOH HOH A . 
+E 4 HOH 143 543 543 HOH HOH A . 
+E 4 HOH 144 544 544 HOH HOH A . 
+E 4 HOH 145 545 545 HOH HOH A . 
+E 4 HOH 146 546 546 HOH HOH A . 
+E 4 HOH 147 547 547 HOH HOH A . 
+E 4 HOH 148 548 548 HOH HOH A . 
+E 4 HOH 149 549 549 HOH HOH A . 
+E 4 HOH 150 550 550 HOH HOH A . 
+E 4 HOH 151 551 551 HOH HOH A . 
+E 4 HOH 152 552 552 HOH HOH A . 
+E 4 HOH 153 553 553 HOH HOH A . 
+E 4 HOH 154 554 554 HOH HOH A . 
+E 4 HOH 155 555 555 HOH HOH A . 
+E 4 HOH 156 556 556 HOH HOH A . 
+E 4 HOH 157 557 557 HOH HOH A . 
+E 4 HOH 158 558 558 HOH HOH A . 
+E 4 HOH 159 559 559 HOH HOH A . 
+E 4 HOH 160 560 560 HOH HOH A . 
+E 4 HOH 161 561 561 HOH HOH A . 
+E 4 HOH 162 562 562 HOH HOH A . 
+E 4 HOH 163 563 563 HOH HOH A . 
+E 4 HOH 164 564 564 HOH HOH A . 
+E 4 HOH 165 565 565 HOH HOH A . 
+E 4 HOH 166 566 566 HOH HOH A . 
+E 4 HOH 167 567 567 HOH HOH A . 
+E 4 HOH 168 568 568 HOH HOH A . 
+E 4 HOH 169 569 569 HOH HOH A . 
+E 4 HOH 170 570 570 HOH HOH A . 
+E 4 HOH 171 571 571 HOH HOH A . 
+E 4 HOH 172 572 572 HOH HOH A . 
+E 4 HOH 173 573 573 HOH HOH A . 
+E 4 HOH 174 574 574 HOH HOH A . 
+E 4 HOH 175 575 575 HOH HOH A . 
+E 4 HOH 176 576 576 HOH HOH A . 
+E 4 HOH 177 577 577 HOH HOH A . 
+E 4 HOH 178 578 578 HOH HOH A . 
+E 4 HOH 179 579 579 HOH HOH A . 
+E 4 HOH 180 580 580 HOH HOH A . 
+E 4 HOH 181 581 581 HOH HOH A . 
+E 4 HOH 182 582 582 HOH HOH A . 
+E 4 HOH 183 583 583 HOH HOH A . 
+E 4 HOH 184 584 584 HOH HOH A . 
+E 4 HOH 185 585 585 HOH HOH A . 
+E 4 HOH 186 586 586 HOH HOH A . 
+E 4 HOH 187 587 587 HOH HOH A . 
+E 4 HOH 188 588 588 HOH HOH A . 
+E 4 HOH 189 589 589 HOH HOH A . 
+E 4 HOH 190 590 590 HOH HOH A . 
+E 4 HOH 191 591 591 HOH HOH A . 
+E 4 HOH 192 592 592 HOH HOH A . 
+# 
+_pdbx_struct_assembly.id                   1 
+_pdbx_struct_assembly.details              author_defined_assembly 
+_pdbx_struct_assembly.method_details       ? 
+_pdbx_struct_assembly.oligomeric_details   dimeric 
+_pdbx_struct_assembly.oligomeric_count     2 
+# 
+_pdbx_struct_assembly_gen.assembly_id       1 
+_pdbx_struct_assembly_gen.oper_expression   1,2 
+_pdbx_struct_assembly_gen.asym_id_list      A,B,C,D,E 
+# 
+loop_
+_pdbx_struct_oper_list.id 
+_pdbx_struct_oper_list.type 
+_pdbx_struct_oper_list.name 
+_pdbx_struct_oper_list.symmetry_operation 
+_pdbx_struct_oper_list.matrix[1][1] 
+_pdbx_struct_oper_list.matrix[1][2] 
+_pdbx_struct_oper_list.matrix[1][3] 
+_pdbx_struct_oper_list.vector[1] 
+_pdbx_struct_oper_list.matrix[2][1] 
+_pdbx_struct_oper_list.matrix[2][2] 
+_pdbx_struct_oper_list.matrix[2][3] 
+_pdbx_struct_oper_list.vector[2] 
+_pdbx_struct_oper_list.matrix[3][1] 
+_pdbx_struct_oper_list.matrix[3][2] 
+_pdbx_struct_oper_list.matrix[3][3] 
+_pdbx_struct_oper_list.vector[3] 
+1 'identity operation'         1_555 x,y,z    1.0000000000 0.0000000000 0.0000000000 0.0000000000 0.0000000000 1.0000000000 
+0.0000000000 0.0000000000 0.0000000000 0.0000000000 1.0000000000  0.0000000000  
+2 'crystal symmetry operation' 7_556 y,x,-z+1 0.0000000000 1.0000000000 0.0000000000 0.0000000000 1.0000000000 0.0000000000 
+0.0000000000 0.0000000000 0.0000000000 0.0000000000 -1.0000000000 80.1200000000 
+# 
+loop_
+_pdbx_audit_revision_history.ordinal 
+_pdbx_audit_revision_history.data_content_type 
+_pdbx_audit_revision_history.major_revision 
+_pdbx_audit_revision_history.minor_revision 
+_pdbx_audit_revision_history.revision_date 
+1 'Structure model' 1 0 1999-09-08 
+2 'Structure model' 1 1 2008-04-27 
+3 'Structure model' 1 2 2011-07-13 
+4 'Structure model' 1 3 2017-10-04 
+# 
+_pdbx_audit_revision_details.ordinal             1 
+_pdbx_audit_revision_details.revision_ordinal    1 
+_pdbx_audit_revision_details.data_content_type   'Structure model' 
+_pdbx_audit_revision_details.provider            repository 
+_pdbx_audit_revision_details.type                'Initial release' 
+_pdbx_audit_revision_details.description         ? 
+# 
+loop_
+_pdbx_audit_revision_group.ordinal 
+_pdbx_audit_revision_group.revision_ordinal 
+_pdbx_audit_revision_group.data_content_type 
+_pdbx_audit_revision_group.group 
+1 2 'Structure model' 'Version format compliance' 
+2 3 'Structure model' 'Non-polymer description'   
+3 3 'Structure model' 'Version format compliance' 
+4 4 'Structure model' 'Refinement description'    
+# 
+_pdbx_audit_revision_category.ordinal             1 
+_pdbx_audit_revision_category.revision_ordinal    4 
+_pdbx_audit_revision_category.data_content_type   'Structure model' 
+_pdbx_audit_revision_category.category            software 
+# 
+loop_
+_pdbx_audit_revision_item.ordinal 
+_pdbx_audit_revision_item.revision_ordinal 
+_pdbx_audit_revision_item.data_content_type 
+_pdbx_audit_revision_item.item 
+1 4 'Structure model' '_software.classification' 
+2 4 'Structure model' '_software.name'           
+# 
+loop_
+_software.name 
+_software.classification 
+_software.version 
+_software.citation_id 
+_software.pdbx_ordinal 
+X-PLOR   'model building'  . ? 1 
+SHELXL   refinement        . ? 2 
+MAR345   'data collection' . ? 3 
+HKL-2000 'data scaling'    . ? 4 
+X-PLOR   phasing           . ? 5 
+# 
+_pdbx_entry_details.entry_id             1CXQ 
+_pdbx_entry_details.compound_details     ? 
+_pdbx_entry_details.source_details       ? 
+_pdbx_entry_details.nonpolymer_details   ? 
+_pdbx_entry_details.sequence_details     
+;THE APPARENT DISCREPANCY BETWEEN THE SEQUENCE PRESENTED
+HERE AND THE "POL_RSVP" SEQUENCE IS A RESULT OF VIRAL
+STRAIN VARIATION. THE STRAIN USED FOR THIS WORK, "ROUS 
+SARCOMA VIRUS SCHMIDT-RUPPIN B", COMPARED TO "POL-RSVP"
+SEQUENCE DIFFERS AT TWO POSITIONS WITH THE CONSERVATIVE 
+AMINO ACID RESIDUE DIFFERENCES NOTED (VAL->ALA 101 & 
+ARG->LYS 166).
+;
+# 
+loop_
+_pdbx_validate_rmsd_bond.id 
+_pdbx_validate_rmsd_bond.PDB_model_num 
+_pdbx_validate_rmsd_bond.auth_atom_id_1 
+_pdbx_validate_rmsd_bond.auth_asym_id_1 
+_pdbx_validate_rmsd_bond.auth_comp_id_1 
+_pdbx_validate_rmsd_bond.auth_seq_id_1 
+_pdbx_validate_rmsd_bond.PDB_ins_code_1 
+_pdbx_validate_rmsd_bond.label_alt_id_1 
+_pdbx_validate_rmsd_bond.auth_atom_id_2 
+_pdbx_validate_rmsd_bond.auth_asym_id_2 
+_pdbx_validate_rmsd_bond.auth_comp_id_2 
+_pdbx_validate_rmsd_bond.auth_seq_id_2 
+_pdbx_validate_rmsd_bond.PDB_ins_code_2 
+_pdbx_validate_rmsd_bond.label_alt_id_2 
+_pdbx_validate_rmsd_bond.bond_value 
+_pdbx_validate_rmsd_bond.bond_target_value 
+_pdbx_validate_rmsd_bond.bond_deviation 
+_pdbx_validate_rmsd_bond.bond_standard_deviation 
+_pdbx_validate_rmsd_bond.linker_flag 
+1 1 CA A ILE 88  ? ? CB A ILE 88  ? B 1.386 1.544 -0.158 0.023 N 
+2 1 CA A VAL 99  ? ? CB A VAL 99  ? B 1.981 1.543 0.438  0.021 N 
+3 1 CA A CYS 125 ? ? CB A CYS 125 ? B 1.777 1.535 0.242  0.022 N 
+4 1 CB A SER 130 ? ? OG A SER 130 ? ? 1.337 1.418 -0.081 0.013 N 
+5 1 CA A ASP 165 ? ? CB A ASP 165 ? B 1.675 1.535 0.140  0.022 N 
+# 
+loop_
+_pdbx_validate_rmsd_angle.id 
+_pdbx_validate_rmsd_angle.PDB_model_num 
+_pdbx_validate_rmsd_angle.auth_atom_id_1 
+_pdbx_validate_rmsd_angle.auth_asym_id_1 
+_pdbx_validate_rmsd_angle.auth_comp_id_1 
+_pdbx_validate_rmsd_angle.auth_seq_id_1 
+_pdbx_validate_rmsd_angle.PDB_ins_code_1 
+_pdbx_validate_rmsd_angle.label_alt_id_1 
+_pdbx_validate_rmsd_angle.auth_atom_id_2 
+_pdbx_validate_rmsd_angle.auth_asym_id_2 
+_pdbx_validate_rmsd_angle.auth_comp_id_2 
+_pdbx_validate_rmsd_angle.auth_seq_id_2 
+_pdbx_validate_rmsd_angle.PDB_ins_code_2 
+_pdbx_validate_rmsd_angle.label_alt_id_2 
+_pdbx_validate_rmsd_angle.auth_atom_id_3 
+_pdbx_validate_rmsd_angle.auth_asym_id_3 
+_pdbx_validate_rmsd_angle.auth_comp_id_3 
+_pdbx_validate_rmsd_angle.auth_seq_id_3 
+_pdbx_validate_rmsd_angle.PDB_ins_code_3 
+_pdbx_validate_rmsd_angle.label_alt_id_3 
+_pdbx_validate_rmsd_angle.angle_value 
+_pdbx_validate_rmsd_angle.angle_target_value 
+_pdbx_validate_rmsd_angle.angle_deviation 
+_pdbx_validate_rmsd_angle.angle_standard_deviation 
+_pdbx_validate_rmsd_angle.linker_flag 
+1  1 NE  A ARG 74  ? ? CZ  A ARG 74  ? ? NH1 A ARG 74  ? ? 116.98 120.30 -3.32  0.50 N 
+2  1 CB  A VAL 81  ? B CA  A VAL 81  ? ? C   A VAL 81  ? ? 98.16  111.40 -13.24 1.90 N 
+3  1 CA  A VAL 81  ? ? CB  A VAL 81  ? B CG2 A VAL 81  ? B 101.78 110.90 -9.12  1.50 N 
+4  1 CB  A GLN 92  ? B CA  A GLN 92  ? B C   A GLN 92  ? ? 94.76  110.40 -15.64 2.00 N 
+5  1 NE  A ARG 95  ? ? CZ  A ARG 95  ? ? NH2 A ARG 95  ? ? 117.05 120.30 -3.25  0.50 N 
+6  1 CA  A VAL 99  ? ? CB  A VAL 99  ? B CG1 A VAL 99  ? B 94.27  110.90 -16.63 1.50 N 
+7  1 CA  A VAL 99  ? ? CB  A VAL 99  ? B CG2 A VAL 99  ? B 80.33  110.90 -30.57 1.50 N 
+8  1 CD  A ARG 114 ? ? NE  A ARG 114 ? ? CZ  A ARG 114 ? ? 114.52 123.60 -9.08  1.40 N 
+9  1 N   A CYS 125 ? ? CA  A CYS 125 ? ? CB  A CYS 125 ? B 123.60 110.80 12.80  1.50 N 
+10 1 CA  A CYS 125 ? ? CB  A CYS 125 ? B SG  A CYS 125 ? B 101.80 114.00 -12.20 1.80 N 
+11 1 N   A MET 155 ? ? CA  A MET 155 ? ? CB  A MET 155 ? B 99.13  110.60 -11.47 1.80 N 
+12 1 CA  A MET 155 ? ? CB  A MET 155 ? B CG  A MET 155 ? B 97.69  113.30 -15.61 1.70 N 
+13 1 NE  A ARG 158 ? ? CZ  A ARG 158 ? ? NH2 A ARG 158 ? ? 123.42 120.30 3.12   0.50 N 
+14 1 CB  A ASP 165 ? B CG  A ASP 165 ? B OD2 A ASP 165 ? B 125.93 118.30 7.63   0.90 N 
+15 1 NE  A ARG 168 ? A CZ  A ARG 168 ? A NH1 A ARG 168 ? A 125.17 120.30 4.87   0.50 N 
+16 1 NE  A ARG 168 ? B CZ  A ARG 168 ? B NH1 A ARG 168 ? B 127.27 120.30 6.97   0.50 N 
+17 1 NE  A ARG 168 ? A CZ  A ARG 168 ? A NH2 A ARG 168 ? A 116.80 120.30 -3.50  0.50 N 
+18 1 NE  A ARG 168 ? B CZ  A ARG 168 ? B NH2 A ARG 168 ? B 117.21 120.30 -3.09  0.50 N 
+19 1 CE1 A HIS 198 ? ? NE2 A HIS 198 ? ? CD2 A HIS 198 ? ? 113.83 109.00 4.83   0.70 N 
+# 
+loop_
+_pdbx_validate_torsion.id 
+_pdbx_validate_torsion.PDB_model_num 
+_pdbx_validate_torsion.auth_comp_id 
+_pdbx_validate_torsion.auth_asym_id 
+_pdbx_validate_torsion.auth_seq_id 
+_pdbx_validate_torsion.PDB_ins_code 
+_pdbx_validate_torsion.label_alt_id 
+_pdbx_validate_torsion.phi 
+_pdbx_validate_torsion.psi 
+1 1 GLN A 153 ? ? -145.53 51.85   
+2 1 LYS A 178 ? ? -130.86 -120.08 
+# 
+_pdbx_validate_planes.id              1 
+_pdbx_validate_planes.PDB_model_num   1 
+_pdbx_validate_planes.auth_comp_id    GLN 
+_pdbx_validate_planes.auth_asym_id    A 
+_pdbx_validate_planes.auth_seq_id     92 
+_pdbx_validate_planes.PDB_ins_code    ? 
+_pdbx_validate_planes.label_alt_id    ? 
+_pdbx_validate_planes.rmsd            0.073 
+_pdbx_validate_planes.type            'SIDE CHAIN' 
+# 
+loop_
+_pdbx_unobs_or_zero_occ_residues.id 
+_pdbx_unobs_or_zero_occ_residues.PDB_model_num 
+_pdbx_unobs_or_zero_occ_residues.polymer_flag 
+_pdbx_unobs_or_zero_occ_residues.occupancy_flag 
+_pdbx_unobs_or_zero_occ_residues.auth_asym_id 
+_pdbx_unobs_or_zero_occ_residues.auth_comp_id 
+_pdbx_unobs_or_zero_occ_residues.auth_seq_id 
+_pdbx_unobs_or_zero_occ_residues.PDB_ins_code 
+_pdbx_unobs_or_zero_occ_residues.label_asym_id 
+_pdbx_unobs_or_zero_occ_residues.label_comp_id 
+_pdbx_unobs_or_zero_occ_residues.label_seq_id 
+1  1 Y 1 A PRO 48  ? A PRO 1   
+2  1 Y 1 A LEU 49  ? A LEU 2   
+3  1 Y 1 A ARG 50  ? A ARG 3   
+4  1 Y 1 A GLU 51  ? A GLU 4   
+5  1 Y 1 A GLY 148 ? A GLY 101 
+6  1 Y 1 A ASN 149 ? A ASN 102 
+7  1 Y 1 A SER 150 ? A SER 103 
+8  1 Y 1 A GLN 151 ? A GLN 104 
+9  1 Y 1 A PHE 199 ? A PHE 152 
+10 1 Y 1 A GLU 200 ? A GLU 153 
+11 1 Y 1 A ARG 201 ? A ARG 154 
+12 1 Y 1 A GLY 202 ? A GLY 155 
+13 1 Y 1 A GLU 203 ? A GLU 156 
+14 1 Y 1 A ASN 204 ? A ASN 157 
+15 1 Y 1 A THR 205 ? A THR 158 
+16 1 Y 1 A LYS 206 ? A LYS 159 
+17 1 Y 1 A THR 207 ? A THR 160 
+18 1 Y 1 A ASN 208 ? A ASN 161 
+19 1 Y 1 A LEU 209 ? A LEU 162 
+# 
+loop_
+_pdbx_entity_nonpoly.entity_id 
+_pdbx_entity_nonpoly.name 
+_pdbx_entity_nonpoly.comp_id 
+2 '4-(2-HYDROXYETHYL)-1-PIPERAZINE ETHANESULFONIC ACID' EPE 
+3 GLYCEROL                                              GOL 
+4 water                                                 HOH 
+# 

--- a/baby-gru/tests/test_data/7ZTVU.cif
+++ b/baby-gru/tests/test_data/7ZTVU.cif
@@ -1,0 +1,264 @@
+#
+data_comp_list
+loop_
+_chem_comp.id
+_chem_comp.three_letter_code
+_chem_comp.name
+_chem_comp.group
+_chem_comp.number_atoms_all
+_chem_comp.number_atoms_nh
+_chem_comp.desc_level
+ZT   7ZTVU       "4-(2-HYDROXYETHYL)-1-PIPERAZINE        ETHANESULFONIC        ACID"        NON-POLYMER        33        15        .        
+#
+data_comp_7ZTVU
+#
+loop_
+_chem_comp_atom.comp_id
+_chem_comp_atom.atom_id
+_chem_comp_atom.type_symbol
+_chem_comp_atom.type_energy
+_chem_comp_atom.charge
+_chem_comp_atom.x
+_chem_comp_atom.y
+_chem_comp_atom.z
+_chem_comp_atom.pdbx_model_Cartn_x_ideal
+_chem_comp_atom.pdbx_model_Cartn_y_ideal
+_chem_comp_atom.pdbx_model_Cartn_z_ideal
+7ZTVU     N1      N       N30     0       61.683      47.309      51.666      61.683      47.309      51.666      
+7ZTVU     C2      C       CH2     0       63.089      46.999      51.976      63.089      46.999      51.976      
+7ZTVU     C3      C       CH2     0       63.999      47.416      50.843      63.999      47.416      50.843      
+7ZTVU     N4      N       N30     0       63.631      46.733      49.592      63.631      46.733      49.592      
+7ZTVU     C5      C       CH2     0       62.226      47.042      49.278      62.226      47.042      49.278      
+7ZTVU     C6      C       CH2     0       61.311      46.635      50.411      61.311      46.635      50.411      
+7ZTVU     C7      C       CH2     0       64.533      47.092      48.482      64.533      47.092      48.482      
+7ZTVU     C8      C       CH2     0       65.897      46.443      48.537      65.897      46.443      48.537      
+7ZTVU     O8      O       OH1     0       65.800      45.041      48.725      65.800      45.041      48.725      
+7ZTVU     C9      C       CH2     0       60.775      46.968      52.784      60.775      46.968      52.784      
+7ZTVU     C10     C       CH2     0       60.796      47.991      53.909      60.796      47.991      53.909      
+7ZTVU     S       S       S3      0       59.472      47.733      55.057      59.472      47.733      55.057      
+7ZTVU     O1S     O       O       0       59.680      48.647      56.146      59.680      48.647      56.146      
+7ZTVU     O2S     O       O       0       59.439      46.326      55.349      59.439      46.326      55.349      
+7ZTVU     O3S     O       OH1     0       58.256      48.133      54.267      58.256      48.133      54.267      
+7ZTVU     H21     H       H       0       63.353      47.466      52.790      63.353      47.466      52.790      
+7ZTVU     H22     H       H       0       63.183      46.041      52.131      63.183      46.041      52.131      
+7ZTVU     H31     H       H       0       64.921      47.200      51.075      64.921      47.200      51.075      
+7ZTVU     H32     H       H       0       63.937      48.381      50.716      63.937      48.381      50.716      
+7ZTVU     H51     H       H       0       61.962      46.569      48.467      61.962      46.569      48.467      
+7ZTVU     H52     H       H       0       62.134      47.998      49.115      62.134      47.998      49.115      
+7ZTVU     H61     H       H       0       60.392      46.864      50.180      60.392      46.864      50.180      
+7ZTVU     H62     H       H       0       61.360      45.669      50.537      61.360      45.669      50.537      
+7ZTVU     H71     H       H       0       64.647      48.064      48.475      64.647      48.064      48.475      
+7ZTVU     H72     H       H       0       64.107      46.840      47.638      64.107      46.840      47.638      
+7ZTVU     H81     H       H       0       66.413      46.836      49.272      66.413      46.836      49.272      
+7ZTVU     H82     H       H       0       66.375      46.627      47.701      66.375      46.627      47.701      
+7ZTVU     HO8     H       H       0       66.536      44.689      48.502      66.536      44.689      48.502      
+7ZTVU     H91     H       H       0       61.027      46.095      53.146      61.027      46.095      53.146      
+7ZTVU     H92     H       H       0       59.861      46.897      52.445      59.861      46.897      52.445      
+7ZTVU     H101    H       H       0       60.717      48.877      53.531      60.717      48.877      53.531      
+7ZTVU     H102    H       H       0       61.638      47.924      54.381      61.638      47.924      54.381      
+7ZTVU     HOS3    H       H       0       57.851      47.474      53.850      57.851      47.474      53.850      
+loop_
+_chem_comp_acedrg.comp_id
+_chem_comp_acedrg.atom_id
+_chem_comp_acedrg.atom_type
+7ZTVU        N1    N[6](C[6]C[6]HH)2(CCHH){1|N<3>,4|H<1>}
+7ZTVU        C2    C[6](C[6]N[6]HH)(N[6]C[6]C)(H)2{2|C<4>,2|H<1>}
+7ZTVU        C3    C[6](C[6]N[6]HH)(N[6]C[6]C)(H)2{2|C<4>,2|H<1>}
+7ZTVU        N4    N[6](C[6]C[6]HH)2(CCHH){1|N<3>,4|H<1>}
+7ZTVU        C5    C[6](C[6]N[6]HH)(N[6]C[6]C)(H)2{2|C<4>,2|H<1>}
+7ZTVU        C6    C[6](C[6]N[6]HH)(N[6]C[6]C)(H)2{2|C<4>,2|H<1>}
+7ZTVU        C7    C(N[6]C[6]2)(CHHO)(H)2
+7ZTVU        C8    C(CN[6]HH)(OH)(H)2
+7ZTVU        O8    O(CCHH)(H)
+7ZTVU        C9    C(N[6]C[6]2)(CHHS)(H)2
+7ZTVU       C10    C(CN[6]HH)(SO3)(H)2
+7ZTVU         S    S(CCHH)(OH)(O)2
+7ZTVU       O1S    O(SCOO)
+7ZTVU       O2S    O(SCOO)
+7ZTVU       O3S    O(SCOO)(H)
+7ZTVU       H21    H(C[6]C[6]N[6]H)
+7ZTVU       H22    H(C[6]C[6]N[6]H)
+7ZTVU       H31    H(C[6]C[6]N[6]H)
+7ZTVU       H32    H(C[6]C[6]N[6]H)
+7ZTVU       H51    H(C[6]C[6]N[6]H)
+7ZTVU       H52    H(C[6]C[6]N[6]H)
+7ZTVU       H61    H(C[6]C[6]N[6]H)
+7ZTVU       H62    H(C[6]C[6]N[6]H)
+7ZTVU       H71    H(CN[6]CH)
+7ZTVU       H72    H(CN[6]CH)
+7ZTVU       H81    H(CCHO)
+7ZTVU       H82    H(CCHO)
+7ZTVU       HO8    H(OC)
+7ZTVU       H91    H(CN[6]CH)
+7ZTVU       H92    H(CN[6]CH)
+7ZTVU      H101    H(CCHS)
+7ZTVU      H102    H(CCHS)
+7ZTVU      HOS3    H(OS)
+loop_
+_chem_comp_bond.comp_id
+_chem_comp_bond.atom_id_1
+_chem_comp_bond.atom_id_2
+_chem_comp_bond.type
+_chem_comp_bond.aromatic
+_chem_comp_bond.value_dist_nucleus
+_chem_comp_bond.value_dist_nucleus_esd
+_chem_comp_bond.value_dist
+_chem_comp_bond.value_dist_esd
+7ZTVU          N1          C2      SINGLE       n     1.468  0.0110     1.468  0.0110
+7ZTVU          N1          C6      SINGLE       n     1.468  0.0110     1.468  0.0110
+7ZTVU          N1          C9      SINGLE       n     1.468  0.0200     1.468  0.0200
+7ZTVU          C2          C3      SINGLE       n     1.509  0.0132     1.509  0.0132
+7ZTVU          C3          N4      SINGLE       n     1.468  0.0110     1.468  0.0110
+7ZTVU          N4          C5      SINGLE       n     1.468  0.0110     1.468  0.0110
+7ZTVU          N4          C7      SINGLE       n     1.471  0.0100     1.471  0.0100
+7ZTVU          C5          C6      SINGLE       n     1.509  0.0132     1.509  0.0132
+7ZTVU          C7          C8      SINGLE       n     1.510  0.0165     1.510  0.0165
+7ZTVU          C8          O8      SINGLE       n     1.418  0.0127     1.418  0.0127
+7ZTVU          C9         C10      SINGLE       n     1.520  0.0107     1.520  0.0107
+7ZTVU         C10           S      SINGLE       n     1.771  0.0100     1.771  0.0100
+7ZTVU           S         O1S      DOUBLE       n     1.437  0.0100     1.437  0.0100
+7ZTVU           S         O2S      DOUBLE       n     1.437  0.0100     1.437  0.0100
+7ZTVU           S         O3S      SINGLE       n     1.503  0.0200     1.503  0.0200
+7ZTVU          C2         H21      SINGLE       n     1.092  0.0100     0.975  0.0100
+7ZTVU          C2         H22      SINGLE       n     1.092  0.0100     0.975  0.0100
+7ZTVU          C3         H31      SINGLE       n     1.092  0.0100     0.975  0.0100
+7ZTVU          C3         H32      SINGLE       n     1.092  0.0100     0.975  0.0100
+7ZTVU          C5         H51      SINGLE       n     1.092  0.0100     0.975  0.0100
+7ZTVU          C5         H52      SINGLE       n     1.092  0.0100     0.975  0.0100
+7ZTVU          C6         H61      SINGLE       n     1.092  0.0100     0.975  0.0100
+7ZTVU          C6         H62      SINGLE       n     1.092  0.0100     0.975  0.0100
+7ZTVU          C7         H71      SINGLE       n     1.092  0.0100     0.978  0.0107
+7ZTVU          C7         H72      SINGLE       n     1.092  0.0100     0.978  0.0107
+7ZTVU          C8         H81      SINGLE       n     1.092  0.0100     0.980  0.0132
+7ZTVU          C8         H82      SINGLE       n     1.092  0.0100     0.980  0.0132
+7ZTVU          O8         HO8      SINGLE       n     0.972  0.0180     0.846  0.0200
+7ZTVU          C9         H91      SINGLE       n     1.092  0.0100     0.978  0.0107
+7ZTVU          C9         H92      SINGLE       n     1.092  0.0100     0.978  0.0107
+7ZTVU         C10        H101      SINGLE       n     1.092  0.0100     0.967  0.0200
+7ZTVU         C10        H102      SINGLE       n     1.092  0.0100     0.967  0.0200
+7ZTVU         O3S        HOS3      SINGLE       n     0.972  0.0180     0.879  0.0200
+loop_
+_chem_comp_angle.comp_id
+_chem_comp_angle.atom_id_1
+_chem_comp_angle.atom_id_2
+_chem_comp_angle.atom_id_3
+_chem_comp_angle.value_angle
+_chem_comp_angle.value_angle_esd
+7ZTVU          C2          N1          C6     108.598    1.50
+7ZTVU          C2          N1          C9     111.163    2.70
+7ZTVU          C6          N1          C9     111.163    2.70
+7ZTVU          N1          C2          C3     110.921    1.50
+7ZTVU          N1          C2         H21     109.441    1.50
+7ZTVU          N1          C2         H22     109.441    1.50
+7ZTVU          C3          C2         H21     109.518    1.50
+7ZTVU          C3          C2         H22     109.518    1.50
+7ZTVU         H21          C2         H22     108.210    1.50
+7ZTVU          C2          C3          N4     110.921    1.50
+7ZTVU          C2          C3         H31     109.518    1.50
+7ZTVU          C2          C3         H32     109.518    1.50
+7ZTVU          N4          C3         H31     109.441    1.50
+7ZTVU          N4          C3         H32     109.441    1.50
+7ZTVU         H31          C3         H32     108.210    1.50
+7ZTVU          C3          N4          C5     108.598    1.50
+7ZTVU          C3          N4          C7     110.979    2.04
+7ZTVU          C5          N4          C7     110.979    2.04
+7ZTVU          N4          C5          C6     110.921    1.50
+7ZTVU          N4          C5         H51     109.441    1.50
+7ZTVU          N4          C5         H52     109.441    1.50
+7ZTVU          C6          C5         H51     109.518    1.50
+7ZTVU          C6          C5         H52     109.518    1.50
+7ZTVU         H51          C5         H52     108.210    1.50
+7ZTVU          N1          C6          C5     110.921    1.50
+7ZTVU          N1          C6         H61     109.441    1.50
+7ZTVU          N1          C6         H62     109.441    1.50
+7ZTVU          C5          C6         H61     109.518    1.50
+7ZTVU          C5          C6         H62     109.518    1.50
+7ZTVU         H61          C6         H62     108.210    1.50
+7ZTVU          N4          C7          C8     114.503    3.00
+7ZTVU          N4          C7         H71     108.706    1.50
+7ZTVU          N4          C7         H72     108.706    1.50
+7ZTVU          C8          C7         H71     109.060    1.50
+7ZTVU          C8          C7         H72     109.060    1.50
+7ZTVU         H71          C7         H72     107.982    1.50
+7ZTVU          C7          C8          O8     111.367    3.00
+7ZTVU          C7          C8         H81     109.327    1.50
+7ZTVU          C7          C8         H82     109.327    1.50
+7ZTVU          O8          C8         H81     109.517    1.50
+7ZTVU          O8          C8         H82     109.517    1.50
+7ZTVU         H81          C8         H82     108.118    1.50
+7ZTVU          C8          O8         HO8     108.433    3.00
+7ZTVU          N1          C9         C10     113.603    3.00
+7ZTVU          N1          C9         H91     109.088    1.50
+7ZTVU          N1          C9         H92     109.088    1.50
+7ZTVU         C10          C9         H91     109.064    1.50
+7ZTVU         C10          C9         H92     109.064    1.50
+7ZTVU         H91          C9         H92     107.977    1.50
+7ZTVU          C9         C10           S     110.778    3.00
+7ZTVU          C9         C10        H101     108.834    1.50
+7ZTVU          C9         C10        H102     108.834    1.50
+7ZTVU           S         C10        H101     108.786    1.50
+7ZTVU           S         C10        H102     108.786    1.50
+7ZTVU        H101         C10        H102     108.248    3.00
+7ZTVU         C10           S         O1S     106.718    1.50
+7ZTVU         C10           S         O2S     106.718    1.50
+7ZTVU         C10           S         O3S     102.407    3.00
+7ZTVU         O1S           S         O2S     117.601    3.00
+7ZTVU         O1S           S         O3S     109.792    3.00
+7ZTVU         O2S           S         O3S     109.792    3.00
+7ZTVU           S         O3S        HOS3     114.950    3.00
+loop_
+_chem_comp_tor.comp_id
+_chem_comp_tor.id
+_chem_comp_tor.atom_id_1
+_chem_comp_tor.atom_id_2
+_chem_comp_tor.atom_id_3
+_chem_comp_tor.atom_id_4
+_chem_comp_tor.value_angle
+_chem_comp_tor.value_angle_esd
+_chem_comp_tor.period
+7ZTVU             sp3_sp3_2          C3          C2          N1          C9     180.000    10.0     3
+7ZTVU            sp3_sp3_38          C5          C6          N1          C9     -60.000    10.0     3
+7ZTVU            sp3_sp3_44         C10          C9          N1          C2     -60.000    10.0     3
+7ZTVU            sp3_sp3_76          C9         C10           S         O1S     180.000    10.0     3
+7ZTVU            sp3_sp3_87        HOS3         O3S           S         C10      60.000    10.0     3
+7ZTVU             sp3_sp3_7          N1          C2          C3          N4     -60.000    10.0     3
+7ZTVU            sp3_sp3_17          C2          C3          N4          C7     180.000    10.0     3
+7ZTVU            sp3_sp3_23          C6          C5          N4          C7      60.000    10.0     3
+7ZTVU            sp3_sp3_50          C8          C7          N4          C3     -60.000    10.0     3
+7ZTVU            sp3_sp3_28          N4          C5          C6          N1      60.000    10.0     3
+7ZTVU            sp3_sp3_55          N4          C7          C8          O8     180.000    10.0     3
+7ZTVU            sp3_sp3_64          C7          C8          O8         HO8     180.000    10.0     3
+7ZTVU            sp3_sp3_67           S         C10          C9          N1     180.000    10.0     3
+loop_
+_chem_comp_chir.comp_id
+_chem_comp_chir.id
+_chem_comp_chir.atom_id_centre
+_chem_comp_chir.atom_id_1
+_chem_comp_chir.atom_id_2
+_chem_comp_chir.atom_id_3
+_chem_comp_chir.volume_sign
+7ZTVU    chir_1    N1    C9    C2    C6    both
+7ZTVU    chir_2    N4    C7    C3    C5    both
+7ZTVU    chir_3    S    O1S    O2S    O3S    both
+loop_
+_pdbx_chem_comp_descriptor.comp_id
+_pdbx_chem_comp_descriptor.type
+_pdbx_chem_comp_descriptor.program
+_pdbx_chem_comp_descriptor.program_version
+_pdbx_chem_comp_descriptor.descriptor
+7ZTVU  SMILES            ACDLabs               10.04  "O=S(=O)(O)CCN1CCN(CCO)CC1"
+7ZTVU  SMILES_CANONICAL  CACTVS                3.341  "OCCN1CCN(CC1)CC[S](O)(=O)=O"
+7ZTVU  SMILES            CACTVS                3.341  "OCCN1CCN(CC1)CC[S](O)(=O)=O"
+7ZTVU  SMILES_CANONICAL  "OpenEye OEToolkits"  1.5.0  "C1CN(CCN1CCO)CCS(=O)(=O)O"
+7ZTVU  SMILES            "OpenEye OEToolkits"  1.5.0  "C1CN(CCN1CCO)CCS(=O)(=O)O"
+7ZTVU  InChI             InChI                 1.03   "InChI=1S/C8H18N2O4S/c11-7-5-9-1-3-10(4-2-9)6-8-15(12,13)14/h11H,1-8H2,(H,12,13,14)"
+7ZTVU  InChIKey          InChI                 1.03   JKMHFZQWWAIEOD-UHFFFAOYSA-N
+loop_
+_pdbx_chem_comp_description_generator.comp_id
+_pdbx_chem_comp_description_generator.program_name
+_pdbx_chem_comp_description_generator.program_version
+_pdbx_chem_comp_description_generator.descriptor
+7ZTVU acedrg               277         "dictionary generator"                  
+7ZTVU acedrg_database      12          "data source"                           
+7ZTVU rdkit                2019.09.1   "Chemoinformatics tool"
+7ZTVU refmac5              5.8.0419    "optimization tool"                     


### PR DESCRIPTION
This update fixes the issue where the action buttons for a residue selection are rendered on top of the draggable modals. It also adds more tests for ligands with 5 letter codes (currently being skipped as they fail).