### PR TITLE
Fecth contour level from EMDB and hide missing loops when dragging atoms

### DIFF
--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -459,6 +459,14 @@ export class MoorhenMolecule implements moorhen.Molecule {
             }, false)
             newMolecule.setAtomsDirty(true)
             if (redraw) {
+                const drawMissingLoops = MoorhenReduxStore.getState().sceneSettings.drawMissingLoops
+                if (drawMissingLoops) {
+                    await this.commandCentre.current.cootCommand({
+                        command: "set_draw_missing_residue_loops",
+                        returnType:'status',
+                        commandArgs: [ false ],
+                    }, false)
+                }    
                 await Promise.all(cid.map(cid => {
                     return this.hideCid(cid, false)
                 }))
@@ -485,7 +493,15 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @param {boolean} [refineAfterMerge=false] - Indicates whether another cycle of refinement should be run after merging the fragment
      */
     async mergeFragmentFromRefinement(cid: string, fragmentMolecule: moorhen.Molecule, acceptTransform: boolean = true, refineAfterMerge: boolean = false) {
-        
+        const drawMissingLoops = MoorhenReduxStore.getState().sceneSettings.drawMissingLoops
+        if (drawMissingLoops) {
+            await this.commandCentre.current.cootCommand({
+                command: "set_draw_missing_residue_loops",
+                returnType:'status',
+                commandArgs: [ true ],
+            }, false)
+        }
+
         await this.commandCentre.current.cootCommand({
             returnType: 'status',
             command: 'clear_refinement',
@@ -1697,9 +1713,10 @@ export class MoorhenMolecule implements moorhen.Molecule {
         } else {
             cidList = await this.getNeighborResiduesCids(cid, dist)
         }
+
         const newMolecule = await this.copyFragmentForRefinement(cidList, activeMap, redraw, redrawFragmentFirst)
         await newMolecule.animateRefine(50, 30, 50)
-        await this.mergeFragmentFromRefinement(cidList.join('||'), newMolecule, true, true)
+        await this.mergeFragmentFromRefinement(cidList.join('||'), newMolecule, true, true)        
     }
 
     /**

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -35,11 +35,13 @@ describe('Testing molecules_container_js', () => {
 
     test('Test fill_rotamer_probability_tables', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         molecules_container.fill_rotamer_probability_tables()
     })
 
     test('Test add', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const ret = molecules_container.add(0)
         expect(ret).toBe(1)
     })
@@ -47,6 +49,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test metaballs", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMol = molecules_container.read_pdb('./5a3h.pdb')
         const gridSize = 0.15
         const radius = 0.65
@@ -58,6 +61,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test read PDB", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         const atomCount = molecules_container.get_number_of_atoms(coordMolNo)
         expect(coordMolNo).toBe(0)
@@ -66,6 +70,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test read MTZ", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const mapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'FWT', 'PHWT', "", false, false)
         expect(mapMolNo).toBe(0)
         
@@ -86,12 +91,14 @@ describe('Testing molecules_container_js', () => {
 
     test('Test glycoblocks', async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5fjj.pdb')
         const glyco_mesh = molecules_container.DrawGlycoBlocks(coordMolNo,"/")
     })
 
     test('Test copy fragment', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
         const coordMolNo_2 = molecules_container.copy_fragment_using_cid(coordMolNo_1, "//A/32-33/*");
         const atomCount = molecules_container.get_number_of_atoms(coordMolNo_2)
@@ -101,6 +108,7 @@ describe('Testing molecules_container_js', () => {
 
     test('Test fit_ligand_right_here 1', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         
         const result_import_dict = molecules_container.import_cif_dictionary('./LZA.cif', -999999)
         expect(result_import_dict).toBe(1)
@@ -124,6 +132,7 @@ describe('Testing molecules_container_js', () => {
 
     test('Test fit_ligand_right_here 2', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         
         const result_import_dict = molecules_container.import_cif_dictionary('./LZA.cif', -999999)
         expect(result_import_dict).toBe(1)
@@ -147,6 +156,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test close_molecule", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         expect(coordMolNo).toBe(0)
         const isValid_1 = molecules_container.is_valid_model_molecule(coordMolNo)
@@ -158,6 +168,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test close_map", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const imol_map = molecules_container.read_mtz("./rnasa-1.8-all_refmac1.mtz", "FWT", "PHWT", "W", false, false)
         expect(imol_map).toBe(0)
         const isValid_1 = molecules_container.is_valid_map_molecule(imol_map)
@@ -169,6 +180,7 @@ describe('Testing molecules_container_js', () => {
 
     test('Test delete methods', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         
         const result_cid = molecules_container.delete_using_cid(coordMolNo, "A/32-33/*", "LITERAL")
@@ -182,6 +194,7 @@ describe('Testing molecules_container_js', () => {
 
     test('Test add_terminal_residue methods', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         const mapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'FWT', 'PHWT', "", false, false)
         molecules_container.set_imol_refinement_map(mapMolNo)
@@ -199,6 +212,7 @@ describe('Testing molecules_container_js', () => {
 
     test('Test merge molecules', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
         const coordMolNo_2 = molecules_container.read_pdb('./tm-A.pdb')
         const mergeMols = coordMolNo_2.toString()
@@ -210,6 +224,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test water validation", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         const mapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'FWT', 'PHWT', "", false, false)
         expect(coordMolNo).toBe(0)
@@ -227,6 +242,7 @@ describe('Testing molecules_container_js', () => {
 
     test('Test ramachandran_validation', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         const rama_info = molecules_container.ramachandran_validation(coordMolNo)
         const rama_info_size = rama_info.size()
@@ -247,6 +263,7 @@ describe('Testing molecules_container_js', () => {
     test.skip('Test get_residue', () => {
         const resSpec = new cootModule.residue_spec_t("A", 217, "");
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         const res = molecules_container.get_residue(coordMolNo, resSpec)
         expect(res.nAtoms).toBe(5)
@@ -316,6 +333,7 @@ describe('Testing molecules_container_js', () => {
 
     test('Test get_single_letter_codes_for_chain', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         molecules_container.geometry_init_standard()
         const imol = molecules_container.read_pdb('./tm-A.pdb')
         const codes = molecules_container.get_single_letter_codes_for_chain(imol, "A")
@@ -332,6 +350,7 @@ describe('Testing molecules_container_js', () => {
 
     test.skip('Test Auto-fit rotamer', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         molecules_container.geometry_init_standard()
         const imol = molecules_container.read_pdb('./tm-A.pdb')
         const imol_map = molecules_container.read_mtz("./rnasa-1.8-all_refmac1.mtz", "FWT", "PHWT", "W", false, false)
@@ -351,6 +370,7 @@ describe('Testing molecules_container_js', () => {
 
     test('Test Rama mesh', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         const simpleMesh = molecules_container.get_ramachandran_validation_markup_mesh(coordMolNo);
         expect(simpleMesh.vertices.size()).toBe(22052)
@@ -360,6 +380,7 @@ describe('Testing molecules_container_js', () => {
 
     test('Test Dodo mesh', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         const simpleMesh = molecules_container.get_rotamer_dodecs(coordMolNo);
         expect(simpleMesh.vertices.size()).toBe(39000)
@@ -369,6 +390,7 @@ describe('Testing molecules_container_js', () => {
 
     test('Test Dodo instanced mesh', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         const instanceMesh = molecules_container.get_rotamer_dodecs_instanced(coordMolNo);
         const geom = instanceMesh.geom
@@ -383,6 +405,7 @@ describe('Testing molecules_container_js', () => {
 
     test.skip('Test backups', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         const mapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'FWT', 'PHWT', "", false, false)
         const resSpec = new cootModule.residue_spec_t("A", 32, "");
@@ -407,6 +430,7 @@ describe('Testing molecules_container_js', () => {
 
     test.skip('Test flip_peptide by residue spec', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         expect(coordMolNo).toBe(0)
 
@@ -430,6 +454,7 @@ describe('Testing molecules_container_js', () => {
 
     test('Create Density Map Mesh', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const imol_map = molecules_container.read_mtz("rnasa-1.8-all_refmac1.mtz", "FWT", "PHWT", "W", false, false);
         const p = new cootModule.Coord_orth(55, 10, 10);
         expect(p.x()).toBe(55)
@@ -450,6 +475,7 @@ describe('Testing molecules_container_js', () => {
 
     test('Create test origin', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const simpleMesh = molecules_container.test_origin_cube();
         const nVertices = molecules_container.count_simple_mesh_vertices(simpleMesh)
         expect(nVertices).toBe(24)
@@ -491,6 +517,7 @@ describe('Testing molecules_container_js', () => {
 
     test('Test Surface mesh', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         const simpleMesh = molecules_container.get_molecular_representation_mesh(
             0, "//", "colorRampChainsScheme", "MolecularSurface"
@@ -501,6 +528,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test ligand surface", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
 
         const result_import_dict = molecules_container.import_cif_dictionary('./LZA.cif', -999999)
         expect(result_import_dict).toBe(1)
@@ -520,6 +548,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test smiles_to_pdb", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const result_1 = molecules_container.smiles_to_pdb('c1ccccc1', 'LIG', 10, 100)
         const fileContents_1 = fs.readFileSync(path.join(__dirname, '..', 'test_data', 'benzene.cif'), { encoding: 'utf8', flag: 'r' })
         expect(result_1.second).toBe(fileContents_1)
@@ -527,6 +556,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test histogram map", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const mapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'FWT', 'PHWT', "", false, false)
         expect(mapMolNo).toBe(0)
 
@@ -538,6 +568,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test get_molecule_atoms pdb", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         const pdbString  = molecules_container.get_molecule_atoms(coordMolNo, "pdb")
         expect(pdbString).toHaveLength(258719)
@@ -545,6 +576,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test get_molecule_atoms mmcif", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         const pdbString  = molecules_container.get_molecule_atoms(coordMolNo, "mmcif")
         expect(pdbString).toHaveLength(297616)
@@ -552,6 +584,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test read_pdb_string pdb-format", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
         const pdbString_1  = molecules_container.get_molecule_atoms(coordMolNo_1, "pdb")
         expect(pdbString_1).toHaveLength(258719)
@@ -563,6 +596,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test read_pdb_string mmcif-format", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
         const pdbString_1  = molecules_container.get_molecule_atoms(coordMolNo_1, "mmcif")
         expect(pdbString_1).toHaveLength(297616)
@@ -575,6 +609,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test replace_molecule_by_model_from_string", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
         const pdbString_1  = molecules_container.get_molecule_atoms(coordMolNo_1, "pdb")
         expect(pdbString_1).toHaveLength(258719)
@@ -586,6 +621,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test get_gphl_chem_comp_info 1 -pdb", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         
         const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
         expect(coordMolNo_1).toBe(0)
@@ -618,6 +654,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test get_gphl_chem_comp_info 1 -mmcif", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         
         const coordMolNo_1 = molecules_container.read_pdb('./5a3h.mmcif')
         expect(coordMolNo_1).toBe(0)
@@ -650,6 +687,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test get_gphl_chem_comp_info 2", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         
         const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
         expect(coordMolNo_1).toBe(0)
@@ -682,6 +720,7 @@ describe('Testing molecules_container_js', () => {
 
     test.skip("Test get_gphl_chem_comp_info 3", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         
         const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
         expect(coordMolNo_1).toBe(0)
@@ -708,6 +747,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test merge ligand and gemmi parse -mmcif", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         
         const coordMolNo_1 = molecules_container.read_pdb('./5a3h.mmcif')
         expect(coordMolNo_1).toBe(0)
@@ -738,6 +778,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test merge ligand and gemmi parse -pdb", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         
         const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
         expect(coordMolNo_1).toBe(0)
@@ -768,6 +809,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test merge ligand.restraints dict and gemmi parse -pdb", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         
         const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
         expect(coordMolNo_1).toBe(0)
@@ -798,6 +840,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test merge ligand.restraints dict and gemmi parse -mmcif", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         
         const coordMolNo_1 = molecules_container.read_pdb('./5a3h.mmcif')
         expect(coordMolNo_1).toBe(0)
@@ -828,6 +871,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test merge ligand and gemmi parse cross-format 1", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         
         const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
         expect(coordMolNo_1).toBe(0)
@@ -866,6 +910,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test merge ligand and gemmi parse cross-format 2", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         
         const coordMolNo_1 = molecules_container.read_pdb('./5a3h.mmcif')
         expect(coordMolNo_1).toBe(0)
@@ -904,6 +949,7 @@ describe('Testing molecules_container_js', () => {
 
     test.skip('Test test_the_threading --pool false', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const mapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'FWT', 'PHWT', "", false, false)
         expect(mapMolNo).toBe(0)
 
@@ -920,6 +966,7 @@ describe('Testing molecules_container_js', () => {
 
     test.skip('Test test_the_threading --pool true', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const mapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'FWT', 'PHWT', "", false, false)
         expect(mapMolNo).toBe(0)
 
@@ -934,6 +981,7 @@ describe('Testing molecules_container_js', () => {
 
     test.skip("Test find ligand (long ligand name)", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./1cxq.cif')
         const mapMolNo = molecules_container.read_mtz('./1cxq_phases.mtz', 'FWT', 'PHWT', "", false, false)
         expect(coordMolNo).toBe(0)
@@ -984,6 +1032,7 @@ describe('Testing molecules_container_js', () => {
 
     test.skip("Test merge ligand (long ligand name)", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./1cxq.cif')
         const mapMolNo = molecules_container.read_mtz('./1cxq_phases.mtz', 'FWT', 'PHWT', "", false, false)
         expect(coordMolNo).toBe(0)
@@ -1030,6 +1079,7 @@ describe('Testing molecules_container_js', () => {
 
     test.skip("Test refine & merge ligand (long ligand name)", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./1cxq.cif')
         const mapMolNo = molecules_container.read_mtz('./1cxq_phases.mtz', 'FWT', 'PHWT', "", false, false)
         expect(coordMolNo).toBe(0)
@@ -1079,6 +1129,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test updating maps", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         const mapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'FWT', 'PHWT', 'FOM', false, false)
         const diffMapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'DELFWT', 'PHDELWT', 'FOM', false, true)
@@ -1110,6 +1161,7 @@ describe('Testing molecules_container_js', () => {
 
     test.skip("Test get_diff_diff_map_peaks", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         const mapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'FWT', 'PHWT', 'FOM', false, false)
         const diffMapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'DELFWT', 'PHDELWT', 'FOM', false, true)
@@ -1131,6 +1183,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test export_model_molecule_as_gltf", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
 
         const fileName = 'molecule-test.glb'
@@ -1142,6 +1195,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test export_map_molecule_as_gltf", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const mapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'FWT', 'PHWT', 'FOM', false, false)
 
         const fileName = 'map-test.glb'
@@ -1153,6 +1207,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test getSecondaryStructure", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
 
         const ss2_vector = molecules_container.GetSecondaryStructure(coordMolNo, 1)
@@ -1163,6 +1218,7 @@ describe('Testing molecules_container_js', () => {
 
     test("Test privateer_validate", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5fjj.pdb')
         const results = molecules_container.privateer_validate(coordMolNo)
         const first = results.get(0)

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -45,6 +45,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test loadToCootFromURL", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -59,6 +60,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test guessCoordFormat pdb", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -74,6 +76,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test guessCoordFormat mmcif", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.mmcif')
         const glRef = {
             current: new MockWebGL()
@@ -89,6 +92,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test guessCoordFormat ligandCif", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', 'LZA.cif')
         const glRef = {
             current: new MockWebGL()
@@ -104,6 +108,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test delete", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -120,6 +125,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test get_atoms pdb", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -135,6 +141,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test get_atoms mmcif", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.mmcif')
         const glRef = {
             current: new MockWebGL()
@@ -150,6 +157,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test get_number_of_atoms", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const glRef = {
             current: new MockWebGL()
         }
@@ -172,6 +180,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test replaceModelWithFile", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const fileUrl_2 = path.join(__dirname, '..', 'test_data', '5fjj.pdb')
         const glRef = {
@@ -195,6 +204,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test copyMolecule", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -216,6 +226,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test copyFragmentUsingCid", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -235,6 +246,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test mergeMolecules", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h_no_ligand.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -262,6 +274,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test addLigandOfType", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h_no_ligand.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -292,6 +305,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test loadMissingMonomers", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -311,6 +325,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test gemmiAtomsForCid 1 -pdb", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -331,6 +346,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test gemmiAtomsForCid 1 -mmcif", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.mmcif')
         const glRef = {
             current: new MockWebGL()
@@ -351,6 +367,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test gemmiAtomsForCid 2 -pdb", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -391,6 +408,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test gemmiAtomsForCid 2 -mmcif", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.mmcif')
         const glRef = {
             current: new MockWebGL()
@@ -431,6 +449,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test gemmiAtomsForCid 3", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -451,6 +470,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test gemmiAtomsForCid 4", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -516,6 +536,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test gemmiAtomsForCid 5", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -562,6 +583,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test getNonSelectedCids 1", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -580,6 +602,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test getNonSelectedCids 2", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -598,6 +621,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test getNonSelectedCids 3", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -616,6 +640,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test getNonSelectedCids 4", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -634,6 +659,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test getNonSelectedCids 5", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -652,6 +678,7 @@ describe("Testing MoorhenMolecule", () => {
     
     test("Test parseSequences pdb", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -683,6 +710,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test parseSequences mmcif", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.mmcif')
         const glRef = {
             current: new MockWebGL()
@@ -714,6 +742,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test updateAtoms pdb", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -739,6 +768,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test updateAtoms mmcif", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.mmcif')
         const glRef = {
             current: new MockWebGL()
@@ -764,6 +794,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test getNeighborResiduesCids 1", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -781,6 +812,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test getNeighborResiduesCids 2", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -815,6 +847,7 @@ describe("Testing MoorhenMolecule", () => {
     
     test("Test getNeighborResiduesCids 3", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -838,6 +871,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test getResidueBFactors", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -861,6 +895,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test checkIsLigand pdb", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const glRef = {
             current: new MockWebGL()
@@ -884,6 +919,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test checkIsLigand mmcif", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.mmcif')
         const glRef = {
             current: new MockWebGL()
@@ -975,6 +1011,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test hideCid 1", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const commandCentre = {
             current: new MockMoorhenCommandCentre(molecules_container, cootModule)
@@ -993,6 +1030,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test hideCid 2", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const commandCentre = {
             current: new MockMoorhenCommandCentre(molecules_container, cootModule)
@@ -1011,6 +1049,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test hideCid 3", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const commandCentre = {
             current: new MockMoorhenCommandCentre(molecules_container, cootModule)
@@ -1029,6 +1068,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test hideCid 4", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const commandCentre = {
             current: new MockMoorhenCommandCentre(molecules_container, cootModule)
@@ -1048,6 +1088,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test.skip("Test hideCid 5", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h.pdb')
         const commandCentre = {
             current: new MockMoorhenCommandCentre(molecules_container, cootModule)
@@ -1133,6 +1174,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test hasDNA pdb", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join('https://files.rcsb.org/download/3L1P.pdb')
         const commandCentre = {
             current: new MockMoorhenCommandCentre(molecules_container, cootModule)
@@ -1149,6 +1191,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test hasDNA mmcif", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join('https://files.rcsb.org/download/3L1P.cif')
         const commandCentre = {
             current: new MockMoorhenCommandCentre(molecules_container, cootModule)
@@ -1165,6 +1208,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test hasGlycans", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h_no_ligand.pdb')
         const commandCentre = {
             current: new MockMoorhenCommandCentre(molecules_container, cootModule)
@@ -1182,6 +1226,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test parseCidIntoSelection", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h_no_ligand.pdb')
         const commandCentre = {
             current: new MockMoorhenCommandCentre(molecules_container, cootModule)
@@ -1202,6 +1247,7 @@ describe("Testing MoorhenMolecule", () => {
 
     test("Test parseCidIntoSelection --multiCid", async () => {
         const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
         const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h_no_ligand.pdb')
         const commandCentre = {
             current: new MockMoorhenCommandCentre(molecules_container, cootModule)


### PR DESCRIPTION
This udpate includes:
- Use `molecules_container.set_use_gemmi(false)` in tests
- Hide missing loops during refinement animations and while dragging atoms
- Maps fetched from EMDB now also have the contour level set as indicated in the EMDB site