### PR TITLE
Add shift field refinement, multiply Bfactors and more tests

### DIFF
--- a/baby-gru/src/components/button/MoorhenEigenFlipLigandButton.tsx
+++ b/baby-gru/src/components/button/MoorhenEigenFlipLigandButton.tsx
@@ -14,7 +14,7 @@ export const MoorhenEigenFlipLigandButton = (props: moorhen.ContextButtonProps) 
             message: 'coot_command',
             returnType: "status",
             command: 'eigen_flip_ligand',
-            commandArgs: [selectedMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}`],
+            commandArgs: [selectedMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}/${chosenAtom.atom_name}${chosenAtom.alt_conf === "" ? "" : ":" + chosenAtom.alt_conf}`],
             changesMolecules: [selectedMolecule.molNo]
         }
     }

--- a/baby-gru/src/components/button/MoorhenMutateButton.tsx
+++ b/baby-gru/src/components/button/MoorhenMutateButton.tsx
@@ -33,7 +33,11 @@ export const MoorhenMutateButton = (props: moorhen.ContextButtonProps) => {
             message: 'coot_command',
             returnType: "status",
             command: 'mutate',
-            commandArgs: [selectedMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}`, selectedMode],
+            commandArgs: [
+                selectedMolecule.molNo,
+                `//${chosenAtom.chain_id}/${chosenAtom.res_no}/${chosenAtom.atom_name}${chosenAtom.alt_conf === "" ? "" : ":" + chosenAtom.alt_conf}`,
+                selectedMode
+            ],
             changesMolecules: [selectedMolecule.molNo]
         }
     }

--- a/baby-gru/src/components/button/MoorhenSideChain180Button.tsx
+++ b/baby-gru/src/components/button/MoorhenSideChain180Button.tsx
@@ -8,7 +8,7 @@ export const MoorhenSideChain180Button = (props: moorhen.ContextButtonProps) => 
             message: 'coot_command',
             returnType: "status",
             command: 'side_chain_180',
-            commandArgs: [selectedMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}`],
+            commandArgs: [selectedMolecule.molNo, `//${chosenAtom.chain_id}/${chosenAtom.res_no}/${chosenAtom.atom_name}${chosenAtom.alt_conf === "" ? "" : ":" + chosenAtom.alt_conf}`],
             changesMolecules: [selectedMolecule.molNo]
         }
     }

--- a/baby-gru/src/components/menu-item/MoorhenChangeChainIdMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenChangeChainIdMenuItem.tsx
@@ -15,6 +15,7 @@ export const MoorhenChangeChainIdMenuItem = (props) => {
     const newChainIdFormRef = useRef<null |HTMLInputElement>(null)
     const minMaxValueRef = useRef<[number, number]>([1, 100])
     const intervalRef = useRef(null)
+
     const [sequenceLength, setSequenceLength] = useState<null | number>(null)
     const [minMaxValue, setMinMaxValue]  = useState<[number, number]>([1, 100])
     const [invalidNewId, setInvalidNewId] = useState<boolean>(false)
@@ -212,7 +213,7 @@ export const MoorhenChangeChainIdMenuItem = (props) => {
                             fontWeight: 'bold',
                             color: 'grey',
                             backgroundColor: 'unset',
-                        },    
+                        },
                     }
                 }}
             />

