### PR TITLE
Update refine after mod so that is also animated

### DIFF
--- a/baby-gru/src/components/button/MoorhenConvertCisTransButton.tsx
+++ b/baby-gru/src/components/button/MoorhenConvertCisTransButton.tsx
@@ -16,6 +16,7 @@ export const MoorhenConvertCisTransButton = (props: moorhen.ContextButtonProps) 
     return <MoorhenContextButtonBase
         icon={<img className="moorhen-context-button__icon" src={`${props.urlPrefix}/baby-gru/pixmaps/cis-trans.svg`} alt='Cis/Trans' />}
         needsMapData={false}
+        refineAfterMod={false}
         toolTipLabel={"Cis/Trans isomerisation"}
         cootCommandInput={getCootCommandInput(props.selectedMolecule, props.chosenAtom)}
         {...props}

--- a/baby-gru/src/components/button/MoorhenMutateButton.tsx
+++ b/baby-gru/src/components/button/MoorhenMutateButton.tsx
@@ -40,7 +40,6 @@ export const MoorhenMutateButton = (props: moorhen.ContextButtonProps) => {
 
     return <MoorhenContextButtonBase
         icon={<img className="moorhen-context-button__icon" src={`${props.urlPrefix}/baby-gru/pixmaps/mutate.svg`} alt='Mutate' />}
-        refineAfterMod={false}
         needsMapData={true}
         onCompleted={autoFitRotamer}
         toolTipLabel="Mutate residue"

--- a/baby-gru/src/components/navbar-menus/MoorhenPreferencesMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenPreferencesMenu.tsx
@@ -96,7 +96,7 @@ export const MoorhenPreferencesMenu = (props: MoorhenNavBarExtendedControlsInter
                             type="switch"
                             checked={enableRefineAfterMod}
                             onChange={() => {dispatch( setEnableRefineAfterMod(!enableRefineAfterMod) )}}
-                            label="Automatic triple refine post-modification"/>
+                            label="Automatic refinement post-modification"/>
                     </InputGroup>
                     <InputGroup className='moorhen-input-group-check'>
                         <Form.Check 

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -114,7 +114,7 @@ declare module 'moorhen' {
         redrawRepresentation: (id: string) => Promise<void>;
         downloadAtoms(format?: 'mmcif' | 'pdb'): Promise<void>;
         mergeFragmentFromRefinement(cid: string, fragmentMolecule: _moorhen.Molecule, acceptTransform?: boolean, refineAfterMod?: boolean): Promise<void>;
-        copyFragmentForRefinement(cid: string[], refinementMap: _moorhen.Map): Promise<_moorhen.Molecule>;
+        copyFragmentForRefinement(cid: string[], refinementMap: _moorhen.Map, redraw?: boolean, readrawFragmentFirst?: boolean): Promise<_moorhen.Molecule>;
         isLigand: boolean;
         type: string;
         excludedCids: string[];

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -93,7 +93,7 @@ export namespace moorhen {
     
     interface Molecule {
         mergeFragmentFromRefinement(cid: string, fragmentMolecule: moorhen.Molecule, acceptTransform?: boolean, refineAfterMod?: boolean): Promise<void>;
-        copyFragmentForRefinement(cid: string[], refinementMap: moorhen.Map): Promise<moorhen.Molecule>;
+        copyFragmentForRefinement(cid: string[], refinementMap: moorhen.Map, redraw?: boolean, readrawFragmentFirst?: boolean): Promise<moorhen.Molecule>;
         exportAsGltf(representationId: string): Promise<ArrayBuffer>;
         getSecondaryStructInfo(modelNumber?: number): Promise<libcootApi.ResidueSpecJS[]>;
         getNonSelectedCids(cid: string): string[];

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -432,9 +432,11 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * Copy a fragment of the current model into a new molecule for refinement
      * @param {string[]} cid - The CID selection indicating the residues that will be copied into the new fragment
      * @param {moorhen.Map} refinementMap - The map instance used in the refinement
+     * @param {boolean} redraw - Indicate if the molecules should be redrawn
+     * @param {boolean} redrawFragmentFirst - Indicate if the fragment should be redrawn first
      * @returns {moorhen.Molecule} A new molecule instance that can be used for refinement
      */
-    async copyFragmentForRefinement(cid: string[], refinementMap: moorhen.Map, redraw: boolean = true): Promise<moorhen.Molecule> {
+    async copyFragmentForRefinement(cid: string[], refinementMap: moorhen.Map, redraw: boolean = true, redrawFragmentFirst: boolean = true): Promise<moorhen.Molecule> {
         const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath)
         const copyResult = await this.commandCentre.current.cootCommand({
             returnType: 'int',
@@ -451,11 +453,16 @@ export class MoorhenMolecule implements moorhen.Molecule {
             }, false)
             if (redraw) {
                 newMolecule.setAtomsDirty(true)
-                await newMolecule.fetchIfDirtyAndDraw('CBs')
                 await Promise.all(cid.map(cid => {
                     return this.hideCid(cid, false)
                 }))
-                await this.redraw()
+                if (redrawFragmentFirst) { 
+                    await newMolecule.fetchIfDirtyAndDraw('CBs')
+                    await this.redraw()
+                } else {
+                    await this.redraw()
+                    await newMolecule.fetchIfDirtyAndDraw('CBs')
+                }
             }
         } else {
             console.warn(`Unable to copy fragment for refinement using cid ${cid} for molecule ${this.molNo}`)

--- a/baby-gru/src/utils/MoorhenPreferences.ts
+++ b/baby-gru/src/utils/MoorhenPreferences.ts
@@ -39,7 +39,7 @@ export class MoorhenPreferences implements moorhen.Preferences {
         enableTimeCapsule: true,
         defaultExpandDisplayCards: true,
         defaultMapLitLines: false,
-        enableRefineAfterMod: false,
+        enableRefineAfterMod: true,
         drawCrosshairs: true,
         drawScaleBar: false,
         drawAxes: false,


### PR DESCRIPTION
Following https://github.com/moorhen-coot/Moorhen/commit/7f4fca1b95864ff0dae35b939e3304c994f8270b this update changes the usual refine after modification so that is also animated.