### PR TITLE
Fix ligand represetnations and add option to change NCS colouring

### DIFF
--- a/baby-gru/src/components/card/MoorhenColourRuleCard.tsx
+++ b/baby-gru/src/components/card/MoorhenColourRuleCard.tsx
@@ -1,11 +1,156 @@
 import { useRef, useState } from "react";
-import { Row, Button, Card, Col, OverlayTrigger, Tooltip } from "react-bootstrap";
+import { Row, Button, Card, Col, OverlayTrigger, Tooltip, Form, FormSelect } from "react-bootstrap";
 import { ArrowUpwardOutlined, ArrowDownwardOutlined, DeleteOutlined, GrainOutlined } from '@mui/icons-material';
 import { RgbColorPicker } from "react-colorful";
 import { rgbToHex } from "../../utils/MoorhenUtils";
 import { moorhen } from "../../types/moorhen";
 import { Popover, hexToRgb } from "@mui/material";
 import { useSelector } from "react-redux";
+
+const ColourSwatch = (props: {
+    rule: moorhen.ColourRule;
+    applyColourChange: () => void;
+}) => {
+
+    const colourSwatchRef = useRef<null | HTMLDivElement>(null)
+
+    const [showColourPicker, setShowColourPicker] = useState<boolean>(false)
+
+    const { rule, applyColourChange } = props
+    
+    let [r, g, b]: number[] = []
+    if (!rule.isMultiColourRule) {
+        [r, g, b] = hexToRgb(rule.color).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+    }
+
+
+    const handleColorChange = (color: { r: number; g: number; b: number; }) => {
+        try {
+            rule.color = rgbToHex(color.r, color.g, color.b)
+            if (!rule.isMultiColourRule) rule.args[1] = rule.color 
+            applyColourChange()
+        }
+        catch (err) {
+            console.log('err', err)
+        }
+    }
+
+    return  <>
+        <div ref={colourSwatchRef} onClick={() => setShowColourPicker(true)}
+            style={{
+                marginLeft: '0.5rem',
+                marginRight: '0.5rem',
+                width: '23px',
+                height: '23px',
+                borderRadius: '8px',
+                border: '3px solid #fff',
+                boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 0 0 1px rgba(0, 0, 0, 0.1)',
+                cursor: 'pointer',
+                backgroundColor: `${rule.color}` 
+        }}/>
+        <Popover 
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+            transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+            open={showColourPicker}
+            onClose={() => setShowColourPicker(false)}
+            anchorEl={colourSwatchRef.current}
+            sx={{
+                '& .MuiPaper-root': {
+                    overflowY: 'hidden', borderRadius: '8px'
+                }
+            }}
+        >
+            <RgbColorPicker color={{r, g, b}} onChange={handleColorChange} />
+        </Popover>
+    </>
+}
+
+const NcsColourSwatch = (props: {
+    rule: moorhen.ColourRule;
+    applyColourChange: () => void;
+}) => {
+
+    const ncsSwatchRef = useRef(null)
+    const newNcsHexValueRef = useRef<string>('')
+    const ncsCopySelectRef = useRef<null | HTMLSelectElement>(null)
+
+    const [rgb, setRgb] = useState<{r: number, g: number, b: number}>({r: 100, g: 100, b: 100})
+    const [ncsCopyValue, setNcsCopyValue] = useState<string>('')
+    const [showColourPicker, setShowColourPicker] = useState<boolean>(false)
+
+    const { rule, applyColourChange } = props
+
+    const applyNcsColourChange = () => {
+        const chainNames: string[] = JSON.parse(ncsCopySelectRef.current.value)
+        const newRules = (rule.args[0] as string).split('|').map(item => {
+            const [chainName, hex] = item.split('^')
+            if (chainNames.includes(chainName)) {
+                return `${chainName}^${newNcsHexValueRef.current}`
+            } 
+            return item
+        }).join('|')
+        rule.args[0] = newRules
+        applyColourChange()
+    }
+
+    const handleColorChange = (color: { r: number; g: number; b: number; }) => {
+        try {
+            if (rule.ruleType === 'mol-symm') {
+                newNcsHexValueRef.current = rgbToHex(color.r, color.g, color.b)
+            } else {
+                rule.color = rgbToHex(color.r, color.g, color.b)
+                if (!rule.isMultiColourRule) rule.args[1] = rule.color 
+                applyColourChange()
+            }
+        }
+        catch (err) {
+            console.log('err', err)
+        }
+    }
+
+    return  <>
+        <GrainOutlined ref={ncsSwatchRef} onClick={() => {
+            setShowColourPicker(true)
+            const hex = (rule.args[0] as string).split('|')[0].split('^')[1]
+            const [_r, _g, _b] = hexToRgb(hex).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+            setRgb({r: _r, g: _g, b: _b})
+        }} style={{ cursor: 'pointer', height:'23px', width:'23px', marginLeft: '0.5rem', marginRight: '0.5rem', borderStyle: 'solid', borderColor: '#ced4da', borderWidth: '3px', borderRadius: '8px' }}/>
+        <Popover 
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+            transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+            open={showColourPicker}
+            onClose={() => setShowColourPicker(false)}
+            anchorEl={ncsSwatchRef.current}
+            sx={{
+                '& .MuiPaper-root': {
+                    overflowY: 'hidden', borderRadius: '8px'
+                }
+            }}
+        >
+        <div style={{ padding: '0.5rem', width: '100%', margin: 0, justifyContent: 'center', display: 'flex', flexDirection: 'column'}}>
+            <Form.Group >
+                <Form.Label style={{ justifyContent: 'center', display: 'flex'}}>NCS colours</Form.Label>
+                <FormSelect ref={ncsCopySelectRef} size="sm" style={{marginBottom: '0.2rem'}} value={ncsCopyValue} onChange={(evt) => {
+                    setNcsCopyValue(evt.target.value)
+                    const chainNames = JSON.parse(evt.target.value)
+                    const hex = (rule.args[0] as string).split('|').find(item => item.includes(chainNames[0]))?.split('^')[1]
+                    const [_r, _g, _b] = hexToRgb(hex).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+                    setRgb({r: _r, g: _g, b: _b})
+                }}>
+                    {[...new Set((rule.args[0] as string).split('|').map(item => item.split('^')[1]))].map((hex, index) => {
+                        const chainNames = JSON.stringify((rule.args[0] as string).split('|').filter(item => item.includes(hex)).map(item => item.split('^')[0]))
+                        return <option key={chainNames} value={chainNames}>{`Copy no. ${index+1}`}</option>
+                    })}
+                </FormSelect>
+            </Form.Group>
+            <RgbColorPicker color={rgb} onChange={handleColorChange} />
+            <Button style={{marginTop: '0.2rem'}} onClick={applyNcsColourChange}>
+                Apply
+            </Button>
+        </div>
+        </Popover>
+    </>
+}
 
 export const MoorhenColourRuleCard = (props: {
     molecule: moorhen.Molecule;
@@ -15,11 +160,8 @@ export const MoorhenColourRuleCard = (props: {
     setRuleList: any;
 }) => {
     
-    const colourSwatchRef = useRef<null | HTMLDivElement>(null)
     const busyRedrawing = useRef<boolean>(false)
     const isDirty = useRef<boolean>(false)
-
-    const [showColourPicker, setShowColourPicker] = useState<boolean>(false)
 
     const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
 
@@ -41,20 +183,6 @@ export const MoorhenColourRuleCard = (props: {
         }
     }
 
-    const handleColorChange = (color: { r: number; g: number; b: number; }) => {
-        try {
-            rule.color = rgbToHex(color.r, color.g, color.b)
-            if (!rule.isMultiColourRule) rule.args[1] = rule.color 
-            isDirty.current = true
-            if (!busyRedrawing.current) {
-                redrawIfDirty()
-            }
-        }
-        catch (err) {
-            console.log('err', err)
-        }
-    }
-
     return <Card className='hide-scrolling' style={{margin: '0.1rem', maxWidth: '100%', overflowX:'scroll'}}>
     <Card.Body>
         <Row className='align-items-center'>
@@ -68,34 +196,12 @@ export const MoorhenColourRuleCard = (props: {
             </Col>
             <Col style={{ display: 'flex', justifyContent: 'right', alignItems:'center' }}>
                 {!rule.isMultiColourRule ?
-                <>
-                    <div ref={colourSwatchRef} onClick={() => setShowColourPicker(true)}
-                        style={{
-                            marginLeft: '0.5rem',
-                            marginRight: '0.5rem',
-                            width: '23px',
-                            height: '23px',
-                            borderRadius: '8px',
-                            border: '3px solid #fff',
-                            boxShadow: '0 0 0 1px rgba(0, 0, 0, 0.1), inset 0 0 0 1px rgba(0, 0, 0, 0.1)',
-                            cursor: 'pointer',
-                            backgroundColor: `${rule.color}` 
+                    <ColourSwatch rule={rule} applyColourChange={() => {
+                        isDirty.current = true
+                        if (!busyRedrawing.current) {
+                            redrawIfDirty()
+                        }
                     }}/>
-                    <Popover 
-                        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
-                        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
-                        open={showColourPicker}
-                        onClose={() => setShowColourPicker(false)}
-                        anchorEl={colourSwatchRef.current}
-                        sx={{
-                            '& .MuiPaper-root': {
-                                overflowY: 'hidden', borderRadius: '8px'
-                            }
-                        }}
-                    >
-                        <RgbColorPicker color={{r, g, b}} onChange={handleColorChange} />
-                    </Popover>
-                </>
                 : rule.ruleType === "secondary-structure" ?
                     <img className='colour-rule-icon' src={`${urlPrefix}/baby-gru/pixmaps/secondary-structure-grey.svg`} alt='ss2' style={{height:'28px', width:'`12px', margin: '0.1rem'}}/>
                 : rule.ruleType === "jones-rainbow" ?
@@ -106,7 +212,12 @@ export const MoorhenColourRuleCard = (props: {
                     <div style={{borderColor: 'rgb(0, 0, 255)', borderWidth:'5px', backgroundColor: 'rgb(0, 0, 255)', height:'20px', width:'5px', margin: '0rem', padding: '0rem'}}/>
                 </>
                 : rule.ruleType === "mol-symm" ?
-                    <GrainOutlined style={{height:'23px', width:'23px', marginLeft: '0.5rem', marginRight: '0.5rem', borderStyle: 'solid', borderColor: '#ced4da', borderWidth: '3px', borderRadius: '8px'}}/>            
+                    <NcsColourSwatch rule={rule} applyColourChange={() => {
+                        isDirty.current = true
+                        if (!busyRedrawing.current) {
+                            redrawIfDirty()
+                        }
+                    }}/>
                 : (rule.ruleType === "b-factor" || rule.ruleType === "b-factor-norm") ?
                     <img className="colour-rule-icon" src={`${urlPrefix}/baby-gru/pixmaps/temperature.svg`} alt='b-factor' style={{height:'28px', width:'`12px', margin: '0.1rem'}}/>
                 :

--- a/baby-gru/src/components/card/MoorhenColourRuleCard.tsx
+++ b/baby-gru/src/components/card/MoorhenColourRuleCard.tsx
@@ -13,20 +13,23 @@ const ColourSwatch = (props: {
 }) => {
 
     const colourSwatchRef = useRef<null | HTMLDivElement>(null)
-
-    const [showColourPicker, setShowColourPicker] = useState<boolean>(false)
+    const newHexValueRef = useRef<string>('')
 
     const { rule, applyColourChange } = props
     
     let [r, g, b]: number[] = []
     if (!rule.isMultiColourRule) {
         [r, g, b] = hexToRgb(rule.color).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+    } else {
+        [r, g, b] = [100, 100, 100]
     }
 
+    const [rgb, setRgb] = useState<{r: number, g: number, b: number}>({r, g, b})
+    const [showColourPicker, setShowColourPicker] = useState<boolean>(false)
 
-    const handleColorChange = (color: { r: number; g: number; b: number; }) => {
+    const handleClick = () => {
         try {
-            rule.color = rgbToHex(color.r, color.g, color.b)
+            rule.color = newHexValueRef.current
             if (!rule.isMultiColourRule) rule.args[1] = rule.color 
             applyColourChange()
         }
@@ -60,7 +63,23 @@ const ColourSwatch = (props: {
                 }
             }}
         >
-            <RgbColorPicker color={{r, g, b}} onChange={handleColorChange} />
+        <div style={{ padding: '0.5rem', width: '100%', margin: 0, justifyContent: 'center', display: 'flex', flexDirection: 'column'}}>
+            <RgbColorPicker color={rgb} onChange={(color: { r: number; g: number; b: number; }) => {
+                newHexValueRef.current = rgbToHex(color.r, color.g, color.b)
+                setRgb(color)
+            }}/>
+            <div style={{width: '100%', display: 'flex', justifyContent: 'center'}}>
+                <div className="moorhen-hex-input-decorator">#</div>
+                <HexColorInput className="moorhen-hex-input" color={rgbToHex(rgb.r, rgb.g, rgb.b)} onChange={(hex) => {
+                    const [r, g, b] = hexToRgb(hex).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+                    newHexValueRef.current = rgbToHex(r, g, b)
+                    setRgb({r, g, b})
+                }}/>
+            </div>
+            <Button style={{marginTop: '0.2rem'}} onClick={handleClick}>
+                Apply
+            </Button>
+        </div>
         </Popover>
     </>
 }
@@ -110,8 +129,7 @@ const NcsColourSwatch = (props: {
                 '& .MuiPaper-root': {
                     overflowY: 'hidden', borderRadius: '8px'
                 }
-            }}
-        >
+            }}>
         <div style={{ padding: '0.5rem', width: '100%', margin: 0, justifyContent: 'center', display: 'flex', flexDirection: 'column'}}>
             <Form.Group >
                 <Form.Label style={{ justifyContent: 'center', display: 'flex'}}>NCS colours</Form.Label>

--- a/baby-gru/src/components/card/MoorhenColourRuleCard.tsx
+++ b/baby-gru/src/components/card/MoorhenColourRuleCard.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
 import { Row, Button, Card, Col, OverlayTrigger, Tooltip, Form, FormSelect } from "react-bootstrap";
 import { ArrowUpwardOutlined, ArrowDownwardOutlined, DeleteOutlined, GrainOutlined } from '@mui/icons-material';
-import { RgbColorPicker } from "react-colorful";
+import { HexColorInput, RgbColorPicker } from "react-colorful";
 import { rgbToHex } from "../../utils/MoorhenUtils";
 import { moorhen } from "../../types/moorhen";
 import { Popover, hexToRgb } from "@mui/material";
@@ -93,21 +93,6 @@ const NcsColourSwatch = (props: {
         applyColourChange()
     }
 
-    const handleColorChange = (color: { r: number; g: number; b: number; }) => {
-        try {
-            if (rule.ruleType === 'mol-symm') {
-                newNcsHexValueRef.current = rgbToHex(color.r, color.g, color.b)
-            } else {
-                rule.color = rgbToHex(color.r, color.g, color.b)
-                if (!rule.isMultiColourRule) rule.args[1] = rule.color 
-                applyColourChange()
-            }
-        }
-        catch (err) {
-            console.log('err', err)
-        }
-    }
-
     return  <>
         <GrainOutlined ref={ncsSwatchRef} onClick={() => {
             setShowColourPicker(true)
@@ -143,7 +128,18 @@ const NcsColourSwatch = (props: {
                     })}
                 </FormSelect>
             </Form.Group>
-            <RgbColorPicker color={rgb} onChange={handleColorChange} />
+            <RgbColorPicker color={rgb} onChange={(color: { r: number; g: number; b: number; }) => {
+                newNcsHexValueRef.current = rgbToHex(color.r, color.g, color.b)
+                setRgb(color)
+            }}/>
+            <div style={{width: '100%', display: 'flex', justifyContent: 'center'}}>
+                <div className="moorhen-hex-input-decorator">#</div>
+                <HexColorInput className="moorhen-hex-input" color={rgbToHex(rgb.r, rgb.g, rgb.b)} onChange={(hex) => {
+                    const [r, g, b] = hexToRgb(hex).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+                    newNcsHexValueRef.current = rgbToHex(r, g, b)
+                    setRgb({r, g, b})
+                }}/>
+            </div>
             <Button style={{marginTop: '0.2rem'}} onClick={applyNcsColourChange}>
                 Apply
             </Button>

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -966,13 +966,14 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @param {string} [cid=undefined] - The CID selection for the representation
      */
     show(style: moorhen.RepresentationStyles, cid?: string): void {
-        if (!cid && style === 'ligands') {
-            cid = "/*/*/(!ALA,CYS,ASP,GLU,PHE,GLY,HIS,ILE,LYS,LEU,MET,ASN,PRO,GLN,ARG,SER,THR,VAL,TRP,TYR,WAT,HOH,THP,SEP,TPO,TYP,PTR,OH2,H2O)"
-        } else if (!cid) {
-            cid = '/*/*/*/*'
-        }
+        let representation: moorhen.MoleculeRepresentation
         try {
-            const representation = this.representations.find(item => item.style === style && item.cid === cid)
+            if (style === 'ligands') {
+                representation = this.representations.find(item => item.style === style)
+            } else {
+                if (!cid) cid = '/*/*/*/*'
+                representation = this.representations.find(item => item.style === style && item.cid === cid)
+            }
             if (representation) {
                 representation.show()
             } else {
@@ -989,13 +990,14 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @param {string} [cid=undefined] - The CID selection for the representation
      */
     hide(style: moorhen.RepresentationStyles, cid?: string) {
-        if (!cid && style === 'ligands') {
-            cid = "/*/*/(!ALA,CYS,ASP,GLU,PHE,GLY,HIS,ILE,LYS,LEU,MET,ASN,PRO,GLN,ARG,SER,THR,VAL,TRP,TYR,WAT,HOH,THP,SEP,TPO,TYP,PTR,OH2,H2O)"
-        } else if (!cid) {
-            cid = '/*/*/*/*'
-        }
+        let representation: moorhen.MoleculeRepresentation
         try {
-            const representation = this.representations.find(item => item.style === style && item.cid === cid)
+            if (style === 'ligands') {
+                representation = this.representations.find(item => item.style === style)
+            } else {
+                if (!cid) cid = '/*/*/*/*'
+                representation = this.representations.find(item => item.style === style && item.cid === cid)
+            }
             if (representation) {
                 representation.hide()
             }


### PR DESCRIPTION
This update includes:
- Now ligand representations use CIDs determined using `gemmi` instead of a blanket assignment of non-standard residues. This fixes issues where DNA would be treated as a ligand and standard residues that are actual ligands were not recognised as such (like in PDB entry 2NW8)
- Added an option to change colours assigned to NCS copies after creating a NCS colour rule. This resolves #308.
- Added hex input boxes that can be used when changing colours of already existing colour rules.