### PR TITLE
Add utility to flip all / fill all

### DIFF
--- a/baby-gru/public/baby-gru/CootWorker.ts
+++ b/baby-gru/public/baby-gru/CootWorker.ts
@@ -1088,6 +1088,7 @@ onmessage = function (e) {
                 postMessage({ consoleMessage: 'Initialized molecules_container', message: e.data.message, messageId: e.data.messageId })
                 cootModule = returnedModule;
                 molecules_container = new cootModule.molecules_container_js(false)
+                molecules_container.set_use_gemmi(false)
                 molecules_container.set_show_timings(false)
                 molecules_container.fill_rotamer_probability_tables()
                 molecules_container.set_map_sampling_rate(1.7)

--- a/baby-gru/src/components/menu-item/MoorhenStepRefinementMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenStepRefinementMenuItem.tsx
@@ -1,100 +1,12 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Form, Stack } from "react-bootstrap";
+import { useCallback, useRef } from "react";
+import { Form } from "react-bootstrap";
 import { MoorhenMoleculeSelect } from "../select/MoorhenMoleculeSelect";
 import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem";
 import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
 import { useDispatch, useSelector } from 'react-redux';
-import { MoorhenNotification } from "../misc/MoorhenNotification";
-import { IconButton, LinearProgress } from "@mui/material";
-import { setNotificationContent } from "../../moorhen";
-import { PauseCircleOutlined, PlayCircleOutlined, StopCircleOutlined } from "@mui/icons-material";
-
-const SteppedRefinementManager = (props: { molecule: moorhen.Molecule; timeCapsuleRef: React.RefObject<moorhen.TimeCapsule> }) => {
-    const dispatch = useDispatch()
-    const timeCapsuleIsEnabled = useSelector((state: moorhen.State) => state.backupSettings.enableTimeCapsule)
-    
-    const [isRunning, setIsRunning] = useState<boolean>(false)
-    const [progress, setProgress] = useState<number>(0)
-    const [buffer, setBuffer] = useState<number>(1)
-    const [cid, setCid] = useState<string | null>('Refining...')
-    
-    const isClosedRef = useRef<boolean>(false)
-    const isRunningRef = useRef<boolean>(false)
-
-    const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
-
-    const exit = useCallback(async () => {
-        props.timeCapsuleRef.current.disableBackups = !timeCapsuleIsEnabled
-        props.molecule.clearBuffersOfStyle('rama')
-        await props.timeCapsuleRef.current.addModification()
-        dispatch( setNotificationContent(null) )
-    }, [timeCapsuleIsEnabled])
-
-    const init = () => {
-        props.timeCapsuleRef.current.disableBackups = true
-        props.molecule.fetchIfDirtyAndDraw('rama')
-    }
-
-    const steppedRefine = async () => {
-        init()
-        const nResidues = props.molecule.sequences.map(item => item.sequence.length).reduce((a, b) => a + b)
-        const residuePercent = nResidues / 50
-        const singleResiduePercent = 1 / residuePercent
-        setProgress(0)
-        for (let item of props.molecule.sequences) {
-            for (let residue of item.sequence) {
-                setBuffer((prev) => prev + singleResiduePercent)
-                if (isClosedRef.current) {
-                    await exit()
-                    return
-                }
-                while (!isRunningRef.current) {
-                    if (isClosedRef.current) {
-                        exit()
-                        return
-                    } else {
-                        await sleep(500)    
-                    }    
-                }
-                setCid(residue.cid)
-                await props.molecule.centreAndAlignViewOn(residue.cid, true)
-                await props.molecule.refineResiduesUsingAtomCid(residue.cid, 'TRIPLE', 4000, true)
-                setProgress((prev) => prev + singleResiduePercent)
-                await sleep(600)
-            }
-        }
-        await exit()
-    }
-
-    useEffect(() => {
-        setIsRunning(true)
-        isRunningRef.current = true
-        steppedRefine()
-    }, [])
-
-    return <MoorhenNotification key={'stepped-refinement-controller'} width={15}>
-                <Stack gap={2} direction='horizontal' style={{width: '100%', display:'flex', justifyContent: 'space-between'}}>
-                    <Stack gap={2} direction='vertical' style={{width: '100%'}}>
-                        <span>{cid}</span>
-                        <LinearProgress variant={isRunning ? 'buffer' : 'determinate'} value={progress} valueBuffer={buffer} style={{width: '100%', display: 'flex', justifyContent: 'start'}}/>
-                    </Stack>
-                    <div style={{display: 'flex', justifyContent: 'end'}}>
-                        <IconButton style={{padding: '0.1rem'}} onClick={() => {
-                            isRunningRef.current = !isRunningRef.current
-                            setIsRunning(isRunningRef.current)
-                        }}>
-                            {isRunning ? <PauseCircleOutlined/> : <PlayCircleOutlined/>}
-                        </IconButton>
-                        <IconButton style={{padding: '0.1rem'}} onClick={() => {
-                            isClosedRef.current = true
-                        }}>
-                            <StopCircleOutlined/>
-                        </IconButton>
-                    </div>
-                </Stack>
-    </MoorhenNotification>   
-}
+import { setNotificationContent } from '../../store/generalStatesSlice';
+import { MoorhenResidueSteps } from "../misc/MoorhenResidueSteps"
 
 export const MoorhenStepRefinementMenuItem = (props: {
     commandCentre: React.RefObject<moorhen.CommandCentre>;
@@ -117,8 +29,26 @@ export const MoorhenStepRefinementMenuItem = (props: {
     const onCompleted = useCallback(async () => {
         const selectedMolecule = molecules.find(molecule => molecule.molNo === parseInt(moleculeSelectRef.current.value))
         if (selectedMolecule) {
+
+            const handleStepRefine = async (cid: string) => {
+                await selectedMolecule.centreAndAlignViewOn(cid, true)
+                await selectedMolecule.refineResiduesUsingAtomCid(cid, 'TRIPLE', 4000, true)
+            }
+
+            const residueList = selectedMolecule.sequences.map(item => item.sequence).map(sequence => sequence.map(residue => residue)).flat()
+        
             dispatch( setNotificationContent(
-                <SteppedRefinementManager molecule={selectedMolecule} timeCapsuleRef={props.timeCapsuleRef}/>
+                <MoorhenResidueSteps 
+                    timeCapsuleRef={props.timeCapsuleRef}
+                    residueList={residueList}
+                    onStep={handleStepRefine}
+                    onStart={async () => {
+                        await selectedMolecule.fetchIfDirtyAndDraw('rama')
+                    }}
+                    onStop={() => {
+                        selectedMolecule.clearBuffersOfStyle('rama')
+                    }}
+                />
             ))
         } else {
             console.warn(`Unable to find molecule with molNo ${moleculeSelectRef.current.value} for stepped refinement...`)

--- a/baby-gru/src/components/misc/MoorhenResidueSteps.tsx
+++ b/baby-gru/src/components/misc/MoorhenResidueSteps.tsx
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Stack } from "react-bootstrap";
+import { moorhen } from "../../types/moorhen";
+import { useDispatch, useSelector } from 'react-redux';
+import { MoorhenNotification } from "./MoorhenNotification";
+import { IconButton, LinearProgress } from "@mui/material";
+import { PauseCircleOutlined, PlayCircleOutlined, StopCircleOutlined } from "@mui/icons-material";
+import { setNotificationContent } from '../../store/generalStatesSlice';
+import { setHoveredAtom } from '../../store/hoveringStatesSlice';
+import { sleep } from "../../utils/MoorhenUtils";
+
+export const MoorhenResidueSteps = (props: { 
+    timeCapsuleRef: React.RefObject<moorhen.TimeCapsule>
+    residueList: { cid: string }[];
+    onStep: (stepInput: any) => Promise<void>;
+    onStart?: () => Promise<void>;
+    onStop?: () => void;
+    onPause?: () => void;
+    onResume?: () => void;
+    onProgress?: (progress: number) => void;
+    disableTimeCapsule?: boolean
+    sleepTime?: number;
+ }) => {
+    const dispatch = useDispatch()
+    const timeCapsuleIsEnabled = useSelector((state: moorhen.State) => state.backupSettings.enableTimeCapsule)
+    
+    const [isRunning, setIsRunning] = useState<boolean>(false)
+    const [progress, setProgress] = useState<number>(0)
+    const [buffer, setBuffer] = useState<number>(1)
+    const [cid, setCid] = useState<string | null>('Refining...')
+    
+    const isClosedRef = useRef<boolean>(false)
+    const isRunningRef = useRef<boolean>(false)
+
+    const exit = useCallback(async () => {
+        props.onStop()
+        if (props.disableTimeCapsule) props.timeCapsuleRef.current.disableBackups = !timeCapsuleIsEnabled
+        await props.timeCapsuleRef.current.addModification()
+        dispatch( setNotificationContent(null) )
+    }, [timeCapsuleIsEnabled])
+
+    const init = async () => {
+        await props.onStart()
+        dispatch( setHoveredAtom({molecule: null, cid: null}) )
+        if (props.disableTimeCapsule) props.timeCapsuleRef.current.disableBackups = true
+    }
+
+    const steppedRefine = async () => {
+        await init()
+        const nSteps = props.residueList.length
+        const stepPercent = nSteps / 100
+        const singleStepPercent = 1 / stepPercent
+        for (let residue of props.residueList) {
+            setBuffer((prev) => prev + singleStepPercent)
+            if (isClosedRef.current) {
+                    await exit()
+                    return
+            }
+            while (!isRunningRef.current) {
+                    if (isClosedRef.current) {
+                        exit()
+                        return
+                    } else {
+                        await sleep(500)    
+                    }    
+            }
+            setCid(residue.cid)
+            await props.onStep(residue.cid)
+            setProgress((prev) => prev + singleStepPercent)
+            await sleep(props.sleepTime)
+        }
+        await exit()
+    }
+
+    useEffect(() => {
+        if(!isRunningRef.current) {
+            setIsRunning(true)
+            isRunningRef.current = true
+            steppedRefine()
+        }
+    }, [])
+
+    return <MoorhenNotification key={'stepped-refinement-controller'} width={15}>
+                <Stack gap={2} direction='horizontal' style={{width: '100%', display:'flex', justifyContent: 'space-between'}}>
+                    <Stack gap={2} direction='vertical' style={{width: '100%'}}>
+                        <span>{cid}</span>
+                        <LinearProgress variant={isRunning ? 'buffer' : 'determinate'} value={progress} valueBuffer={buffer} style={{width: '100%', display: 'flex', justifyContent: 'start'}}/>
+                    </Stack>
+                    <div style={{display: 'flex', justifyContent: 'end'}}>
+                        <IconButton style={{padding: '0.1rem'}} onClick={() => {
+                            if (isRunningRef.current) {
+                                props.onPause()
+                            } else {
+                                props.onResume()
+                            }
+                            isRunningRef.current = !isRunningRef.current
+                            setIsRunning(isRunningRef.current)
+                        }}>
+                            {isRunning ? <PauseCircleOutlined/> : <PlayCircleOutlined/>}
+                        </IconButton>
+                        <IconButton style={{padding: '0.1rem'}} onClick={() => {
+                            isClosedRef.current = true
+                        }}>
+                            <StopCircleOutlined/>
+                        </IconButton>
+                    </div>
+                </Stack>
+    </MoorhenNotification>   
+}
+
+MoorhenResidueSteps.defaultProps = {
+    disableTimeCapsule: true, sleepTime: 600, onStart: () => {}, onStop: () => {}, 
+    onPause: () => {}, onResume: () => {}, onProgress: () => {}
+}

--- a/baby-gru/src/components/validation-tools/MoorhenFillMissingAtoms.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenFillMissingAtoms.tsx
@@ -67,7 +67,6 @@ export const MoorhenFillMissingAtoms = (props: Props) => {
         dispatch( setShowFillPartialResValidationModal(false) )
         if (selectedMolecule) {
             const handleStepFillAtoms = async (cid: string) => {
-                console.log('>>>>>>>>>>> STEP!!! ', cid)
                 const resSpec = cidToSpec(cid)
                 await selectedMolecule.centreAndAlignViewOn(cid, true)
                 await sleep(1000)

--- a/baby-gru/src/components/validation-tools/MoorhenValidationListWidgetBase.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenValidationListWidgetBase.tsx
@@ -3,7 +3,6 @@ import { Col, Row, Form } from 'react-bootstrap';
 import { MoorhenMapSelect } from '../select/MoorhenMapSelect'
 import { MoorhenMoleculeSelect } from '../select/MoorhenMoleculeSelect'
 import { moorhen } from "../../types/moorhen";
-import { gemmi } from "../../types/gemmi";
 import { useSelector } from "react-redux";
 
 export const MoorhenValidationListWidgetBase = (props: {

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -470,6 +470,8 @@ export namespace libcootApi {
         getRamachandranData(arg0: string, arg1: string): emscriptem.vector<RamaData>
     }
     interface MoleculesContainerJS {
+        set_use_gemmi(arg0: boolean): void;
+        get_use_gemmi(): boolean;
         export_model_molecule_as_gltf(imol: number, cid: string, mode: string, isDark: boolean, bondWidth: number, atomRadius: number, bondSmoothness: number, drawHydrogens: boolean, drawMissingResidues: boolean, fileName: string): void;
         export_map_molecule_as_gltf(imol: number, x: number, y: number, z: number, radius: number, contourLevel: number, fileName: string): void;
         set_max_number_of_threads(arg0: number): void;

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -109,7 +109,7 @@ declare module 'moorhen' {
         redraw: () => Promise<void>;
         setAtomsDirty: (newVal: boolean) => void;
         isVisible: (excludeBuffers?: string[]) => boolean;
-        centreAndAlignViewOn(selectionCid: string, animate?: boolean): Promise<void>;
+        centreAndAlignViewOn: (selectionCid: string, alignWithCB?: boolean, zoomLevel?: number) => Promise<void>;
         buffersInclude: (bufferIn: { id: string; }) => boolean;
         redrawRepresentation: (id: string) => Promise<void>;
         downloadAtoms(format?: 'mmcif' | 'pdb'): Promise<void>;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -153,7 +153,7 @@ export namespace moorhen {
         redraw: () => Promise<void>;
         setAtomsDirty: (newVal: boolean) => void;
         isVisible: (excludeBuffers?: string[]) => boolean;
-        centreAndAlignViewOn(selectionCid: string, animate?: boolean): Promise<void>;
+        centreAndAlignViewOn: (selectionCid: string, alignWithCB?: boolean, zoomLevel?: number) => Promise<void>;
         buffersInclude: (bufferIn: { id: string; }) => boolean;
         redrawRepresentation: (id: string) => Promise<void>;
         type: string;

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -768,6 +768,8 @@ export class MoorhenMolecule implements moorhen.Molecule {
         let selectionCentre = centreOnGemmiAtoms(selectionAtomsCentre)
         if (newQuat) {
             this.glRef.current.setOriginOrientationAndZoomAnimated(selectionCentre, newQuat, zoomLevel);
+        } else {
+            await this.centreOn(selectionCid, true, true)
         }
     }
 

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -16,6 +16,8 @@ import { setContourLevel, setMapAlpha, setMapColours, setMapRadius, setMapStyle,
 import { enableUpdatingMaps, setConnectedMoleculeMolNo, setFoFcMapMolNo, setReflectionMapMolNo, setTwoFoFcMapMolNo } from "../store/connectedMapsSlice";
 import { libcootApi } from "../types/libcoot";
 
+export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
 export const getLigandSVG = async (commandCentre: React.RefObject<moorhen.CommandCentre>, imol: number, compId: string, isDark: boolean): Promise<string> => {
     const result = await commandCentre.current.cootCommand({
         returnType: "string",

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -178,7 +178,7 @@ bool isSugar(const std::string &resName);
 class molecules_container_js : public molecules_container_t {
     public:
         explicit molecules_container_js(bool verbose=true) : molecules_container_t(verbose) {
-            use_gemmi = false;
+            
         }
 
         std::vector<coot::residue_spec_t> GetSecondaryStructure(int imol, int imodel=1) {
@@ -1068,6 +1068,8 @@ EMSCRIPTEN_BINDINGS(my_module) {
     ;
     class_<molecules_container_t>("molecules_container_t")
     .constructor<bool>()
+    .function("get_use_gemmi", &molecules_container_t::get_use_gemmi)
+    .function("set_use_gemmi", &molecules_container_t::set_use_gemmi)
     .function("generate_local_self_restraints", &molecules_container_t::generate_local_self_restraints)
     .function("get_ncs_related_chains", &molecules_container_t::get_ncs_related_chains)
     .function("set_max_number_of_threads", &molecules_container_t::set_max_number_of_threads)


### PR DESCRIPTION
This update includes:
- Refactored code so that `molecules_container_t::set_use_gemmi` is used instead of overwriting the attribute in the bindings
- Added button to flip all / fill all in the corresponding validation tabs. The compononent `StepRefinementManager` has been refactored into a shared component named `MoorhenResidueSteps`
- Updates `MoorhenMolecule.centreAndAlignViewOn` so that if unable to align the view falls back to `MoorhenMolecule.centreOn` 