### PR TITLE
Add colour ramp rule

### DIFF
--- a/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
+++ b/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
@@ -114,6 +114,7 @@ export const MoorhenAddCustomRepresentationCard = (props: {
                         label: cidSelection
                     }]
                     break
+                case 'colour-ramp':
                 case 'mol-symm':
                 case "b-factor":
                 case "b-factor-norm":

--- a/baby-gru/src/components/card/MoorhenColourRuleCard.tsx
+++ b/baby-gru/src/components/card/MoorhenColourRuleCard.tsx
@@ -96,6 +96,13 @@ export const MoorhenColourRuleCard = (props: {
                         <RgbColorPicker color={{r, g, b}} onChange={handleColorChange} />
                     </Popover>
                 </>
+                : rule.ruleType === "colour-ramp" ?
+                <>
+                    <div style={{borderColor: 'rgb(255, 0, 0)', borderWidth:'5px', backgroundColor:  'rgb(255, 0, 0)', height:'20px', width:'5px', margin: '0rem', padding: '0rem'}}/>
+                    <div style={{borderColor: 'rgb(255, 255, 0)', borderWidth:'5px', backgroundColor: 'rgb(255, 255, 0)', height:'20px', width:'5px', margin: '0rem', padding: '0rem'}}/>
+                    <div style={{borderColor: 'rgb(0, 255, 0)', borderWidth:'5px', backgroundColor: 'rgb(0, 255, 0)', height:'20px', width:'5px', margin: '0rem', padding: '0rem'}}/>
+                    <div style={{borderColor: 'rgb(0, 0, 255)', borderWidth:'5px', backgroundColor: 'rgb(0, 0, 255)', height:'20px', width:'5px', margin: '0rem', padding: '0rem'}}/>
+                </>
                 : rule.ruleType === "mol-symm" ?
                     <GrainOutlined style={{height:'23px', width:'`23px', marginLeft: '0.5rem', marginRight: '0.5rem', borderStyle: 'solid', borderColor: '#ced4da', borderWidth: '3px', borderRadius: '8px'}}/>            
                 : (rule.ruleType === "b-factor" || rule.ruleType === "b-factor-norm") ?

--- a/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
+++ b/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
@@ -253,6 +253,7 @@ export const MoorhenModifyColourRulesCard = (props: {
                         <Form.Label>Property</Form.Label>
                             <FormSelect size="sm" ref={ruleSelectRef} defaultValue={'b-factor'} onChange={(val) => setColourProperty(val.target.value)}>
                                 {devMode && <option value={'mol-symm'} key={'mol-symm'}>Mol. Symmetry</option>}
+                                <option value={'colour-ramp'} key={'colour-ramp'}>Colour ramp</option>
                                 <option value={'b-factor'} key={'b-factor'}>B-Factor</option>
                                 <option value={'b-factor-norm'} key={'b-factor-norm'}>B-Factor (normalised)</option>
                                 <option value={'af2-plddt'} key={'af2-plddt'}>AF2 PLDDT</option>

--- a/baby-gru/src/utils/MoorhenMap.ts
+++ b/baby-gru/src/utils/MoorhenMap.ts
@@ -8,12 +8,9 @@ import MoorhenReduxStore from "../store/MoorhenReduxStore";
  * Represents a map
  * @property {string} name - The name assigned to this map instance
  * @property {number} molNo - The imol assigned to this map instance
- * @property {number} mapRadius - The map radius currently displayed
- * @property {number} contourLevel - The map contour level currently displayed
  * @property {string} style - Indicates whether the rendered map is drawn as lines, lit lines or a solid surphace
  * @property {boolean} isDifference - Indicates whether this is a difference map instance
  * @property {boolean} hasReflectionData - Indicates whether this map instance has been associated with observed reflection data
- * @property {object} rgba - Object that stores the map colour and alpha
  * @property {React.RefObject<moorhen.CommandCentre>} commandCentre - A react reference to the command centre instance
  * @property {React.RefObject<webGL.MGWebGL>} glRef - A react reference to the MGWebGL instance
  * @constructor
@@ -396,7 +393,7 @@ export class MoorhenMap implements moorhen.Map {
     }
 
     /**
-     * Hide the map
+     * Hide the map contour
      */
     hideMapContour(): void {
         this.clearBuffersOfStyle('Coot')

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -661,6 +661,16 @@ export function rgbToHex(r: number, g: number, b: number): string {
     return "#" + componentToHex(r) + componentToHex(g) + componentToHex(b)
 }
 
+const getChainColourRamp = (residueCids: string[]) => {
+    const delta = 240 / residueCids.length
+    const colours = residueCids.map((cid, index) => {
+        const rgb = hsvToRgb(240 - Math.round(delta * index), 1, 1)
+        const hex = rgbToHex(...rgb.map(i => Math.round(i * 255)) as [number, number, number])
+        return `${cid}^${hex}`
+    })
+    return colours.join('|')
+}
+
 const getBfactorColourRules = (bFactors: { cid: string; bFactor: number; normalised_bFactor: number }[], normaliseBFactors: boolean = true): string => {
     const getColour = (bFactor: number): string => {
         let r: number, g: number, b: number
@@ -729,6 +739,15 @@ export const getMultiColourRuleArgs = async (molecule: moorhen.Molecule, ruleTyp
 
     let multiRulesArgs: string
     switch (ruleType) {
+        case 'colour-ramp':
+            const chainResidueInfo = molecule.sequences.map(sequence => sequence.sequence.map(residue => {
+                return residue.cid
+            }))
+            const ts = performance.now()
+            multiRulesArgs = chainResidueInfo.map(chainInfo => getChainColourRamp(chainInfo)).join("|")
+            const te = performance.now()
+            console.log('HI! ', te-ts)
+            break;
         case 'b-factor':
         case 'b-factor-norm':
             const bFactors = molecule.getResidueBFactors()


### PR DESCRIPTION
This update adds the option to colour the chains in the molecule using a colour ramp red-green-blue (as described in issue #244)