### PR TITLE
Cache results from privateer

### DIFF
--- a/baby-gru/src/components/list/MoorhenCarbohydrateList.tsx
+++ b/baby-gru/src/components/list/MoorhenCarbohydrateList.tsx
@@ -15,25 +15,29 @@ export const MoorhenCarbohydrateList = (props: {
     height?: number | string;
 }) => {
 
-    const newCootCommandAlert = useSelector((state: moorhen.State) => state.generalStates.newCootCommandAlert)
+    const scoresUpdateMolNo = useSelector((state: moorhen.State) => state.connectedMaps.scoresUpdate.molNo)
+    const toggleScoresUpdate = useSelector((state: moorhen.State) => state.connectedMaps.scoresUpdate.toggle)
     
     const [carbohydrateList, setCarbohydrateList] = useState<privateer.ResultsEntry[] | null>(null)
 
+    const validate = async () => {
+        props.setBusy(true)
+        const result = await props.molecule.getPrivateerValidation(true)
+        setCarbohydrateList(result)
+        props.setBusy(false)
+    }
+    
     useEffect(() => {
-        const validate = async () => {
-            if (props.molecule) {
-                props.setBusy(true)
-                const result = await props.commandCentre.current.cootCommand({
-                    command: 'privateer_validate',
-                    commandArgs: [props.molecule.molNo],
-                    returnType: 'privateer_results'
-                }, false) as moorhen.WorkerResponse<privateer.ResultsEntry[]>
-                setCarbohydrateList(result.data.result.result)
-                props.setBusy(false)
-            }
+        if (props.molecule?.molNo === scoresUpdateMolNo) {
+            validate()
         }
-        validate()
-    }, [newCootCommandAlert])
+    }, [toggleScoresUpdate])
+
+    useEffect(() => {
+        if (props.molecule) {
+            validate()
+        }
+    }, [])
 
     return <>
             {carbohydrateList === null ?

--- a/baby-gru/src/components/validation-tools/MoorhenCarbohydrateValidation.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenCarbohydrateValidation.tsx
@@ -19,12 +19,8 @@ export const MoorhenCarbohydrateValidation = (props: Props) => {
     const fetchCardData = async (selectedModel: number): Promise<privateer.ResultsEntry[]> => {
         const selectedMolecule = molecules.find(molecule => molecule.molNo === selectedModel)
         if (selectedMolecule) {
-            const result = await props.commandCentre.current.cootCommand({
-                command: 'privateer_validate',
-                commandArgs: [selectedMolecule.molNo],
-                returnType: 'privateer_results'
-            }, false) as moorhen.WorkerResponse<privateer.ResultsEntry[]>
-            return result.data.result.result
+            const result = await selectedMolecule.getPrivateerValidation(true)
+            return result
         }
     }
 

--- a/baby-gru/src/components/validation-tools/MoorhenValidationChartWidgetBase.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenValidationChartWidgetBase.tsx
@@ -36,7 +36,8 @@ export const MoorhenValidationChartWidgetBase = forwardRef<Chart, ValidationChar
     const [selectedMap, setSelectedMap] = useState<number | null>(null)
     const [selectedChain, setSelectedChain] = useState<string | null>(null)
 
-    const newCootCommandAlert = useSelector((state: moorhen.State) => state.generalStates.newCootCommandAlert)
+    const scoresUpdateMolNo = useSelector((state: moorhen.State) => state.connectedMaps.scoresUpdate.molNo)
+    const toggleScoresUpdate = useSelector((state: moorhen.State) => state.connectedMaps.scoresUpdate.toggle)
     const height = useSelector((state: moorhen.State) => state.sceneSettings.height)
     const backgroundColor = useSelector((state: moorhen.State) => state.sceneSettings.backgroundColor)
     const molecules = useSelector((state: moorhen.State) => state.molecules)
@@ -79,14 +80,20 @@ export const MoorhenValidationChartWidgetBase = forwardRef<Chart, ValidationChar
 
     }, [maps.length])
     