--- a/baby-gru/src/components/menu-item/MoorhenMultiplyBfactorMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenMultiplyBfactorMenuItem.tsx
@@ -1,0 +1,198 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import { useDispatch, useSelector } from "react-redux"
+import { moorhen } from "../../types/moorhen"
+import { triggerUpdate } from "../../store/moleculeMapUpdateSlice"
+import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem"
+import { MoorhenMoleculeSelect } from "../select/MoorhenMoleculeSelect"
+import { MoorhenCidInputForm } from "../form/MoorhenCidInputForm"
+import { Button, Form, FormSelect } from "react-bootstrap"
+import { MoorhenChainSelect } from "../select/MoorhenChainSelect"
+import { MoorhenLigandSelect } from "../select/MoorhenLigandSelect"
+import { Slider } from "@mui/material"
+
+export const MoorhenMultiplyBfactorMenuItem = (props) => {
+    const moleculeSelectRef = useRef<null | HTMLSelectElement>(null)
+    const chainSelectRef = useRef<null | HTMLSelectElement>(null)
+    const cidFormRef = useRef<null | HTMLInputElement>(null)
+    const ruleSelectRef = useRef<null | HTMLSelectElement>(null)
+    const ligandSelectRef = useRef<null | HTMLSelectElement>(null)
+    const bfactorValueRef = useRef<null | number>(0)
+
+    const dispatch = useDispatch()
+    const molecules = useSelector((state: moorhen.State) => state.molecules)
+
+    const [cid, setCid] = useState<string>("")
+    const [invalidCid, setInvalidCid] = useState<boolean>(false)
+    const [selectionType, setSelectionType] = useState<string>("molecule")
+    const [selectedChain, setSelectedChain] = useState<string | number>(null)
+    const [selectedModel, setSelectedModel] = useState<number | number>(null)
+    const [bfactor, setBfactor] = useState<number | number>(0)
+    
+    const handleModelChange = useCallback((evt: React.ChangeEvent<HTMLSelectElement>) => {
+        setSelectedModel(parseInt(evt.target.value))
+        setSelectedChain(chainSelectRef.current?.value)
+    }, [molecules])
+
+    const handleChainChange = useCallback((evt) => {
+        setSelectedChain(evt.target.value)
+    }, [molecules])
+
+    useEffect(() => {
+        let selectedMolecule: moorhen.Molecule
+        if (molecules.length === 0) {
+            setSelectedModel(null)
+            setSelectedChain(null)
+        } else if (selectedModel === null) {
+            setSelectedModel(molecules[0].molNo)
+            setSelectedChain(molecules[0].sequences[0]?.chain)
+            selectedMolecule = molecules[0]
+        } else if (!molecules.map(molecule => molecule.molNo).includes(selectedModel)) {
+            setSelectedModel(molecules[0].molNo)
+            setSelectedChain(molecules[0].sequences[0]?.chain)
+            selectedMolecule = molecules[0]
+        }
+    }, [molecules])
+
+    const convertValue = (value: number) => {
+        if (value >= 0) {
+            return `+${value + 1}0%`
+        }
+        return `${value}0%`
+    }
+
+    const handleBFactorChange = (evt: any, newValue: number) => {
+        setBfactor(newValue)
+        if (newValue >= 0) {
+            bfactorValueRef.current = 1 + ( (newValue + 1) / 10 )
+        } else {
+            bfactorValueRef.current = 1 - (-newValue / 10)
+        }
+    }
+
+    const multiplyBfactor = async () => {
+        if (!moleculeSelectRef.current.value || !ruleSelectRef.current?.value || bfactorValueRef.current === null) {
+            console.warn('Missing data, doing nothing...')
+            return
+        }
+
+        const selectedMolecule = molecules.find(molecule => molecule.molNo === parseInt(moleculeSelectRef.current.value))
+        if (!selectedMolecule) {
+            console.warn(`Cannot find molecule with molNo ${moleculeSelectRef.current.value}`)
+            return
+        }
+
+        let cid: string
+        switch (ruleSelectRef.current.value) {
+            case 'molecule':
+                cid = '/*/*/*/*'
+                break
+            case 'chain':
+                cid = chainSelectRef.current?.value ? `//${chainSelectRef.current.value}` : undefined
+                break
+            case 'ligand':
+                cid = ligandSelectRef.current?.value ? ligandSelectRef.current.value : undefined
+                break
+            case 'cid':
+                cid = cidFormRef.current?.value ? cidFormRef.current.value : undefined
+                break
+            default:
+                console.warn(`Unrecognised selection type ${ruleSelectRef.current.value}`)
+                break
+        }
+
+        const isValid = cid && await selectedMolecule.isValidSelection(cid)
+        if (isValid) {
+            await props.commandCentre.current.cootCommand({
+                command: 'multiply_residue_temperature_factors',
+                commandArgs: [selectedMolecule.molNo, cid, bfactorValueRef.current],
+                returnType: 'status'
+            }, false)
+            dispatch( triggerUpdate(selectedMolecule.molNo) )
+            props.setPopoverIsShown(false)
+            document.body.click()    
+        } else {
+            if (ruleSelectRef.current.value === 'cid') setInvalidCid(true)
+            console.warn(`Invalid selection of type ${ruleSelectRef.current.value}`)
+        }
+    }
+
+    const panelContent = <>
+        <Form.Group style={{ width: '100%', margin: 0 }}>
+            <Form.Label>Selection type</Form.Label>
+            <FormSelect size="sm" ref={ruleSelectRef} defaultValue={'molecule'} onChange={(val) => setSelectionType(val.target.value)}>
+                <option value={'molecule'} key={'molecule'}>By molecule</option>
+                <option value={'chain'} key={'chain'}>By chain</option>
+                <option value={'ligand'} key={'ligand'}>By ligand</option>
+                <option value={'cid'} key={'cid'}>By atom selection</option>
+            </FormSelect>
+        </Form.Group>
+        <MoorhenMoleculeSelect
+            molecules={molecules}
+            onChange={handleModelChange}
+            allowAny={false}
+            ref={moleculeSelectRef} />
+        {selectionType === 'chain' && 
+        <MoorhenChainSelect
+            molecules={molecules}
+            onChange={handleChainChange}
+            selectedCoordMolNo={selectedModel}
+            ref={chainSelectRef}/>
+        }
+        {selectionType === 'ligand' && 
+          <MoorhenLigandSelect
+            molecules={molecules}
+            selectedCoordMolNo={selectedModel}
+            ref={ligandSelectRef} />
+        }
+        {selectionType === 'cid' &&
+        <MoorhenCidInputForm
+            ref={cidFormRef}
+            label='Atom selection'
+            margin='0.5rem'
+            defaultValue={props.initialCid}
+            onChange={(evt) => setCid(evt.target.value)}
+            invalidCid={invalidCid}
+            allowUseCurrentSelection={true}/>
+        }
+        <div style={{ paddingLeft: '2rem', paddingRight: '2rem', paddingTop: '0.1rem', paddingBottom: '0.1rem' }}>
+        <Slider
+            aria-label="Factor"
+            getAriaValueText={convertValue}
+            valueLabelFormat={convertValue}
+            valueLabelDisplay="on"
+            value={bfactor}
+            onChange={handleBFactorChange}
+            marks={true}
+            defaultValue={0}
+            step={1}
+            min={-9}
+            max={9}
+            sx={{
+                marginTop: '1.7rem',
+                marginBottom: '0.8rem',
+                    '& .MuiSlider-valueLabel': {
+                        top: -1,
+                        fontSize: 14,
+                        fontWeight: 'bold',
+                        color: 'grey',
+                        backgroundColor: 'unset',
+                    },
+            }}
+        />
+        </div>
+        <Button variant="primary" onClick={multiplyBfactor}>
+            OK
+        </Button>
+    </>
+
+    return <MoorhenBaseMenuItem
+        id='multiply-bfactor-menu-item'
+        popoverPlacement='right'
+        popoverContent={panelContent}
+        menuItemText="Multiply molecule B-factors..."
+        onCompleted={() => {}}
+        showOkButton={false}
+        setPopoverIsShown={props.setPopoverIsShown}
+    />
+
+}

