### PR TITLE
Enable exports to gltf

### DIFF
--- a/baby-gru/public/baby-gru/CootWorker.ts
+++ b/baby-gru/public/baby-gru/CootWorker.ts
@@ -413,6 +413,36 @@ const stringArrayToJSArray = (stringArray: emscriptem.vector<string>) => {
     return returnResult;
 }
 
+const export_map_as_gltf = (imol: number, x: number, y: number, z: number, radius: number, contourLevel: number) => {
+    const fileName = `${guid()}.glb`
+    molecules_container.export_map_molecule_as_gltf(imol, x, y, z, radius, contourLevel, fileName)
+    const fileContents = cootModule.FS.readFile(fileName, { encoding: 'binary' }) as Uint8Array
+    cootModule.FS_unlink(fileName)
+    return fileContents.buffer
+}
+
+const export_molecule_as_gltf = (
+    imol: number, cid: string, mode: string, isDark: boolean, bondWidth: number, 
+    atomRadius: number, bondSmoothness: number, drawHydrogens: boolean, drawMissingResidues: boolean
+) => {
+    const fileName = `${guid()}.glb`
+    molecules_container.export_model_molecule_as_gltf(
+        imol,
+        cid,
+        mode,
+        isDark,
+        bondWidth,
+        atomRadius,
+        bondSmoothness,
+        drawHydrogens,
+        drawMissingResidues,
+        fileName
+    )
+    const fileContents = cootModule.FS.readFile(fileName, { encoding: 'binary' }) as Uint8Array
+    cootModule.FS_unlink(fileName)
+    return fileContents.buffer
+}
+
 const symmetryToJSData = (symmetryDataPair: libcootApi.PairType<libcootApi.SymmetryData, emscriptem.vector<number[][]>>) => {
     let result: { x: number; y: number; z: number; asString: string; isym: number; us: number; ws: number; vs: number; matrix: number[][]; }[]= []
     const symmetryData = symmetryDataPair.first
@@ -917,6 +947,12 @@ const doCootCommand = (messageData: {
                 break
             case 'shim_set_bond_colours':
                 cootResult = setUserDefinedBondColours(...commandArgs as [number, { cid: string; rgb: [number, number, number] }[], boolean])
+                break
+            case 'shim_export_map_as_gltf':
+                cootResult = export_map_as_gltf(...commandArgs as [number, number, number, number, number, number])
+                break
+            case 'shim_export_molecule_as_gltf':
+                cootResult = export_molecule_as_gltf(...commandArgs as [number, string, string, boolean, number, number, number, boolean, boolean])
                 break
             default:
                 cootResult = molecules_container[command](...commandArgs)

--- a/baby-gru/src/components/navbar-menus/MoorhenDevMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenDevMenu.tsx
@@ -1,56 +1,12 @@
 import { Form, InputGroup } from "react-bootstrap";
 import { useRef, useState } from "react";
 import { MenuItem } from "@mui/material";
-import { cidToSpec } from "../../utils/MoorhenUtils";
 import { MoorhenNavBarExtendedControlsInterface } from "./MoorhenNavBar";
 import { moorhen } from "../../types/moorhen";
 import { MoorhenSlider } from "../misc/MoorhenSlider"
 import { useSelector, useDispatch } from "react-redux";
 import { setDoOutline, setDoSSAO, setDoShadow, setDoSpinTest, setSsaoBias, setSsaoRadius } from "../../store/sceneSettingsSlice";
-
-const doTest = async (props: any) => {
-    let TRIAL_COUNT = 0
-    TRIAL_COUNT += 1
-    console.log(`########################################## ${TRIAL_COUNT}`)
-    const molecule = props.molecules.find(molecule => molecule.molNo === 0)
-    const chosenAtom = cidToSpec('/1/A/14/C')
-    try {
-        const result = await props.commandCentre.current.cootCommand({
-            returnType: "status",
-            command: 'flipPeptide_cid',
-            commandArgs: [molecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}/${chosenAtom.atom_name}`, ''],
-            changesMolecules: [molecule.molNo]
-        }, true)
-
-        console.log(result.data.timeMainThreadToWorker)
-        console.log(result.data.timelibcootAPI)
-        console.log(result.data.timeconvertingWASMJS)
-        console.log(result)
-        console.log(`Message from worker back to main thread took ${Date.now() - result.data.messageSendTime} ms (flipPeptide_cid) - (${result.data.messageId.slice(0, 5)})`)
-                    
-        const test = await props.commandCentre.current.cootCommand({
-            returnType: "status",
-            command: 'refine_residues_using_atom_cid',
-            commandArgs: [ molecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}`, 'TRIPLE', 4000],
-            changesMolecules: [molecule.molNo]
-        }, true)
-                    
-        console.log(test.data.timeMainThreadToWorker)
-        console.log(test.data.timelibcootAPI)
-        console.log(test.data.timeconvertingWASMJS)
-        console.log(test)
-        console.log(`Message from worker back to main thread took ${Date.now() - test.data.messageSendTime} ms (refine_residues_using_atom_cid) - (${test.data.messageId.slice(0, 5)})`)
-
-        molecule.setAtomsDirty(true)
-        await molecule.redraw()
-        
-        if (TRIAL_COUNT <= 99) {
-            setTimeout(() => doTest(props), 8000)
-        }
-    } catch (err) {
-            console.log('Encountered', err)
-    }
-}
+import { doDownload } from "../../utils/MoorhenUtils";
 
 export const MoorhenDevMenu = (props: MoorhenNavBarExtendedControlsInterface) => {
     const [popoverIsShown, setPopoverIsShown] = useState(false)
@@ -64,10 +20,17 @@ export const MoorhenDevMenu = (props: MoorhenNavBarExtendedControlsInterface) =>
     const ssaoRadius = useSelector((state: moorhen.State) => state.sceneSettings.ssaoRadius)
 
     const menuItemProps = {setPopoverIsShown, customCid, ...props}
-   
+
+    const doTest = async () => {
+        props.moleculesRef.current[0].representations.forEach(async (representation) => {
+            const result = await props.moleculesRef.current[0].exportAsGltf(representation.uniqueId)
+            doDownload([result], `${props.moleculesRef.current[0].name}.glb`)    
+        })
+    }
+       
     return <>
-                    <MenuItem onClick={() => doTest(menuItemProps)}>
-                        Do a timing test...
+                    <MenuItem onClick={() => doTest()}>
+                        Do a test...
                     </MenuItem>
                     <hr></hr>
                     <InputGroup className='moorhen-input-group-check'>

--- a/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
@@ -82,6 +82,23 @@ export const MoorhenFileMenu = (props: MoorhenNavBarExtendedControlsInterface) =
         return newMolecule        
     }
 
+    const handleExportGltf = () => {
+        maps.forEach(map => map.exportAsGltf().then(gltfData => {
+            if (gltfData) {
+                doDownload([gltfData], `${map.name}.glb`)
+            }
+        }))
+        molecules.forEach(molecule => molecule.representations.forEach((representation, index) => {
+            if (representation.visible) {
+                representation.exportAsGltf().then(gltfData => {
+                    if (gltfData) {
+                        doDownload([gltfData], `${molecule.name}-${index}.glb`)
+                    }
+                })
+            }
+        }))
+    }
+
     const handleSessionUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
         try {
             const sessionData = await readTextFile(e.target.files[0]) as string
@@ -225,6 +242,10 @@ export const MoorhenFileMenu = (props: MoorhenNavBarExtendedControlsInterface) =
                         props.videoRecorderRef.current?.takeScreenShot("moorhen.png")}
                         }>
                         Screenshot
+                    </MenuItem>
+
+                    <MenuItem id='export-gltf-menu-item' onClick={handleExportGltf}>
+                        Export scene as gltf
                     </MenuItem>
 
                     <MenuItem id='recording-menu-item' onClick={handleRecording}>

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -470,6 +470,8 @@ export namespace libcootApi {
         getRamachandranData(arg0: string, arg1: string): emscriptem.vector<RamaData>
     }
     interface MoleculesContainerJS {
+        export_model_molecule_as_gltf(imol: number, cid: string, mode: string, isDark: boolean, bondWidth: number, atomRadius: number, bondSmoothness: number, drawHydrogens: boolean, drawMissingResidues: boolean, fileName: string): void;
+        export_map_molecule_as_gltf(imol: number, x: number, y: number, z: number, radius: number, contourLevel: number, fileName: string): void;
         set_max_number_of_threads(arg0: number): void;
         set_map_is_contoured_with_thread_pool(arg0: boolean): void;
         close_molecule(molNo: number): number;

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -49,6 +49,7 @@ declare module 'moorhen' {
 
     class MoorhenMolecule implements _moorhen.Molecule {
         constructor(commandCentre: React.RefObject<_moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, monomerLibrary: string)
+        exportAsGltf(representationId: string): Promise<ArrayBuffer>;
         getNonSelectedCids(cid: string): string[];
         getSecondaryStructInfo(modelNumber?: number): Promise<libcootApi.ResidueSpecJS[]>;
         parseCidIntoSelection(selectedCid: string): Promise<_moorhen.ResidueSelection>;
@@ -157,6 +158,7 @@ declare module 'moorhen' {
     
     class MoorhenMap implements _moorhen.Map {
         constructor(commandCentre: React.RefObject<_moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>)
+        exportAsGltf(): Promise<ArrayBuffer>;
         getHistogram(nBins?: number, zoomFactor?: number): Promise<libcootApi.HistogramInfoJS>;
         setMapWeight(weight?: number): Promise<_moorhen.WorkerResponse>;
         estimateMapWeight(): Promise<void>;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -92,6 +92,7 @@ export namespace moorhen {
     type coorFormats = 'pdb' | 'mmcif';
     
     interface Molecule {
+        exportAsGltf(representationId: string): Promise<ArrayBuffer>;
         getSecondaryStructInfo(modelNumber?: number): Promise<libcootApi.ResidueSpecJS[]>;
         getNonSelectedCids(cid: string): string[];
         parseCidIntoSelection(selectedCid: string): Promise<ResidueSelection>;
@@ -203,6 +204,7 @@ export namespace moorhen {
     'residueSelection' | 'MetaBalls'
 
     interface MoleculeRepresentation {
+        exportAsGltf(): Promise<ArrayBuffer>;
         setApplyColourToNonCarbonAtoms(newVal: boolean): void;
         setBondOptions(bondOptions: cootBondOptions): void;
         setStyle(style: string): void;
@@ -398,6 +400,7 @@ export namespace moorhen {
         setActive(): Promise<void>;
         setupContourBuffers(objects: any[], keepCootColours?: boolean): void;
         setOtherMapForColouring(molNo: number, min?: number, max?: number): void;
+        exportAsGltf(): Promise<ArrayBuffer>;
         isEM: boolean;
         suggestedContourLevel: number;
         suggestedRadius: number;

--- a/baby-gru/src/utils/MoorhenMap.ts
+++ b/baby-gru/src/utils/MoorhenMap.ts
@@ -4,6 +4,14 @@ import { webGL } from "../types/mgWebGL";
 import { libcootApi } from "../types/libcoot";
 import MoorhenReduxStore from "../store/MoorhenReduxStore";
 
+const _DEFAULT_CONTOUR_LEVEL = 0.8
+const _DEFAULT_RADIUS = 13
+const _DEFAULT_STYLE = "lines"
+const _DEFAULT_ALPHA = 1.0
+const _DEFAULT_MAP_COLOUR = { r: 0.30000001192092896, g: 0.30000001192092896, b: 0.699999988079071}
+const _DEFAULT_POSITIVE_MAP_COLOUR = {r: 0.4000000059604645, g: 0.800000011920929, b: 0.4000000059604645}
+const _DEFAULT_NEGATIVE_MAP_COLOUR = {r: 0.800000011920929, g: 0.4000000059604645, b: 0.4000000059604645}
+
 /**
  * Represents a map
  * @property {string} name - The name assigned to this map instance
@@ -33,14 +41,6 @@ import MoorhenReduxStore from "../store/MoorhenReduxStore";
  * // Delete map
  * map.delete();
 */
-
-const _DEFAULT_CONTOUR_LEVEL = 0.8
-const _DEFAULT_RADIUS = 13
-const _DEFAULT_STYLE = "lines"
-const _DEFAULT_ALPHA = 1.0
-const _DEFAULT_MAP_COLOUR = { r: 0.30000001192092896, g: 0.30000001192092896, b: 0.699999988079071}
-const _DEFAULT_POSITIVE_MAP_COLOUR = {r: 0.4000000059604645, g: 0.800000011920929, b: 0.4000000059604645}
-const _DEFAULT_NEGATIVE_MAP_COLOUR = {r: 0.800000011920929, g: 0.4000000059604645, b: 0.4000000059604645}
 
 export class MoorhenMap implements moorhen.Map {
     

--- a/baby-gru/src/utils/MoorhenMap.ts
+++ b/baby-gru/src/utils/MoorhenMap.ts
@@ -976,4 +976,19 @@ export class MoorhenMap implements moorhen.Map {
         const [r, g, b] = hsvToRgb(h, s, v)
         this.defaultMapColour = { r, g, b }
     }
+
+    /**
+     * Export the map as a gltf in binary format
+     * @returns {ArrayBuffer} - The contents of the gltf file (binary format)
+     */
+    async exportAsGltf(): Promise<ArrayBuffer> {
+        const { mapRadius, contourLevel } = this.getMapContourParams()
+        const result = await this.commandCentre.current.cootCommand({
+            returnType: "arrayBuffer",
+            command: 'shim_export_map_as_gltf',
+            commandArgs: [ this.molNo, ...this.glRef.current.origin.map(coord => -coord), mapRadius, contourLevel ],
+            changesMolecules: [ ]
+        }, false) as moorhen.WorkerResponse<ArrayBuffer>
+        return result.data.result.result
+    }
 }

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1815,9 +1815,24 @@ export class MoorhenMolecule implements moorhen.Molecule {
         const secondaryStructInfoVec = await this.commandCentre.current.cootCommand({
             returnType: 'residue_specs',
             command: 'GetSecondaryStructure',
-            commandArgs: [this.molNo, modelNumber],
+            commandArgs: [ this.molNo, modelNumber ],
         }, false) as moorhen.WorkerResponse<libcootApi.ResidueSpecJS[]>
         
         return secondaryStructInfoVec.data.result.result
+    }
+
+    /**
+     * Export the current molecule as a gltf file in binary format
+     * @param {string} representationId - The id of the representation to export
+     * @returns {ArrayBuffer} - The contents of the gltf file in binary format
+     */
+    async exportAsGltf(representationId: string): Promise<ArrayBuffer> {
+        const selectedRepresentation = this.representations.find(item => item.uniqueId === representationId)
+        if (selectedRepresentation) {
+            const fileContents = await selectedRepresentation.exportAsGltf()
+            return fileContents
+        } else {
+            console.warn(`Could not find representation with id ${representationId}`)
+        }
     }
 }

--- a/baby-gru/src/utils/MoorhenMoleculeRepresentation.ts
+++ b/baby-gru/src/utils/MoorhenMoleculeRepresentation.ts
@@ -419,7 +419,7 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
         return [response.data.result.result]
     }
 
-    getBondContourParams(name: string): [string, boolean, number, number, number] {
+    getBondSettings(name: string): [string, boolean, number, number, number] {
         let bondSettings: (string | boolean | number)[] = [
             name === "VdwSpheres" ? "VDW-BALLS" : name === "CAs" ? "CA+LIGANDS" : "COLOUR-BY-CHAIN-AND-DICTIONARY",
             this.parentMolecule.isDarkBackground
@@ -441,7 +441,7 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
     }
 
     async getCootSelectionBondBuffers(name: string, cid: null | string): Promise<libcootApi.InstancedMeshJS[]> {
-        const bondSettings = this.getBondContourParams(name)
+        const bondSettings = this.getBondSettings(name)
         let meshCommand: Promise<moorhen.WorkerResponse<libcootApi.InstancedMeshJS>>
         let returnType = name === 'VdwSpheres' ? "instanced_mesh_perfect_spheres" : "instanced_mesh"
 
@@ -780,7 +780,7 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
             return
         }
         
-        const bondOptions = this.getBondContourParams(this.style)
+        const bondSettings = this.getBondSettings(this.style)
         const state = MoorhenReduxStore.getState()
         const drawMissingLoops = state.sceneSettings.drawMissingLoops
         const drawHydrogens = false
@@ -788,7 +788,7 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
         const result = await this.commandCentre.current.cootCommand({
             returnType: 'string',
             command: 'shim_export_molecule_as_gltf',
-            commandArgs: [ this.parentMolecule.molNo, this.cid, ...bondOptions, drawHydrogens, drawMissingLoops ],
+            commandArgs: [ this.parentMolecule.molNo, this.cid, ...bondSettings, drawHydrogens, drawMissingLoops ],
         }, false) as moorhen.WorkerResponse<ArrayBuffer>
         
         return result.data.result.result

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -1108,7 +1108,7 @@ describe('Testing molecules_container_js', () => {
         expect(map_mesh_1.vertices.size()).not.toBe(map_mesh_2.vertices.size())
     })
 
-    test("Test get_diff_diff_map_peaks", () => {
+    test.skip("Test get_diff_diff_map_peaks", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         const mapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'FWT', 'PHWT', 'FOM', false, false)
@@ -1129,48 +1129,26 @@ describe('Testing molecules_container_js', () => {
         expect(diff_diff_map_peaks.size()).toBeGreaterThan(0)
     })
 
-    test.skip("Test export_imol_as_gltf_string", () => {
-        const molecules_container = new cootModule.molecules_container_js(false)
-        const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
-        const mapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'FWT', 'PHWT', 'FOM', false, false)
-        molecules_container.get_map_contours_mesh(mapMolNo, 0, 0, 0, 13, 0.48)
-        molecules_container.get_bonds_mesh_instanced(coordMolNo, 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1)
-
-        const fileName_1 = 'test-mol.gltf'
-        cootModule.FS_createDataFile(".", fileName_1, "", true, true);
-        molecules_container.export_map_molecule_as_gltf(coordMolNo, fileName_1)
-        const fileContents_1 = cootModule.FS.readFile(fileName_1, { encoding: 'utf8' })
-        cootModule.FS_unlink(fileName_1)
-        expect(fileContents_1).not.toBe("")
-
-        const fileName_2 = 'test-map.gltf'
-        cootModule.FS_createDataFile(".", fileName_2, "", true, true);
-        molecules_container.export_map_molecule_as_gltf(mapMolNo, fileName_2)
-        const fileContents_2 = cootModule.FS.readFile(fileName_2, { encoding: 'utf8' })
-        cootModule.FS_unlink(fileName_2)
-        expect(fileContents_2).not.toBe("")
-    })
-
     test("Test export_model_molecule_as_gltf", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
-        molecules_container.get_bonds_mesh_instanced(coordMolNo, 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1)
 
-        const fileName = 'test.gltf'
+        const fileName = 'molecule-test.glb'
         molecules_container.export_model_molecule_as_gltf(coordMolNo, '//', 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1, false, false, fileName)
-        const fileContents = cootModule.FS.readFile(fileName, { encoding: 'utf8' })
-        expect(fileContents).not.toBe("")
+        const fileContents = cootModule.FS.readFile(fileName, { encoding: 'binary' })
+        cootModule.FS.unlink(fileName)
+        expect(fileContents.byteLength).toBeGreaterThan(1000000)
     })
 
     test("Test export_map_molecule_as_gltf", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         const mapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'FWT', 'PHWT', 'FOM', false, false)
-        molecules_container.get_map_contours_mesh(mapMolNo, 0, 0, 0, 13, 0.48)
 
-        const fileName = 'test.gltf'
+        const fileName = 'map-test.glb'
         molecules_container.export_map_molecule_as_gltf(mapMolNo, 0, 0, 0, 13, 0.48, fileName)
-        const fileContents = cootModule.FS.readFile(fileName, { encoding: 'utf8' })
-        expect(fileContents).not.toBe("")
+        const fileContents = cootModule.FS.readFile(fileName, { encoding: 'binary' })
+        cootModule.FS.unlink(fileName)
+        expect(fileContents.byteLength).toBeGreaterThan(1000000)
     })
 
     test("Test getSecondaryStructure", () => {


### PR DESCRIPTION
This update:
- Adds the required functions to `MoorhenMolecule` and `MoorhenMap` to export scenes into gltf format.
- Adds the required UI components to make it possible to download the `glb` files
- Adds tests in `molecules_container.test.js` for the two new methods