### PR TITLE
Add notification when worker is too busy and refactor score updates redux slice

### DIFF
--- a/baby-gru/src/components/MoorhenContainer.tsx
+++ b/baby-gru/src/components/MoorhenContainer.tsx
@@ -13,10 +13,11 @@ import { MoorhenModalsContainer } from './misc/MoorhenModalsContainer'
 import { moorhen } from '../types/moorhen';
 import { webGL } from '../types/mgWebGL';
 import { MoorhenPreferencesContainer } from './misc/MoorhenPreferencesContainer'
+import { MoorhenLongJobNotification } from './misc/MoorhenLongJobNotification'
 import { MoorhenResidueSelectionActions } from './misc/MoorhenResidueSelectionActions'
 import { useSelector, useDispatch } from 'react-redux';
 import { setDefaultBackgroundColor, setBackgroundColor, setHeight, setIsDark, setWidth } from '../store/sceneSettingsSlice';
-import { setCootInitialized, setNotificationContent, setTheme, toggleCootCommandAlert } from '../store/generalStatesSlice';
+import { setCootInitialized, setNotificationContent, setTheme, toggleCootCommandExit, toggleCootCommandStart } from '../store/generalStatesSlice';
 import { setEnableAtomHovering, setHoveredAtom } from '../store/hoveringStatesSlice';
 
 /**
@@ -285,7 +286,10 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
                 dispatch( setCootInitialized(true) )
             },
             onCommandExit: (kwargs) => {
-
+                dispatch( toggleCootCommandExit() )
+            },
+            onCommandStart: (kwargs) => {
+                dispatch( toggleCootCommandStart() )
             }
         })
         return () => {
@@ -423,6 +427,7 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
             </Col>
         </Row>
         {notificationContent}
+        <MoorhenLongJobNotification commandCentre={props.commandCentre}/>
     </Container>
     </>
 }

--- a/baby-gru/src/components/MoorhenContainer.tsx
+++ b/baby-gru/src/components/MoorhenContainer.tsx
@@ -285,9 +285,7 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
                 dispatch( setCootInitialized(true) )
             },
             onCommandExit: (kwargs) => {
-                if (kwargs.doJournal) {
-                    dispatch( toggleCootCommandAlert() )
-                }
+
             }
         })
         return () => {

--- a/baby-gru/src/components/button/MoorhenContextButtonBase.tsx
+++ b/baby-gru/src/components/button/MoorhenContextButtonBase.tsx
@@ -4,7 +4,7 @@ import { Button, FormLabel, FormSelect, Stack } from "react-bootstrap"
 import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
 import { useDispatch, useSelector } from "react-redux";
-import { triggerScoresUpdate } from "../../store/connectedMapsSlice";
+import { triggerUpdate } from "../../store/moleculeMapUpdateSlice";
 import { setHoveredAtom } from "../../store/hoveringStatesSlice";
 
 const MoorhenPopoverOptions = (props: {
@@ -132,7 +132,7 @@ export const MoorhenContextButtonBase = (props: {
             await props.selectedMolecule.redraw()
         }
         
-        dispatch( triggerScoresUpdate(props.selectedMolecule.molNo) )
+        dispatch( triggerUpdate(props.selectedMolecule.molNo) )
         props.selectedMolecule.clearBuffersOfStyle('hover')
       
         if(props.onExit) {

--- a/baby-gru/src/components/button/MoorhenRefineResiduesButton.tsx
+++ b/baby-gru/src/components/button/MoorhenRefineResiduesButton.tsx
@@ -4,7 +4,7 @@ import { moorhen } from "../../types/moorhen";
 import { MoorhenContextButtonBase } from "./MoorhenContextButtonBase";
 import { useDispatch, useSelector } from "react-redux";
 import { setHoveredAtom } from "../../store/hoveringStatesSlice";
-import { triggerScoresUpdate } from "../../store/connectedMapsSlice";
+import { triggerUpdate } from "../../store/moleculeMapUpdateSlice";
 
 export const MoorhenRefineResiduesButton = (props: moorhen.ContextButtonProps) => {
     const dispatch = useDispatch()
@@ -29,7 +29,7 @@ export const MoorhenRefineResiduesButton = (props: moorhen.ContextButtonProps) =
         } else  {
             await molecule.refineResiduesUsingAtomCid(`//${chosenAtom.chain_id}/${chosenAtom.res_no}`, 'SPHERE', 4000)
         }
-        dispatch( triggerScoresUpdate(molecule.molNo) )
+        dispatch( triggerUpdate(molecule.molNo) )
     }, [animateRefine])
     
     return <MoorhenContextButtonBase

--- a/baby-gru/src/components/button/MoorhenRotamerChangeButton.tsx
+++ b/baby-gru/src/components/button/MoorhenRotamerChangeButton.tsx
@@ -10,7 +10,7 @@ import { useSelector, useDispatch, batch } from 'react-redux';
 import { setHoveredAtom } from "../../store/hoveringStatesSlice";
 import { removeMolecule } from "../../store/moleculesSlice";
 import { setIsChangingRotamers } from "../../store/generalStatesSlice";
-import { triggerScoresUpdate } from "../../store/connectedMapsSlice";
+import { triggerUpdate } from "../../store/moleculeMapUpdateSlice";
 
 export const MoorhenRotamerChangeButton = (props: moorhen.ContextButtonProps) => {
     const fragmentMolecule = useRef<null | moorhen.Molecule>(null)
@@ -47,7 +47,7 @@ export const MoorhenRotamerChangeButton = (props: moorhen.ContextButtonProps) =>
         fragmentMolecule.current.delete(true)
         chosenMolecule.current.unhideAll()
 
-        dispatch( triggerScoresUpdate(chosenMolecule.current.molNo) )
+        dispatch( triggerUpdate(chosenMolecule.current.molNo) )
         dispatch(setIsChangingRotamers(false))
 
     }, [props.commandCentre, props.glRef])

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -17,7 +17,7 @@ import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
 import { addMolecule } from '../../store/moleculesSlice';
 import { showMolecule } from '../../store/moleculeRepresentationsSlice';
-import { triggerScoresUpdate } from '../../store/connectedMapsSlice';
+import { triggerUpdate } from '../../store/moleculeMapUpdateSlice';
 import { MoorhenCarbohydrateList } from "../list/MoorhenCarbohydrateList";
 
 const allRepresentations = [ 'CBs', 'CAs', 'CRs', 'ligands', 'gaussian', 'MolecularSurface', 'DishyBases', 'VdwSpheres', 'rama', 'rotamer', 'CDs', 'allHBonds','glycoBlocks', 'restraints' ]
@@ -412,13 +412,13 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
     const handleUndo = async () => {
         await props.molecule.undo()
         props.setCurrentDropdownMolNo(-1)
-        dispatch( triggerScoresUpdate(props.molecule.molNo) )
+        dispatch( triggerUpdate(props.molecule.molNo) )
     }
 
     const handleRedo = async () => {
         await props.molecule.redo()
         props.setCurrentDropdownMolNo(-1)
-        dispatch( triggerScoresUpdate(props.molecule.molNo) )
+        dispatch( triggerUpdate(props.molecule.molNo) )
     }
 
     const handleCentering = () => {

--- a/baby-gru/src/components/list/MoorhenCarbohydrateList.tsx
+++ b/baby-gru/src/components/list/MoorhenCarbohydrateList.tsx
@@ -15,8 +15,8 @@ export const MoorhenCarbohydrateList = (props: {
     height?: number | string;
 }) => {
 
-    const scoresUpdateMolNo = useSelector((state: moorhen.State) => state.connectedMaps.scoresUpdate.molNo)
-    const toggleScoresUpdate = useSelector((state: moorhen.State) => state.connectedMaps.scoresUpdate.toggle)
+    const updateMolNo = useSelector((state: moorhen.State) => state.moleculeMapUpdate.moleculeUpdate.molNo)
+    const updateSwitch = useSelector((state: moorhen.State) => state.moleculeMapUpdate.moleculeUpdate.switch)
     const showModelsModal = useSelector((state: moorhen.State) => state.activeModals.showModelsModal)
     
     const [carbohydrateList, setCarbohydrateList] = useState<privateer.ResultsEntry[] | null>(null)
@@ -29,10 +29,10 @@ export const MoorhenCarbohydrateList = (props: {
     }
    
     useEffect(() => {
-        if (props.molecule?.molNo === scoresUpdateMolNo && showModelsModal) {
+        if (props.molecule?.molNo === updateMolNo && showModelsModal) {
             validate()
         }
-    }, [toggleScoresUpdate])
+    }, [updateSwitch])
 
     useEffect(() => {
         if (showModelsModal) {

--- a/baby-gru/src/components/list/MoorhenLigandList.tsx
+++ b/baby-gru/src/components/list/MoorhenLigandList.tsx
@@ -14,8 +14,8 @@ export const MoorhenLigandList = (props: {
     height?: number | string;
 }) => {
 
-    const scoresUpdateMolNo = useSelector((state: moorhen.State) => state.connectedMaps.scoresUpdate.molNo)
-    const toggleScoresUpdate = useSelector((state: moorhen.State) => state.connectedMaps.scoresUpdate.toggle)
+    const updateMolNo = useSelector((state: moorhen.State) => state.moleculeMapUpdate.moleculeUpdate.molNo)
+    const updateSwitch = useSelector((state: moorhen.State) => state.moleculeMapUpdate.moleculeUpdate.switch)
     const showModelsModal = useSelector((state: moorhen.State) => state.activeModals.showModelsModal)
 
     const [ligandList, setLigandList] = useState<moorhen.LigandInfo[]>(null)
@@ -56,10 +56,10 @@ export const MoorhenLigandList = (props: {
     }, [showModelsModal])
     
     useEffect(() => {
-        if (props.molecule?.molNo === scoresUpdateMolNo && showModelsModal) {
+        if (props.molecule?.molNo === updateMolNo && showModelsModal) {
             updateLigandList()
         }
-    }, [toggleScoresUpdate])
+    }, [updateSwitch])
 
     return <>
             {ligandList === null ?

--- a/baby-gru/src/components/menu-item/MoorhenAddSimpleMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenAddSimpleMenuItem.tsx
@@ -5,7 +5,7 @@ import { MoorhenMoleculeSelect } from "../select/MoorhenMoleculeSelect";
 import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
 import { useDispatch, useSelector } from 'react-redux';
-import { triggerScoresUpdate } from "../../store/connectedMapsSlice";
+import { triggerUpdate } from "../../store/moleculeMapUpdateSlice";
 
 export const MoorhenAddSimpleMenuItem = (props: {
     glRef: React.RefObject<webGL.MGWebGL>
@@ -36,7 +36,7 @@ export const MoorhenAddSimpleMenuItem = (props: {
         const selectedMolecule = molecules.find(molecule => molecule.molNo === parseInt(moleculeSelectRef.current.value))
         if (selectedMolecule) {
             await selectedMolecule.addLigandOfType(molTypeSelectRef.current.value)
-            dispatch( triggerScoresUpdate(selectedMolecule.molNo) )
+            dispatch( triggerUpdate(selectedMolecule.molNo) )
         }
     }, [props.glRef, molecules])
 

--- a/baby-gru/src/components/menu-item/MoorhenAddWatersMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenAddWatersMenuItem.tsx
@@ -5,7 +5,7 @@ import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
 import { useDispatch, useSelector } from 'react-redux';
 import { MoorhenMapSelect } from "../select/MoorhenMapSelect";
-import { triggerScoresUpdate } from "../../store/connectedMapsSlice";
+import { triggerUpdate } from "../../store/moleculeMapUpdateSlice";
 
 export const MoorhenAddWatersMenuItem = (props: {
     setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>;
@@ -45,7 +45,7 @@ export const MoorhenAddWatersMenuItem = (props: {
         selectedMolecule.setAtomsDirty(true)
         await selectedMolecule.redraw()
         
-        dispatch( triggerScoresUpdate(moleculeMolNo) )
+        dispatch( triggerUpdate(moleculeMolNo) )
 
     }, [molecules, maps, props.glRef, props.commandCentre])
 

--- a/baby-gru/src/components/menu-item/MoorhenImportFSigFMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenImportFSigFMenuItem.tsx
@@ -6,7 +6,7 @@ import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem"
 import { moorhen } from "../../types/moorhen";
 import { batch, useDispatch, useSelector } from 'react-redux';
 import { setContourLevel } from "../../store/mapContourSettingsSlice"
-import { enableUpdatingMaps, setConnectedMoleculeMolNo, setFoFcMapMolNo, setReflectionMapMolNo, setTwoFoFcMapMolNo } from "../../store/connectedMapsSlice"
+import { enableUpdatingMaps, setConnectedMoleculeMolNo, setFoFcMapMolNo, setReflectionMapMolNo, setTwoFoFcMapMolNo } from "../../store/moleculeMapUpdateSlice"
 
 export const MoorhenImportFSigFMenuItem = (props:{
     selectedMolNo?: number;
@@ -22,7 +22,7 @@ export const MoorhenImportFSigFMenuItem = (props:{
     const dispatch = useDispatch()
     const molecules = useSelector((state: moorhen.State) => state.molecules)
     const maps = useSelector((state: moorhen.State) => state.maps)
-    const connectedMoleculeMolNo = useSelector((state: moorhen.State) => state.connectedMaps.connectedMolecule)
+    const connectedMoleculeMolNo = useSelector((state: moorhen.State) => state.moleculeMapUpdate.connectedMolecule)
 
     const connectMap = async () => {
         const [molecule, reflectionMap, twoFoFcMap, foFcMap] = [

--- a/baby-gru/src/components/menu-item/MoorhenImportLigandDictionary.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenImportLigandDictionary.tsx
@@ -10,7 +10,7 @@ import { webGL } from "../../types/mgWebGL";
 import { libcootApi } from "../../types/libcoot"
 import { useSelector, useDispatch } from 'react-redux';
 import { addMolecule } from "../../store/moleculesSlice"
-import { triggerScoresUpdate } from "../../store/connectedMapsSlice"
+import { triggerUpdate } from "../../store/moleculeMapUpdateSlice"
 
 const MoorhenImportLigandDictionary = (props: { 
     id: string;
@@ -100,7 +100,7 @@ const MoorhenImportLigandDictionary = (props: {
                         const otherMolecules = [newMolecule]
                         await toMolecule.mergeMolecules(otherMolecules, true)
                         await toMolecule.redraw()
-                        dispatch( triggerScoresUpdate(toMolecule.molNo) )
+                        dispatch( triggerUpdate(toMolecule.molNo) )
                     } else {
                         await newMolecule.redraw()
                     }

--- a/baby-gru/src/components/menu-item/MoorhenMergeMoleculesMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenMergeMoleculesMenuItem.tsx
@@ -4,7 +4,7 @@ import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem"
 import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
 import { useDispatch, useSelector } from 'react-redux';
-import { triggerScoresUpdate } from "../../store/connectedMapsSlice";
+import { triggerUpdate } from "../../store/moleculeMapUpdateSlice";
 
 export const MoorhenMergeMoleculesMenuItem = (props: {
     fromMolNo?: null | number; 
@@ -35,7 +35,7 @@ export const MoorhenMergeMoleculesMenuItem = (props: {
         }
         await toMolecule.mergeMolecules(otherMolecules, true)
         props.setPopoverIsShown(false)
-        dispatch( triggerScoresUpdate(toMolecule.molNo) )
+        dispatch( triggerUpdate(toMolecule.molNo) )
     }, [toRef.current, fromRef.current, molecules, props.fromMolNo, props.glRef])
 
     return <MoorhenBaseMenuItem

--- a/baby-gru/src/components/menu-item/MoorhenMoveMoleculeHere.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenMoveMoleculeHere.tsx
@@ -4,7 +4,7 @@ import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem"
 import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
 import { useDispatch, useSelector } from 'react-redux';
-import { triggerScoresUpdate } from "../../store/connectedMapsSlice";
+import { triggerUpdate } from "../../store/moleculeMapUpdateSlice";
 
 export const MoorhenMoveMoleculeHere = (props: {
     popoverPlacement?: 'left' | 'right'
@@ -28,7 +28,7 @@ export const MoorhenMoveMoleculeHere = (props: {
         const selectedMolecule = molecules.find(molecule => molecule.molNo === parseInt(moleculeSelectRef.current.value))
         if (selectedMolecule) {
             await selectedMolecule.moveMoleculeHere(...props.glRef.current.origin.map(coord => -coord) as [number, number, number])
-            dispatch( triggerScoresUpdate(selectedMolecule.molNo) )
+            dispatch( triggerUpdate(selectedMolecule.molNo) )
         }
     }, [molecules])
 

--- a/baby-gru/src/components/menu-item/MoorhenScoresToastPreferencesMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenScoresToastPreferencesMenuItem.tsx
@@ -1,7 +1,7 @@
 import { Form, InputGroup } from "react-bootstrap";
 import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem";
 import { useSelector, useDispatch } from "react-redux";
-import { addMapUpdatingScore, removeMapUpdatingScore, setShowScoresToast } from "../../store/connectedMapsSlice";
+import { addMapUpdatingScore, removeMapUpdatingScore, setShowScoresToast } from "../../store/moleculeMapUpdateSlice";
 import { moorhen } from "../../types/moorhen";
 import { useCallback } from "react";
 
@@ -10,8 +10,8 @@ export const MoorhenScoresToastPreferencesMenuItem = (props: {
 }) => {
 
     const dispatch = useDispatch()
-    const showScoresToast = useSelector((state: moorhen.State) => state.connectedMaps.showScoresToast)
-    const defaultUpdatingScores = useSelector((state: moorhen.State) => state.connectedMaps.defaultUpdatingScores)
+    const showScoresToast = useSelector((state: moorhen.State) => state.moleculeMapUpdate.showScoresToast)
+    const defaultUpdatingScores = useSelector((state: moorhen.State) => state.moleculeMapUpdate.defaultUpdatingScores)
 
     const handleScoreChange = useCallback((score: string) => {
         dispatch(

--- a/baby-gru/src/components/misc/MoorhenAcceptRejectDragAtoms.tsx
+++ b/baby-gru/src/components/misc/MoorhenAcceptRejectDragAtoms.tsx
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useRef } from "react"
 import { cidToSpec } from '../../utils/MoorhenUtils';
 import { webGL } from "../../types/mgWebGL"
 import { setIsDraggingAtoms } from "../../store/generalStatesSlice"
-import { triggerScoresUpdate } from "../../store/connectedMapsSlice"
+import { triggerUpdate } from "../../store/moleculeMapUpdateSlice"
 
 export const MoorhenAcceptRejectDragAtoms = (props: {
     onExit: () => void;
@@ -39,7 +39,7 @@ export const MoorhenAcceptRejectDragAtoms = (props: {
         }
         await props.moleculeRef.current.mergeFragmentFromRefinement(props.cidRef.current.join('||'), moltenFragmentRef.current, acceptTransform, false)
         if (acceptTransform) {
-            dispatch( triggerScoresUpdate(props.moleculeRef.current.molNo) )
+            dispatch( triggerUpdate(props.moleculeRef.current.molNo) )
         }
         dispatch( setIsDraggingAtoms(false) )
     }

--- a/baby-gru/src/components/misc/MoorhenAcceptRejectRotateTranslate.tsx
+++ b/baby-gru/src/components/misc/MoorhenAcceptRejectRotateTranslate.tsx
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { getTooltipShortcutLabel } from '../../utils/MoorhenUtils';
 import { setIsRotatingAtoms } from "../../store/generalStatesSlice"
 import { webGL } from "../../types/mgWebGL"
-import { triggerScoresUpdate } from "../../store/connectedMapsSlice"
+import { triggerUpdate } from "../../store/moleculeMapUpdateSlice"
 
 export const MoorhenAcceptRejectRotateTranslate = (props: {
     onExit: () => void;
@@ -30,7 +30,7 @@ export const MoorhenAcceptRejectRotateTranslate = (props: {
         if (acceptTransform) {
             const transformedAtoms = fragmentMoleculeRef.current.transformedCachedAtomsAsMovedAtoms()
             await props.moleculeRef.current.updateWithMovedAtoms(transformedAtoms)
-            dispatch( triggerScoresUpdate(props.moleculeRef.current.molNo) )
+            dispatch( triggerUpdate(props.moleculeRef.current.molNo) )
         }
         fragmentMoleculeRef.current.delete(true)
         props.moleculeRef.current.unhideAll()

--- a/baby-gru/src/components/misc/MoorhenLongJobNotification.tsx
+++ b/baby-gru/src/components/misc/MoorhenLongJobNotification.tsx
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useState } from "react"
+import { LinearProgress } from "@mui/material"
+import { MoorhenNotification } from "./MoorhenNotification"
+import { Stack } from "react-bootstrap"
+import { moorhen } from "../../types/moorhen"
+import { useSelector } from "react-redux"
+import { sleep } from "../../utils/MoorhenUtils"
+
+export const MoorhenLongJobNotification = (props: { commandCentre: React.RefObject<moorhen.CommandCentre> }) => {
+    
+    const [busy, setBusy] = useState<boolean>(false)
+
+    const newCommandStart = useSelector((state: moorhen.State) => state.generalStates.newCootCommandStart)
+    const newCommandExit = useSelector((state: moorhen.State) => state.generalStates.newCootCommandExit)
+    
+    const checkJobInQueueTooLong = useCallback((messages: string[]) => {
+        if (
+            messages.length > 0
+            && props.commandCentre.current.activeMessages.length > 0 
+            && props.commandCentre.current.activeMessages.some(item => messages.includes(item?.messageId))
+        ) {
+            setBusy(true)
+        }
+    }, [])
+
+    const checkWorkerBusy = useCallback(async () => {
+        for (let i = 0; i < 30; i++) {
+            await sleep(100)
+            if (props.commandCentre.current?.activeMessages.length === 0) {
+                break
+            }
+            if (i === 29) {
+                setBusy(true)
+            }
+        }
+    }, [])
+
+    const debouncedClearBusy = useCallback(() => {
+        if (props.commandCentre.current?.activeMessages.length === 0) {
+            setBusy(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        const messages = props.commandCentre.current?.activeMessages.map(item => item?.messageId)
+        if (props.commandCentre.current?.activeMessages.length > 0) {
+            // Check if any of the jobs in the list spends more than 3 seconds in the queue
+            const timeoutId = setTimeout(() => {
+                checkJobInQueueTooLong(messages)
+            }, 3000)
+            // Check if the worker has at least one job running for the last 3 seconds
+            checkWorkerBusy()
+            // Clear timeout
+            return () => {
+                clearTimeout(timeoutId)
+            }
+        } 
+    }, [newCommandStart, checkWorkerBusy, checkJobInQueueTooLong])
+
+    useEffect(() => {
+        if (props.commandCentre.current?.activeMessages.length === 0) {
+            // If in 500 ms the queue is still empty then the worker is not busy anymore
+            const timeoutId = setTimeout(debouncedClearBusy, 500)
+            return () => {
+                clearTimeout(timeoutId)
+            }
+        }
+    }, [newCommandExit])
+
+    return  busy && <MoorhenNotification placeOnTop={false} width={25}>
+                <Stack gap={1} direction='vertical'>
+                    <span>Please wait...</span>
+                    <LinearProgress/>
+                </Stack>
+            </MoorhenNotification>
+}

--- a/baby-gru/src/components/misc/MoorhenNotification.tsx
+++ b/baby-gru/src/components/misc/MoorhenNotification.tsx
@@ -4,15 +4,17 @@ import { Zoom } from '@mui/material';
 import { useSelector } from 'react-redux';
 import { moorhen } from '../../types/moorhen';
 
-export const MoorhenNotification = (props: {width?: number, hideDelay?: number, children: JSX.Element}) => {
+export const MoorhenNotification = (props: {width?: number, hideDelay?: number, children: JSX.Element, placeOnTop?: boolean}) => {
     const canvasElement = document.getElementById('moorhen-canvas-background')
     let canvasTop: number
+    let canvasBottom: number
     let canvasLeft: number
     let canvasRight: number
     if (canvasElement !== null) {
         const rect = canvasElement.getBoundingClientRect()
         canvasLeft = rect.left
         canvasTop = rect.top
+        canvasBottom = rect.bottom
         canvasRight = rect.right
     } else {
         canvasLeft = 0
@@ -38,7 +40,8 @@ export const MoorhenNotification = (props: {width?: number, hideDelay?: number, 
         style={{
             position: 'absolute',
             width: `${props.width}rem`,
-            top: canvasTop + convertRemToPx(0.5),
+            top: props.placeOnTop ? canvasTop + convertRemToPx(0.5) : null,
+            bottom: !props.placeOnTop ? canvasTop + convertRemToPx(0.5) : null,
             left: canvasLeft + (width / 2) - convertRemToPx(props.width / 2),
             color: isDark ? 'white' : 'grey',
             backgroundColor: isDark ? 'grey' : 'white',
@@ -48,4 +51,4 @@ export const MoorhenNotification = (props: {width?: number, hideDelay?: number, 
         </Zoom>
 }
 
-MoorhenNotification.defaultProps = { width: 14 }
+MoorhenNotification.defaultProps = { width: 14, placeOnTop: true }

--- a/baby-gru/src/components/misc/MoorhenPreferencesContainer.tsx
+++ b/baby-gru/src/components/misc/MoorhenPreferencesContainer.tsx
@@ -4,7 +4,7 @@ import { setDefaultMapLitLines, setDefaultMapSamplingRate, setDefaultMapSurface,
 import { useSelector, useDispatch } from "react-redux"
 import { setContourWheelSensitivityFactor, setMouseSensitivity, setZoomWheelSensitivityFactor } from "../../store/mouseSettings";
 import { setEnableTimeCapsule, setMakeBackups, setMaxBackupCount, setModificationCountBackupThreshold } from "../../store/backupSettingsSlice";
-import { overwriteMapUpdatingScores, setShowScoresToast } from "../../store/connectedMapsSlice";
+import { overwriteMapUpdatingScores, setShowScoresToast } from "../../store/moleculeMapUpdateSlice";
 import { setShortCuts, setShortcutOnHoveredAtom, setShowShortcutToast } from "../../store/shortCutsSlice";
 import { setAtomLabelDepthMode, setGLLabelsFontFamily, setGLLabelsFontSize } from "../../store/labelSettingsSlice";
 import { setClipCap, setDefaultBackgroundColor, setDefaultBondSmoothness, setDepthBlurDepth, setDepthBlurRadius, setDoOutline, setDoPerspectiveProjection, setDoSSAO, setDoShadow, setDoShadowDepthDebug, setDoSpinTest, setDrawAxes, setDrawCrosshairs, setDrawFPS, setDrawInteractions, setDrawMissingLoops, setResetClippingFogging, setSsaoBias, setSsaoRadius, setUseOffScreenBuffers, setDrawScaleBar } from "../../store/sceneSettingsSlice";
@@ -40,8 +40,8 @@ export const MoorhenPreferencesContainer = (props: {
     const shortcutOnHoveredAtom = useSelector((state: moorhen.State) => state.shortcutSettings.shortcutOnHoveredAtom)
 
     // Updating scores
-    const showScoresToast = useSelector((state: moorhen.State) => state.connectedMaps.showScoresToast)
-    const defaultUpdatingScores = useSelector((state: moorhen.State) => state.connectedMaps.defaultUpdatingScores)
+    const showScoresToast = useSelector((state: moorhen.State) => state.moleculeMapUpdate.showScoresToast)
+    const defaultUpdatingScores = useSelector((state: moorhen.State) => state.moleculeMapUpdate.defaultUpdatingScores)
 
     // Label settings
     const atomLabelDepthMode = useSelector((state: moorhen.State) => state.labelSettings.atomLabelDepthMode)

--- a/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
+++ b/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
@@ -12,7 +12,7 @@ import { HexColorInput, HexColorPicker } from "react-colorful"
 import { MoorhenCidInputForm } from "../form/MoorhenCidInputForm"
 import { MoorhenAcceptRejectRotateTranslate } from "./MoorhenAcceptRejectRotateTranslate"
 import { MoorhenAcceptRejectDragAtoms } from "./MoorhenAcceptRejectDragAtoms"
-import { triggerScoresUpdate } from "../../store/connectedMapsSlice"
+import { triggerUpdate } from "../../store/moleculeMapUpdateSlice"
 
 export const MoorhenResidueSelectionActions = (props) => {
 
@@ -188,7 +188,7 @@ export const MoorhenResidueSelectionActions = (props) => {
                 await residueSelection.molecule.refineResidueRange(startResSpec.chain_id, startResSpec.res_no, startResSpec.res_no, 5000, true)
             }
         }
-        dispatch( triggerScoresUpdate(residueSelection.molecule.molNo) )
+        dispatch( triggerUpdate(residueSelection.molecule.molNo) )
         dispatch( clearResidueSelection() )
     }, [residueSelection, animateRefine, activeMap])
 
@@ -211,7 +211,7 @@ export const MoorhenResidueSelectionActions = (props) => {
                 await residueSelection.molecule.delete()
                 dispatch(removeMolecule(residueSelection.molecule))
             }
-            dispatch( triggerScoresUpdate(residueSelection.molecule.molNo) )
+            dispatch( triggerUpdate(residueSelection.molecule.molNo) )
         }
 
         dispatch( clearResidueSelection() )
@@ -342,7 +342,7 @@ export const MoorhenResidueSelectionActions = (props) => {
 
         if (cid) {
             await residueSelection.molecule.rigidBodyFit(cid, activeMap.molNo, true)
-            dispatch( triggerScoresUpdate(residueSelection.molecule.molNo) )
+            dispatch( triggerUpdate(residueSelection.molecule.molNo) )
         }
 
         dispatch( clearResidueSelection() )

--- a/baby-gru/src/components/misc/MoorhenUpdatingMapsToast.tsx
+++ b/baby-gru/src/components/misc/MoorhenUpdatingMapsToast.tsx
@@ -4,7 +4,7 @@ import { convertViewtoPx } from '../../utils/MoorhenUtils';
 import { useDispatch, useSelector } from 'react-redux';
 import { moorhen } from '../../types/moorhen';
 import { webGL } from '../../types/mgWebGL';
-import { disableUpdatingMaps, triggerScoresUpdate } from '../../store/connectedMapsSlice';
+import { disableUpdatingMaps, triggerUpdate } from '../../store/moleculeMapUpdateSlice';
 
 export const MoorhenUpdatingMapsToast = (props: {
     glRef: React.RefObject<webGL.MGWebGL>;
@@ -16,23 +16,23 @@ export const MoorhenUpdatingMapsToast = (props: {
     const [scoresToastContents, setScoreToastContents] = useState<null | JSX.Element>(null)
 
     const dispatch = useDispatch()
-    const scoresUpdateMolNo = useSelector((state: moorhen.State) => state.connectedMaps.scoresUpdate.molNo)
-    const toggleScoresUpdate = useSelector((state: moorhen.State) => state.connectedMaps.scoresUpdate.toggle)
-    const updatingMapsIsEnabled = useSelector((state: moorhen.State) => state.connectedMaps.updatingMapsIsEnabled)
-    const reflectionMap = useSelector((state: moorhen.State) => state.connectedMaps.reflectionMap)
-    const foFcMap = useSelector((state: moorhen.State) => state.connectedMaps.foFcMap)
-    const twoFoFcMap = useSelector((state: moorhen.State) => state.connectedMaps.twoFoFcMap)
-    const uniqueMaps = useSelector((state: moorhen.State) => state.connectedMaps.uniqueMaps)
-    const connectedMoleculeMolNo = useSelector((state: moorhen.State) => state.connectedMaps.connectedMolecule)
+    const updateMolNo = useSelector((state: moorhen.State) => state.moleculeMapUpdate.moleculeUpdate.molNo)
+    const updateSwitch = useSelector((state: moorhen.State) => state.moleculeMapUpdate.moleculeUpdate.switch)
+    const updatingMapsIsEnabled = useSelector((state: moorhen.State) => state.moleculeMapUpdate.updatingMapsIsEnabled)
+    const reflectionMap = useSelector((state: moorhen.State) => state.moleculeMapUpdate.reflectionMap)
+    const foFcMap = useSelector((state: moorhen.State) => state.moleculeMapUpdate.foFcMap)
+    const twoFoFcMap = useSelector((state: moorhen.State) => state.moleculeMapUpdate.twoFoFcMap)
+    const uniqueMaps = useSelector((state: moorhen.State) => state.moleculeMapUpdate.uniqueMaps)
+    const connectedMoleculeMolNo = useSelector((state: moorhen.State) => state.moleculeMapUpdate.connectedMolecule)
     const width = useSelector((state: moorhen.State) => state.sceneSettings.width)
-    const defaultUpdatingScores = useSelector((state: moorhen.State) => state.connectedMaps.defaultUpdatingScores)
-    const showScoresToast = useSelector((state: moorhen.State) => state.connectedMaps.showScoresToast)
+    const defaultUpdatingScores = useSelector((state: moorhen.State) => state.moleculeMapUpdate.defaultUpdatingScores)
+    const showScoresToast = useSelector((state: moorhen.State) => state.moleculeMapUpdate.showScoresToast)
     const maps = useSelector((state: moorhen.State) => state.maps)
     const molecules = useSelector((state: moorhen.State) => state.molecules)
 
     useEffect(() => {
         const handleScoresUpdate = async () => {
-            if (scoresUpdateMolNo !== null && connectedMoleculeMolNo === scoresUpdateMolNo && props.glRef !== null && typeof props.glRef !== 'function') {
+            if (updateMolNo !== null && connectedMoleculeMolNo === updateMolNo && props.glRef !== null && typeof props.glRef !== 'function') {
                 
                 await Promise.all(
                     maps.filter(map => uniqueMaps.includes(map.molNo)).map(map => {
@@ -105,7 +105,7 @@ export const MoorhenUpdatingMapsToast = (props: {
             } 
         }
         handleScoresUpdate()
-    }, [toggleScoresUpdate])
+    }, [updateSwitch])
     
     useEffect(() => {
         const handleConnectMaps = async () => {

--- a/baby-gru/src/components/modal/MoorhenFindLigandModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenFindLigandModal.tsx
@@ -9,7 +9,7 @@ import { MoorhenMoleculeSelect } from "../select/MoorhenMoleculeSelect";
 import { MoorhenNumberForm } from "../select/MoorhenNumberForm";
 import { Backdrop, IconButton, Tooltip } from "@mui/material";
 import { CenterFocusWeakOutlined, CrisisAlertOutlined, MergeTypeOutlined } from "@mui/icons-material";
-import { triggerScoresUpdate } from "../../store/connectedMapsSlice";
+import { triggerUpdate } from "../../store/moleculeMapUpdateSlice";
 
 export const MoorheFindLigandModal = (props: { show: boolean; setShow: React.Dispatch<React.SetStateAction<boolean>>; }) => {    
     const dispatch = useDispatch()
@@ -73,7 +73,7 @@ export const MoorheFindLigandModal = (props: { show: boolean; setShow: React.Dis
                         <Tooltip title="Merge">
                         <IconButton style={{marginRight:'0.5rem'}} onClick={() => {
                             molecule.mergeMolecules([newLigandMolecule], true).then(_ => newLigandMolecule.delete())
-                            dispatch( triggerScoresUpdate(molecule.molNo) )
+                            dispatch( triggerUpdate(molecule.molNo) )
                             setLigandResults((prevLigands) => prevLigands.filter(ligand => ligand.molNo !== newLigandMolecule.molNo))
                         }}>
                             <MergeTypeOutlined/>

--- a/baby-gru/src/components/sequence-viewer/MoorhenSequenceViewer.tsx
+++ b/baby-gru/src/components/sequence-viewer/MoorhenSequenceViewer.tsx
@@ -74,6 +74,8 @@ export const MoorhenSequenceViewer = (props: MoorhenSequenceViewerPropsType) => 
     });
     
     const dispatch = useDispatch()
+    const updateMolNo = useSelector((state: moorhen.State) => state.moleculeMapUpdate.moleculeUpdate.molNo)
+    const updateSwitch = useSelector((state: moorhen.State) => state.moleculeMapUpdate.moleculeUpdate.switch)
     const hoveredAtom = useSelector((state: moorhen.State) => state.hoveringStates.hoveredAtom)
     const residueSelection = useSelector((state: moorhen.State) => state.generalStates.residueSelection)
 
@@ -309,7 +311,16 @@ export const MoorhenSequenceViewer = (props: MoorhenSequenceViewerPropsType) => 
      * Hook used to update the displayed sequence after adding/removing/mutating a residue in the sequence
      */
     useEffect(()=> {
-        const [newRulerStart, newSeqLenght, newDisplaySequence, newStart, newEnd] = parseSequenceData(props.sequence.sequence)
+        if (props.molecule.molNo !== updateMolNo) {
+            return
+        }
+
+        const newSequence = props.molecule.sequences.find(sequence => sequence.name === props.sequence.name)?.sequence
+        if (!newSequence) {
+            return
+        }
+        
+        const [newRulerStart, newSeqLenght, newDisplaySequence, newStart, newEnd] = parseSequenceData(newSequence)
         
         if (newDisplaySequence !== displaySettings.displaySequence) {
             sequenceRef.current.sequence = newDisplaySequence
@@ -322,9 +333,9 @@ export const MoorhenSequenceViewer = (props: MoorhenSequenceViewerPropsType) => 
                 seqLenght: newSeqLenght,
                 displaySequence: newDisplaySequence     
             })
-        }
+        } 
 