--- a/baby-gru/src/components/menu-item/MoorhenShiftFieldBFactorRefinement.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenShiftFieldBFactorRefinement.tsx
@@ -1,0 +1,47 @@
+import { useDispatch, useSelector } from "react-redux"
+import { moorhen } from "../../types/moorhen"
+import { MoorhenMoleculeSelect } from "../select/MoorhenMoleculeSelect"
+import { useRef } from "react"
+import { MoorhenMapSelect } from "../select/MoorhenMapSelect"
+import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem"
+import { triggerUpdate } from "../../store/moleculeMapUpdateSlice"
+
+export const MoorhenShiftFieldBFactorRefinement = (props) => {
+    const moleculeSelectRef = useRef<null | HTMLSelectElement>(null)
+    const mapSelectRef = useRef<null | HTMLSelectElement>(null)
+    
+    const dispatch = useDispatch()
+    const maps = useSelector((state: moorhen.State) => state.maps)
+    const molecules = useSelector((state: moorhen.State) => state.molecules)
+
+    const doRefinement = async () => {
+        if (!moleculeSelectRef.current.value || !mapSelectRef.current.value) {
+            return
+        }
+
+        const selectedMoleculeMolNo = parseInt(moleculeSelectRef.current.value)
+        const selectedMapMolNo = parseInt(moleculeSelectRef.current.value)
+
+        await props.commandCentre.current.cootCommand({
+            command: 'shift_field_b_factor_refinement',
+            commandArgs: [selectedMoleculeMolNo, selectedMapMolNo],
+            returnType: 'status'
+        }, false)
+
+        dispatch( triggerUpdate(selectedMoleculeMolNo) )
+    }
+
+    const panelContent = <>
+        <MoorhenMoleculeSelect molecules={molecules} allowAny={false} ref={moleculeSelectRef} />
+        <MoorhenMapSelect maps={maps} ref={mapSelectRef} filterFunction={(map) => map.hasReflectionData} width='100%' label='Map with reflection data' />
+    </>
+
+    return <MoorhenBaseMenuItem
+        id='shift-field-bfactor-refinement-menu-item'
+        popoverPlacement='right'
+        popoverContent={panelContent}
+        menuItemText="Shift field B-factor refinement..."
+        onCompleted={doRefinement}
+        setPopoverIsShown={props.setPopoverIsShown}
+    />
+}

