### PR TITLE
Cache ligand SVGs

### DIFF
--- a/baby-gru/src/components/validation-tools/MoorhenLigandValidation.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenLigandValidation.tsx
@@ -2,7 +2,6 @@ import { moorhen } from "../../types/moorhen";
 import { useSelector } from 'react-redux';
 import { MoorhenValidationListWidgetBase } from "./MoorhenValidationListWidgetBase";
 import { MoorhenLigandCard } from "../card/MoorhenLigandCard";
-import { getLigandSVG } from "../../utils/MoorhenUtils";
 
 interface Props extends moorhen.CollectedProps {
     dropdownId: number;
@@ -14,7 +13,6 @@ interface Props extends moorhen.CollectedProps {
 
 export const MoorhenLigandValidation = (props: Props) => {
     const molecules = useSelector((state: moorhen.State) => state.molecules)
-    const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
 
     const fetchCardData = async (selectedModel: number, selectedMap: number): Promise<moorhen.LigandInfo[]> => {
         let ligandInfo: moorhen.LigandInfo[] = []
@@ -22,7 +20,7 @@ export const MoorhenLigandValidation = (props: Props) => {
 
         if (selectedMolecule) {
             ligandInfo = await Promise.all(selectedMolecule.ligands.map(async (ligand) => {
-                const ligandSVG = await getLigandSVG(props.commandCentre, selectedModel, ligand.resName, isDark)
+                const ligandSVG = await selectedMolecule.getLigandSVG(ligand.resName, true)
                 return {...ligand, svg: ligandSVG}
             }))
         }

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -118,6 +118,8 @@ declare module 'moorhen' {
         copyFragmentForRefinement(cid: string[], refinementMap: _moorhen.Map, redraw?: boolean, readrawFragmentFirst?: boolean): Promise<_moorhen.Molecule>;
         refineResiduesUsingAtomCidAnimated(cid: string, activeMap: _moorhen.Map, dist?: number, redraw?: boolean, redrawFragmentFirst?: boolean): Promise<void>;
         getPrivateerValidation(useCache?: boolean): Promise<privateer.ResultsEntry[]>;
+        getLigandSVG(resName: string, useCache?: boolean): Promise<string>;
+        cachedLigandSVGs: {[key: string]: string}[];
         cachedPrivateerValidation: privateer.ResultsEntry[];
         isLigand: boolean;
         type: string;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -160,7 +160,9 @@ export namespace moorhen {
         buffersInclude: (bufferIn: { id: string; }) => boolean;
         redrawRepresentation: (id: string) => Promise<void>;
         getPrivateerValidation(useCache?: boolean): Promise<privateer.ResultsEntry[]>;
+        getLigandSVG(resName: string, useCache?: boolean): Promise<string>;
         type: string;
+        cachedLigandSVGs: {[key: string]: string}[];
         cachedPrivateerValidation: privateer.ResultsEntry[];
         isLigand: boolean;
         excludedCids: string[];

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -18,15 +18,10 @@ import { libcootApi } from "../types/libcoot";
 
 export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
-export const getLigandSVG = async (commandCentre: React.RefObject<moorhen.CommandCentre>, imol: number, compId: string, isDark: boolean): Promise<string> => {
-    const result = await commandCentre.current.cootCommand({
-        returnType: "string",
-        command: 'get_svg_for_residue_type',
-        commandArgs: [imol, compId, false, isDark],
-    }, false) as moorhen.WorkerResponse<string>
+export const formatLigandSVG = (svg: string): string => {
     
     const parser = new DOMParser()
-    let theText = result.data.result.result
+    let theText = svg
     let doc = parser.parseFromString(theText, "image/svg+xml")
     let xmin = 999
     let ymin = 999


### PR DESCRIPTION
Just like #286, after this update ligand SVG descriptions are cached in `MoorhenMolecule` so that they don't need to be recalculated whenever the dropdown / validation tab mounts.