-    }, [props.sequence.sequence])
+    }, [updateSwitch])
     
     /**
      * Hook used to clear the current selection if user selects residue from different chain

--- a/baby-gru/src/components/validation-tools/MoorhenFillMissingAtoms.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenFillMissingAtoms.tsx
@@ -3,7 +3,7 @@ import { MoorhenValidationListWidgetBase } from "./MoorhenValidationListWidgetBa
 import { moorhen } from "../../types/moorhen";
 import { libcootApi } from '../../types/libcoot';
 import { useDispatch, useSelector } from 'react-redux';
-import { triggerScoresUpdate } from '../../store/connectedMapsSlice';
+import { triggerUpdate } from '../../store/moleculeMapUpdateSlice';
 import { useCallback } from 'react';
 import { MoorhenResidueSteps } from '../misc/MoorhenResidueSteps';
 import { setNotificationContent } from '../../store/generalStatesSlice';
@@ -41,7 +41,7 @@ export const MoorhenFillMissingAtoms = (props: Props) => {
         }
         selectedMolecule.setAtomsDirty(true)
         await selectedMolecule.redraw()
-        dispatch( triggerScoresUpdate(selectedMolecule.molNo) )
+        dispatch( triggerUpdate(selectedMolecule.molNo) )
     }
 
     const handleAtomFill = (...args: [moorhen.Molecule, string, number, string]) => {

--- a/baby-gru/src/components/validation-tools/MoorhenPepflipsDifferenceMap.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenPepflipsDifferenceMap.tsx
@@ -5,7 +5,7 @@ import { MoorhenSlider } from '../misc/MoorhenSlider'
 import { libcootApi } from "../../types/libcoot";
 import { moorhen } from "../../types/moorhen";
 import { useDispatch, useSelector } from "react-redux";
-import { triggerScoresUpdate } from "../../store/connectedMapsSlice";
+import { triggerUpdate } from "../../store/moleculeMapUpdateSlice";
 import { MoorhenResidueSteps } from '../misc/MoorhenResidueSteps';
 import { setNotificationContent } from '../../store/generalStatesSlice';
 import { cidToSpec, sleep } from '../../utils/MoorhenUtils';
@@ -48,7 +48,7 @@ export const MoorhenPepflipsDifferenceMap = (props: Props) => {
 
         selectedMolecule.setAtomsDirty(true)
         await selectedMolecule.redraw()
-        dispatch( triggerScoresUpdate(selectedMolecule.molNo) )
+        dispatch( triggerUpdate(selectedMolecule.molNo) )
     }
 
     const handleFlip = (...args: [moorhen.Molecule, string, number, string]) => {

--- a/baby-gru/src/components/validation-tools/MoorhenRamachandran.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenRamachandran.tsx
@@ -48,8 +48,8 @@ export const MoorhenRamachandran = (props: Props) => {
     const [molName, setMolName] = useState<null | string>(null)
     const [chainId, setChainId] = useState<null | string>(null)
     
-    const scoresUpdateMolNo = useSelector((state: moorhen.State) => state.connectedMaps.scoresUpdate.molNo)
-    const toggleScoresUpdate = useSelector((state: moorhen.State) => state.connectedMaps.scoresUpdate.toggle)
+    const updateMolNo = useSelector((state: moorhen.State) => state.moleculeMapUpdate.moleculeUpdate.molNo)
+    const updateSwitch = useSelector((state: moorhen.State) => state.moleculeMapUpdate.moleculeUpdate.switch)
     const hoveredAtom = useSelector((state: moorhen.State) => state.hoveringStates.hoveredAtom)
     const width = useSelector((state: moorhen.State) => state.sceneSettings.width)
     const height = useSelector((state: moorhen.State) => state.sceneSettings.height)
@@ -435,10 +435,10 @@ export const MoorhenRamachandran = (props: Props) => {
     }, [selectedModel, selectedChain, fetchRamaData])
 
     useEffect(() => {
-        if (selectedModel === scoresUpdateMolNo && ramaPlotData !== null && selectedModel !== null && chainSelectRef.current.value !== null && molecules.length !== 0) {
+        if (selectedModel === updateMolNo && ramaPlotData !== null && selectedModel !== null && chainSelectRef.current.value !== null && molecules.length !== 0) {
             fetchRamaData()
         }
-    }, [toggleScoresUpdate, fetchRamaData])
+    }, [updateSwitch, fetchRamaData])
 
     useEffect(() => {
         if (molecules.length === 0) {

--- a/baby-gru/src/components/validation-tools/MoorhenValidationChartWidgetBase.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenValidationChartWidgetBase.tsx
@@ -36,8 +36,8 @@ export const MoorhenValidationChartWidgetBase = forwardRef<Chart, ValidationChar
     const [selectedMap, setSelectedMap] = useState<number | null>(null)
     const [selectedChain, setSelectedChain] = useState<string | null>(null)
 
-    const scoresUpdateMolNo = useSelector((state: moorhen.State) => state.connectedMaps.scoresUpdate.molNo)
-    const toggleScoresUpdate = useSelector((state: moorhen.State) => state.connectedMaps.scoresUpdate.toggle)
+    const updateMolNo = useSelector((state: moorhen.State) => state.moleculeMapUpdate.moleculeUpdate.molNo)
+    const updateSwitch = useSelector((state: moorhen.State) => state.moleculeMapUpdate.moleculeUpdate.switch)
     const height = useSelector((state: moorhen.State) => state.sceneSettings.height)
     const backgroundColor = useSelector((state: moorhen.State) => state.sceneSettings.backgroundColor)
     const molecules = useSelector((state: moorhen.State) => state.molecules)
@@ -90,10 +90,10 @@ export const MoorhenValidationChartWidgetBase = forwardRef<Chart, ValidationChar
     }, [selectedChain, selectedMap, selectedModel, props.extraControlFormValue])
 
     useEffect(() => {
-        if (selectedModel !== null  && selectedModel === scoresUpdateMolNo) {
+        if (selectedModel !== null  && selectedModel === updateMolNo) {
             fetchData()
         }
-    }, [toggleScoresUpdate])
+    }, [updateSwitch])
 
     useEffect(() => {
         if (chartRef !== null && typeof chartRef !== 'function' && chartRef.current) {

--- a/baby-gru/src/components/validation-tools/MoorhenValidationListWidgetBase.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenValidationListWidgetBase.tsx
@@ -28,8 +28,8 @@ export const MoorhenValidationListWidgetBase = (props: {
     const [cardList, setCardList] = useState<JSX.Element[]>([])
     const [busy, setBusy] = useState<boolean>(false)
 
-    const scoresUpdateMolNo = useSelector((state: moorhen.State) => state.connectedMaps.scoresUpdate.molNo)
-    const toggleScoresUpdate = useSelector((state: moorhen.State) => state.connectedMaps.scoresUpdate.toggle)
+    const updateMolNo = useSelector((state: moorhen.State) => state.moleculeMapUpdate.moleculeUpdate.molNo)
+    const updateSwitch = useSelector((state: moorhen.State) => state.moleculeMapUpdate.moleculeUpdate.switch)
     const backgroundColor = useSelector((state: moorhen.State) => state.sceneSettings.backgroundColor)
     const molecules = useSelector((state: moorhen.State) => state.molecules)
     const maps = useSelector((state: moorhen.State) => state.maps)
@@ -82,10 +82,10 @@ export const MoorhenValidationListWidgetBase = (props: {
     }, [selectedMap, selectedModel, props.extraControlFormValue])
 
     useEffect(() => {
-        if (selectedModel !== null  && selectedModel === scoresUpdateMolNo) {
+        if (selectedModel !== null  && selectedModel === updateMolNo) {
             fetchData()
         }
-    }, [toggleScoresUpdate])
+    }, [updateSwitch])
 
     useEffect(() => {
         if (selectedModel === null || (props.enableMapSelect && selectedMap === null) || cardData === null || props.dropdownId !== props.accordionDropdownId || !props.showSideBar) {

--- a/baby-gru/src/components/validation-tools/MoorhenWaterValidation.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenWaterValidation.tsx
@@ -5,7 +5,7 @@ import { libcootApi } from "../../types/libcoot";
 import { moorhen } from "../../types/moorhen";
 import { useDispatch, useSelector } from "react-redux";
 import { MoorhenNumberForm } from "../select/MoorhenNumberForm";
-import { triggerScoresUpdate } from "../../store/connectedMapsSlice";
+import { triggerUpdate } from "../../store/moleculeMapUpdateSlice";
 
 interface Props extends moorhen.CollectedProps {
     dropdownId: number;
@@ -50,7 +50,7 @@ export const MoorhenWaterValidation = (props: Props) => {
         if (selectedMolecule) {
             const cid = `/${water.model_number}/${water.chain_id}/${water.res_no}`
             await selectedMolecule.deleteCid(cid)
-            dispatch( triggerScoresUpdate(selectedModel) )
+            dispatch( triggerUpdate(selectedModel) )
         }
     }, [molecules])
 
@@ -59,7 +59,7 @@ export const MoorhenWaterValidation = (props: Props) => {
         if (selectedMolecule) {
             const cid = `/${water.model_number}/${water.chain_id}/${water.res_no}`
             await selectedMolecule.refineResiduesUsingAtomCid(cid, 'SNGLE')
-            dispatch( triggerScoresUpdate(selectedModel) )
+            dispatch( triggerUpdate(selectedModel) )
         }
     }, [molecules])
 

--- a/baby-gru/src/moorhen.ts
+++ b/baby-gru/src/moorhen.ts
@@ -35,7 +35,7 @@ import { setDefaultExpandDisplayCards, setTransparentModalsOnMouseOut, setEnable
 import { addMolecule, removeMolecule, emptyMolecules, addMoleculeList } from './store/moleculesSlice';
 import { setContourWheelSensitivityFactor, setZoomWheelSensitivityFactor, setMouseSensitivity } from './store/mouseSettings';
 import { setShowShortcutToast, setShortcutOnHoveredAtom, setShortCuts } from './store/shortCutsSlice';
-import { setShowScoresToast, addMapUpdatingScore, removeMapUpdatingScore, overwriteMapUpdatingScores } from './store/connectedMapsSlice'
+import { setShowScoresToast, addMapUpdatingScore, removeMapUpdatingScore, overwriteMapUpdatingScores } from './store/moleculeMapUpdateSlice'
 import { showMolecule, hideMolecule } from "./store/moleculeRepresentationsSlice";
 
 export {

--- a/baby-gru/src/store/MoorhenReduxStore.ts
+++ b/baby-gru/src/store/MoorhenReduxStore.ts
@@ -12,7 +12,7 @@ import hoveringStatesReducer from './hoveringStatesSlice'
 import activeModalsReducer from './activeModalsSlice'
 import mapContourSettingsReducer from './mapContourSettingsSlice'
 import moleculeRepresentationsReducer from './moleculeRepresentationsSlice'
-import connectedMapsReducer from './connectedMapsSlice'
+import moleculeMapUpdateReducer from './moleculeMapUpdateSlice'
 
 export default configureStore({
     reducer: {
@@ -29,7 +29,7 @@ export default configureStore({
         activeModals: activeModalsReducer,
         mapContourSettings: mapContourSettingsReducer,
         moleculeRepresentations: moleculeRepresentationsReducer,
-        connectedMaps: connectedMapsReducer,
+        moleculeMapUpdate: moleculeMapUpdateReducer,
     },
     middleware: (getDefaultMiddleware) =>
         getDefaultMiddleware({

--- a/baby-gru/src/store/generalStatesSlice.ts
+++ b/baby-gru/src/store/generalStatesSlice.ts
@@ -17,14 +17,18 @@ export const generalStatesSlice = createSlice({
     isChangingRotamers: false,
     isDraggingAtoms: false,
     isRotatingAtoms: false,
-    newCootCommandAlert: false,
+    newCootCommandExit: false,
+    newCootCommandStart: false,
   },
   reducers: {
     setShowResidueSelection: (state, action: {payload: boolean, type: string}) => {
       return {...state, showResidueSelection: action.payload}
     },
-    toggleCootCommandAlert: (state) => {
-      return {...state, newCootCommandAlert: !state.newCootCommandAlert}
+    toggleCootCommandStart: (state) => {
+      return {...state, newCootCommandStart: !state.newCootCommandStart}
+    },
+    toggleCootCommandExit: (state) => {
+      return {...state, newCootCommandExit: !state.newCootCommandExit}
     },
     setIsChangingRotamers: (state, action: {payload: boolean, type: string}) => {
       return {...state, isChangingRotamers: action.payload}
@@ -88,8 +92,8 @@ export const {
   setAppTittle, setUserPreferencesMounted, setDevMode, setCootInitialized, 
   setStopResidueSelection, setStartResidueSelection, clearResidueSelection,
   setMoleculeResidueSelection, setResidueSelection, setCidResidueSelection,
-  setIsRotatingAtoms, setIsChangingRotamers, toggleCootCommandAlert, 
-  setShowResidueSelection
+  setIsRotatingAtoms, setIsChangingRotamers, setShowResidueSelection,
+  toggleCootCommandExit, toggleCootCommandStart
 } = generalStatesSlice.actions
 
 export default generalStatesSlice.reducer

--- a/baby-gru/src/store/moleculeMapUpdateSlice.ts
+++ b/baby-gru/src/store/moleculeMapUpdateSlice.ts
@@ -1,8 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit'
 import { moorhen } from '../types/moorhen'
 
-export const connectedMapsSlice = createSlice({
-  name: 'connectedMapsSlice',
+export const moleculeMapUpdateSlice = createSlice({
+  name: 'moleculeMapUpdateSlice',
   initialState: {
     updatingMapsIsEnabled: false,
     connectedMolecule: null,
@@ -12,15 +12,15 @@ export const connectedMapsSlice = createSlice({
     uniqueMaps: [],
     defaultUpdatingScores: null,
     showScoresToast: null,
-    scoresUpdate: { toggle: false, molNo: null },
+    moleculeUpdate: { switch: false, molNo: null },
   },
   reducers: {
-    triggerScoresUpdate: (state, action: {payload: number, type: string}) => {
+    triggerUpdate: (state, action: {payload: number, type: string}) => {
         return {
             ...state, 
-            scoresUpdate: {
+            moleculeUpdate: {
                 molNo: action.payload,
-                toggle: !state.scoresUpdate.toggle
+                switch: !state.moleculeUpdate.switch
             }
         }
     },  
@@ -102,7 +102,7 @@ export const {
     setConnectedMolecule, enableUpdatingMaps, disableUpdatingMaps, setReflectionMap,
     setFoFcMap, setTwoFoFcMap, setReflectionMapMolNo, overwriteMapUpdatingScores,
     setConnectedMoleculeMolNo, setFoFcMapMolNo, setTwoFoFcMapMolNo, removeMapUpdatingScore,
-    setShowScoresToast, addMapUpdatingScore, triggerScoresUpdate
-} = connectedMapsSlice.actions
+    setShowScoresToast, addMapUpdatingScore, triggerUpdate
+} = moleculeMapUpdateSlice.actions
 
-export default connectedMapsSlice.reducer
+export default moleculeMapUpdateSlice.reducer

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -812,7 +812,8 @@ export namespace moorhen {
             isChangingRotamers: boolean;
             isDraggingAtoms: boolean;
             isRotatingAtoms: boolean;
-            newCootCommandAlert: boolean;
+            newCootCommandExit: boolean;
+            newCootCommandStart: boolean;        
             showResidueSelection: boolean;
         };
         hoveringStates: {

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -859,7 +859,7 @@ export namespace moorhen {
         moleculeRepresentations: {
             visibleMolecules: number[];
         };
-        connectedMaps: {
+        moleculeMapUpdate: {
             updatingMapsIsEnabled: boolean;
             connectedMolecule: number;
             reflectionMap: number;
@@ -868,7 +868,7 @@ export namespace moorhen {
             uniqueMaps: number[];
             defaultUpdatingScores: string[];
             showScoresToast: boolean;
-            scoresUpdate: {toggle: boolean, molNo: number};
+            moleculeUpdate: { switch: boolean, molNo: number };
         };
     }
     

--- a/baby-gru/src/utils/MoorhenKeyboardAccelerators.tsx
+++ b/baby-gru/src/utils/MoorhenKeyboardAccelerators.tsx
@@ -13,13 +13,13 @@ import { AnyAction } from "@reduxjs/toolkit";
 import { setNotificationContent } from "../store/generalStatesSlice";
 import { setHoveredAtom } from "../store/hoveringStatesSlice";
 import { changeMapRadius } from "../store/mapContourSettingsSlice";
-import { triggerScoresUpdate } from "../store/connectedMapsSlice";
+import { triggerUpdate } from "../store/moleculeMapUpdateSlice";
 
 const apresEdit = (molecule: moorhen.Molecule, glRef: React.RefObject<webGL.MGWebGL>, dispatch: Dispatch<AnyAction>) => {
     molecule.setAtomsDirty(true)
     molecule.redraw()
     dispatch( setHoveredAtom({ molecule: null, cid: null }) )
-    dispatch( triggerScoresUpdate(molecule.molNo) )
+    dispatch( triggerUpdate(molecule.molNo) )
 }
 
 export const babyGruKeyPress = (
@@ -158,7 +158,7 @@ export const babyGruKeyPress = (
             promise = selectedMolecule.redo()
         }
         promise.then(_ => {
-            dispatch( triggerScoresUpdate(selectedMolecule.molNo) )
+            dispatch( triggerUpdate(selectedMolecule.molNo) )
         })
         return false
     }

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -13,7 +13,7 @@ import { addMap, emptyMaps } from "../store/mapsSlice";
 import { batch } from "react-redux";
 import { setActiveMap } from "../store/generalStatesSlice";
 import { setContourLevel, setMapAlpha, setMapColours, setMapRadius, setMapStyle, setNegativeMapColours, setPositiveMapColours } from "../store/mapContourSettingsSlice";
-import { enableUpdatingMaps, setConnectedMoleculeMolNo, setFoFcMapMolNo, setReflectionMapMolNo, setTwoFoFcMapMolNo } from "../store/connectedMapsSlice";
+import { enableUpdatingMaps, setConnectedMoleculeMolNo, setFoFcMapMolNo, setReflectionMapMolNo, setTwoFoFcMapMolNo } from "../store/moleculeMapUpdateSlice";
 import { libcootApi } from "../types/libcoot";
 
 export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))


### PR DESCRIPTION
This update includes:
- A new notification that indicates when the worker is busy over long periods of time
- Refactor redux slice in charge of scores updates and remove unnecessary `cootCommandAlert`
- Update dependencies in sequence viewer hook used to update sequence