--- a/baby-gru/src/components/navbar-menus/MoorhenEditMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenEditMenu.tsx
@@ -9,6 +9,8 @@ import { MoorhenAddRemoveHydrogenAtomsMenuItem } from "../menu-item/MoorhenAddRe
 import { MoorhenMoveMoleculeHere } from "../menu-item/MoorhenMoveMoleculeHere"
 import { MoorhenChangeChainIdMenuItem } from "../menu-item/MoorhenChangeChainIdMenuItem"
 import { MoorhenCreateSelectionMenuItem } from "../menu-item/MoorhenCreateSelectionMenuItem"
+import { MoorhenShiftFieldBFactorRefinement } from "../menu-item/MoorhenShiftFieldBFactorRefinement"
+import { MoorhenMultiplyBfactorMenuItem } from "../menu-item/MoorhenMultiplyBfactorMenuItem"
 import { MoorhenNavBarExtendedControlsInterface } from "./MoorhenNavBar";
 import { moorhen } from "../../types/moorhen";
 import { useDispatch, useSelector } from "react-redux";
@@ -28,6 +30,8 @@ export const MoorhenEditMenu = (props: MoorhenNavBarExtendedControlsInterface) =
             <MoorhenMergeMoleculesMenuItem key="merge" {...menuItemProps} />
             <MoorhenMoveMoleculeHere key="move" {...menuItemProps}/>
             <MoorhenChangeChainIdMenuItem key="change_chain_id" {...menuItemProps}/>
