### PR TITLE
Move colour by mol. symmetry out of dev mode and make CAs 1.5 times thicker

### DIFF
--- a/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
+++ b/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
@@ -88,7 +88,6 @@ export const MoorhenModifyColourRulesCard = (props: {
     const [sequenceRangeSelect, setSequenceRangeSelect] = useState(null)
     const [ruleList, setRuleList] = useReducer(itemReducer, initialRuleState, () => { return props.molecule.defaultColourRules })
     
-    const devMode = useSelector((state: moorhen.State) => state.generalStates.devMode)
     const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
     const height = useSelector((state: moorhen.State) => state.sceneSettings.height)
     const molecules = useSelector((state: moorhen.State) => state.molecules)
@@ -262,7 +261,7 @@ export const MoorhenModifyColourRulesCard = (props: {
                     <Form.Group style={{ margin: '0px', width: '100%' }}>
                         <Form.Label>Property</Form.Label>
                             <FormSelect size="sm" ref={ruleSelectRef} defaultValue={'b-factor'} onChange={(val) => setColourProperty(val.target.value)}>
-                                {devMode && <option value={'mol-symm'} key={'mol-symm'}>Mol. Symmetry</option>}
+                                <option value={'mol-symm'} key={'mol-symm'}>Mol. Symmetry</option>
                                 <option value={'secondary-structure'} key={'secondary-structure'}>Secondary structure</option>
                                 <option value={'jones-rainbow'} key={'jones-rainbow'}>Jones' rainbow</option>
                                 <option value={'b-factor'} key={'b-factor'}>B-Factor</option>

--- a/baby-gru/src/utils/MoorhenMoleculeRepresentation.ts
+++ b/baby-gru/src/utils/MoorhenMoleculeRepresentation.ts
@@ -426,14 +426,14 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
         ]
         if (this.useDefaultBondOptions) {
             bondSettings.push(
-                name === 'ligands' ? this.parentMolecule.defaultBondOptions.width * 1.5 : this.parentMolecule.defaultBondOptions.width,
-                name === 'ligands' ? this.parentMolecule.defaultBondOptions.atomRadiusBondRatio * 1.5 : this.parentMolecule.defaultBondOptions.atomRadiusBondRatio,
+                (name === 'ligands' || name === 'CAs') ? this.parentMolecule.defaultBondOptions.width * 1.5 : this.parentMolecule.defaultBondOptions.width,
+                (name === 'ligands' || name === 'CAs') ? this.parentMolecule.defaultBondOptions.atomRadiusBondRatio * 1.5 : this.parentMolecule.defaultBondOptions.atomRadiusBondRatio,
                 this.parentMolecule.defaultBondOptions.smoothness
             )
         } else {
             bondSettings.push(
-                name === 'ligands' ? this.bondOptions.width * 1.5 : this.bondOptions.width,
-                name === 'ligands' ? this.bondOptions.atomRadiusBondRatio * 1.5 : this.bondOptions.atomRadiusBondRatio,
+                (name === 'ligands' || name === 'CAs') ? this.bondOptions.width * 1.5 : this.bondOptions.width,
+                (name === 'ligands' || name === 'CAs') ? this.bondOptions.atomRadiusBondRatio * 1.5 : this.bondOptions.atomRadiusBondRatio,
                 this.bondOptions.smoothness    
             )
         }


### PR DESCRIPTION
This update iuncludes:
- Colour by mol. symmetry is now out of dev mode since the current gemmi version can handle chain names with "-" characters.
- C-alpha representations are now 50% thicker as requested