### PR TITLE
Fixes to double sliders and other changes

### DIFF
--- a/baby-gru/src/components/card/MoorhenMapCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMapCard.tsx
@@ -16,7 +16,7 @@ import { MoorhenNotification } from "../misc/MoorhenNotification"
 import { useSelector, useDispatch, batch } from 'react-redux';
 import { setActiveMap, setNotificationContent } from "../../store/generalStatesSlice";
 import { addMap } from "../../store/mapsSlice";
-import { hideMap, setContourLevel, setMapAlpha, setMapColours, setMapRadius, setMapStyle, setNegativeMapColours, setPositiveMapColours, showMap } from "../../store/mapContourSettingsSlice";
+import { hideMap, setContourLevel, changeContourLevel, setMapAlpha, setMapColours, setMapRadius, setMapStyle, setNegativeMapColours, setPositiveMapColours, showMap, changeMapRadius } from "../../store/mapContourSettingsSlice";
 
 type ActionButtonType = {
     label: string;
@@ -152,6 +152,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     const busyContouring = useRef<boolean>(false)
     const isDirty = useRef<boolean>(false)
     const histogramRef = useRef(null)
+    const intervalRef = useRef(null)
 
     const mapColour: {r: number; g: number; b: number;} = JSON.parse(mapColourString)
     const negativeMapColour: {r: number; g: number; b: number;} = JSON.parse(negativeMapColourString)
@@ -407,18 +408,54 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
 
     }, [doContourIfDirty])
 