+            <MoorhenMultiplyBfactorMenuItem key="bfactor-multiply" {...menuItemProps}/>
+            <MoorhenShiftFieldBFactorRefinement key="bfactor-refinement" {...menuItemProps}/>
             <MoorhenDeleteUsingCidMenuItem key="delete" {...menuItemProps} />
             <MoorhenCreateSelectionMenuItem key="create-selection" {...menuItemProps} />
             <MoorhenCopyFragmentUsingCidMenuItem key="copy_fragment" {...menuItemProps} />

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -16,6 +16,22 @@ import { setContourLevel, setMapAlpha, setMapColours, setMapRadius, setMapStyle,
 import { enableUpdatingMaps, setConnectedMoleculeMolNo, setFoFcMapMolNo, setReflectionMapMolNo, setTwoFoFcMapMolNo } from "../store/moleculeMapUpdateSlice";
 import { libcootApi } from "../types/libcoot";
 
+export const getCentreAtom = async (molecules: moorhen.Molecule[], commandCentre: React.RefObject<moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>): Promise<[moorhen.Molecule, string]> => {
+    const visibleMolecules: moorhen.Molecule[] = molecules.filter((molecule: moorhen.Molecule) => molecule.isVisible())
+    if (visibleMolecules.length === 0) {
+        return [null, null]
+    }
+    const response = await commandCentre.current.cootCommand({
+        returnType: "int_string_pair",
+        command: "get_active_atom",
+        commandArgs: [...glRef.current.origin.map(coord => coord * -1), visibleMolecules.map(molecule => molecule.molNo).join(':')]
+    }, false) as moorhen.WorkerResponse<libcootApi.PairType<number, string>>
+    const moleculeMolNo: number = response.data.result.result.first
+    const residueCid: string = response.data.result.result.second
+    const selectedMolecule = visibleMolecules.find((molecule: moorhen.Molecule) => molecule.molNo === moleculeMolNo)
+    return [selectedMolecule, residueCid]
+}
+
 export const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 export const formatLigandSVG = (svg: string): string => {

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -1182,7 +1182,8 @@ describe('Testing molecules_container_js', () => {
 
         molecules_container.associate_data_mtz_file_with_map(mapMolNo, './5a3h_sigmaa.mtz', 'FP', 'SIGFP', 'FREE')
         molecules_container.connect_updating_maps(coordMolNo, mapMolNo, mapMolNo, diffMapMolNo)
-        molecules_container.sfcalc_genmaps_using_bulk_solvent(coordMolNo, mapMolNo, diffMapMolNo, mapMolNo)
+        const result = molecules_container.sfcalc_genmaps_using_bulk_solvent(coordMolNo, mapMolNo, diffMapMolNo, mapMolNo)
+        expect(result.r_factor).not.toBe(-1)
 
         molecules_container.get_r_factor_stats()
         molecules_container.get_map_contours_mesh(mapMolNo, 77.501, 45.049, 22.663, 13, 0.48)

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -1838,21 +1838,66 @@ describe('Testing molecules_container_js', () => {
         expect(mapMolNo).toBe(1)
         expect(diffMapMolNo).toBe(2)
 
+        const pdbString_1  = molecules_container.get_molecule_atoms(coordMolNo, "pdb")
+        const st_1 = cootModule.read_structure_from_string(pdbString_1, 'test-molecule')
+        cootModule.gemmi_setup_entities(st_1)
+        cootModule.gemmi_add_entity_types(st_1, true)
+        const bfactor_vec_1 = cootModule.get_structure_bfactors(st_1)
+        const bfactor_vec_1_size = bfactor_vec_1.size()
+        let bfactors_1 = []
+        for (let i = 0; i < bfactor_vec_1_size; i++) {
+            const resInfo = bfactor_vec_1.get(i)
+            bfactors_1.push({...resInfo})
+        }
+
         molecules_container.associate_data_mtz_file_with_map(mapMolNo, './5a3h_sigmaa.mtz', 'FP', 'SIGFP', 'FREE')
         molecules_container.connect_updating_maps(coordMolNo, mapMolNo, mapMolNo, diffMapMolNo)
         molecules_container.sfcalc_genmaps_using_bulk_solvent(coordMolNo, mapMolNo, diffMapMolNo, mapMolNo)
 
         const scores_1 =  molecules_container.get_r_factor_stats()
-        const map_mesh_1 = molecules_container.get_map_contours_mesh(mapMolNo, 0, 0, 0, 13, 0.48)
+        molecules_container.get_map_contours_mesh(mapMolNo, 0, 0, 0, 13, 0.48)
         expect(scores_1.r_factor).not.toBe(-1)
 
         molecules_container.multiply_residue_temperature_factors(coordMolNo, '//', 2)
+        const pdbString_2  = molecules_container.get_molecule_atoms(coordMolNo, "pdb")
+        const st_2 = cootModule.read_structure_from_string(pdbString_2, 'test-molecule')
+        cootModule.gemmi_setup_entities(st_2)
+        cootModule.gemmi_add_entity_types(st_2, true)
+        const bfactor_vec_2 = cootModule.get_structure_bfactors(st_2)
+        const bfactor_vec_2_size = bfactor_vec_2.size()
+        let bfactors_2 = []
+        for (let i = 0; i < bfactor_vec_2_size; i++) {
+            const resInfo = bfactor_vec_2.get(i)
+            bfactors_2.push({...resInfo})
+        }
 
-        const map_mesh_2 = molecules_container.get_map_contours_mesh(mapMolNo, 0, 0, 0, 13, 0.48)
+        molecules_container.get_map_contours_mesh(mapMolNo, 0, 0, 0, 13, 0.48)
         const scores_2 =  molecules_container.get_r_factor_stats()
 
         expect(scores_2.r_factor).not.toBe(-1)
         expect(scores_1).not.toEqual(scores_2)
+
+        expect(
+            bfactors_1.map(item => item.cid)
+        ).toEqual(
+            bfactors_2.map(item => item.cid)
+        )
+
+        expect(
+            bfactors_1.map(item => item.bFactor * 2)
+        ).toEqual(
+            bfactors_2.map(item => item.bFactor)
+        )
+        
+        expect(
+            bfactors_1.map(item => item.normalised_bFactor)
+        ).toEqual(
+            bfactors_2.map(item => item.normalised_bFactor)
+        )
+        
+        cleanUpVariables.push(
+            st_2, bfactor_vec_2, bfactor_vec_1
+        )
     })
 })
 

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -1560,7 +1560,7 @@ describe('Testing molecules_container_js', () => {
         cleanUpVariables.push(instanceMesh_1, instanceMesh_2)
     })
 
-    test("Test change chain ID --first", () => {
+    test("Test change chain ID -- whole chain", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
@@ -1591,7 +1591,7 @@ describe('Testing molecules_container_js', () => {
         cleanUpVariables.push(original_chains_vec, new_chains_vec)
     })
 
-    test("Test change chain ID --second", () => {
+    test("Test change chain ID -- residue range", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
@@ -1636,7 +1636,7 @@ describe('Testing molecules_container_js', () => {
         cleanUpVariables.push(original_chains_vec, new_chains_vec)
     })
 
-    test("Test change chain ID --third", () => {
+    test("Test change chain ID -- colour rules", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -1810,6 +1810,18 @@ describe('Testing molecules_container_js', () => {
         expect(mapMolNo).toBe(1)
         expect(diffMapMolNo).toBe(2)
 
+        const pdbString_1  = molecules_container.get_molecule_atoms(coordMolNo, "pdb")
+        const st_1 = cootModule.read_structure_from_string(pdbString_1, 'test-molecule')
+        cootModule.gemmi_setup_entities(st_1)
+        cootModule.gemmi_add_entity_types(st_1, true)
+        const bfactor_vec_1 = cootModule.get_structure_bfactors(st_1)
+        const bfactor_vec_1_size = bfactor_vec_1.size()
+        let bfactors_1 = []
+        for (let i = 0; i < bfactor_vec_1_size; i++) {
+            const resInfo = bfactor_vec_1.get(i)
+            bfactors_1.push({...resInfo})
+        }
+
         molecules_container.associate_data_mtz_file_with_map(mapMolNo, './5a3h_sigmaa.mtz', 'FP', 'SIGFP', 'FREE')
         molecules_container.connect_updating_maps(coordMolNo, mapMolNo, mapMolNo, diffMapMolNo)
         molecules_container.sfcalc_genmaps_using_bulk_solvent(coordMolNo, mapMolNo, diffMapMolNo, mapMolNo)
@@ -1821,11 +1833,45 @@ describe('Testing molecules_container_js', () => {
         const result = molecules_container.shift_field_b_factor_refinement(coordMolNo, mapMolNo)
         expect(result).toBeTruthy()
 
+        const pdbString_2  = molecules_container.get_molecule_atoms(coordMolNo, "pdb")
+        const st_2 = cootModule.read_structure_from_string(pdbString_2, 'test-molecule')
+        cootModule.gemmi_setup_entities(st_2)
+        cootModule.gemmi_add_entity_types(st_2, true)
+        const bfactor_vec_2 = cootModule.get_structure_bfactors(st_2)
+        const bfactor_vec_2_size = bfactor_vec_2.size()
+        let bfactors_2 = []
+        for (let i = 0; i < bfactor_vec_2_size; i++) {
+            const resInfo = bfactor_vec_2.get(i)
+            bfactors_2.push({...resInfo})
+        }
+
         const map_mesh_2 = molecules_container.get_map_contours_mesh(mapMolNo, 0, 0, 0, 13, 0.48)
         const scores_2 =  molecules_container.get_r_factor_stats()
 
         expect(scores_2.r_factor).not.toBe(-1)
         expect(scores_1).not.toEqual(scores_2)
+
+        expect(
+            bfactors_1.map(item => item.cid)
+        ).toEqual(
+            bfactors_2.map(item => item.cid)
+        )
+
+        expect(
+            bfactors_1.map(item => item.bFactor)
+        ).not.toEqual(
+            bfactors_2.map(item => item.bFactor)
+        )
+        
+        expect(
+            bfactors_1.map(item => item.normalised_bFactor)
+        ).not.toEqual(
+            bfactors_2.map(item => item.normalised_bFactor)
+        )
+        
+        cleanUpVariables.push(
+            st_2, bfactor_vec_2, bfactor_vec_1
+        )
     })
 
     test("Test multiply_residue_temperature_factors", () => {
@@ -1859,6 +1905,7 @@ describe('Testing molecules_container_js', () => {
         expect(scores_1.r_factor).not.toBe(-1)
 
         molecules_container.multiply_residue_temperature_factors(coordMolNo, '//', 2)
+        
         const pdbString_2  = molecules_container.get_molecule_atoms(coordMolNo, "pdb")
         const st_2 = cootModule.read_structure_from_string(pdbString_2, 'test-molecule')
         cootModule.gemmi_setup_entities(st_2)

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -1488,6 +1488,77 @@ describe('Testing molecules_container_js', () => {
         cleanUpVariables.push(instanceMesh_1, instanceMesh_2, indexedResiduesVec, colourMap, geom_2, geom_1)
     })
 
+    test("Test colour rules and multi CID selection mesh --third", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
+        const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
+
+        const instanceMesh_1 = molecules_container.get_bonds_mesh_for_selection_instanced(
+            coordMolNo, '//A/10-20||//A/25-30', 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1
+        )
+        
+        const geom_1 = instanceMesh_1.geom
+        const geomSize_1 = geom_1.size()
+        let colours_1 = []
+        for (let i = 0; i < geomSize_1; i++) {
+            const inst = geom_1.get(i);
+            const As = inst.instancing_data_A;
+            const Asize = As.size();
+    
+            for (let j = 0; j < Asize; j++) {
+                const inst_data = As.get(j)
+                const instDataColour = inst_data.colour
+                colours_1.push(instDataColour[0])
+                colours_1.push(instDataColour[1])
+                colours_1.push(instDataColour[2])
+                colours_1.push(instDataColour[3])    
+            }
+            As.delete()
+        }
+
+        let colourMap = new cootModule.MapIntFloat3()
+        let indexedResiduesVec = new cootModule.VectorStringUInt_pair()
+        
+        const colours = [
+            { cid: "//A", rgb: [1, 0, 0] }
+        ]
+        colours.forEach((colour, index) => {
+            colourMap.set(index + 51, colour.rgb)
+            const i = { first: colour.cid, second: index + 51 }
+            indexedResiduesVec.push_back(i)
+        })
+    
+        molecules_container.set_user_defined_bond_colours(coordMolNo, colourMap)
+        molecules_container.set_user_defined_atom_colour_by_selection(coordMolNo, indexedResiduesVec, false)
+
+        const instanceMesh_2 = molecules_container.get_bonds_mesh_for_selection_instanced(
+            coordMolNo, '//A/10-20||//A/25-30', 'COLOUR-BY-CHAIN-AND-DICTIONARY', false, 0.1, 1, 1
+        )
+
+        const geom_2 = instanceMesh_2.geom
+        const geomSize_2 = geom_2.size()
+        let colours_2 = []
+        for (let i = 0; i < geomSize_2; i++) {
+            const inst = geom_2.get(i);
+            const As = inst.instancing_data_A;
+            const Asize = As.size();
+    
+            for (let j = 0; j < Asize; j++) {
+                const inst_data = As.get(j)
+                const instDataColour = inst_data.colour
+                colours_2.push(instDataColour[0])
+                colours_2.push(instDataColour[1])
+                colours_2.push(instDataColour[2])
+                colours_2.push(instDataColour[3])    
+            }
+            As.delete()
+        }
+
+        expect(colours_2).not.toEqual(colours_1)
+
+        cleanUpVariables.push(instanceMesh_1, instanceMesh_2, indexedResiduesVec, colourMap, geom_2, geom_1)
+    })
+
     test("Test non-drawn bonds and multi CID selection mesh --first", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         molecules_container.set_use_gemmi(false)
@@ -1531,6 +1602,12 @@ describe('Testing molecules_container_js', () => {
             instanceMesh_2.geom.get(1).instancing_data_B.size()
         ).not.toBe(
             instanceMesh_1.geom.get(1).instancing_data_B.size()
+        )
+
+        expect(
+            instanceMesh_2.geom.get(0).instancing_data_A.size()
+        ).not.toBe(
+            instanceMesh_1.geom.get(0).instancing_data_A.size()
         )
 
         cleanUpVariables.push(instanceMesh_1, instanceMesh_2)

--- a/coot/moorhen-wrappers.cc
+++ b/coot/moorhen-wrappers.cc
@@ -1093,6 +1093,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     ;
     class_<molecules_container_t>("molecules_container_t")
     .constructor<bool>()
+    .function("split_multi_model_molecule", &molecules_container_t::split_multi_model_molecule)
     .function("print_non_drawn_bonds", &molecules_container_t::print_non_drawn_bonds)
     .function("pop_back", &molecules_container_t::pop_back)
     .function("get_use_gemmi", &molecules_container_t::get_use_gemmi)


### PR DESCRIPTION
This update includes:
- More tests added to the testing suite (shift field refinement, multiply bfactor, diff_diff_map_peaks, colour rules...)
- Added shift field refinement to the UI (resolves #321)
- Added multiply bfactor menu item to the UI (resolves #322)
- Refactor `getCentreAtom` into `utils`