### PR TITLE
Optimise `MoorhenMolecule.gemmiAtomsForCid` and other fixes for adaptative bonds

### DIFF
--- a/baby-gru/public/baby-gru/CootWorker.ts
+++ b/baby-gru/public/baby-gru/CootWorker.ts
@@ -852,10 +852,8 @@ const new_positions_for_residue_atoms = (molToUpDate: number, residues: libcootA
     const movedResidueVector  = new cootModule.Vectormoved_residue_t()
     residues.forEach(atoms => {
         if (atoms.length > 0) {
-            const cidFields = atoms[0].label.split('/')
-            let [resNoStr, insCode] = cidFields[3].split(".")
-            insCode = insCode ? insCode : ""
-            const movedResidue = new cootModule.moved_residue_t(cidFields[2], parseInt(resNoStr), insCode)
+            const atomInfo = atoms[0]
+            const movedResidue = new cootModule.moved_residue_t(atomInfo.chain_id, parseInt(atomInfo.res_no), "")
             atoms.forEach(atom => {
                 const movedAtom = new cootModule.moved_atom_t(atom.name, atom.alt_loc, atom.x, atom.y, atom.z, -1)
                 movedResidue.add_atom(movedAtom)

--- a/baby-gru/src/components/MoorhenContainer.tsx
+++ b/baby-gru/src/components/MoorhenContainer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useCallback, useRef, useMemo } from 'react';
 import { Container, Col, Row, Spinner } from 'react-bootstrap';
 import { MoorhenWebMG } from './webMG/MoorhenWebMG';
-import { getTooltipShortcutLabel, createLocalStorageInstance } from '../utils/MoorhenUtils';
+import { getTooltipShortcutLabel, createLocalStorageInstance, getAtomInfoLabel } from '../utils/MoorhenUtils';
 import { MoorhenCommandCentre } from "../utils/MoorhenCommandCentre"
 import { MoorhenTimeCapsule } from '../utils/MoorhenTimeCapsule';
 import { Backdrop } from "@mui/material";
@@ -310,7 +310,7 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
         checkMoleculeSizes()
     }, [molecules])
 
-    const onAtomHovered = useCallback((identifier: { buffer: { id: string; }; atom: { label: string; }; }) => {
+    const onAtomHovered = useCallback((identifier: { buffer: { id: string; }; atom: moorhen.AtomInfo; }) => {
         if (identifier == null) {
             if (lastHoveredAtomRef.current !== null && lastHoveredAtomRef.current.molecule !== null) {
                 dispatch( setHoveredAtom({ molecule: null, cid: null }) )
@@ -319,8 +319,9 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
         else {
             molecules.forEach(molecule => {
                 if (molecule.buffersInclude(identifier.buffer)) {
-                    if (molecule !== hoveredAtom.molecule || identifier.atom.label !== hoveredAtom.cid) {
-                        dispatch( setHoveredAtom({ molecule: molecule, cid: identifier.atom.label }) )
+                    const newCid = getAtomInfoLabel(identifier.atom)
+                    if (molecule !== hoveredAtom.molecule || newCid !== hoveredAtom.cid) {
+                        dispatch( setHoveredAtom({ molecule: molecule, cid: newCid }) )
                     }
                 }
             })

--- a/baby-gru/src/components/button/MoorhenContextButtonBase.tsx
+++ b/baby-gru/src/components/button/MoorhenContextButtonBase.tsx
@@ -25,7 +25,7 @@ const MoorhenPopoverOptions = (props: {
     const selectRef = useRef<HTMLSelectElement | null>(null)
     const extraInputRef = useRef(null)
     
-    const handleRightClick = useCallback((e) => {
+    const handleRightClick = useCallback((e: moorhen.AtomRightClickEvent) => {
         if (props.showContextMenu) {
             props.setShowOverlay(false)
         }

--- a/baby-gru/src/components/context-menu/MoorhenContextMenu.tsx
+++ b/baby-gru/src/components/context-menu/MoorhenContextMenu.tsx
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
 import { ClickAwayListener, FormGroup, List, Tooltip } from '@mui/material';
 import { MoorhenBackgroundColorMenuItem } from "../menu-item/MoorhenBackgroundColorMenuItem"
-import { cidToSpec, convertRemToPx } from "../../utils/MoorhenUtils";
+import { atomInfoToResSpec, cidToSpec, convertRemToPx } from "../../utils/MoorhenUtils";
 import { useEffect, useRef, useState, useCallback, MutableRefObject, RefObject } from "react";
 import { Popover, Overlay, FormLabel, FormSelect, Button, Stack } from "react-bootstrap";
 import { MoorhenAddAltConfButton } from "../button/MoorhenAddAltConfButton"
@@ -141,7 +141,7 @@ export const MoorhenContextMenu = (props: {
     selectedMolecule = molecules.find(molecule => molecule.buffersInclude(props.showContextMenu ? props.showContextMenu.buffer : null))
   }
   if (props.showContextMenu && props.showContextMenu.atom) {
-    chosenAtom = cidToSpec(props.showContextMenu.atom.label)
+    chosenAtom = atomInfoToResSpec(props.showContextMenu.atom)
   }
 
   // Do not show context menu unless clicked on atom. We might to revert this in the future...

--- a/baby-gru/src/components/misc/MoorhenAcceptRejectDragAtoms.tsx
+++ b/baby-gru/src/components/misc/MoorhenAcceptRejectDragAtoms.tsx
@@ -5,7 +5,7 @@ import { IconButton } from "@mui/material"
 import { useDispatch, useSelector } from "react-redux"
 import { moorhen } from "../../types/moorhen"
 import { useCallback, useEffect, useRef } from "react"
-import { cidToSpec } from '../../utils/MoorhenUtils';
+import { cidToSpec, getAtomInfoLabel } from '../../utils/MoorhenUtils';
 import { webGL } from "../../types/mgWebGL"
 import { setIsDraggingAtoms } from "../../store/generalStatesSlice"
 import { triggerUpdate } from "../../store/moleculeMapUpdateSlice"
@@ -48,7 +48,7 @@ export const MoorhenAcceptRejectDragAtoms = (props: {
         draggingDirty.current = true
         if (!busy.current) {
             moltenFragmentRef.current.clearBuffersOfStyle('hover')
-            await handleAtomDragged(evt.detail.atom.atom.label)
+            await handleAtomDragged(evt)
         }
     }, [moltenFragmentRef])
 
@@ -60,7 +60,8 @@ export const MoorhenAcceptRejectDragAtoms = (props: {
         moltenFragmentRef.current.displayObjectsTransformation.quat = null
     }, [moltenFragmentRef])
 
-    const handleAtomDragged = async (atomCid: string) => {
+    const handleAtomDragged = async (evt: moorhen.AtomDraggedEvent) => {
+        const atomCid = getAtomInfoLabel(evt.detail.atom)
         if (draggingDirty.current && atomCid) {
             busy.current = true
             refinementDirty.current = true
@@ -80,7 +81,7 @@ export const MoorhenAcceptRejectDragAtoms = (props: {
             }, false)
             await moltenFragmentRef.current.drawWithStyleFromMesh('CBs', [result.data.result.result])
             busy.current = false
-            handleAtomDragged(atomCid)
+            handleAtomDragged(evt)
         }
     }
 

--- a/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
+++ b/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
@@ -1,5 +1,5 @@
 import { IconButton, Popover, Tooltip } from "@mui/material"
-import { cidToSpec, guid } from "../../utils/MoorhenUtils"
+import { atomInfoToResSpec, cidToSpec, getAtomInfoLabel, guid } from "../../utils/MoorhenUtils"
 import { MoorhenNotification } from "./MoorhenNotification"
 import { AdsClickOutlined, AllOutOutlined, CloseOutlined, CopyAllOutlined, CrisisAlertOutlined, DeleteOutlined, EditOutlined, FormatColorFillOutlined, Rotate90DegreesCw, SwapVertOutlined, SwipeRightAlt } from "@mui/icons-material"
 import { batch, useDispatch, useSelector } from "react-redux"
@@ -67,12 +67,12 @@ export const MoorhenResidueSelectionActions = (props) => {
         }
         
         if (residueSelection.first === null || residueSelection.molecule === null || residueSelection.molecule.molNo !== selectedMolecule.molNo) {
-            const resSpec = cidToSpec(evt.detail.atom.label)
+            const resSpec = atomInfoToResSpec(evt.detail.atom)
             await selectedMolecule.drawResidueSelection(`/*/${resSpec.chain_id}/${resSpec.res_no}-${resSpec.res_no}/*`)
             dispatch(
                 setResidueSelection({
                     molecule: selectedMolecule,
-                    first: evt.detail.atom.label,
+                    first: resSpec.cid,
                     second: null,
                     cid: null,
                     isMultiCid: false,
@@ -84,7 +84,7 @@ export const MoorhenResidueSelectionActions = (props) => {
         }
 
         const startResSpec = cidToSpec(residueSelection.first)
-        const stopResSpec = cidToSpec(evt.detail.atom.label)
+        const stopResSpec = atomInfoToResSpec(evt.detail.atom)
         if (startResSpec.chain_id !== stopResSpec.chain_id) {
             dispatch( clearResidueSelection() )
         } else {
@@ -95,7 +95,7 @@ export const MoorhenResidueSelectionActions = (props) => {
                 setResidueSelection({
                     molecule: selectedMolecule,
                     first: residueSelection.first,
-                    second: evt.detail.atom.label,
+                    second: stopResSpec.cid,
                     cid: cid,
                     isMultiCid: false,
                     label: `/${startResSpec.mol_no}/${startResSpec.chain_id}/${sortedResNums[0]}-${sortedResNums[1]}`

--- a/baby-gru/src/components/modal/MoorhenCreateAcedrgLinkModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenCreateAcedrgLinkModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useImperativeHandle, forwardRef } from 'react';
-import { cidToSpec, convertRemToPx, convertViewtoPx } from "../../utils/MoorhenUtils";
+import { cidToSpec, convertRemToPx, convertViewtoPx, getAtomInfoLabel } from "../../utils/MoorhenUtils";
 import { Button, Card, Dropdown, Form, InputGroup, Row, Spinner, SplitButton, Stack } from "react-bootstrap";
 import { Backdrop, TextField } from "@mui/material";
 import { moorhen } from "../../types/moorhen";
@@ -157,7 +157,10 @@ const AceDRGtomPicker = forwardRef<any, AceDRGtomPickerProps>((props, ref) => {
                     }}>No</Dropdown.Item>
                 </SplitButton>
                 <Form.Select disabled={!deleteAtom} ref={deleteSelectedAtomValueRef}>
-                    {monomerAtoms.map(atom => <option key={atom.label} value={atom.label}>{atom.has_altloc ? `${atom.name}:${atom.alt_loc}` : atom.name}</option>) }
+                    {monomerAtoms.map(atom => {
+                        const label = getAtomInfoLabel(atom)
+                        return <option key={label} value={label}>{atom.has_altloc ? `${atom.name}:${atom.alt_loc}` : atom.name}</option>
+                    }) }
                 </Form.Select>
             </InputGroup>
             </div>
@@ -206,7 +209,10 @@ const AceDRGtomPicker = forwardRef<any, AceDRGtomPickerProps>((props, ref) => {
                     }}>No</Dropdown.Item>
                 </SplitButton>
                 <Form.Select disabled={!changeAtomCharge} ref={changeSelectedAtomChargeValueRef}>
-                    {monomerAtoms.map(atom => <option key={atom.label} value={atom.label}>{atom.has_altloc ? `${atom.name}:${atom.alt_loc}` : atom.name}</option>) }
+                    {monomerAtoms.map(atom => {
+                        const label = getAtomInfoLabel(atom)
+                        return <option key={label} value={label}>{atom.has_altloc ? `${atom.name}:${atom.alt_loc}` : atom.name}</option>
+                    }) }
                 </Form.Select>
             </InputGroup>
             <Row style={{justifyContent: 'center', display: changeAtomCharge ? 'flex' : 'none'}}>

--- a/baby-gru/src/components/sequence-viewer/MoorhenSequenceViewer.tsx
+++ b/baby-gru/src/components/sequence-viewer/MoorhenSequenceViewer.tsx
@@ -8,7 +8,7 @@ import { webGL } from "../../types/mgWebGL";
 import { clickedResidueType } from '../card/MoorhenMoleculeCard';
 import { useSelector, useDispatch } from 'react-redux';
 import { setHoveredAtom } from "../../store/hoveringStatesSlice";
-import { cidToSpec } from "../../utils/MoorhenUtils";
+import { cidToAtomInfo, cidToSpec } from "../../utils/MoorhenUtils";
 
 !window.customElements.get('protvista-navigation') && window.customElements.define("protvista-navigation", ProtvistaNavigation);
 !window.customElements.get('protvista-sequence') && window.customElements.define("protvista-sequence", ProtvistaSequence);
@@ -222,7 +222,7 @@ export const MoorhenSequenceViewer = (props: MoorhenSequenceViewerPropsType) => 
                 } else if (shiftKey.current && props.useMainStateResidueSelections) {
                     let atomClicked: moorhen.AtomClickedEvent = new CustomEvent("atomClicked", {
                         "detail": {
-                            atom: {label: residue.cid},
+                            atom: cidToAtomInfo(residue.cid),
                             buffer: {id: props.molecule.representations[0]?.buffers[0]?.id},
                             isResidueSelection: true
                         }

--- a/baby-gru/src/components/webMG/MoorhenWebMG.tsx
+++ b/baby-gru/src/components/webMG/MoorhenWebMG.tsx
@@ -16,7 +16,7 @@ interface MoorhenWebMGPropsInterface {
     viewOnly: boolean;
     urlPrefix: string;
     extraDraggableModals: JSX.Element[];
-    onAtomHovered: (identifier: { buffer: { id: string; }; atom: { label: string; }; }) => void;
+    onAtomHovered: (identifier: { buffer: { id: string; }; atom: moorhen.AtomInfo; }) => void;
     onKeyPress: (event: KeyboardEvent) =>  boolean | Promise<boolean>;
     videoRecorderRef: React.MutableRefObject<null | moorhen.ScreenRecorder>;
 }

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -68,8 +68,7 @@ export namespace libcootApi {
         y: number;
         z: number;
         charge: number;
-        element: emscriptem.instance<string>;
-        symbol: string;
+        element: string;
         tempFactor: number;
         serial: number;
         name: string;
@@ -79,7 +78,7 @@ export namespace libcootApi {
         chain_id: string;
         res_no: string;
         res_name: string;
-        label: string;
+        label: string
     }
     interface AutoReadMtzInfo {
         idx: number;

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -78,7 +78,6 @@ export namespace libcootApi {
         chain_id: string;
         res_no: string;
         res_name: string;
-        label: string
     }
     interface AutoReadMtzInfo {
         idx: number;

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -127,7 +127,8 @@ declare module 'moorhen' {
         setDrawAdaptativeBonds(newValue: boolean): Promise<void>;
         getActiveAtom(): Promise<string>;
         adaptativeBondsEnabled: boolean;
-        cachedLigandSVGs: {[key: string]: string}[];
+        cachedLigandSVGs: {[key: string]: string};
+        cachedGemmiAtoms: _moorhen.AtomInfo[];
         cachedPrivateerValidation: privateer.ResultsEntry[];
         isLigand: boolean;
         type: string;

--- a/baby-gru/src/types/mgWebGL.d.ts
+++ b/baby-gru/src/types/mgWebGL.d.ts
@@ -217,7 +217,7 @@ export namespace webGL {
         doRedraw: boolean;
         circleCanvasInitialized: boolean;
         textCanvasInitialized: boolean;
-        currentlyDraggedAtom: null | {atom: {charge: number, tempFactor: number, x: number, y: number, z: number, symbol: string, label:string}, buffer: DisplayBuffer};
+        currentlyDraggedAtom: null | {atom: moorhen.AtomInfo; buffer: DisplayBuffer};
         gl_cursorPos: Float32Array;
         textCtx: CanvasRenderingContext2D;
         circleCtx: CanvasRenderingContext2D;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -65,7 +65,6 @@ export namespace moorhen {
         chain_id: string;
         res_no: string;
         res_name: string;
-        label: string;
     }
     
     type DisplayObject = {
@@ -540,7 +539,7 @@ export namespace moorhen {
     }
 
     type AtomRightClickEventInfo = {
-        atom: {label: string};
+        atom: moorhen.AtomInfo;
         buffer: {id: string};
         coords: string,
         pageX: number;
@@ -549,12 +548,10 @@ export namespace moorhen {
 
     type AtomRightClickEvent = CustomEvent<AtomRightClickEventInfo>
     
-    type AtomDraggedEvent = CustomEvent<{ atom: {
-        atom: {
-            label: string;
-        };
+    type AtomDraggedEvent = CustomEvent<{ 
+        atom: moorhen.AtomInfo
         buffer: any;
-    } }>
+    }>
 
     type OriginUpdateEvent = CustomEvent<{ origin: [number, number, number]; }>
 
@@ -564,7 +561,7 @@ export namespace moorhen {
 
     type AtomClickedEvent = CustomEvent<{
         buffer: { id: string };
-        atom: { label: string };
+        atom: moorhen.AtomInfo;
         isResidueSelection: boolean;
     }>
 

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -167,7 +167,8 @@ export namespace moorhen {
         isValidSelection(cid: string): Promise<boolean>;
         type: string;
         adaptativeBondsEnabled: boolean;
-        cachedLigandSVGs: {[key: string]: string}[];
+        cachedLigandSVGs: {[key: string]: string};
+        cachedGemmiAtoms: AtomInfo[];
         cachedPrivateerValidation: privateer.ResultsEntry[];
         isLigand: boolean;
         excludedCids: string[];

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -51,7 +51,6 @@ export namespace moorhen {
     }
     
     type AtomInfo = {
-        pos: [number, number, number];
         x: number;
         y: number;
         z: number;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -56,8 +56,7 @@ export namespace moorhen {
         y: number;
         z: number;
         charge: number;
-        element: emscriptem.instance<string>;
-        symbol: string;
+        element: string;
         tempFactor: number;
         serial: number;
         name: string;

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1,7 +1,7 @@
 import 'pako';
 import { 
     guid, readTextFile, readGemmiStructure, centreOnGemmiAtoms, 
-    getRandomMoleculeColour, doDownload, formatLigandSVG, getCentreAtom
+    getRandomMoleculeColour, doDownload, formatLigandSVG, getCentreAtom, getAtomInfoLabel
  } from './MoorhenUtils'
 import { MoorhenMoleculeRepresentation } from "./MoorhenMoleculeRepresentation"
 import { quatToMat4 } from '../WebGLgComponents/quatToMat4.js';
@@ -1350,7 +1350,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
                         let z = gemmiAtomPos.z + this.glRef.current.origin[2] - diff[2]
                         const origin = this.displayObjectsTransformation.origin
                         const quat = this.displayObjectsTransformation.quat
-                        const cid = `/${model.name}/${chain.name}/${residueSeqId.str()}/${atom.name}${atomHasAltLoc ? ':' + String.fromCharCode(atomAltLoc) : ''}`
                         if (quat) {
                             const theMatrix = quatToMat4(quat)
                             theMatrix[12] = origin[0]
@@ -1376,7 +1375,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
                                 serial: atomSerial,
                                 has_altloc: atomHasAltLoc,
                                 alt_loc: atomHasAltLoc ? String.fromCharCode(atomAltLoc) : '',
-                                label: cid
                             })
                         }
                         atom.delete()
@@ -1657,13 +1655,10 @@ export class MoorhenMolecule implements moorhen.Molecule {
         const atomInfoVecSize = atomInfoVec.size()
         for (let i = 0; i < atomInfoVecSize; i++) {
             const atomInfo = atomInfoVec.get(i)
-            result.push({
-                ...atomInfo,
-                label: `/${atomInfo.mol_name}/${atomInfo.chain_id}/${atomInfo.res_no}(${atomInfo.res_name})/${atomInfo.name}${atomInfo.has_altloc ? `:${atomInfo.alt_loc}` : ""}`
-            })
+            result.push(atomInfo)
         }
         atomInfoVec.delete()
-        
+
         return result
     }
 
@@ -2075,8 +2070,8 @@ export class MoorhenMolecule implements moorhen.Molecule {
 
         return {
             molecule: this,
-            first: selectionAtoms[0].label,
-            second: selectionAtoms[selectionAtoms.length - 1].label,
+            first: getAtomInfoLabel(selectionAtoms[0]),
+            second: getAtomInfoLabel(selectionAtoms[selectionAtoms.length - 1]),
             isMultiCid: cid.includes('||'),
             cid: cid.includes('||') ? cid.split('||') : cid,
             label: cid

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1368,11 +1368,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
                                 res_name: residue.name,
                                 name: atomName,
                                 element: atomElementString,
-                                pos: [
-                                    transPos[0] - this.glRef.current.origin[0] + diff[0],
-                                    transPos[1] - this.glRef.current.origin[1] + diff[1],
-                                    transPos[2] - this.glRef.current.origin[2] + diff[2]
-                                ],
                                 tempFactor: atom.b_iso,
                                 charge: atom.charge,
                                 x: transPos[0] - this.glRef.current.origin[0] + diff[0],
@@ -1664,7 +1659,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
             const atomInfo = atomInfoVec.get(i)
             result.push({
                 ...atomInfo,
-                pos: [atomInfo.x, atomInfo.y, atomInfo.z],
                 label: `/${atomInfo.mol_name}/${atomInfo.chain_id}/${atomInfo.res_no}(${atomInfo.res_name})/${atomInfo.name}${atomInfo.has_altloc ? `:${atomInfo.alt_loc}` : ""}`
             })
         }

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1342,8 +1342,8 @@ export class MoorhenMolecule implements moorhen.Molecule {
                         const atomAltLoc = atom.altloc
                         const atomSerial = atom.serial
                         const atomHasAltLoc = atom.has_altloc()
-                        const atomSymbol: string = window.CCP4Module.getElementNameAsString(atomElement)
-                        const atomName = atomSymbol.length === 2 ? (atom.name).padEnd(4, " ") : (" " + atom.name).padEnd(4, " ")
+                        const atomElementString: string = window.CCP4Module.getElementNameAsString(atomElement)
+                        const atomName = atomElementString.length === 2 ? (atom.name).padEnd(4, " ") : (" " + atom.name).padEnd(4, " ")
                         const diff = this.displayObjectsTransformation.centre
                         let x = gemmiAtomPos.x + this.glRef.current.origin[0] - diff[0]
                         let y = gemmiAtomPos.y + this.glRef.current.origin[1] - diff[1]
@@ -1367,7 +1367,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
                                 res_no: residueSeqId.str(),
                                 res_name: residue.name,
                                 name: atomName,
-                                element: atomElement,
+                                element: atomElementString,
                                 pos: [
                                     transPos[0] - this.glRef.current.origin[0] + diff[0],
                                     transPos[1] - this.glRef.current.origin[1] + diff[1],
@@ -1375,7 +1375,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
                                 ],
                                 tempFactor: atom.b_iso,
                                 charge: atom.charge,
-                                symbol: atomSymbol,
                                 x: transPos[0] - this.glRef.current.origin[0] + diff[0],
                                 y: transPos[1] - this.glRef.current.origin[1] + diff[1],
                                 z: transPos[2] - this.glRef.current.origin[2] + diff[2],
@@ -1657,13 +1656,17 @@ export class MoorhenMolecule implements moorhen.Molecule {
         if (this.atomsDirty || this.gemmiStructure.isDeleted()) {
             await this.updateAtoms()
         }
-        
+
         let result: moorhen.AtomInfo[] = []
         const atomInfoVec = window.CCP4Module.get_atom_info_for_selection(this.gemmiStructure, cid, omitExcludedCids ? this.excludedSelections.join("||") : "")
         const atomInfoVecSize = atomInfoVec.size()
         for (let i = 0; i < atomInfoVecSize; i++) {
             const atomInfo = atomInfoVec.get(i)
-            result.push({...atomInfo, pos: [atomInfo.x, atomInfo.y, atomInfo.z]})
+            result.push({
+                ...atomInfo,
+                pos: [atomInfo.x, atomInfo.y, atomInfo.z],
+                label: `/${atomInfo.mol_name}/${atomInfo.chain_id}/${atomInfo.res_no}(${atomInfo.res_name})/${atomInfo.name}${atomInfo.has_altloc ? `:${atomInfo.alt_loc}` : ""}`
+            })
         }
         atomInfoVec.delete()
         

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -910,7 +910,7 @@ export const getDashedCylinder = (nsteps: number, cylinder_accu: number): [numbe
 }
 
 export const gemmiAtomPairsToCylindersInfo = (
-    atoms: [{ pos: [number, number, number], serial: (number | string) }, { pos: [number, number, number], serial: (number | string) }][],
+    atoms: [{ x: number, y: number, z: number, serial: (number | string) }, { x: number, y: number, z: number, serial: (number | string) }][],
     size: number,
     colourScheme: { [x: string]: number[]; },
     labelled: boolean = false,
@@ -952,8 +952,8 @@ export const gemmiAtomPairsToCylindersInfo = (
         let ab = vec3.create()
         let midpoint = vec3.create()
 
-        vec3.set(ab, at0.pos[0] - at1.pos[0], at0.pos[1] - at1.pos[1], at0.pos[2] - at1.pos[2])
-        vec3.set(midpoint, 0.5 * (at0.pos[0] + at1.pos[0]), 0.5 * (at0.pos[1] + at1.pos[1]), 0.5 * (at0.pos[2] + at1.pos[2]))
+        vec3.set(ab, at0.x - at1.x, at0.y - at1.y, at0.z - at1.z)
+        vec3.set(midpoint, 0.5 * (at0.x + at1.x), 0.5 * (at0.y + at1.y), 0.5 * (at0.z + at1.z))
         const l = vec3.length(ab)
 
         totTextLabels.push(l.toFixed(2))
@@ -967,13 +967,17 @@ export const gemmiAtomPairsToCylindersInfo = (
             thisInstance_colours.push(colourScheme[`${at0.serial}`][ip])
             totTextPrimCol.push(colourScheme[`${at0.serial}`][ip])
         }
-        thisInstance_origins.push(...at0.pos)
+        thisInstance_origins.push(at0.x, at0.y, at0.z)
         thisInstance_sizes.push(...[size, size, l])
         let v = vec3.create()
         let au = vec3.create()
         let a = vec3.create()
         let b = vec3.create()
-        let aup = at0.pos.map((v, i) => v - at1.pos[i])
+        const aup = [
+            at0.x - at1.x,
+            at0.y - at1.y,
+            at0.z - at1.z
+        ]
         vec3.set(au, ...aup)
         vec3.normalize(a, au)
         vec3.set(b, 0.0, 0.0, -1.0)
@@ -1070,22 +1074,14 @@ export const gemmiAtomsToCirclesSpheresInfo = (atoms: moorhen.AtomInfo[], size: 
 
     for (let iat = 0; iat < atoms.length; iat++) {
         sphere_idx_tri.push(iat);
-        sphere_vert_tri.push(atoms[iat].pos[0]);
-        sphere_vert_tri.push(atoms[iat].pos[1]);
-        sphere_vert_tri.push(atoms[iat].pos[2]);
+        sphere_vert_tri.push(atoms[iat].x);
+        sphere_vert_tri.push(atoms[iat].y);
+        sphere_vert_tri.push(atoms[iat].z);
         for (let ip = 0; ip < colourScheme[`${atoms[iat].serial}`].length; ip++) {
             sphere_col_tri.push(colourScheme[`${atoms[iat].serial}`][ip])
         }
         sphere_sizes.push(size);
-        let atom = {};
-        atom["x"] = atoms[iat].pos[0];
-        atom["y"] = atoms[iat].pos[1];
-        atom["z"] = atoms[iat].pos[2];
-        atom["tempFactor"] = atoms[iat].tempFactor;
-        atom["charge"] = atoms[iat].charge;
-        atom["symbol"] = atoms[iat].element;
-        atom["label"] = ""
-        sphere_atoms.push(atom);
+        sphere_atoms.push(atoms[iat]);
         if (primType === "PERFECT_SPHERES") {
             totInstanceUseColours.push(true);
             totInstance_orientations.push(...[
@@ -1146,7 +1142,7 @@ export const findConsecutiveRanges = (numbers: number[]): [number, number][] => 
     return ranges;
 }
 
-export function getCubeLines(unitCell: gemmi.UnitCell): [{ pos: [number, number, number], serial: string }, { pos: [number, number, number], serial: string }][] {
+export function getCubeLines(unitCell: gemmi.UnitCell): [{ x: number, y: number, z: number, serial: string }, { x: number, y: number, z: number, serial: string }][] {
 
     const orthogonalize = (x: number, y: number, z: number) => {
         const fractPosition = new window.CCP4Module.Fractional(x, y, z)
@@ -1183,15 +1179,23 @@ export function getCubeLines(unitCell: gemmi.UnitCell): [{ pos: [number, number,
         [3, 7]
     ];
 
-    const lines: [{ pos: [number, number, number], serial: string }, { pos: [number, number, number], serial: string }][] = [];
+    const lines: [{ x: number, y: number, z: number, serial: string }, { x: number, y: number, z: number, serial: string }][] = [];
     edges.forEach(edge => {
         const [v1Index, v2Index] = edge
+        
+        const [v1_x, v1_y, v1_z] = orthogonalize(...vertices[v1Index])
         const v1 = {
-            pos: orthogonalize(...vertices[v1Index]),
+            x: v1_x,
+            y: v1_y,
+            z: v1_z,
             serial: 'unit_cell'
         };
+        
+        const [v2_x, v2_y, v2_z] = orthogonalize(...vertices[v2Index])
         const v2 = {
-            pos: orthogonalize(...vertices[v2Index]),
+            x: v2_x,
+            y: v2_y,
+            z: v2_z,
             serial: 'unit_cell'
         };
         lines.push([v1, v2]);

--- a/coot/gemmi-wrappers.cc
+++ b/coot/gemmi-wrappers.cc
@@ -345,7 +345,7 @@ std::vector<SequenceEntry> get_sequence_info(const gemmi::Structure &Structure, 
                 } else {
                     seq_entry.resCode = residueCodesThreeToOne[residue.name];
                 }
-                currentSequence.push_back(seq_entry);
+                currentSequence.push_back(std::move(seq_entry));
             }
             if (currentSequence.size() > 0) {
                 SequenceEntry seq_entry;
@@ -353,7 +353,7 @@ std::vector<SequenceEntry> get_sequence_info(const gemmi::Structure &Structure, 
                 seq_entry.chain = chain.name;
                 seq_entry.sequence = currentSequence;
                 seq_entry.type = int(polymerType);
-                sequences.push_back(seq_entry);
+                sequences.push_back(std::move(seq_entry));
             }
         }
     }
@@ -614,7 +614,7 @@ std::vector<AtomInfo> get_atom_info_for_selection(const gemmi::Structure &Struct
 
     std::vector<gemmi::Selection> selections_vec = parse_multi_cid_selections(cids);
     std::vector<gemmi::Selection> excluded_selections_vec = parse_multi_cid_selections(excluded_cids);
-    std::vector<AtomInfo> atom_info_vec;
+std::vector<AtomInfo> atom_info_vec;
 
     auto _structure = Structure;
     for (const auto& selection : excluded_selections_vec) {
@@ -633,7 +633,6 @@ std::vector<AtomInfo> get_atom_info_for_selection(const gemmi::Structure &Struct
                         atom_info.z = atom.pos.z;
                         atom_info.charge = atom.charge;
                         atom_info.element = get_element_name_as_string(atom.element);
-                        atom_info.symbol = get_element_name_as_string(atom.element);
                         atom_info.tempFactor = atom.b_iso;
                         atom_info.serial = atom.serial;
                         atom_info.name = atom.name;
@@ -642,15 +641,11 @@ std::vector<AtomInfo> get_atom_info_for_selection(const gemmi::Structure &Struct
                         atom_info.chain_id = chain.name;
                         atom_info.res_no = residue.seqid.str();
                         atom_info.res_name = residue.name;
-                        atom_info.label = "/" + model.name + "/" + chain.name + "/" + residue.seqid.str() +"(" + residue.name + ")/" + atom.name;
                         if (atom.has_altloc()) {
                             std::string altloc_str(1, atom.altloc);
-                            atom_info.label += ":" + altloc_str;
                             atom_info.alt_loc = altloc_str;
-                        } else {
-                            atom_info.alt_loc = "";
-                        }
-                        atom_info_vec.push_back(atom_info);
+                        } 
+                        atom_info_vec.push_back(std::move(atom_info)); 
                     }
                 }
             }
@@ -2657,7 +2652,6 @@ EMSCRIPTEN_BINDINGS(gemmi_module) {
     .field("z", &AtomInfo::z)
     .field("charge", &AtomInfo::charge)
     .field("element", &AtomInfo::element)
-    .field("symbol", &AtomInfo::symbol)
     .field("tempFactor", &AtomInfo::tempFactor)
     .field("serial", &AtomInfo::serial)
     .field("name", &AtomInfo::name)
@@ -2667,7 +2661,6 @@ EMSCRIPTEN_BINDINGS(gemmi_module) {
     .field("chain_id", &AtomInfo::chain_id)
     .field("res_no", &AtomInfo::res_no)
     .field("res_name", &AtomInfo::res_name)
-    .field("label", &AtomInfo::label)
     ;
 
     register_vector<AtomInfo>("VectorAtomInfo");


### PR DESCRIPTION
This update includes:
- Refactor code for speed optimisation of `MoorhenMolecule.gemmiAtomsForCid`. Now atom labels are computed on demand and are therefore no longer part of `moorhen.AtomInfo`.
- Cache the atom information for a molecule in `MoorhenMolecule.gemmiAtomsForCid` to avoid unnecessary recalculations.
- A fix for a bug causing adaptive bonds to disappear after deleting the active atom.