-    const increaseLevelButton = <IconButton onClick={() => dispatch( setContourLevel({ molNo: props.map.molNo, contourLevel: mapContourLevel + contourWheelSensitivityFactor }) )} style={{padding: 0, color: isDark ? 'white' : 'black'}}>
-                                    <AddCircleOutline/>
-                                </IconButton>
-    const decreaseLevelButton = <IconButton onClick={() => dispatch( setContourLevel({ molNo: props.map.molNo, contourLevel: mapContourLevel - contourWheelSensitivityFactor }) )} style={{padding: 0, color: isDark ? 'white' : 'black'}}>
-                                    <RemoveCircleOutline/>
-                                </IconButton>
-    const increaseRadiusButton = <IconButton onClick={() => dispatch( setMapRadius({ molNo: props.map.molNo, radius: mapRadius + 2 }) )} style={{padding: 0, color: isDark ? 'white' : 'black'}}>
-                                    <AddCircleOutline/>
-                                </IconButton>
-    const decreaseRadiusButton = <IconButton onClick={() => dispatch( setMapRadius({ molNo: props.map.molNo, radius: mapRadius - 2 }) )} style={{padding: 0, color: isDark ? 'white' : 'black'}}>
-                                    <RemoveCircleOutline/>
-                                </IconButton>
+    const increaseLevelButton = <IconButton 
+        style={{padding: 0, color: isDark ? 'white' : 'black'}}
+        onClick={() => dispatch( changeContourLevel({ molNo: props.map.molNo, factor: contourWheelSensitivityFactor }) )} 
+        onMouseDown={() => {
+            intervalRef.current = setInterval(() => {
+                dispatch( changeContourLevel({ molNo: props.map.molNo, factor: contourWheelSensitivityFactor }) )
+            }, 100)
+        }} onMouseUp={() => {
+            clearInterval(intervalRef.current)                   
+        }}>
+            <AddCircleOutline/>
+    </IconButton>
+    const decreaseLevelButton = <IconButton 
+        style={{padding: 0, color: isDark ? 'white' : 'black'}}
+        onClick={() => dispatch( changeContourLevel({ molNo: props.map.molNo, factor: -contourWheelSensitivityFactor }) )} 
+        onMouseDown={() => {
+            intervalRef.current = setInterval(() => {
+                dispatch( changeContourLevel({ molNo: props.map.molNo, factor: -contourWheelSensitivityFactor }) )
+            }, 100)
+        }} onMouseUp={() => {
+            clearInterval(intervalRef.current)                   
+        }}>
+            <RemoveCircleOutline/>
+    </IconButton>
+    const increaseRadiusButton = <IconButton 
+        style={{padding: 0, color: isDark ? 'white' : 'black'}}
+        onClick={() => dispatch( changeMapRadius({ molNo: props.map.molNo, factor: 2 }) )} 
+        onMouseDown={() => {
+            intervalRef.current = setInterval(() => {
+                dispatch( changeMapRadius({ molNo: props.map.molNo, factor: 2 }) )
+            }, 100)
+        }} onMouseUp={() => {
+            clearInterval(intervalRef.current)                   
+        }}>
+            <AddCircleOutline/>
+    </IconButton>
+    const decreaseRadiusButton = <IconButton 
+        style={{padding: 0, color: isDark ? 'white' : 'black'}}
+        onClick={() => dispatch( changeMapRadius({ molNo: props.map.molNo, factor: -2 }) )}
+        onMouseDown={() => {
+            intervalRef.current = setInterval(() => {
+                dispatch( changeMapRadius({ molNo: props.map.molNo, factor: -2 }) )
+            }, 100)
+        }} onMouseUp={() => {
+            clearInterval(intervalRef.current)                   
+        }}>
+            <RemoveCircleOutline/>
+    </IconButton>
 
     const getMapColourSelector = () => {
         if (mapColour === null) {

--- a/baby-gru/src/components/menu-item/MoorhenChangeChainIdMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenChangeChainIdMenuItem.tsx
@@ -3,9 +3,10 @@ import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem";
 import { useSelector } from 'react-redux';
 import { useCallback, useEffect, useRef, useState } from "react";
 import { MoorhenMoleculeSelect } from "../select/MoorhenMoleculeSelect";
-import { Button, Form } from "react-bootstrap";
+import { Button, Form, Stack } from "react-bootstrap";
 import { MoorhenChainSelect } from "../select/MoorhenChainSelect";
-import { Slider } from "@mui/material";
+import { IconButton, Slider } from "@mui/material";
+import { AddCircleOutline, RemoveCircleOutline, RemoveCircleOutlined } from "@mui/icons-material";
 
 export const MoorhenChangeChainIdMenuItem = (props) => {
 
@@ -13,13 +14,14 @@ export const MoorhenChangeChainIdMenuItem = (props) => {
     const moleculeSelectRef = useRef<null | HTMLSelectElement>(null)
     const newChainIdFormRef = useRef<null |HTMLInputElement>(null)
     const minMaxValueRef = useRef<[number, number]>([1, 100])
-
+    const intervalRef = useRef(null)
     const [sequenceLength, setSequenceLength] = useState<null | number>(null)
     const [minMaxValue, setMinMaxValue]  = useState<[number, number]>([1, 100])
     const [invalidNewId, setInvalidNewId] = useState<boolean>(false)
     const [selectedChain, setSelectedChain] = useState<string>(null)
     const [selectedModel, setSelectedModel] = useState<number | null>(null)
 
+    const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
     const molecules = useSelector((state: moorhen.State) => state.molecules)
 
     const handleModelChange = useCallback((evt: React.ChangeEvent<HTMLSelectElement>) => {
@@ -133,7 +135,7 @@ export const MoorhenChangeChainIdMenuItem = (props) => {
     
     }, [molecules, selectedModel, selectedChain])
 
-    const handleMinMaxChange = (event: Event, newValue: [number, number]) => {
+    const handleMinMaxChange = (_event: any, newValue: [number, number]) => {
         setMinMaxValue(newValue)
         minMaxValueRef.current = newValue
     }
@@ -150,7 +152,36 @@ export const MoorhenChangeChainIdMenuItem = (props) => {
             onChange={handleChainChange}
             ref={chainSelectRef}/>
         <span style={{margin: '0.5rem'}}>Residue range</span>
-        <div style={{ paddingLeft: '2rem', paddingRight: '2rem', paddingTop: '0.5rem', paddingBottom: '0.5rem'}}>
+        <Stack direction='horizontal' gap={1} style={{ }}>
+            <Stack direction='vertical' gap={0} style={{justifyContent: 'center'}}>
+                <IconButton onMouseDown={() => {
+                    intervalRef.current = setInterval(() => {
+                        const newValue = [minMaxValueRef.current[0] + 1, minMaxValueRef.current[1]] as [number, number]
+                        handleMinMaxChange(null, newValue)                    
+                    }, 100)
+                }} onMouseUp={() => {
+                    clearInterval(intervalRef.current)                   
+                }} onClick={() => {
+                    const newValue = [minMaxValueRef.current[0] + 1, minMaxValueRef.current[1]] as [number, number]
+                    handleMinMaxChange(null, newValue)
+                }} style={{padding: 0, color: isDark ? 'white' : 'grey'}}>
+                    <AddCircleOutline/>
+                </IconButton>
+                <IconButton onMouseDown={() => {
+                    intervalRef.current = setInterval(() => {
+                        const newValue = [minMaxValueRef.current[0] - 1, minMaxValueRef.current[1]] as [number, number]
+                        handleMinMaxChange(null, newValue)                    
+                    }, 100)
+                }} onMouseUp={() => {
+                    clearInterval(intervalRef.current)                   
+                }} onClick={() => {
+                    const newValue = [minMaxValueRef.current[0] - 1, minMaxValueRef.current[1]] as [number, number]
+                    handleMinMaxChange(null, newValue)
+                }} style={{padding: 0, color: isDark ? 'white' : 'grey'}}>
+                    <RemoveCircleOutline/>
+                </IconButton>
+            </Stack>
+            <div style={{ width: '80%', paddingLeft: '1rem', paddingRight: '1rem', paddingTop: '0.1rem', paddingBottom: '0.1rem' }}>
             <Slider
                 getAriaLabel={() => 'Residue range'}
                 value={minMaxValue}
@@ -163,11 +194,11 @@ export const MoorhenChangeChainIdMenuItem = (props) => {
                 step={1}
                 marks={true}
                 sx={{
-                    marginTop: '1.5rem',
+                    marginTop: '1.7rem',
                     marginBottom: '0.8rem',
                     '& .MuiSlider-thumb[data-index="1"]': {
                         '& .MuiSlider-valueLabel': {
-                            top: -1,
+                            top: '-0.7rem',
                             fontSize: 14,
                             fontWeight: 'bold',
                             color: 'grey',
@@ -176,7 +207,7 @@ export const MoorhenChangeChainIdMenuItem = (props) => {
                     },
                     '& .MuiSlider-thumb[data-index="0"]': {
                         '& .MuiSlider-valueLabel': {
-                            top:'3rem',
+                            top:'3.5rem',
                             fontSize: 14,
                             fontWeight: 'bold',
                             color: 'grey',
@@ -185,7 +216,36 @@ export const MoorhenChangeChainIdMenuItem = (props) => {
                     }
                 }}
             />
-        </div>
+            </div>
+            <Stack direction='vertical' gap={0} style={{display: 'flex', verticalAlign: 'center', justifyContent: 'center'}}>
+                <IconButton onMouseDown={() => {
+                    intervalRef.current = setInterval(() => {
+                        const newValue = [minMaxValueRef.current[0], minMaxValueRef.current[1] + 1] as [number, number]
+                        handleMinMaxChange(null, newValue)                    
+                    }, 100)
+                }} onMouseUp={() => {
+                    clearInterval(intervalRef.current)                   
+                }} onClick={() => {
+                    const newValue = [minMaxValueRef.current[0], minMaxValueRef.current[1] + 1] as [number, number]
+                    handleMinMaxChange(null, newValue)                    
+                }} style={{padding: 0, color: isDark ? 'white' : 'grey'}}>
+                    <AddCircleOutline/>
+                </IconButton>
+                <IconButton onMouseDown={() => {
+                    intervalRef.current = setInterval(() => {
+                        const newValue = [minMaxValueRef.current[0], minMaxValueRef.current[1] - 1] as [number, number]
+                        handleMinMaxChange(null, newValue)                    
+                    }, 100)
+                }} onMouseUp={() => {
+                    clearInterval(intervalRef.current)                   
+                }} onClick={() => {
+                    const newValue = [minMaxValueRef.current[0], minMaxValueRef.current[1] - 1] as [number, number]
+                    handleMinMaxChange(null, newValue)                    
+                }} style={{padding: 0, color: isDark ? 'white' : 'grey'}}>
+                    <RemoveCircleOutline/>
+                </IconButton>
+            </Stack>
+        </Stack>
         <Form.Group style={{ width: "95%", margin: "0.5rem", height: "4rem" }}>
             <Form.Label>New chain ID</Form.Label>
             <Form.Control

--- a/baby-gru/src/components/menu-item/MoorhenChangeChainIdMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenChangeChainIdMenuItem.tsx
@@ -164,13 +164,25 @@ export const MoorhenChangeChainIdMenuItem = (props) => {
                 marks={true}
                 sx={{
                     marginTop: '1.5rem',
-                    '& .MuiSlider-valueLabel': {
-                        fontSize: 14,
-                        fontWeight: 'bold',
-                        top: -1,
-                        color: 'grey',
-                        backgroundColor: 'unset',
+                    marginBottom: '0.8rem',
+                    '& .MuiSlider-thumb[data-index="1"]': {
+                        '& .MuiSlider-valueLabel': {
+                            top: -1,
+                            fontSize: 14,
+                            fontWeight: 'bold',
+                            color: 'grey',
+                            backgroundColor: 'unset',
+                        },
                     },
+                    '& .MuiSlider-thumb[data-index="0"]': {
+                        '& .MuiSlider-valueLabel': {
+                            top:'3rem',
+                            fontSize: 14,
+                            fontWeight: 'bold',
+                            color: 'grey',
+                            backgroundColor: 'unset',
+                        },    
+                    }
                 }}
             />
         </div>

--- a/baby-gru/src/components/menu-item/MoorhenColourMapByOtherMapMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenColourMapByOtherMapMenuItem.tsx
@@ -80,13 +80,25 @@ export const MoorhenColourMapByOtherMapMenuItem = (props: {
             valueLabelDisplay="on"
             sx={{
                 marginTop: '1.5rem',
-                '& .MuiSlider-valueLabel': {
-                    fontSize: 14,
-                    fontWeight: 'bold',
-                    top: -1,
-                    color: 'grey',
-                    backgroundColor: 'unset',
+                marginBottom: '1.2rem',
+                '& .MuiSlider-thumb[data-index="1"]': {
+                    '& .MuiSlider-valueLabel': {
+                        top: -1,
+                        fontSize: 14,
+                        fontWeight: 'bold',
+                        color: 'grey',
+                        backgroundColor: 'unset',
+                    },
                 },
+                '& .MuiSlider-thumb[data-index="0"]': {
+                    '& .MuiSlider-valueLabel': {
+                        top:'3rem',
+                        fontSize: 14,
+                        fontWeight: 'bold',
+                        color: 'grey',
+                        backgroundColor: 'unset',
+                    },
+                }
             }}
         />
         <Button variant="primary" onClick={handleApply}>

--- a/baby-gru/src/store/mapContourSettingsSlice.ts
+++ b/baby-gru/src/store/mapContourSettingsSlice.ts
@@ -42,6 +42,11 @@ export const mapContourSettingsSlice = createSlice({
       state = { ...state, mapStyles: [ ...state.mapStyles.filter(item => item.molNo !== action.payload.molNo), action.payload ] }
       return state
     },
+    changeContourLevel: (state, action: {payload: { molNo: number; factor: number }, type: string}) => {
+      const map = state.contourLevels.find(item => item.molNo === action.payload.molNo)
+      state = { ...state, contourLevels: [ ...state.contourLevels.filter(item => item.molNo !== action.payload.molNo), { molNo: action.payload.molNo, contourLevel: map.contourLevel + action.payload.factor } ] }
+      return state
+    },
     changeMapRadius: (state, action: {payload: { molNo: number; factor: number }, type: string}) => {
       const map = state.mapRadii.find(item => item.molNo === action.payload.molNo)
       state = { ...state, mapRadii: [ ...state.mapRadii.filter(item => item.molNo !== action.payload.molNo), { molNo: action.payload.molNo, radius: map.radius + action.payload.factor } ] }
@@ -77,7 +82,7 @@ export const mapContourSettingsSlice = createSlice({
 export const {
   showMap, hideMap, setContourLevel, setMapRadius, setMapAlpha, setMapStyle, changeMapRadius,
   setDefaultMapSamplingRate, setDefaultMapLitLines, setMapLineWidth, setDefaultMapSurface,
-  setMapColours, setNegativeMapColours, setPositiveMapColours
+  setMapColours, setNegativeMapColours, setPositiveMapColours, changeContourLevel
 } = mapContourSettingsSlice.actions
 
 export default mapContourSettingsSlice.reducer

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1148,17 +1148,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
         this.adaptativeBondsEnabled = true
         const drawMissingLoops = MoorhenReduxStore.getState().sceneSettings.drawMissingLoops
         
-        await Promise.all(neighBoringResidues.map(i => {
-            this.commandCentre.current.cootCommand({
-                message: 'coot_command',
-                command: "add_to_non_drawn_bonds",
-                returnType: 'status',
-                commandArgs: [this.molNo, i],
-            }, false)
-        }))
-
-        await this.adaptativeBondsRepresentation.alphas.redraw()
-
         if (drawMissingLoops) {
             await this.commandCentre.current.cootCommand({
                 command: "set_draw_missing_residue_loops",
@@ -1176,6 +1165,17 @@ export class MoorhenMolecule implements moorhen.Molecule {
                 commandArgs: [ true ],
             }, false)
         }
+
+        await Promise.all(neighBoringResidues.map(i => {
+            this.commandCentre.current.cootCommand({
+                message: 'coot_command',
+                command: "add_to_non_drawn_bonds",
+                returnType: 'status',
+                commandArgs: [this.molNo, i],
+            }, false)
+        }))
+
+        await this.adaptativeBondsRepresentation.alphas.redraw()
 
         await this.commandCentre.current.cootCommand({
             message: 'coot_command',

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -913,9 +913,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
             zoomLevel = 0.4
         }
 
-        console.log('>>>> HI!')
-        console.log(zoomLevel)
-
         let selectionCentre = centreOnGemmiAtoms(selectionAtoms)
         if (animate && setZoom) {
             this.glRef.current.setOriginAndZoomAnimated(selectionCentre, zoomLevel)


### PR DESCRIPTION
This update includes:
- A fix for adaptative bonds.
- The labels for the double slider in the "Colour map by other map" menu item do not obscure each other now that one of them is below the slider.
- Same fix as above for the double slider in "Change chain ID" menu item.
- Added buttons to the "Change chain ID" menu item to allow fine control of residue number.
- Holding buttons to increase/decrease the map contour level / radius now will keep changing the value.