### PR TITLE
Add adaptative bonds and changeChainID to moorhenMolecule

### DIFF
--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -158,7 +158,6 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
         if (moleculeMolNo === props.molecule.molNo) {
             await props.molecule.drawAdaptativeBonds(residueCid, 10)
         }
-
     }
 
     const handleOriginUpdate = useCallback(() => {

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -147,6 +147,20 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
         }
     }
 
+    const redrawAdaptativeBonds = async () => {
+        const response = await props.commandCentre.current.cootCommand({
+            returnType: "int_string_pair",
+            command: "get_active_atom",
+            commandArgs: [...props.glRef.current.origin.map(coord => coord * -1), props.molecule.molNo.toString()]
+        }, false) as moorhen.WorkerResponse<libcootApi.PairType<number, string>>
+        const moleculeMolNo: number = response.data.result.result.first
+        const residueCid: string = response.data.result.result.second
+        if (moleculeMolNo === props.molecule.molNo) {
+            await props.molecule.drawAdaptativeBonds(residueCid, 10)
+        }
+
+    }
+
     const handleOriginUpdate = useCallback(() => {
         isDirty.current = true
         if (!busyRedrawing.current) {

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -19,6 +19,7 @@ import { addMolecule } from '../../store/moleculesSlice';
 import { showMolecule } from '../../store/moleculeRepresentationsSlice';
 import { triggerUpdate } from '../../store/moleculeMapUpdateSlice';
 import { MoorhenCarbohydrateList } from "../list/MoorhenCarbohydrateList";
+import { libcootApi } from '../../types/libcoot';
 
 const allRepresentations = [ 'CBs', 'CAs', 'CRs', 'ligands', 'gaussian', 'MolecularSurface', 'DishyBases', 'VdwSpheres', 'rama', 'rotamer', 'CDs', 'allHBonds','glycoBlocks', 'restraints' ]
 

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -120,6 +120,7 @@ declare module 'moorhen' {
         getPrivateerValidation(useCache?: boolean): Promise<privateer.ResultsEntry[]>;
         getLigandSVG(resName: string, useCache?: boolean): Promise<string>;
         isValidSelection(cid: string): Promise<boolean>;
+        changeChainId(oldId: string, newId: string, startResNo?: number, endResNo?: number): Promise<number>;
         cachedLigandSVGs: {[key: string]: string}[];
         cachedPrivateerValidation: privateer.ResultsEntry[];
         isLigand: boolean;

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -121,6 +121,7 @@ declare module 'moorhen' {
         getLigandSVG(resName: string, useCache?: boolean): Promise<string>;
         isValidSelection(cid: string): Promise<boolean>;
         changeChainId(oldId: string, newId: string, startResNo?: number, endResNo?: number): Promise<number>;
+        drawAdaptativeBonds(selectionString?: string, maxDist?: number): Promise<void>;
         cachedLigandSVGs: {[key: string]: string}[];
         cachedPrivateerValidation: privateer.ResultsEntry[];
         isLigand: boolean;
@@ -156,6 +157,7 @@ declare module 'moorhen' {
         defaultColourRules: _moorhen.ColourRule[];
         restraints: {maxRadius: number, cid: string}[];
         monomerLibraryPath: string;
+        adaptativeBondsRepresentation: { bonds: _moorhen.MoleculeRepresentation; alphas: _moorhen.MoleculeRepresentation };
         hoverRepresentation: _moorhen.MoleculeRepresentation;
         unitCellRepresentation: _moorhen.MoleculeRepresentation;
         environmentRepresentation: _moorhen.MoleculeRepresentation;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -92,6 +92,7 @@ export namespace moorhen {
     type coorFormats = 'pdb' | 'mmcif';
     
     interface Molecule {
+        changeChainId(oldId: string, newId: string, startResNo?: number, endResNo?: number): Promise<number>;
         refineResiduesUsingAtomCidAnimated(cid: string, activeMap: moorhen.Map, dist?: number, redraw?: boolean, redrawFragmentFirst?: boolean): Promise<void>;
         mergeFragmentFromRefinement(cid: string, fragmentMolecule: moorhen.Molecule, acceptTransform?: boolean, refineAfterMerge?: boolean): Promise<void>;
         copyFragmentForRefinement(cid: string[], refinementMap: moorhen.Map, redraw?: boolean, readrawFragmentFirst?: boolean): Promise<moorhen.Molecule>;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -92,6 +92,7 @@ export namespace moorhen {
     type coorFormats = 'pdb' | 'mmcif';
     
     interface Molecule {
+        drawAdaptativeBonds(selectionString?: string, maxDist?: number): Promise<void>;
         changeChainId(oldId: string, newId: string, startResNo?: number, endResNo?: number): Promise<number>;
         refineResiduesUsingAtomCidAnimated(cid: string, activeMap: moorhen.Map, dist?: number, redraw?: boolean, redrawFragmentFirst?: boolean): Promise<void>;
         mergeFragmentFromRefinement(cid: string, fragmentMolecule: moorhen.Molecule, acceptTransform?: boolean, refineAfterMerge?: boolean): Promise<void>;
@@ -198,6 +199,7 @@ export namespace moorhen {
         defaultColourRules: ColourRule[];
         restraints: {maxRadius: number, cid: string}[];
         monomerLibraryPath: string;
+        adaptativeBondsRepresentation: { bonds: moorhen.MoleculeRepresentation; alphas: moorhen.MoleculeRepresentation };
         hoverRepresentation: MoleculeRepresentation;
         unitCellRepresentation: MoleculeRepresentation;
         environmentRepresentation: MoleculeRepresentation;

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -2051,4 +2051,26 @@ export class MoorhenMolecule implements moorhen.Molecule {
 
         return ligandSVG
     }
+
+    /**
+     * Change the ID of a given chain
+     * @param {string} oldId - The old chain ID
+     * @param {string} newId - The new chain ID
+     * @param {number} startResNo - The start residue number
+     * @param {number} endResNo - The end residue number
+     * @returns {number} - Status code -1 on a conflict, 1 on good, 0 on did nothing
+     */
+    async changeChainId(oldId: string, newId: string, startResNo?: number, endResNo?: number): Promise<number> {
+        const status = await this.commandCentre.current.cootCommand({
+            returnType: 'int',
+            command: 'change_chain_id',
+            commandArgs: [ this.molNo, oldId, newId, (startResNo !== undefined && endResNo !== undefined), startResNo ? startResNo : 0, endResNo ? endResNo : 0 ],
+        }, false) as moorhen.WorkerResponse<number>
+        
+        if (status.data.result.result !== 0) {
+            this.setAtomsDirty(true)
+        }
+        
+        return status.data.result.result
+    }
 }

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -81,6 +81,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
     uniqueId: string;
     monomerLibraryPath: string;
     defaultColourRules: moorhen.ColourRule[];
+    adaptativeBondsRepresentation: { bonds: moorhen.MoleculeRepresentation; alphas: moorhen.MoleculeRepresentation };
     hoverRepresentation: moorhen.MoleculeRepresentation;
     unitCellRepresentation: moorhen.MoleculeRepresentation;
     environmentRepresentation: moorhen.MoleculeRepresentation;
@@ -93,6 +94,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
     cachedPrivateerValidation: privateer.ResultsEntry[];
     cachedLigandSVGs: {[key: string]: string}[];
     moleculeDiameter: number;
+    adaptativeBondsEnabled: boolean;
 
     constructor(commandCentre: React.RefObject<moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, monomerLibraryPath = "./baby-gru/monomers") {
         this.type = 'molecule'
@@ -130,6 +132,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
             atomRadiusBondRatio: 1
         }
         this.restraints = []
+        this.adaptativeBondsEnabled = false
         this.hasDNA = false
         this.hasGlycans = false
         this.isLigand = false
@@ -146,6 +149,12 @@ export class MoorhenMolecule implements moorhen.Molecule {
         this.hoverRepresentation.setParentMolecule(this)
         this.selectionRepresentation = new MoorhenMoleculeRepresentation('residueSelection', null, this.commandCentre, this.glRef)
         this.selectionRepresentation.setParentMolecule(this)
+        this.adaptativeBondsRepresentation = {
+            bonds: new MoorhenMoleculeRepresentation('CBs', null, this.commandCentre, this.glRef),
+            alphas: new MoorhenMoleculeRepresentation('CAs', '/*/*/*/*', this.commandCentre, this.glRef)
+        }
+        this.adaptativeBondsRepresentation.bonds.setParentMolecule(this)
+        this.adaptativeBondsRepresentation.alphas.setParentMolecule(this)
     }
 
     /**
@@ -349,6 +358,8 @@ export class MoorhenMolecule implements moorhen.Molecule {
         this.unitCellRepresentation?.deleteBuffers()
         this.environmentRepresentation?.deleteBuffers()
         this.selectionRepresentation?.deleteBuffers()
+        this.adaptativeBondsRepresentation?.bonds.deleteBuffers()
+        this.adaptativeBondsRepresentation?.alphas.deleteBuffers()
         this.representations.forEach(representation => representation.deleteBuffers())
         this.glRef.current.drawScene()
         const response = await this.commandCentre.current.cootCommand({
@@ -452,7 +463,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
                         returnType:'status',
                         commandArgs: [ false ],
                     }, false)
-                }    
+                }
                 await Promise.all(cid.map(cid => {
                     return this.hideCid(cid, false)
                 }))
@@ -1035,6 +1046,9 @@ export class MoorhenMolecule implements moorhen.Molecule {
             this.environmentRepresentation?.deleteBuffers()
         } else if (style === 'residueSelection') {
             this.selectionRepresentation?.deleteBuffers()
+        } else if (style === 'adaptativeBonds') {
+            this.adaptativeBondsRepresentation?.bonds.deleteBuffers()
+            this.adaptativeBondsRepresentation?.alphas.deleteBuffers()   
         } else {
             this.representations.forEach(representation => representation.style === style ? representation.deleteBuffers() : null)
             this.representations = this.representations.filter(representation => representation.style !== style)
@@ -1056,20 +1070,29 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @returns {boolean} True if the buffer is included in this molecule
      */
     buffersInclude(bufferIn: { id: string; }): boolean {
-        const BreakException = {};
         try {
-            this.representations.forEach(representation => {
+            for (let representation of this.representations) {
                 if (Array.isArray(representation.buffers)) {
-                    const matchedBuffer = representation.buffers.find(buffer => bufferIn.id === buffer.id)
-                    if (matchedBuffer) {
-                        throw BreakException;
+                    for (let buffer of representation.buffers) {
+                        if (bufferIn.id === buffer.id) {
+                            return true
+                        }
+                    }
+                }   
+            }
+            if (this.adaptativeBondsEnabled) {
+                for (let key in this.adaptativeBondsRepresentation) {
+                    for (let buffer of this.adaptativeBondsRepresentation[key].buffers) {
+                        if (bufferIn.id === buffer.id) {
+                            return true
+                        }
                     }
                 }
-            })
+            }
         }
         catch (e) {
-            if (e !== BreakException) throw e;
-            return true
+            console.log(e);
+            return false
         }
         return false
     }
@@ -1108,6 +1131,73 @@ export class MoorhenMolecule implements moorhen.Molecule {
     }
 
     /**
+     * Draw bonds for a given glRef origin
+     * @param {string} selectionString - The CID selection for the residues that will be highlighted
+     * @param {number} maxDist - The maximum distance from the central residue to draw bonds
+     */
+    async drawAdaptativeBonds(selectionString?: string, maxDist: number = 8): Promise<void> {
+        let neighBoringResidues: string[] = []
+        if (!selectionString && !this.adaptativeBondsRepresentation.bonds.cid) {
+            console.warn(`No selection string provided when drawing origin bonds`)
+            this.adaptativeBondsEnabled = false
+            return
+        } else if (!selectionString) {
+            neighBoringResidues = this.adaptativeBondsRepresentation.bonds.cid.split('||')
+        } else {
+            neighBoringResidues = await this.getNeighborResiduesCids(selectionString, maxDist)
+            this.adaptativeBondsRepresentation.bonds.cid = neighBoringResidues.join('||')   
+        }
+
+        this.adaptativeBondsEnabled = true
+        const drawMissingLoops = MoorhenReduxStore.getState().sceneSettings.drawMissingLoops
+        
+        await Promise.all(neighBoringResidues.map(i => {
+            this.commandCentre.current.cootCommand({
+                message: 'coot_command',
+                command: "add_to_non_drawn_bonds",
+                returnType: 'status',
+                commandArgs: [this.molNo, i],
+            }, false)
+        }))
+
+        await this.adaptativeBondsRepresentation.alphas.redraw()
+
+        if (drawMissingLoops) {
+            await this.commandCentre.current.cootCommand({
+                command: "set_draw_missing_residue_loops",
+                returnType:'status',
+                commandArgs: [ false ],
+            }, false)
+        }
+
+        await this.adaptativeBondsRepresentation.bonds.redraw()
+
+        if (drawMissingLoops) {
+            await this.commandCentre.current.cootCommand({
+                command: "set_draw_missing_residue_loops",
+                returnType:'status',
+                commandArgs: [ true ],
+            }, false)
+        }
+
+        await this.commandCentre.current.cootCommand({
+            message: 'coot_command',
+            command: "clear_non_drawn_bonds",
+            returnType: 'status',
+            commandArgs: [this.molNo],
+        }, false)    
+
+        await Promise.all(this.excludedSelections.map(i => {
+            this.commandCentre.current.cootCommand({
+                message: 'coot_command',
+                command: "add_to_non_drawn_bonds",
+                returnType: 'status',
+                commandArgs: [this.molNo, i],
+            }, false)
+        }))
+    }
+
+    /**
      * Draw enviroment distances for a given residue
      * @param {string} selectionCid - The CID
      * @param {boolean} [labelled=false] - Indicates whether the distances should be labelled
@@ -1138,6 +1228,10 @@ export class MoorhenMolecule implements moorhen.Molecule {
             } else {
                 representation.deleteBuffers()
             }
+        }
+
+        if (this.adaptativeBondsEnabled) {
+            await this.drawAdaptativeBonds()
         }
 
         await this.drawSymmetry(false)

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -1273,6 +1273,219 @@ describe('Testing molecules_container_js', () => {
         cleanUpVariables.push(instanceMesh_1, instanceMesh_2)
     })
 
+    test("Test colour rules and bond mesh", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
+        const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
+
+        const instanceMesh_1 = molecules_container.get_bonds_mesh_instanced(
+            coordMolNo, 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1
+        )
+        
+        const geom_1 = instanceMesh_1.geom
+        const geomSize_1 = geom_1.size()
+        let colours_1 = []
+        for (let i = 0; i < geomSize_1; i++) {
+            const inst = geom_1.get(i);
+            const As = inst.instancing_data_A;
+            const Asize = As.size();
+    
+            for (let j = 0; j < Asize; j++) {
+                const inst_data = As.get(j)
+                const instDataColour = inst_data.colour
+                colours_1.push(instDataColour[0])
+                colours_1.push(instDataColour[1])
+                colours_1.push(instDataColour[2])
+                colours_1.push(instDataColour[3])    
+            }
+            As.delete()
+        }
+
+        let colourMap = new cootModule.MapIntFloat3()
+        let indexedResiduesVec = new cootModule.VectorStringUInt_pair()
+        
+        const colours = [
+            { cid: "//A/12-15", rgb: [1, 0, 0] }
+        ]
+        colours.forEach((colour, index) => {
+            colourMap.set(index + 51, colour.rgb)
+            const i = { first: colour.cid, second: index + 51 }
+            indexedResiduesVec.push_back(i)
+        })
+    
+        molecules_container.set_user_defined_bond_colours(coordMolNo, colourMap)
+        molecules_container.set_user_defined_atom_colour_by_selection(coordMolNo, indexedResiduesVec, false)
+
+        const instanceMesh_2 = molecules_container.get_bonds_mesh_instanced(
+            coordMolNo, 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1
+        )
+
+        const geom_2 = instanceMesh_2.geom
+        const geomSize_2 = geom_2.size()
+        let colours_2 = []
+        for (let i = 0; i < geomSize_2; i++) {
+            const inst = geom_2.get(i);
+            const As = inst.instancing_data_A;
+            const Asize = As.size();
+    
+            for (let j = 0; j < Asize; j++) {
+                const inst_data = As.get(j)
+                const instDataColour = inst_data.colour
+                colours_2.push(instDataColour[0])
+                colours_2.push(instDataColour[1])
+                colours_2.push(instDataColour[2])
+                colours_2.push(instDataColour[3])    
+            }
+            As.delete()
+        }
+
+        expect(colours_2).not.toEqual(colours_1)
+
+        cleanUpVariables.push(instanceMesh_1, instanceMesh_2, indexedResiduesVec, colourMap, geom_2, geom_1)
+    })
+
+
+    test("Test colour rules and multi CID selection mesh --first", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
+        const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
+
+        const instanceMesh_1 = molecules_container.get_bonds_mesh_for_selection_instanced(
+            coordMolNo, '//A/10-20||//A/25-30', 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1
+        )
+        
+        const geom_1 = instanceMesh_1.geom
+        const geomSize_1 = geom_1.size()
+        let colours_1 = []
+        for (let i = 0; i < geomSize_1; i++) {
+            const inst = geom_1.get(i);
+            const As = inst.instancing_data_A;
+            const Asize = As.size();
+    
+            for (let j = 0; j < Asize; j++) {
+                const inst_data = As.get(j)
+                const instDataColour = inst_data.colour
+                colours_1.push(instDataColour[0])
+                colours_1.push(instDataColour[1])
+                colours_1.push(instDataColour[2])
+                colours_1.push(instDataColour[3])    
+            }
+            As.delete()
+        }
+
+        let colourMap = new cootModule.MapIntFloat3()
+        let indexedResiduesVec = new cootModule.VectorStringUInt_pair()
+        
+        const colours = [
+            { cid: "//A/12-15", rgb: [1, 0, 0] }
+        ]
+        colours.forEach((colour, index) => {
+            colourMap.set(index + 51, colour.rgb)
+            const i = { first: colour.cid, second: index + 51 }
+            indexedResiduesVec.push_back(i)
+        })
+    
+        molecules_container.set_user_defined_bond_colours(coordMolNo, colourMap)
+        molecules_container.set_user_defined_atom_colour_by_selection(coordMolNo, indexedResiduesVec, false)
+
+        const instanceMesh_2 = molecules_container.get_bonds_mesh_for_selection_instanced(
+            coordMolNo, '//A/10-20||//A/25-30', 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1
+        )
+
+        const geom_2 = instanceMesh_2.geom
+        const geomSize_2 = geom_2.size()
+        let colours_2 = []
+        for (let i = 0; i < geomSize_2; i++) {
+            const inst = geom_2.get(i);
+            const As = inst.instancing_data_A;
+            const Asize = As.size();
+    
+            for (let j = 0; j < Asize; j++) {
+                const inst_data = As.get(j)
+                const instDataColour = inst_data.colour
+                colours_2.push(instDataColour[0])
+                colours_2.push(instDataColour[1])
+                colours_2.push(instDataColour[2])
+                colours_2.push(instDataColour[3])    
+            }
+            As.delete()
+        }
+
+        expect(colours_2).not.toEqual(colours_1)
+
+        cleanUpVariables.push(instanceMesh_1, instanceMesh_2, indexedResiduesVec, colourMap, geom_2, geom_1)
+    })
+
+    test("Test colour rules and multi CID selection mesh --second", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
+        const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
+
+        const instanceMesh_1 = molecules_container.get_bonds_mesh_for_selection_instanced(
+            coordMolNo, '//A/10-20||//A/25-30', 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1
+        )
+        
+        const geom_1 = instanceMesh_1.geom
+        const geomSize_1 = geom_1.size()
+        let colours_1 = []
+        for (let i = 0; i < geomSize_1; i++) {
+            const inst = geom_1.get(i);
+            const As = inst.instancing_data_A;
+            const Asize = As.size();
+    
+            for (let j = 0; j < Asize; j++) {
+                const inst_data = As.get(j)
+                const instDataColour = inst_data.colour
+                colours_1.push(instDataColour[0])
+                colours_1.push(instDataColour[1])
+                colours_1.push(instDataColour[2])
+                colours_1.push(instDataColour[3])    
+            }
+            As.delete()
+        }
+
+        let colourMap = new cootModule.MapIntFloat3()
+        let indexedResiduesVec = new cootModule.VectorStringUInt_pair()
+        
+        const colours = [
+            { cid: "//A/26-29", rgb: [1, 0, 0] }
+        ]
+        colours.forEach((colour, index) => {
+            colourMap.set(index + 51, colour.rgb)
+            const i = { first: colour.cid, second: index + 51 }
+            indexedResiduesVec.push_back(i)
+        })
+    
+        molecules_container.set_user_defined_bond_colours(coordMolNo, colourMap)
+        molecules_container.set_user_defined_atom_colour_by_selection(coordMolNo, indexedResiduesVec, false)
+
+        const instanceMesh_2 = molecules_container.get_bonds_mesh_for_selection_instanced(
+            coordMolNo, '//A/10-20||//A/25-30', 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1
+        )
+
+        const geom_2 = instanceMesh_2.geom
+        const geomSize_2 = geom_2.size()
+        let colours_2 = []
+        for (let i = 0; i < geomSize_2; i++) {
+            const inst = geom_2.get(i);
+            const As = inst.instancing_data_A;
+            const Asize = As.size();
+    
+            for (let j = 0; j < Asize; j++) {
+                const inst_data = As.get(j)
+                const instDataColour = inst_data.colour
+                colours_2.push(instDataColour[0])
+                colours_2.push(instDataColour[1])
+                colours_2.push(instDataColour[2])
+                colours_2.push(instDataColour[3])    
+            }
+            As.delete()
+        }
+
+        expect(colours_2).not.toEqual(colours_1)
+
+        cleanUpVariables.push(instanceMesh_1, instanceMesh_2, indexedResiduesVec, colourMap, geom_2, geom_1)
+    })
 
     test("Test non-drawn bonds and bonds mesh", () => {
         const molecules_container = new cootModule.molecules_container_js(false)

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -1249,6 +1249,55 @@ describe('Testing molecules_container_js', () => {
         expect(diameter).toBeCloseTo(43.90, 1)
     })
 
+    test("Test non-drawn bonds and selection mesh", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
+        const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
+
+        const instanceMesh_1 = molecules_container.get_bonds_mesh_for_selection_instanced(
+            coordMolNo, '//A/10-20', 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1
+        )
+        
+        molecules_container.add_to_non_drawn_bonds(coordMolNo, '//A/12-15')
+
+        const instanceMesh_2 = molecules_container.get_bonds_mesh_for_selection_instanced(
+            coordMolNo, '//A/10-20', 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1
+        )
+
+        expect(
+            instanceMesh_2.geom.get(1).instancing_data_B.size()
+        ).not.toBe(
+            instanceMesh_1.geom.get(1).instancing_data_B.size()
+        )
+
+        cleanUpVariables.push(instanceMesh_1, instanceMesh_2)
+    })
+
+
+    test("Test non-drawn bonds and bonds mesh", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
+        const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
+
+        const instanceMesh_1 = molecules_container.get_bonds_mesh_instanced(
+            coordMolNo, 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1
+        )
+        
+        molecules_container.add_to_non_drawn_bonds(coordMolNo, '//A/12-15')
+
+        const instanceMesh_2 = molecules_container.get_bonds_mesh_instanced(
+            coordMolNo, 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1
+        )
+
+        expect(
+            instanceMesh_2.geom.get(1).instancing_data_B.size()
+        ).not.toBe(
+            instanceMesh_1.geom.get(1).instancing_data_B.size()
+        )
+
+        cleanUpVariables.push(instanceMesh_1, instanceMesh_2)
+    })
+
 })
 
 const testDataFiles = ['1cxq_phases.mtz', '1cxq.cif', '7ZTVU.cif', '5fjj.pdb', '5a3h.pdb', '5a3h.mmcif', '5a3h_no_ligand.pdb', 'MOI.restraints.cif', 'LZA.cif', 'nitrobenzene.cif', 'benzene.cif', '5a3h_sigmaa.mtz', 'rnasa-1.8-all_refmac1.mtz', 'tm-A.pdb']

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -1534,7 +1534,7 @@ describe('Testing molecules_container_js', () => {
 
         cleanUpVariables.push(instanceMesh_1, instanceMesh_2)
     })
-    
+
     test("Test non-drawn bonds and bonds mesh", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         molecules_container.set_use_gemmi(false)
@@ -1559,6 +1559,80 @@ describe('Testing molecules_container_js', () => {
         cleanUpVariables.push(instanceMesh_1, instanceMesh_2)
     })
 
+    test.only("Test change chain ID", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
+        const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
+
+        let original_chains = []
+        const original_chains_vec = molecules_container.get_chains_in_model(coordMolNo)
+        const original_chains_vec_size = original_chains_vec.size()
+        for (let i = 0; i < original_chains_vec_size; i++) {
+            const chain_name = original_chains_vec.get(i)
+            original_chains.push(chain_name)
+        }
+
+        molecules_container.change_chain_id(coordMolNo, 'A', 'X', false, 0, 0)
+        
+        let new_chains = []
+        const new_chains_vec = molecules_container.get_chains_in_model(coordMolNo)
+        const new_chains_vec_size = new_chains_vec.size()
+        for (let i = 0; i < new_chains_vec_size; i++) {
+            const chain_name = new_chains_vec.get(i)
+            new_chains.push(chain_name)
+        }
+
+        expect(new_chains).not.toEqual(original_chains)
+        expect(original_chains.includes('X')).toBeFalsy()
+        expect(new_chains.includes('X')).toBeTruthy()
+
+        cleanUpVariables.push(original_chains_vec, new_chains_vec)
+    })
+
+    test.only("Test change chain ID", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
+        const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
+
+        let original_chains = []
+        const original_chains_vec = molecules_container.get_chains_in_model(coordMolNo)
+        const original_chains_vec_size = original_chains_vec.size()
+        for (let i = 0; i < original_chains_vec_size; i++) {
+            const chain_name = original_chains_vec.get(i)
+            original_chains.push(chain_name)
+        }
+
+        molecules_container.change_chain_id(coordMolNo, 'A', 'X', true, 10, 20)
+        
+        let new_chains = []
+        const new_chains_vec = molecules_container.get_chains_in_model(coordMolNo)
+        const new_chains_vec_size = new_chains_vec.size()
+        for (let i = 0; i < new_chains_vec_size; i++) {
+            const chain_name = new_chains_vec.get(i)
+            new_chains.push(chain_name)
+        }
+
+        expect(new_chains).not.toEqual(original_chains)
+        expect(original_chains.includes('X')).toBeFalsy()
+        expect(new_chains.includes('X')).toBeTruthy()
+
+        const original_chain_res_names = []
+        for (let idx = 10; idx < 21; idx++) {
+            const resName = molecules_container.get_residue_name(coordMolNo, 'A', idx, '')
+            original_chain_res_names.push(resName)   
+        }
+
+        const new_chain_res_names = []
+        for (let idx = 10; idx < 21; idx++) {
+            const resName = molecules_container.get_residue_name(coordMolNo, 'X', idx, '')
+            new_chain_res_names.push(resName)   
+        }
+
+        expect(new_chain_res_names.every(item => item !== '')).toBeTruthy()
+        expect(original_chain_res_names.every(item => item === '')).toBeTruthy()
+        
+        cleanUpVariables.push(original_chains_vec, new_chains_vec)
+    })
 })
 
 const testDataFiles = ['1cxq_phases.mtz', '1cxq.cif', '7ZTVU.cif', '5fjj.pdb', '5a3h.pdb', '5a3h.mmcif', '5a3h_no_ligand.pdb', 'MOI.restraints.cif', 'LZA.cif', 'nitrobenzene.cif', 'benzene.cif', '5a3h_sigmaa.mtz', 'rnasa-1.8-all_refmac1.mtz', 'tm-A.pdb']

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -1487,6 +1487,54 @@ describe('Testing molecules_container_js', () => {
         cleanUpVariables.push(instanceMesh_1, instanceMesh_2, indexedResiduesVec, colourMap, geom_2, geom_1)
     })
 
+    test("Test non-drawn bonds and multi CID selection mesh --first", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
+        const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
+
+        const instanceMesh_1 = molecules_container.get_bonds_mesh_for_selection_instanced(
+            coordMolNo, '//A/10-20||//A/25-30', 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1
+        )
+        
+        molecules_container.add_to_non_drawn_bonds(coordMolNo, '//A/12-15')
+
+        const instanceMesh_2 = molecules_container.get_bonds_mesh_for_selection_instanced(
+            coordMolNo, '//A/10-20||//A/25-30', 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1
+        )
+
+        expect(
+            instanceMesh_2.geom.get(1).instancing_data_B.size()
+        ).not.toBe(
+            instanceMesh_1.geom.get(1).instancing_data_B.size()
+        )
+
+        cleanUpVariables.push(instanceMesh_1, instanceMesh_2)
+    })
+
+    test("Test non-drawn bonds and multi CID selection mesh --second", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
+        const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
+
+        const instanceMesh_1 = molecules_container.get_bonds_mesh_for_selection_instanced(
+            coordMolNo, '//A/10-20||//A/25-30', 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1
+        )
+        
+        molecules_container.add_to_non_drawn_bonds(coordMolNo, '//A/26-27')
+
+        const instanceMesh_2 = molecules_container.get_bonds_mesh_for_selection_instanced(
+            coordMolNo, '//A/10-20||//A/25-30', 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1
+        )
+
+        expect(
+            instanceMesh_2.geom.get(1).instancing_data_B.size()
+        ).not.toBe(
+            instanceMesh_1.geom.get(1).instancing_data_B.size()
+        )
+
+        cleanUpVariables.push(instanceMesh_1, instanceMesh_2)
+    })
+    
     test("Test non-drawn bonds and bonds mesh", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         molecules_container.set_use_gemmi(false)

--- a/coot/CMakeLists.txt
+++ b/coot/CMakeLists.txt
@@ -176,6 +176,7 @@ ${coot_src}/api/coot_molecule_replace_fragment.cc
 ${coot_src}/api/add-terminal-residue.cc
 ${coot_src}/api/molecules_container.cc
 ${coot_src}/api/rama-plot-phi-psi.cc
+${coot_src}/api/coot_molecule_change_chain_id.cc
 ${coot_src}/analysis/daca.cc
 ${coot_src}/analysis/kolmogorov.cc
 ${coot_src}/analysis/stats.cc

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -1145,6 +1145,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     .function("get_molecule_diameter", &molecules_container_t::get_molecule_diameter)
     .function("multiply_residue_temperature_factors", &molecules_container_t::multiply_residue_temperature_factors)
     .function("shift_field_b_factor_refinement", &molecules_container_t::shift_field_b_factor_refinement)
+    .function("change_chain_id", &molecules_container_t::change_chain_id)
     .function("write_map",&molecules_container_t::write_map)
     .function("delete_atom",&molecules_container_t::delete_atom)
     .function("delete_atom_using_cid",&molecules_container_t::delete_atom_using_cid)


### PR DESCRIPTION
This update adds the infrastructure required to change chain IDs and to draw adaptive bonds to `MoorhenMolecule`. The latter is still not exposed in the UI as there are still some issues in the api.