-    useEffect(() => {
-        const fetchData = async () => {
-            const newPlotData = await props.fetchData(selectedModel, selectedMap, props.enableChainSelect ? chainSelectRef.current.value : null)
-            setPlotData(newPlotData)
-        }
-        fetchData()
+    const fetchData = async () => {
+        const newPlotData = await props.fetchData(selectedModel, selectedMap, props.enableChainSelect ? chainSelectRef.current.value : null)
+        setPlotData(newPlotData)
+    }
 
-    }, [selectedChain, selectedMap, selectedModel, newCootCommandAlert, props.extraControlFormValue])
+    useEffect(() => {
+        fetchData()
+    }, [selectedChain, selectedMap, selectedModel, props.extraControlFormValue])
+
+    useEffect(() => {
+        if (selectedModel !== null  && selectedModel === scoresUpdateMolNo) {
+            fetchData()
+        }
+    }, [toggleScoresUpdate])
 
     useEffect(() => {
         if (chartRef !== null && typeof chartRef !== 'function' && chartRef.current) {

--- a/baby-gru/src/components/validation-tools/MoorhenValidationListWidgetBase.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenValidationListWidgetBase.tsx
@@ -28,7 +28,8 @@ export const MoorhenValidationListWidgetBase = (props: {
     const [cardList, setCardList] = useState<JSX.Element[]>([])
     const [busy, setBusy] = useState<boolean>(false)
 
-    const newCootCommandAlert = useSelector((state: moorhen.State) => state.generalStates.newCootCommandAlert)
+    const scoresUpdateMolNo = useSelector((state: moorhen.State) => state.connectedMaps.scoresUpdate.molNo)
+    const toggleScoresUpdate = useSelector((state: moorhen.State) => state.connectedMaps.scoresUpdate.toggle)
     const backgroundColor = useSelector((state: moorhen.State) => state.sceneSettings.backgroundColor)
     const molecules = useSelector((state: moorhen.State) => state.molecules)
     const maps = useSelector((state: moorhen.State) => state.maps)
@@ -65,21 +66,26 @@ export const MoorhenValidationListWidgetBase = (props: {
 
     }, [maps.length])
 
-    useEffect(() => {
-        async function fetchData() {
-            setBusy(true)
-            if (selectedModel === null || (props.enableMapSelect && selectedMap === null)) {
-                setCardData(null)
-            } else {
-                let newData = await props.fetchData(selectedModel, selectedMap)
-                setCardData(newData)
-            }
-            setBusy(false)      
-        }        
-    
-        fetchData()   
+    async function fetchData() {
+        setBusy(true)
+        if (selectedModel === null || (props.enableMapSelect && selectedMap === null)) {
+            setCardData(null)
+        } else {
+            let newData = await props.fetchData(selectedModel, selectedMap)
+            setCardData(newData)
+        }
+        setBusy(false)      
+    }        
 
-    }, [selectedMap, selectedModel, newCootCommandAlert, props.extraControlFormValue])
+    useEffect(() => {
+        fetchData()
+    }, [selectedMap, selectedModel, props.extraControlFormValue])
+
+    useEffect(() => {
+        if (selectedModel !== null  && selectedModel === scoresUpdateMolNo) {
+            fetchData()
+        }
+    }, [toggleScoresUpdate])
 
     useEffect(() => {
         if (selectedModel === null || (props.enableMapSelect && selectedMap === null) || cardData === null || props.dropdownId !== props.accordionDropdownId || !props.showSideBar) {

--- a/baby-gru/src/components/validation-tools/MoorhenWaterValidation.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenWaterValidation.tsx
@@ -3,8 +3,9 @@ import { Col, Row, Form, Card, Button, Stack, InputGroup } from 'react-bootstrap
 import { MoorhenValidationListWidgetBase } from "./MoorhenValidationListWidgetBase"
 import { libcootApi } from "../../types/libcoot";
 import { moorhen } from "../../types/moorhen";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { MoorhenNumberForm } from "../select/MoorhenNumberForm";
+import { triggerScoresUpdate } from "../../store/connectedMapsSlice";
 
 interface Props extends moorhen.CollectedProps {
     dropdownId: number;
@@ -33,6 +34,7 @@ export const MoorhenWaterValidation = (props: Props) => {
     const [ignorePartOcc, setIgnorePartOcc] = useState<boolean>(false)
     const [ignoreZeroOcc, setIgnoreZeroOcc] = useState<boolean>(false)
 
+    const dispatch = useDispatch()
     const molecules = useSelector((state: moorhen.State) => state.molecules)
 
     const viewWater = useCallback(async (selectedModel: number, water: libcootApi.AtomSpecJS) => {
@@ -48,6 +50,7 @@ export const MoorhenWaterValidation = (props: Props) => {
         if (selectedMolecule) {
             const cid = `/${water.model_number}/${water.chain_id}/${water.res_no}`
             await selectedMolecule.deleteCid(cid)
+            dispatch( triggerScoresUpdate(selectedModel) )
         }
     }, [molecules])
 
@@ -56,6 +59,7 @@ export const MoorhenWaterValidation = (props: Props) => {
         if (selectedMolecule) {
             const cid = `/${water.model_number}/${water.chain_id}/${water.res_no}`
             await selectedMolecule.refineResiduesUsingAtomCid(cid, 'SNGLE')
+            dispatch( triggerScoresUpdate(selectedModel) )
         }
     }, [molecules])
 

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -2,6 +2,7 @@ import { moorhen as _moorhen } from "./moorhen"
 import { webGL } from "./mgWebGL";
 import { libcootApi } from "./libcoot";
 import { gemmi } from "./gemmi";
+import { privateer } from "./privateer";
 
 declare module 'moorhen' {
 
@@ -115,7 +116,9 @@ declare module 'moorhen' {
         downloadAtoms(format?: 'mmcif' | 'pdb'): Promise<void>;
         mergeFragmentFromRefinement(cid: string, fragmentMolecule: _moorhen.Molecule, acceptTransform?: boolean, refineAfterMerge?: boolean): Promise<void>;
         copyFragmentForRefinement(cid: string[], refinementMap: _moorhen.Map, redraw?: boolean, readrawFragmentFirst?: boolean): Promise<_moorhen.Molecule>;
-        refineResiduesUsingAtomCidAnimated(cid: string, activeMap: moorhen.Map, dist?: number, redraw?: boolean, redrawFragmentFirst?: boolean): Promise<void>;
+        refineResiduesUsingAtomCidAnimated(cid: string, activeMap: _moorhen.Map, dist?: number, redraw?: boolean, redrawFragmentFirst?: boolean): Promise<void>;
+        getPrivateerValidation(useCache?: boolean): Promise<privateer.ResultsEntry[]>;
+        cachedPrivateerValidation: privateer.ResultsEntry[];
         isLigand: boolean;
         type: string;
         excludedCids: string[];

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -159,7 +159,9 @@ export namespace moorhen {
         centreAndAlignViewOn: (selectionCid: string, alignWithCB?: boolean, zoomLevel?: number) => Promise<void>;
         buffersInclude: (bufferIn: { id: string; }) => boolean;
         redrawRepresentation: (id: string) => Promise<void>;
+        getPrivateerValidation(useCache?: boolean): Promise<privateer.ResultsEntry[]>;
         type: string;
+        cachedPrivateerValidation: privateer.ResultsEntry[];
         isLigand: boolean;
         excludedCids: string[];
         commandCentre: React.RefObject<CommandCentre>;

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1949,7 +1949,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @returns {Promise<privateer.ResultsEntry[]>} A list of results from privateer validation
      */
     async getPrivateerValidation(useCache: boolean = false): Promise<privateer.ResultsEntry[]> {
-        console.log('>>>>>> HI!!! ', this.atomsDirty)
         if (useCache && this.cachedPrivateerValidation && !this.atomsDirty) {
             return this.cachedPrivateerValidation
         }


### PR DESCRIPTION
This update refactors the code in `MoorhenMolecule` so that results from privateer validation are cached and it is not necessary to recalculate SVGs unless the molecule is modified.