### PR TITLE
Update scores after merging the ligand and patch version bump

### DIFF
--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moorhen",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": false,
   "main": "moorhen.js",
   "types": "./types/main.d.ts",

--- a/baby-gru/src/components/modal/MoorhenFindLigandModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenFindLigandModal.tsx
@@ -3,14 +3,16 @@ import { moorhen } from "../../types/moorhen";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button, Card, Col, Form, Row, Spinner, Stack } from "react-bootstrap";
 import { convertRemToPx, convertViewtoPx} from '../../utils/MoorhenUtils';
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { MoorhenMapSelect } from "../select/MoorhenMapSelect";
 import { MoorhenMoleculeSelect } from "../select/MoorhenMoleculeSelect";
 import { MoorhenNumberForm } from "../select/MoorhenNumberForm";
 import { Backdrop, IconButton, Tooltip } from "@mui/material";
 import { CenterFocusWeakOutlined, CrisisAlertOutlined, MergeTypeOutlined } from "@mui/icons-material";
+import { triggerScoresUpdate } from "../../store/connectedMapsSlice";
 
 export const MoorheFindLigandModal = (props: { show: boolean; setShow: React.Dispatch<React.SetStateAction<boolean>>; }) => {    
+    const dispatch = useDispatch()
     const molecules = useSelector((state: moorhen.State) => state.molecules)
     const maps = useSelector((state: moorhen.State) => state.maps)
     const width = useSelector((state: moorhen.State) => state.sceneSettings.width)
@@ -61,6 +63,7 @@ export const MoorheFindLigandModal = (props: { show: boolean; setShow: React.Dis
                         <Tooltip title="Merge">
                         <IconButton style={{marginRight:'0.5rem'}} onClick={() => {
                             molecule.mergeMolecules([newLigandMolecule], true).then(_ => newLigandMolecule.delete())
+                            dispatch( triggerScoresUpdate(molecule.molNo) )
                             setLigandResults((prevLigands) => prevLigands.filter(ligand => ligand.molNo !== newLigandMolecule.molNo))
                         }}>
                             <MergeTypeOutlined/>

--- a/baby-gru/src/moorhen.ts
+++ b/baby-gru/src/moorhen.ts
@@ -27,12 +27,16 @@ import {
 import { addMap, addMapList, removeMap, emptyMaps } from "./store/mapsSlice";
 import { setCursorStyle, setEnableAtomHovering, setHoveredAtom } from './store/hoveringStatesSlice';
 import { addAvailableFontList, setAtomLabelDepthMode, setGLLabelsFontFamily, setGLLabelsFontSize } from './store/labelSettingsSlice';
-import { setPositiveMapColours, setNegativeMapColours, setMapAlpha, setMapColours, setMapRadius, setMapStyle, setDefaultMapSamplingRate, setDefaultMapLitLines, setMapLineWidth, setDefaultMapSurface } from './store/mapContourSettingsSlice';
+import { 
+    showMap, hideMap, setPositiveMapColours, setNegativeMapColours, setMapAlpha, setMapColours, setMapRadius, 
+    setMapStyle, setDefaultMapSamplingRate, setDefaultMapLitLines, setMapLineWidth, setDefaultMapSurface, setContourLevel
+} from './store/mapContourSettingsSlice';
 import { setDefaultExpandDisplayCards, setTransparentModalsOnMouseOut, setEnableRefineAfterMod } from './store/miscAppSettingsSlice';
 import { addMolecule, removeMolecule, emptyMolecules, addMoleculeList } from './store/moleculesSlice';
 import { setContourWheelSensitivityFactor, setZoomWheelSensitivityFactor, setMouseSensitivity } from './store/mouseSettings';
 import { setShowShortcutToast, setShortcutOnHoveredAtom, setShortCuts } from './store/shortCutsSlice';
 import { setShowScoresToast, addMapUpdatingScore, removeMapUpdatingScore, overwriteMapUpdatingScores } from './store/connectedMapsSlice'
+import { showMolecule, hideMolecule } from "./store/moleculeRepresentationsSlice";
 
 export {
     ErrorBoundary, MoorhenApp, MoorhenContainer, MoorhenTimeCapsule, MoorhenMoleculeSelect, MoorhenMolecule, MoorhenMap,
@@ -50,5 +54,6 @@ export {
     setZoomWheelSensitivityFactor, setMouseSensitivity, setShowShortcutToast, setShortcutOnHoveredAtom, setShortCuts,
     setShowScoresToast, addMapUpdatingScore, removeMapUpdatingScore, overwriteMapUpdatingScores, MoorhenSlider,
     addMap, addMapList, removeMap, emptyMaps, setPositiveMapColours, setNegativeMapColours, setMapAlpha, setMapColours, 
-    setMapRadius, setMapStyle, MoorhenQuerySequenceModal, MoorhenPreferences
+    setMapRadius, setMapStyle, showMap, hideMap, setContourLevel, showMolecule, hideMolecule, 
+    MoorhenQuerySequenceModal, MoorhenPreferences
 };

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -240,6 +240,21 @@ declare module 'moorhen' {
 
     function setMapAlpha(arg0: {molNo: number, alpha: number}): any;
     module.exports = setMapAlpha;
+
+    function showMap(arg0: {molNo: number, show: boolean}): any;
+    module.exports = showMap;
+
+    function hideMap(arg0: {molNo: number}): any;
+    module.exports = hideMap;
+
+    function setContourLevel(arg0: {molNo: number, level: number}): any;
+    module.exports = setContourLevel;
+
+    function showMolecule(arg0: {molNo: number, show: boolean}): any;
+    module.exports = showMolecule;
+
+    function hideMolecule(arg0: {molNo: number}): any;
+    module.exports = hideMolecule;
     
     function setMapStyle(arg0: {molNo: number, style: "lines" | "solid" | "lit-lines"}): any;
     module.exports = setMapStyle;


### PR DESCRIPTION
This update includes:
- Fix for a bug where after merging a ligand the scores / maps do not update
- Update the TS definitions for the npm module
- Update the functions exported in the npm module to include the new setters in the redux store
- Patch version bump