### PR TITLE
Decompress file fetched from EMDB if failed to read

### DIFF
--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -152,7 +152,7 @@
     "nightingale-linegraph-track": "^3.8.10",
     "node-fetch": "^2.7.0",
     "nodemon": "^2.0.22",
-    "pako": "^2.0.4",
+    "pako": "^2.1.0",
     "parcel-bundler": "^1.12.5",
     "pca-js": "^1.0.2",
     "plotly.js": "^2.12.1",

--- a/baby-gru/public/baby-gru/CootWorker.ts
+++ b/baby-gru/public/baby-gru/CootWorker.ts
@@ -904,8 +904,14 @@ const read_ccp4_map = (mapData: ArrayBufferLike, name: string, isDiffMap: boolea
     cootModule.FS_createDataFile(".", `${theGuid}${fileExtension}`, asUint8Array, true, true);
     const tempFilename = `./${theGuid}${fileExtension}`
     const read_map_args: [string, boolean] = [tempFilename, isDiffMap]
-    const molNo = molecules_container.read_ccp4_map(...read_map_args)
-    cootModule.FS_unlink(tempFilename)
+    let molNo = -1
+    try {
+        molNo = molecules_container.read_ccp4_map(...read_map_args)
+    } catch (err) {
+        console.warn(err)
+    } finally {
+        cootModule.FS_unlink(tempFilename)
+    }
     return molNo
 }
 

--- a/baby-gru/src/components/form/MoorhenFetchOnlineSourcesForm.tsx
+++ b/baby-gru/src/components/form/MoorhenFetchOnlineSourcesForm.tsx
@@ -162,7 +162,17 @@ export const MoorhenFetchOnlineSourcesForm = (props: {
     const fetchMapFromURL = async (url: RequestInfo | URL, mapName: string, isDiffMap: boolean = false, contourLevel?: number): Promise<moorhen.Map> => {
         const newMap = new MoorhenMap(commandCentre, glRef)
         try {
-            await newMap.loadToCootFromMapURL(url, mapName, isDiffMap)
+            try {
+                await newMap.loadToCootFromMapURL(url, mapName, isDiffMap)
+            } catch (err) {
+                // Try again if this is a compressed file...
+                if (url.toString().includes('.gz')) {
+                    await newMap.loadToCootFromMapURL(url, mapName.replace('.gz', ''), isDiffMap, true)
+                } else {
+                    console.warn(err)
+                    throw new Error("Cannot read the fetched map...")
+                }
+            }
             if (newMap.molNo === -1) throw new Error("Cannot read the fetched map...")
             if (contourLevel) newMap.suggestedContourLevel = contourLevel
             batch(() => {

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -202,7 +202,7 @@ declare module 'moorhen' {
         fetchReflectionData(): Promise<_moorhen.WorkerResponse<Uint8Array>>;
         getMap(): Promise<_moorhen.WorkerResponse>;
         loadToCootFromMtzURL(url: RequestInfo | URL, name: string, selectedColumns: _moorhen.selectedMtzColumns, options?: RequestInit): Promise<_moorhen.Map>;
-        loadToCootFromMapURL(url: RequestInfo | URL, name: string, isDiffMap?: boolean, options?: RequestInit): Promise<_moorhen.Map>;
+        loadToCootFromMapURL(url: RequestInfo | URL, name: string, isDiffMap?: boolean, decompress?: boolean, options?: RequestInit): Promise<_moorhen.Map>;
         setActive(): Promise<void>;
         setupContourBuffers(objects: any[], keepCootColours?: boolean): void;
         setOtherMapForColouring(molNo: number, min?: number, max?: number): void;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -410,7 +410,7 @@ export namespace moorhen {
         fetchReflectionData(): Promise<WorkerResponse<Uint8Array>>;
         getMap(): Promise<WorkerResponse>;
         loadToCootFromMtzURL(url: RequestInfo | URL, name: string, selectedColumns: selectedMtzColumns, options?: RequestInit): Promise<Map>;
-        loadToCootFromMapURL(url: RequestInfo | URL, name: string, isDiffMap?: boolean, options?: RequestInit): Promise<Map>;
+        loadToCootFromMapURL(url: RequestInfo | URL, name: string, isDiffMap?: boolean, decompress?: boolean, options?: RequestInit): Promise<Map>;
         setActive(): Promise<void>;
         setupContourBuffers(objects: any[], keepCootColours?: boolean): void;
         setOtherMapForColouring(molNo: number, min?: number, max?: number): void;


### PR DESCRIPTION
This update fixes #260. Now files fetched from EMDB will be decompressed on the fly if libcoot api fails to read them on the first attempt.