### PR TITLE
Fix when displaying symmetry mates

### DIFF
--- a/baby-gru/public/baby-gru/CootWorker.ts
+++ b/baby-gru/public/baby-gru/CootWorker.ts
@@ -417,7 +417,6 @@ const symmetryToJSData = (symmetryDataPair: libcootApi.PairType<libcootApi.Symme
     let result: { x: number; y: number; z: number; asString: string; isym: number; us: number; ws: number; vs: number; matrix: number[][]; }[]= []
     const symmetryData = symmetryDataPair.first
     const symmetryMatrices = symmetryDataPair.second
-    const cell = symmetryData.cell
     const symm_trans = symmetryData.symm_trans
     const symmetrySize = symm_trans.size()
 
@@ -441,7 +440,6 @@ const symmetryToJSData = (symmetryDataPair: libcootApi.PairType<libcootApi.Symme
         symTransT.delete()
     }
 
-    cell.delete()
     symm_trans.delete()
     symmetryMatrices.delete()
     return result


### PR DESCRIPTION
This update fixes a bug where symmetry mates cannot be displayed because `.delete()` is called on an instance of `Cell_Translation` which is wrapped using `value_object`