### PR TITLE
Add missing colour rules for custom representations and use pop_back for molten fragments

### DIFF
--- a/baby-gru/src/components/button/MoorhenRotamerChangeButton.tsx
+++ b/baby-gru/src/components/button/MoorhenRotamerChangeButton.tsx
@@ -44,7 +44,7 @@ export const MoorhenRotamerChangeButton = (props: moorhen.ContextButtonProps) =>
 
         chosenMolecule.current.atomsDirty = true
         await chosenMolecule.current.redraw()
-        fragmentMolecule.current.delete()
+        fragmentMolecule.current.delete(true)
         chosenMolecule.current.unhideAll()
 
         dispatch( triggerScoresUpdate(chosenMolecule.current.molNo) )
@@ -54,7 +54,7 @@ export const MoorhenRotamerChangeButton = (props: moorhen.ContextButtonProps) =>
 
     const rejectTransform = async () => {
         dispatch(removeMolecule(fragmentMolecule.current))
-        fragmentMolecule.current.delete()
+        fragmentMolecule.current.delete(true)
         chosenMolecule.current.unhideAll()
         dispatch(setIsChangingRotamers(false))
     }

--- a/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
+++ b/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
@@ -8,7 +8,7 @@ import { HexColorPicker } from "react-colorful";
 import { MoorhenSequenceRangeSelect } from '../sequence-viewer/MoorhenSequenceRangeSelect';
 import { webGL } from '../../types/mgWebGL';
 import { MoorhenSlider } from '../misc/MoorhenSlider';
-import { AddCircleOutline, RemoveCircleOutline } from '@mui/icons-material';
+import { AddCircleOutline, GrainOutlined, RemoveCircleOutline } from '@mui/icons-material';
 import { useSelector } from 'react-redux';
 
 const customRepresentations = [ 'CBs', 'CAs', 'CRs', 'gaussian', 'MolecularSurface', 'DishyBases', 'VdwSpheres', 'MetaBalls' ]
