### PR TITLE
Move molecule visibility into redux store

### DIFF
--- a/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
+++ b/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
@@ -43,6 +43,7 @@ export const MoorhenAddCustomRepresentationCard = (props: {
     const colourModeSelectRef = useRef<HTMLSelectElement | null>(null)
     const colourSwatchRef = useRef<HTMLDivElement | null>(null)
     const residueRangeSelectRef = useRef<any>()
+    
     const [representationStyle, setRepresentationStyle] = useState<string>(props.initialRepresentationStyleValue)
     const [colourMode, setColourMode] = useState<string>(props.initialColourMode)
     const [showColourPicker, setShowColourPicker] = useState<boolean>(false)
@@ -56,6 +57,7 @@ export const MoorhenAddCustomRepresentationCard = (props: {
     const [atomRadiusBondRatio, setAtomRadiusBondRatio] = useState<number>( props.initialAtomRadiusBondRatio ? props.initialAtomRadiusBondRatio : props.molecule.defaultBondOptions.atomRadiusBondRatio)
     const [bondWidth, setBondWidth] = useState<number>(props.initialBondWidth ? props.initialBondWidth : props.molecule.defaultBondOptions.width)
     const [bondSmoothness, setBondSmoothness] = useState<number>(props.molecule.defaultBondOptions.smoothness === 1 ? 1 : props.molecule.defaultBondOptions.smoothness === 2 ? 50 : 100)
+    
     const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
     const molecules = useSelector((state: moorhen.State) => state.molecules)
 

--- a/baby-gru/src/components/webMG/MoorhenWebMG.tsx
+++ b/baby-gru/src/components/webMG/MoorhenWebMG.tsx
@@ -52,6 +52,7 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
     const [showContextMenu, setShowContextMenu] = useState<false | moorhen.AtomRightClickEventInfo>(false)
     const [defaultActionButtonSettings, setDefaultActionButtonSettings] = useReducer(actionButtonSettingsReducer, intialDefaultActionButtonSettings)
 
+    const visibleMolecules = useSelector((state: moorhen.State) => state.moleculeRepresentations.visibleMolecules)
     const residueSelection = useSelector((state: moorhen.State) => state.generalStates.residueSelection)
     const isChangingRotamers = useSelector((state: moorhen.State) => state.generalStates.isChangingRotamers)
     const isDraggingAtoms = useSelector((state: moorhen.State) => state.generalStates.isDraggingAtoms)
@@ -140,8 +141,8 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
             busyDrawingHBonds.current = true
             hBondsDirty.current = false
 
-            const visibleMolecules: moorhen.Molecule[] = molecules.filter(molecule => molecule.isVisible && molecule.hasVisibleBuffers())
-            if (visibleMolecules.length === 0) {
+            const _visibleMolecules: moorhen.Molecule[] = molecules.filter(molecule => molecule.isVisible())
+            if (_visibleMolecules.length === 0) {
                 busyDrawingHBonds.current = false
                 return
             }
@@ -149,7 +150,7 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
             const response = await props.commandCentre.current.cootCommand({
                 returnType: "int_string_pair",
                 command: "get_active_atom",
-                commandArgs: [...glRef.current.origin.map(coord => -coord), visibleMolecules.map(molecule => molecule.molNo).join(':')]
+                commandArgs: [...glRef.current.origin.map(coord => -coord), _visibleMolecules.map(molecule => molecule.molNo).join(':')]
             }, false) as moorhen.WorkerResponse<libcootApi.PairType<number, string>>
             const moleculeMolNo: number = response.data.result.result.first
             const residueCid: string = response.data.result.result.second
@@ -163,7 +164,7 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
             drawHBonds()
         }
 
-    }, [props.commandCentre, molecules, glRef])
+    }, [props.commandCentre, molecules, glRef, visibleMolecules])
 
     const clearHBonds = useCallback(async () => {
         if(!drawInteractions) {

--- a/baby-gru/src/store/MoorhenReduxStore.ts
+++ b/baby-gru/src/store/MoorhenReduxStore.ts
@@ -12,6 +12,7 @@ import generalStatesReducer from './generalStatesSlice'
 import hoveringStatesReducer from './hoveringStatesSlice'
 import activeModalsReducer from './activeModalsSlice'
 import mapContourSettingsReducer from './mapContourSettingsSlice'
+import moleculeRepresentationsReducer from './moleculeRepresentationsSlice'
 
 export default configureStore({
     reducer: {
@@ -27,7 +28,8 @@ export default configureStore({
         generalStates: generalStatesReducer,
         hoveringStates: hoveringStatesReducer,
         activeModals: activeModalsReducer,
-        mapContourSettings: mapContourSettingsReducer
+        mapContourSettings: mapContourSettingsReducer,
+        moleculeRepresentations: moleculeRepresentationsReducer
     },
     middleware: (getDefaultMiddleware) =>
         getDefaultMiddleware({

--- a/baby-gru/src/store/moleculeRepresentationsSlice.ts
+++ b/baby-gru/src/store/moleculeRepresentationsSlice.ts
@@ -1,0 +1,74 @@
+import { createSlice } from '@reduxjs/toolkit'
+import { moorhen } from "../types/moorhen"
+
+export const moleculeRepresentationsSlice = createSlice({
+  name: 'moleculeRepresentations',
+  initialState: {
+    visibleMolecules: [],
+    representations: [],
+    visibleRepresentations: [],
+  },
+  reducers: {
+    showMolecule: (state, action: {payload: moorhen.Molecule, type: string}) => {
+        if (!state.visibleMolecules.includes(action.payload.molNo)) {
+          state = { ...state, visibleMolecules: [...state.visibleMolecules, action.payload.molNo] }
+        }
+        return state
+    },
+    hideMolecule: (state, action: {payload: moorhen.Molecule, type: string}) => {
+      state = { ...state, visibleMolecules: state.visibleMolecules.filter(item => item !== action.payload.molNo) }
+      return state
+    },
+    addRepresentation: (state, action: {payload: { molNo: number; representationId: string }, type: string}) => {
+      state = { 
+        ...state,
+        representations: [
+          ...state.representations.filter(item => item.molNo !== action.payload.molNo && item.representationId !== action.payload.representationId), 
+          action.payload 
+        ],
+        visibleRepresentations: [
+          ...state.visibleRepresentations.filter(item => item.molNo !== action.payload.molNo && item.representationId !== action.payload.representationId), 
+          action.payload 
+        ]
+      }
+      return state
+    },
+    removeRepresentation: (state, action: {payload: { molNo: number; representationId: string }, type: string}) => {
+      state = { 
+        ...state,
+        representations: [
+          ...state.representations.filter(item => item.molNo !== action.payload.molNo && item.representationId !== action.payload.representationId)
+        ],
+        visibleRepresentations: [
+          ...state.visibleRepresentations.filter(item => item.molNo !== action.payload.molNo && item.representationId !== action.payload.representationId)
+        ]
+      }
+      return state
+    },
+    hideRepresentation: (state, action: {payload: { molNo: number; representationId: string }, type: string}) => {
+      state = { 
+        ...state,
+        visibleRepresentations: [
+          ...state.visibleRepresentations.filter(item => item.molNo !== action.payload.molNo && item.representationId !== action.payload.representationId)
+        ] 
+      }
+      return state
+    },
+    showRepresentation: (state, action: {payload: { molNo: number; representationId: string }, type: string}) => {
+      state = { 
+        ...state,
+        visibleRepresentations: [
+          ...state.visibleRepresentations.filter(item => item.molNo !== action.payload.molNo && item.representationId !== action.payload.representationId), 
+          action.payload 
+        ] 
+      }
+      return state
+    },
+},
+})
+
+export const {
+  showMolecule, hideMolecule, removeRepresentation, hideRepresentation, showRepresentation, addRepresentation
+} = moleculeRepresentationsSlice.actions
+
+export default moleculeRepresentationsSlice.reducer

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -106,7 +106,7 @@ declare module 'moorhen' {
         hide: (style: string, cid?: string) => void;
         redraw: () => Promise<void>;
         setAtomsDirty: (newVal: boolean) => void;
-        hasVisibleBuffers: (excludeBuffers?: string[]) => boolean;
+        isVisible: (excludeBuffers?: string[]) => boolean;
         centreAndAlignViewOn(selectionCid: string, animate?: boolean): Promise<void>;
         buffersInclude: (bufferIn: { id: string; }) => boolean;
         redrawRepresentation: (id: string) => Promise<void>;
@@ -117,7 +117,7 @@ declare module 'moorhen' {
         commandCentre: React.RefObject<_moorhen.CommandCentre>;
         glRef: React.RefObject<webGL.MGWebGL>;
         atomsDirty: boolean;
-        isVisible: boolean;
+        showOnLoad: boolean;
         name: string;
         molNo: number;
         gemmiStructure: gemmi.Structure;

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -117,7 +117,6 @@ declare module 'moorhen' {
         commandCentre: React.RefObject<_moorhen.CommandCentre>;
         glRef: React.RefObject<webGL.MGWebGL>;
         atomsDirty: boolean;
-        showOnLoad: boolean;
         name: string;
         molNo: number;
         gemmiStructure: gemmi.Structure;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -150,7 +150,7 @@ export namespace moorhen {
         hide: (style: string, cid?: string) => void;
         redraw: () => Promise<void>;
         setAtomsDirty: (newVal: boolean) => void;
-        hasVisibleBuffers: (excludeBuffers?: string[]) => boolean;
+        isVisible: (excludeBuffers?: string[]) => boolean;
         centreAndAlignViewOn(selectionCid: string, animate?: boolean): Promise<void>;
         buffersInclude: (bufferIn: { id: string; }) => boolean;
         redrawRepresentation: (id: string) => Promise<void>;
@@ -160,7 +160,7 @@ export namespace moorhen {
         commandCentre: React.RefObject<CommandCentre>;
         glRef: React.RefObject<webGL.MGWebGL>;
         atomsDirty: boolean;
-        isVisible: boolean;
+        showOnLoad: boolean;
         name: string;
         molNo: number;
         gemmiStructure: gemmi.Structure;
@@ -850,7 +850,12 @@ export namespace moorhen {
             mapColours: { molNo: number; rgb: {r: number, g: number, b: number} }[];
             negativeMapColours: { molNo: number; rgb: {r: number, g: number, b: number} }[];
             positiveMapColours: { molNo: number; rgb: {r: number, g: number, b: number} }[];
-        }
+        };
+        moleculeRepresentations: {
+            visibleMolecules: number[];
+            representations: { molNo: number; representationId: string }[];
+            visibleRepresentations: { molNo: number; representationId: string }[];        
+        };
     }
     
     type actionButtonSettings = {

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -160,7 +160,6 @@ export namespace moorhen {
         commandCentre: React.RefObject<CommandCentre>;
         glRef: React.RefObject<webGL.MGWebGL>;
         atomsDirty: boolean;
-        showOnLoad: boolean;
         name: string;
         molNo: number;
         gemmiStructure: gemmi.Structure;

--- a/baby-gru/src/utils/MoorhenKeyboardAccelerators.tsx
+++ b/baby-gru/src/utils/MoorhenKeyboardAccelerators.tsx
@@ -48,7 +48,7 @@ export const babyGruKeyPress = (
     } = collectedProps;
 
     const getCentreAtom = async (): Promise<[moorhen.Molecule, string]> => {
-        const visibleMolecules: moorhen.Molecule[] = molecules.filter((molecule: moorhen.Molecule) => molecule.isVisible && molecule.hasVisibleBuffers())
+        const visibleMolecules: moorhen.Molecule[] = molecules.filter((molecule: moorhen.Molecule) => molecule.isVisible())
         if (visibleMolecules.length === 0) {
             return
         }

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -54,7 +54,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
     commandCentre: React.RefObject<moorhen.CommandCentre>;
     glRef: React.RefObject<webGL.MGWebGL>;
     atomsDirty: boolean;
-    showOnLoad: boolean;
     name: string;
     molNo: number | null
     gemmiStructure: gemmi.Structure;
@@ -96,7 +95,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
         this.commandCentre = commandCentre
         this.glRef = glRef
         this.atomsDirty = true
-        this.showOnLoad = true
         this.name = "unnamed"
         this.molNo = null
         this.coordsFormat = null

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -19,7 +19,6 @@ import { hideMolecule } from '../store/moleculeRepresentationsSlice';
  * @property {number} molNo - The imol assigned to this molecule instance
  * @property {boolean} atomsDirty - Whether the cached atoms are outdated 
  * @property {boolean} symmetryOn - Whether the symmetry is currently being displayed
- * @property {boolean} showOnLoad - Whether the molecule is to be displayed right after loading
  * @property {object} sequences - List of sequences present in the molecule
  * @property {object} gemmiStructure - Object representation of the cached gemmi structure for this molecule
  * @property {React.RefObject<moorhen.CommandCentre>} commandCentre - A react reference to the command centre instance

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -11,6 +11,7 @@ import { webGL } from "../types/mgWebGL"
 import { gemmi } from "../types/gemmi"
 import { libcootApi } from '../types/libcoot';
 import MoorhenReduxStore from "../store/MoorhenReduxStore";
+import { hideMolecule } from '../store/moleculeRepresentationsSlice';
 
 /**
  * Represents a molecule
@@ -1200,7 +1201,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
             let promises = []
             otherMolecules.forEach(molecule => {
                 if (doHide) {
-                    molecule.representations.forEach(item => item.hide())
+                    MoorhenReduxStore.dispatch(hideMolecule(molecule))
                 }
                 Object.keys(molecule.ligandDicts).forEach(key => {
                     if (!Object.hasOwn(this.ligandDicts, key)) {


### PR DESCRIPTION
Equivalent to #233 but for molecule representations. This update adds new states to the redux store to control the visibility of the molecules (related to #225). 