### PR TITLE
Add option to use current atom selection and add more space to map and molecule labels

### DIFF
--- a/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
+++ b/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
@@ -10,6 +10,7 @@ import { webGL } from '../../types/mgWebGL';
 import { MoorhenSlider } from '../misc/MoorhenSlider';
 import { AddCircleOutline, GrainOutlined, RemoveCircleOutline } from '@mui/icons-material';
 import { useSelector } from 'react-redux';
+import { MoorhenCidInputForm } from '../form/MoorhenCidInputForm';
 
 const customRepresentations = [ 'CBs', 'CAs', 'CRs', 'gaussian', 'MolecularSurface', 'DishyBases', 'VdwSpheres', 'MetaBalls' ]
 
@@ -98,8 +99,13 @@ export const MoorhenAddCustomRepresentationCard = (props: {
                 cidSelection = cidFormRef.current.value
                 break
             default:
-                console.log('Unrecgnised residue selection for the custom representation')    
+                console.warn('Unrecognised residue selection for the custom representation')    
                 break
+        }
+
+        if (!cidSelection) {
+            console.warn('Invalid CID selection to create a custom representation')
+            return
         }
 
         let colourRules: moorhen.ColourRule[] = []
@@ -211,10 +217,14 @@ export const MoorhenAddCustomRepresentationCard = (props: {
                             <option value={'cid'} key={'cid'}>Atom selection</option>
                         </FormSelect>
                 </Form.Group>
+                {ruleType === 'cid' && 
+                    <MoorhenCidInputForm ref={cidFormRef} label='Atom selection' margin='0.5rem' width='97%' defaultValue={props.initialCid} allowUseCurrentSelection={true}/>
+                }
+                {(ruleType === 'chain' || ruleType === 'residue-range')  &&
                 <div style={{justifyContent: 'center', display: 'flex'}}>
-                    {(ruleType === 'chain' || ruleType === 'residue-range')  && <MoorhenChainSelect molecules={molecules} onChange={handleChainChange} selectedCoordMolNo={props.molecule.molNo} ref={chainSelectRef} allowedTypes={[1, 2]}/>}
-                    {ruleType === 'cid' && <Form.Control ref={cidFormRef} defaultValue={props.initialCid} size="sm" type='text' placeholder={'Atom selection'} style={{margin: '0.5rem'}}/> }
+                    <MoorhenChainSelect molecules={molecules} onChange={handleChainChange} selectedCoordMolNo={props.molecule.molNo} ref={chainSelectRef} allowedTypes={[1, 2]}/>
                 </div>
+                }
                 {ruleType === 'residue-range' && 
                     <div style={{width: '100%'}}>
                         {sequenceRangeSelect}

--- a/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
+++ b/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
@@ -190,6 +190,8 @@ export const MoorhenModifyColourRulesCard = (props: {
                     color: selectedColour,
                     label: cidLabel,
                 }
+            } else {
+                console.warn('Invalid CID selection used to create a colour rule')
             }
         } else {
             const ruleArgs = await getMultiColourRuleArgs(props.molecule, ruleSelectRef.current.value)
@@ -255,7 +257,7 @@ export const MoorhenModifyColourRulesCard = (props: {
                         </FormSelect>
                     </Form.Group>
                     {(ruleType === 'chain' || ruleType === 'residue-range')  && <MoorhenChainSelect width="100%" margin={'0px'} molecules={molecules} onChange={handleChainChange} selectedCoordMolNo={props.molecule.molNo} ref={chainSelectRef}/>}
-                    {ruleType === 'cid' && <MoorhenCidInputForm margin={'0px'} width="100%" onChange={handleResidueCidChange} ref={cidFormRef}/> }
+                    {ruleType === 'cid' && <MoorhenCidInputForm allowUseCurrentSelection={true} margin={'0px'} width="100%" onChange={handleResidueCidChange} ref={cidFormRef}/> }
                     {ruleType === 'property' && 
                     <Form.Group style={{ margin: '0px', width: '100%' }}>
                         <Form.Label>Property</Form.Label>

--- a/baby-gru/src/components/card/cardUtils.tsx
+++ b/baby-gru/src/components/card/cardUtils.tsx
@@ -2,7 +2,7 @@ import { OverlayTrigger, Tooltip } from "react-bootstrap"
 import { moorhen } from "../../types/moorhen";
 
 export const getNameLabel = (item: moorhen.Molecule | moorhen.Map) => {
-    if (item.name.length > 9) {
+    if (item.name.length > 16) {
         return <OverlayTrigger
                 key={item.molNo}
                 placement="top"
@@ -15,7 +15,7 @@ export const getNameLabel = (item: moorhen.Molecule | moorhen.Map) => {
                 }
                 >
                 <div>
-                    {`#${item.molNo} ${item.type === 'molecule' ? 'Mol.' : 'Map'} ${item.name.slice(0,5)}...`}
+                    {`#${item.molNo} ${item.type === 'molecule' ? 'Mol.' : 'Map'} ${item.name.slice(0,15)}...`}
                 </div>
                 </OverlayTrigger>
     }

--- a/baby-gru/src/components/form/MoorhenCidInputForm.tsx
+++ b/baby-gru/src/components/form/MoorhenCidInputForm.tsx
@@ -1,5 +1,7 @@
 import { forwardRef } from "react";
 import { Form } from "react-bootstrap";
+import { useSelector } from "react-redux";
+import { moorhen } from "../../types/moorhen";
 
 type MoorhenCidInputFormPropsType = {
     height?: string;
@@ -10,9 +12,12 @@ type MoorhenCidInputFormPropsType = {
     defaultValue?: string;
     onChange?: (arg0: React.ChangeEvent<HTMLInputElement>) => void;
     invalidCid?: boolean;
+    allowUseCurrentSelection?: boolean;
 }
 
 export const MoorhenCidInputForm = forwardRef<HTMLInputElement, MoorhenCidInputFormPropsType>((props, cidFormRef) => {
+    const residueSelection = useSelector((state: moorhen.State) => state.generalStates.residueSelection)
+    const showResidueSelection = useSelector((state: moorhen.State) => state.generalStates.showResidueSelection)
 
     const handleChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
         if (props.onChange) {
@@ -21,11 +26,28 @@ export const MoorhenCidInputForm = forwardRef<HTMLInputElement, MoorhenCidInputF
         if(cidFormRef !== null && typeof cidFormRef !== 'function') cidFormRef.current.value = evt.target.value
     }
 
-    return  <Form.Group style={{ width: props.width, margin: props.margin, height:props.height }}>
-                <Form.Label>{props.label}</Form.Label>
-                <Form.Control size="sm" type='text' placeholder={props.placeholder} defaultValue={props.defaultValue} style={{width: "100%", color: props.invalidCid ? 'red' : '', borderColor: props.invalidCid ? 'red' : ''}} onChange={handleChange} ref={cidFormRef}/>
-            </Form.Group>
+    const handleFillCurrentSelection = (evt: React.ChangeEvent<HTMLInputElement>) => {
+        if (evt.target.checked) {
+            if (residueSelection.cid) {
+                // @ts-ignore
+                handleChange({target: {value: typeof residueSelection.cid === 'string' ? residueSelection.cid : residueSelection.cid.join('||')}})
+            }
+        } else {
+            // @ts-ignore
+            handleChange({target: {value: ''}})
+        }
+    }
 
+    return  <>
+    <Form.Group style={{ width: props.width, margin: props.margin, height:props.height }}>
+        <Form.Label>{props.label}</Form.Label>
+        <Form.Control size="sm" type='text' placeholder={props.placeholder} defaultValue={props.defaultValue} style={{width: "100%", color: props.invalidCid ? 'red' : '', borderColor: props.invalidCid ? 'red' : ''}} onChange={handleChange} ref={cidFormRef}/>
+    </Form.Group>
+    {props.allowUseCurrentSelection && showResidueSelection && <Form.Check type="checkbox" id='cid-input-checkbox' label="Use current selection?" style={{width: props.width, margin: props.margin}} onChange={handleFillCurrentSelection}/>}
+    </>
 })
 
-MoorhenCidInputForm.defaultProps = { height: '4rem', width: '20rem', margin: '0.1rem', label: "Atom selection", placeholder: "", defaultValue: "", invalidCid: false}
+MoorhenCidInputForm.defaultProps = { 
+    height: '4rem', width: '20rem', margin: '0.1rem', label: "Atom selection", 
+    placeholder: "", defaultValue: "", invalidCid: false, allowUseCurrentSelection: false
+}

--- a/baby-gru/src/components/menu-item/MoorhenCopyFragmentUsingCidMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenCopyFragmentUsingCidMenuItem.tsx
@@ -1,11 +1,13 @@
-import { useRef, useState } from "react"
-import { Form } from "react-bootstrap"
+import { useCallback, useRef, useState } from "react"
+import { Button } from "react-bootstrap"
 import { MoorhenMoleculeSelect } from "../select/MoorhenMoleculeSelect"
 import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem"
 import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
 import { useSelector, useDispatch } from 'react-redux';
 import { addMolecule } from "../../store/moleculesSlice";
+import { MoorhenCidInputForm } from "../form/MoorhenCidInputForm";
+import { clearResidueSelection } from "../../store/generalStatesSlice";
 
 export const MoorhenCopyFragmentUsingCidMenuItem = (props: {
     setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>;
@@ -14,44 +16,63 @@ export const MoorhenCopyFragmentUsingCidMenuItem = (props: {
     monomerLibraryPath: string;
 }) => {
 
-    const fromRef = useRef<null | HTMLSelectElement>(null)
-    const cidRef = useRef<null |HTMLInputElement>(null)
+    const moleculeSelectRef = useRef<null | HTMLSelectElement>(null)
+    const cidFormRef = useRef<null |HTMLInputElement>(null)
     
     const [cid, setCid] = useState<string>("")
+    const [invalidCid, setInvalidCid] = useState<boolean>(false)
     
     const dispatch = useDispatch()
+    const residueSelection = useSelector((state: moorhen.State) => state.generalStates.residueSelection)
     const molecules = useSelector((state: moorhen.State) => state.molecules)
 
-    const panelContent = <>
-        <MoorhenMoleculeSelect molecules={molecules} label="From molecule" allowAny={false} ref={fromRef} />
-        <Form.Group className='moorhen-form-group' controlId="cid">
-            <Form.Label>Selection to copy</Form.Label>
-            <Form.Control ref={cidRef} type="text" value={cid} onChange={(e) => {
-                setCid(e.target.value)
-            }} />
-        </Form.Group>
-
-    </>
-
-    const onCompleted = async () => {
-        const fromMolecule = molecules.find(molecule => molecule.molNo === parseInt(fromRef.current.value))
-        const cidToCopy = cidRef.current.value
-
-        if (!fromMolecule || !cidToCopy) {
+    const createSelection = useCallback(async () => {
+        const selectedCid = cidFormRef.current.value
+        if (!selectedCid || !moleculeSelectRef.current.value) {
+            return
+        }
+        
+        const molecule = molecules.find(molecule => molecule.molNo === parseInt(moleculeSelectRef.current.value))
+        if (!molecule) {
             return
         }
 
-        const newMolecule = await fromMolecule.copyFragmentUsingCid(cidToCopy, true)
-        dispatch( addMolecule(newMolecule) )
-        props.setPopoverIsShown(false)
-    }
+        const isValidSelection = await molecule.isValidSelection(selectedCid)
+        if (!isValidSelection) {
+            setInvalidCid(true)
+            return
+        }
+
+        try {
+            setInvalidCid(false)
+            const newMolecule = await molecule.copyFragmentUsingCid(selectedCid, true)
+            dispatch( addMolecule(newMolecule) )
+            props.setPopoverIsShown(false)
+            document.body.click()
+            if (selectedCid === residueSelection.cid) {
+                dispatch( clearResidueSelection() )
+            }
+        } catch (err) {
+            setInvalidCid(true)
+            console.warn(err)
+        }
+    }, [residueSelection, molecules])
+    
+    const panelContent = <>
+        <MoorhenMoleculeSelect molecules={molecules} label="From molecule" allowAny={false} ref={moleculeSelectRef} />
+        <MoorhenCidInputForm margin={'0.5rem'} width="95%" label="Selection to copy" onChange={(evt) => setCid(evt.target.value)} ref={cidFormRef} invalidCid={invalidCid} allowUseCurrentSelection={true}/> 
+        <Button variant="primary" onClick={createSelection}>
+            OK
+        </Button>
+    </>
 
     return <MoorhenBaseMenuItem
         id='copy-fragment-menu-item'
         popoverPlacement='right'
         popoverContent={panelContent}
         menuItemText="Copy fragment..."
-        onCompleted={onCompleted}
+        showOkButton={false}
+        onCompleted={() => {}}
         setPopoverIsShown={props.setPopoverIsShown}
     />
 }

--- a/baby-gru/src/components/menu-item/MoorhenMapMaskingMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenMapMaskingMenuItem.tsx
@@ -55,7 +55,7 @@ export const MoorhenMapMaskingMenuItem = (props: {
         </Form.Group>
         <MoorhenMapSelect maps={maps} ref={mapSelectRef} />
         <MoorhenMoleculeSelect {...props} molecules={molecules} allowAny={false} ref={moleculeSelectRef} />
-        {maskTypeSelectRef.current?.value === 'cid' && <MoorhenCidInputForm {...props} width='20rem' margin='0.5rem' ref={cidInputRef} />}
+        {maskTypeSelectRef.current?.value === 'cid' && <MoorhenCidInputForm {...props} width='20rem' margin='0.5rem' ref={cidInputRef} allowUseCurrentSelection={true}/>}
         {maskTypeSelectRef.current?.value === 'chain' && <MoorhenChainSelect {...props} molecules={molecules} selectedCoordMolNo={parseInt(moleculeSelectRef.current?.value)} ref={chainSelectRef} />}
         {maskTypeSelectRef.current?.value === 'ligand' && <MoorhenLigandSelect {...props} molecules={molecules} selectedCoordMolNo={parseInt(moleculeSelectRef.current?.value)} ref={ligandSelectRef} />}
         {!useDefaultMaskRadius && <MoorhenNumberForm ref={maskRadiusFormRef} defaultValue={2.5} label="Mask radius" allowNegativeValues={false}/>}

--- a/baby-gru/src/components/menu-item/MoorhenRandomJiggleBlurMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenRandomJiggleBlurMenuItem.tsx
@@ -8,7 +8,8 @@ import { AddCircleOutline, RemoveCircleOutline } from "@mui/icons-material";
 import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
 import { MoorhenMapSelect } from "../select/MoorhenMapSelect";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { clearResidueSelection } from "../../store/generalStatesSlice";
 
 export const MoorhenRandomJiggleBlurMenuItem = (props: {
     commandCentre: React.RefObject<moorhen.CommandCentre>;
@@ -17,6 +18,8 @@ export const MoorhenRandomJiggleBlurMenuItem = (props: {
     setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
     
+    const dispatch = useDispatch()
+    const residueSelection = useSelector((state: moorhen.State) => state.generalStates.residueSelection)
     const maps = useSelector((state: moorhen.State) => state.maps)
     const molecules = useSelector((state: moorhen.State) => state.molecules)
     const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
@@ -115,6 +118,7 @@ export const MoorhenRandomJiggleBlurMenuItem = (props: {
             ref={cidSelectRef}
             margin="0.5rem"
             onChange={(evt) => setCid(evt.target.value)}
+            allowUseCurrentSelection={true}
             placeholder={cidSelectRef.current ? "" : "Input custom selection e.g. //A,B"}/>
         <MoorhenSlider
             ref={bFactorSliderRef}
@@ -166,6 +170,10 @@ export const MoorhenRandomJiggleBlurMenuItem = (props: {
             return
         }
 
+        if (cidSelectRef.current.value === residueSelection?.cid) {
+            dispatch( clearResidueSelection() )
+        }
+        
         await props.commandCentre.current.cootCommand({
             command: "fit_to_map_by_random_jiggle_with_blur_using_cid",
             returnType: 'status',

--- a/baby-gru/src/components/menu-item/MoorhenSelfRestraintsMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenSelfRestraintsMenuItem.tsx
@@ -88,6 +88,7 @@ export const MoorhenSelfRestraintsMenuItem = (props: {
             ref={cidSelectRef}
             margin="0.5rem"
             onChange={(evt) => setCid(evt.target.value)}
+            allowUseCurrentSelection={true}
             placeholder={cidSelectRef.current ? "" : "Input custom selection e.g. //A,B"}/>}
         <MoorhenSlider
             ref={maxDistSliderRef}

--- a/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
+++ b/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
@@ -40,15 +40,20 @@ export const MoorhenResidueSelectionActions = (props) => {
     const animateRefine = useSelector((state: moorhen.State) => state.miscAppSettings.animateRefine)
 
     const clearSelection = useCallback(() => {
-        dispatch( clearResidueSelection() )
-        dispatch( setNotificationContent(null) )
         dispatch( setShowResidueSelection(false) )
+        dispatch( setNotificationContent(null) )
         setCidFormValue(null)
         setShowCidEditForm(false)
         setShowColourPopover(false)
         setInvalidCid(false)
         molecules.forEach(molecule => molecule.clearBuffersOfStyle('residueSelection'))
     }, [molecules])
+
+    useEffect(() => {
+        if (Object.keys(residueSelection).every(key => !residueSelection[key])) {
+            clearSelection()
+        }
+    }, [residueSelection, clearSelection])
 
     const handleAtomClicked = useCallback(async (evt: moorhen.AtomClickedEvent) => {
         if (!evt.detail.isResidueSelection || evt.detail.buffer.id == null || isDraggingAtoms || isRotatingAtoms || isChangingRotamers) {
@@ -57,7 +62,7 @@ export const MoorhenResidueSelectionActions = (props) => {
 
         const selectedMolecule = molecules.find(molecule => molecule.buffersInclude(evt.detail.buffer))
         if (!selectedMolecule) {
-            clearSelection()
+            dispatch( clearResidueSelection() )
             return
         }
         
@@ -81,7 +86,7 @@ export const MoorhenResidueSelectionActions = (props) => {
         const startResSpec = cidToSpec(residueSelection.first)
         const stopResSpec = cidToSpec(evt.detail.atom.label)
         if (startResSpec.chain_id !== stopResSpec.chain_id) {
-            clearSelection()
+            dispatch( clearResidueSelection() )
         } else {
             const sortedResNums = [startResSpec.res_no, stopResSpec.res_no].sort(function(a, b){return a - b})
             const cid = `/*/${startResSpec.chain_id}/${sortedResNums[0]}-${sortedResNums[1]}/*`
@@ -98,7 +103,7 @@ export const MoorhenResidueSelectionActions = (props) => {
             )
             dispatch( setShowResidueSelection(true) )
         }
-    }, [clearSelection, residueSelection, isRotatingAtoms, isChangingRotamers, isDraggingAtoms])
+    }, [residueSelection, isRotatingAtoms, isChangingRotamers, isDraggingAtoms])
 
     useEffect(() => {
         document.addEventListener('atomClicked', handleAtomClicked)
@@ -136,7 +141,7 @@ export const MoorhenResidueSelectionActions = (props) => {
             setInvalidCid(true)
         }
 
-    }, [residueSelection, clearResidueSelection, cidFormValue])
+    }, [residueSelection, cidFormValue])
 
     const handleSelectionCopy = useCallback(async () => {
         let cid: string
@@ -155,8 +160,8 @@ export const MoorhenResidueSelectionActions = (props) => {
             dispatch( addMolecule(newMolecule) )
         }
         
-        clearSelection()
-    }, [residueSelection, clearSelection])
+        dispatch( clearResidueSelection() )
+    }, [residueSelection])
 
     const handleRefinement = useCallback(async () => {
         molecules.forEach(molecule => molecule.clearBuffersOfStyle('residueSelection'))
@@ -184,8 +189,8 @@ export const MoorhenResidueSelectionActions = (props) => {
             }
         }
         dispatch( triggerScoresUpdate(residueSelection.molecule.molNo) )
-        clearSelection()
-    }, [clearSelection, residueSelection, animateRefine, activeMap])
+        dispatch( clearResidueSelection() )
+    }, [residueSelection, animateRefine, activeMap])
 
     const handleDelete = useCallback(async () => {
         let cid: string
@@ -209,8 +214,8 @@ export const MoorhenResidueSelectionActions = (props) => {
             dispatch( triggerScoresUpdate(residueSelection.molecule.molNo) )
         }
 
-        clearSelection()
-    }, [residueSelection, clearSelection])
+        dispatch( clearResidueSelection() )
+    }, [residueSelection])
 
     const handleExpandSelection = useCallback(async () => {
         let cid: string
@@ -245,7 +250,7 @@ export const MoorhenResidueSelectionActions = (props) => {
                 })
             )
         }
-    }, [residueSelection, clearSelection])
+    }, [residueSelection])
 
     const handleInvertSelection = useCallback(async () => {
         let cid: string
@@ -274,7 +279,7 @@ export const MoorhenResidueSelectionActions = (props) => {
                 })
             )
         }
-    }, [residueSelection, clearResidueSelection])
+    }, [residueSelection])
 
     const handleColourChange = useCallback(async () => {
         let newColourRules: moorhen.ColourRule[] = []
@@ -316,7 +321,7 @@ export const MoorhenResidueSelectionActions = (props) => {
 
         setShowColourPopover(false)
 
-    }, [residueSelection, clearSelection, selectedColour])
+    }, [residueSelection, selectedColour])
 
     const handleRigidBodyFit = useCallback(async () => {
         if (!activeMap) {
@@ -340,8 +345,8 @@ export const MoorhenResidueSelectionActions = (props) => {
             dispatch( triggerScoresUpdate(residueSelection.molecule.molNo) )
         }
 
-        clearSelection()
-    }, [activeMap, residueSelection, clearSelection])
+        dispatch( clearResidueSelection() )
+    }, [activeMap, residueSelection])
 
     const handleRotateTranslate = useCallback(async () => {
         let cid: string
@@ -358,11 +363,11 @@ export const MoorhenResidueSelectionActions = (props) => {
         if (cid) {
             const onExit = () => {
                 dispatch( setNotificationContent(null) )
-                clearSelection()
+                dispatch( clearResidueSelection() )
             }
             batch(() => {
                 molecules.forEach(molecule => molecule.clearBuffersOfStyle('residueSelection'))
-                dispatch( setShowResidueSelection(false) )
+                dispatch( clearResidueSelection() )
                 dispatch( setHoveredAtom({ molecule: null, cid: null }) )
                 dispatch( setIsRotatingAtoms(true) )
                 dispatch( setNotificationContent(
@@ -375,7 +380,7 @@ export const MoorhenResidueSelectionActions = (props) => {
             })
         }
 
-    }, [residueSelection, clearSelection])
+    }, [residueSelection])
 
     const handleDragAtoms = useCallback(() => {
         let cid: string[]
@@ -392,11 +397,11 @@ export const MoorhenResidueSelectionActions = (props) => {
         if (cid) {
             const onExit = () => {
                 dispatch( setNotificationContent(null) )
-                clearSelection()
+                dispatch( clearResidueSelection() )
             }
             molecules.forEach(molecule => molecule.clearBuffersOfStyle('residueSelection'))
             batch(() => {
-                dispatch( setShowResidueSelection(false) )
+                dispatch( clearResidueSelection() )
                 dispatch( setHoveredAtom({ molecule: null, cid: null }) )
                 dispatch( setIsDraggingAtoms(true) )
                 dispatch( setNotificationContent(
@@ -411,7 +416,7 @@ export const MoorhenResidueSelectionActions = (props) => {
             })
         }
 
-    }, [residueSelection, clearSelection])
+    }, [residueSelection])
 
     return showResidueSelection ?
         <MoorhenNotification key={notificationKeyRef.current} width={19}>
@@ -419,9 +424,9 @@ export const MoorhenResidueSelectionActions = (props) => {
             <Stack ref={notificationComponentRef} direction="vertical" gap={1}>
                 <Stack gap={0} direction="horizontal" style={{ width: '100%', display: 'flex', justifyContent: 'space-between' }}>
                     <span style={{paddingLeft: '2.2rem', width: '100%', display: 'flex', justifyContent: 'center'}}>{
-                        `${residueSelection.label.length > 16 ? residueSelection.label.substring(0, 12) + '...' : residueSelection.label}`
+                        `${residueSelection.label?.length > 16 ? residueSelection.label.substring(0, 12) + '...' : residueSelection.label}`
                     }</span>
-                    <IconButton onClick={clearSelection} onMouseEnter={() => setTooltipContents('Clear selection')} style={{padding: 0}}>
+                    <IconButton onClick={() => dispatch( clearResidueSelection() )} onMouseEnter={() => setTooltipContents('Clear selection')} style={{padding: 0}}>
                         <CloseOutlined/>
                     </IconButton>
                 </Stack>

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -119,6 +119,7 @@ declare module 'moorhen' {
         refineResiduesUsingAtomCidAnimated(cid: string, activeMap: _moorhen.Map, dist?: number, redraw?: boolean, redrawFragmentFirst?: boolean): Promise<void>;
         getPrivateerValidation(useCache?: boolean): Promise<privateer.ResultsEntry[]>;
         getLigandSVG(resName: string, useCache?: boolean): Promise<string>;
+        isValidSelection(cid: string): Promise<boolean>;
         cachedLigandSVGs: {[key: string]: string}[];
         cachedPrivateerValidation: privateer.ResultsEntry[];
         isLigand: boolean;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -161,6 +161,7 @@ export namespace moorhen {
         redrawRepresentation: (id: string) => Promise<void>;
         getPrivateerValidation(useCache?: boolean): Promise<privateer.ResultsEntry[]>;
         getLigandSVG(resName: string, useCache?: boolean): Promise<string>;
+        isValidSelection(cid: string): Promise<boolean>;
         type: string;
         cachedLigandSVGs: {[key: string]: string}[];
         cachedPrivateerValidation: privateer.ResultsEntry[];

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1918,6 +1918,24 @@ export class MoorhenMolecule implements moorhen.Molecule {
     }
 
     /**
+     * Test whether an atom selection is valid
+     * @param {string} cid - The CID selection
+     * @returns {boolean} Whether the selection is valid
+     */
+    async isValidSelection(cid: string): Promise<boolean> {
+        try {
+            const selectedAtoms = await this.gemmiAtomsForCid(cid)
+            if (!selectedAtoms || selectedAtoms.length === 0) {
+                return false
+            }
+        } catch (error) {
+            console.warn(error)
+            return false
+        }
+        return true
+    }
+
+    /**
      * Get the CIDs of residues not included in the input CID
      * @param {string} cid - The input CID selection
      * @returns {string[]} An array of CIDs for the residue ranges not included in the input CID

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -178,6 +178,20 @@ describe('Testing molecules_container_js', () => {
         expect(isValid_2).toBeFalsy()
     })
 
+    test("Test pop_back", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
+        const coordMolNo_1 = molecules_container.read_pdb('./5a3h.pdb')
+        expect(coordMolNo_1).toBe(0)
+        const isValid_1 = molecules_container.is_valid_model_molecule(coordMolNo_1)
+        expect(isValid_1).toBeTruthy()
+        molecules_container.pop_back()
+        const isValid_2 = molecules_container.is_valid_model_molecule(coordMolNo_1)
+        expect(isValid_2).toBeFalsy()
+        const coordMolNo_2 = molecules_container.read_pdb('./5a3h.pdb')
+        expect(coordMolNo_2).toBe(0)
+    })
+
     test('Test delete methods', () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         molecules_container.set_use_gemmi(false)

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -189,7 +189,7 @@ describe('Testing molecules_container_js', () => {
         const isValid_2 = molecules_container.is_valid_model_molecule(coordMolNo_1)
         expect(isValid_2).toBeFalsy()
         const coordMolNo_2 = molecules_container.read_pdb('./5a3h.pdb')
-        expect(coordMolNo_2).toBe(0)
+        expect(coordMolNo_2).toBe(coordMolNo_1)
     })
 
     test('Test delete methods', () => {

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -1265,6 +1265,58 @@ describe("Testing MoorhenMolecule", () => {
         expect(newSelection.first).toBe('/1/A/4(SER)/N')
         expect(newSelection.second).toBe('/1/A/20(VAL)/CG2')
     })
+
+    test("Test isValidSelection", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h_no_ligand.pdb')
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+        const glRef = {
+            current: new MockWebGL()
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl, 'mol-test-1')
+        const isValid = await molecule.isValidSelection("//A/15-20")
+        expect(isValid).toBeTruthy()
+    })
+
+    test("Test isValidSelection --falsy", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h_no_ligand.pdb')
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+        const glRef = {
+            current: new MockWebGL()
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl, 'mol-test-1')
+        const isValid = await molecule.isValidSelection("//X/1-10")
+        expect(isValid).toBeFalsy()
+    })
+
+    test("Test isValidSelection --multiCid", async () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
+        const fileUrl = path.join(__dirname, '..', 'test_data', '5a3h_no_ligand.pdb')
+        const commandCentre = {
+            current: new MockMoorhenCommandCentre(molecules_container, cootModule)
+        }
+        const glRef = {
+            current: new MockWebGL()
+        }
+
+        const molecule = new MoorhenMolecule(commandCentre, glRef, mockMonomerLibraryPath)
+        await molecule.loadToCootFromURL(fileUrl, 'mol-test-1')
+        const isValid = await molecule.isValidSelection("//A/1-10||//A/15-20")
+        expect(isValid).toBeTruthy()
+    })
+
 })
 
 const testDataFiles = ['5fjj.pdb', '5a3h.pdb', '5a3h.mmcif', '5a3h_no_ligand.pdb', 'LZA.cif', 'nitrobenzene.cif', 'benzene.cif', '5a3h_sigmaa.mtz', 'rnasa-1.8-all_refmac1.mtz', 'tm-A.pdb']


### PR DESCRIPTION
This update includes:
- Add more space for molecule and map labels to avoid the issue where map names are truncated too early (e.g. "Map Chain...")
- Added `MoorhenMolecule.isValidSelection` 
- Added tests for `molecules_container.pop_back` and `MoorhenMolecule.isValidSelection` 
- Add an option to use the current selection as input in `MoorhenCidForm`. This resolves #302. 