@@ -304,12 +304,26 @@ export const MoorhenAddCustomRepresentationCard = (props: {
                 <>
                 <Row style={{paddingLeft: '1rem'}}>
                     <FormSelect style={{ width: '50%', marginRight: '0.5rem' }} size="sm" ref={colourModeSelectRef} defaultValue={colourMode} onChange={(val) => { setColourMode(val.target.value) }}>
-                            <option value={'custom'} key={'custom'}>User defined colour</option>
-                            <option value={'b-factor'} key={'b-factor'}>B-Factor</option>
-                            <option value={'af2-plddt'} key={'af2-plddt'}>AF2 PLDDT</option>
+                        <option value={'custom'} key={'custom'}>User defined colour</option>
+                        <option value={'secondary-structure'} key={'secondary-structure'}>Secondary structure</option>
+                        <option value={'jones-rainbow'} key={'jones-rainbow'}>Jones' rainbow</option>
+                        <option value={'b-factor'} key={'b-factor'}>B-Factor</option>
+                        <option value={'b-factor-norm'} key={'b-factor-norm'}>B-Factor (normalised)</option>
+                        <option value={'af2-plddt'} key={'af2-plddt'}>AF2 PLDDT</option>
                     </FormSelect>
-                    {colourMode === 'b-factor' ?
-                    <img className="colour-rule-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/temperature.svg`} alt='b-factor' style={{ width: '36px', height: '30px', borderRadius: '3px', border: '1px solid #c9c9c9', padding: 0}}/>
+                    {(colourMode === 'b-factor' || colourMode === 'b-factor-norm') ?
+                        <img className="colour-rule-icon" src={`${props.urlPrefix}/baby-gru/pixmaps/temperature.svg`} alt='b-factor' style={{ width: '36px', height: '30px', borderRadius: '3px', border: '1px solid #c9c9c9', padding: 0}}/>
+                    : colourMode === "secondary-structure" ?
+                        <img className='colour-rule-icon' src={`${props.urlPrefix}/baby-gru/pixmaps/secondary-structure-grey.svg`} alt='ss2' style={{ width: '36px', height: '30px', borderRadius: '3px', border: '1px solid #c9c9c9', padding: 0}}/>
+                    : colourMode === "jones-rainbow" ?
+                    <>
+                        <div style={{borderColor: 'rgb(255, 0, 0)', borderWidth:'5px', backgroundColor:  'rgb(255, 0, 0)', height:'20px', width:'5px', marginTop: '0.2rem', padding: '0rem'}}/>
+                        <div style={{borderColor: 'rgb(255, 255, 0)', borderWidth:'5px', backgroundColor: 'rgb(255, 255, 0)', height:'20px', width:'5px', marginTop: '0.2rem', padding: '0rem'}}/>
+                        <div style={{borderColor: 'rgb(0, 255, 0)', borderWidth:'5px', backgroundColor: 'rgb(0, 255, 0)', height:'20px', width:'5px', marginTop: '0.2rem', padding: '0rem'}}/>
+                        <div style={{borderColor: 'rgb(0, 0, 255)', borderWidth:'5px', backgroundColor: 'rgb(0, 0, 255)', height:'20px', width:'5px', marginTop: '0.2rem', padding: '0rem'}}/>
+                    </>
+                    : colourMode === "mol-symm" ?
+                        <GrainOutlined style={{height:'30px', width:'36px', marginLeft: '0.5rem', marginRight: '0.5rem', borderStyle: 'solid', borderColor: '#ced4da', borderWidth: '3px', borderRadius: '8px'}}/>            
                     :
                     colourMode === 'custom' ?
                     <div 

--- a/baby-gru/src/components/card/MoorhenColourRuleCard.tsx
+++ b/baby-gru/src/components/card/MoorhenColourRuleCard.tsx
@@ -106,7 +106,7 @@ export const MoorhenColourRuleCard = (props: {
                     <div style={{borderColor: 'rgb(0, 0, 255)', borderWidth:'5px', backgroundColor: 'rgb(0, 0, 255)', height:'20px', width:'5px', margin: '0rem', padding: '0rem'}}/>
                 </>
                 : rule.ruleType === "mol-symm" ?
-                    <GrainOutlined style={{height:'23px', width:'`23px', marginLeft: '0.5rem', marginRight: '0.5rem', borderStyle: 'solid', borderColor: '#ced4da', borderWidth: '3px', borderRadius: '8px'}}/>            
+                    <GrainOutlined style={{height:'23px', width:'23px', marginLeft: '0.5rem', marginRight: '0.5rem', borderStyle: 'solid', borderColor: '#ced4da', borderWidth: '3px', borderRadius: '8px'}}/>            
                 : (rule.ruleType === "b-factor" || rule.ruleType === "b-factor-norm") ?
                     <img className="colour-rule-icon" src={`${urlPrefix}/baby-gru/pixmaps/temperature.svg`} alt='b-factor' style={{height:'28px', width:'`12px', margin: '0.1rem'}}/>
                 :

--- a/baby-gru/src/components/misc/MoorhenAcceptRejectRotateTranslate.tsx
+++ b/baby-gru/src/components/misc/MoorhenAcceptRejectRotateTranslate.tsx
@@ -32,7 +32,7 @@ export const MoorhenAcceptRejectRotateTranslate = (props: {
             await props.moleculeRef.current.updateWithMovedAtoms(transformedAtoms)
             dispatch( triggerScoresUpdate(props.moleculeRef.current.molNo) )
         }
-        fragmentMoleculeRef.current.delete()
+        fragmentMoleculeRef.current.delete(true)
         props.moleculeRef.current.unhideAll()
         dispatch( setIsRotatingAtoms(false) )
     }, [props, props.moleculeRef, fragmentMoleculeRef])

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -95,7 +95,7 @@ declare module 'moorhen' {
         drawSymmetry: (fetchSymMatrix?: boolean) => Promise<void>;
         getUnitCellParams():  { a: number; b: number; c: number; alpha: number; beta: number; gamma: number; };
         replaceModelWithFile(fileUrl: string): Promise<void>
-        delete(): Promise<_moorhen.WorkerResponse> 
+        delete(popBackImol?: boolean): Promise<_moorhen.WorkerResponse>;
         fetchDefaultColourRules(): Promise<void>;
         fetchIfDirtyAndDraw(arg0: string): Promise<void>;
         drawEnvironment: (cid: string, labelled?: boolean) => Promise<void>;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -140,8 +140,8 @@ export namespace moorhen {
         setSymmetryRadius(radius: number): Promise<void>;
         drawSymmetry: (fetchSymMatrix?: boolean) => Promise<void>;
         getUnitCellParams():  { a: number; b: number; c: number; alpha: number; beta: number; gamma: number; };
-        replaceModelWithFile(fileUrl: string): Promise<void>
-        delete(): Promise<WorkerResponse> 
+        replaceModelWithFile(fileUrl: string): Promise<void>;
+        delete(popBackImol?: boolean): Promise<WorkerResponse>;
         fetchDefaultColourRules(): Promise<void>;
         fetchIfDirtyAndDraw(arg0: string): Promise<void>;
         drawEnvironment: (cid: string, labelled?: boolean) => Promise<void>;

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -354,8 +354,9 @@ export class MoorhenMolecule implements moorhen.Molecule {
 
     /**
      * Delete this molecule instance
+     * @param {boolean} [popBackImol=false] - Indicates whether the imol for this molecule instance should be popped back (useful for ephemeral molecules)
      */
-    async delete(): Promise<moorhen.WorkerResponse> {
+    async delete(popBackImol: boolean = false): Promise<moorhen.WorkerResponse> {
         this.hoverRepresentation?.deleteBuffers()
         this.unitCellRepresentation?.deleteBuffers()
         this.environmentRepresentation?.deleteBuffers()
@@ -364,8 +365,8 @@ export class MoorhenMolecule implements moorhen.Molecule {
         this.glRef.current.drawScene()
         const response = await this.commandCentre.current.cootCommand({
             returnType: "status",
-            command: 'close_molecule',
-            commandArgs: [this.molNo]
+            command: popBackImol ? 'pop_back' : 'close_molecule',
+            commandArgs: popBackImol ? [ ] : [ this.molNo ]
         }, true) as moorhen.WorkerResponse<number>
         if (this.gemmiStructure && !this.gemmiStructure.isDeleted()) {
             this.gemmiStructure.delete()
@@ -495,7 +496,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
                 command: 'replace_fragment',
                 commandArgs: [this.molNo, fragmentMolecule.molNo, cid],
                 changesMolecules: [this.molNo]
-            }, false)    
+            }, false)
             if (refineAfterMerge) {
                 await this.refineResiduesUsingAtomCid(cid, 'LITERAL', 4000, false)
             }
@@ -503,7 +504,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         }
 
         await this.unhideAll()
-        await fragmentMolecule.delete()
+        await fragmentMolecule.delete(true)
     }
 
     /**

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -1089,6 +1089,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     ;
     class_<molecules_container_t>("molecules_container_t")
     .constructor<bool>()
+    .function("pop_back", &molecules_container_t::pop_back)
     .function("get_use_gemmi", &molecules_container_t::get_use_gemmi)
     .function("set_use_gemmi", &molecules_container_t::set_use_gemmi)
     .function("generate_local_self_restraints", &molecules_container_t::generate_local_self_restraints)


### PR DESCRIPTION
This update fixes #292 and resolves #291 