### PR TITLE
Small bug fixes for session storage and better map colour handling

### DIFF
--- a/baby-gru/src/components/card/MoorhenMapCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMapCard.tsx
@@ -73,67 +73,74 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
             return 1.0
         }
     })
+    
+    // Need to stringify to ensure the selector is stable... (dont want to return a new obj reference)
     const mapColourString = useSelector((state: moorhen.State) => {
         const map = state.mapContourSettings.mapColours.find(item => item.molNo === props.map.molNo)
-        let result: {r: number, g: number, b: number}
-        if (map) {
-            result = map.rgb
-        } else {
-            result = {r: props.map.defaultMapColour.r * 255., g: props.map.defaultMapColour.g * 255., b: props.map.defaultMapColour.b * 255.}
-        }
-        // Need to stringify to ensure the selector is stable... (dont want to return a new obj reference)
-        return JSON.stringify(result)
+        return map ? JSON.stringify(map.rgb) : ""
     })
-    const mapColourHex = useSelector((state: moorhen.State) => {
-        const map = state.mapContourSettings.mapColours.find(item => item.molNo === props.map.molNo)
-        let result: string
-        if (map) {
-            result = rgbToHex(map.rgb.r, map.rgb.g, map.rgb.b)
-        } else {
-            result = rgbToHex(props.map.defaultMapColour.r, props.map.defaultMapColour.g, props.map.defaultMapColour.b)
-        }
-        return result
-    })
+    
     const negativeMapColourString = useSelector((state: moorhen.State) => {
         const map = state.mapContourSettings.negativeMapColours.find(item => item.molNo === props.map.molNo)
-        let result: {r: number, g: number, b: number}
-        if (map) {
-            result = map.rgb
-        } else {
-            result = {r: props.map.defaultNegativeMapColour.r * 255., g: props.map.defaultNegativeMapColour.g * 255., b: props.map.defaultNegativeMapColour.b * 255.}
-        }
-        return JSON.stringify(result)
+        return map ? JSON.stringify(map.rgb) : ""
     })
-    const negativeMapColourHex = useSelector((state: moorhen.State) => {
-        const map = state.mapContourSettings.negativeMapColours.find(item => item.molNo === props.map.molNo)
-        let result: string
-        if (map) {
-            result = rgbToHex(map.rgb.r, map.rgb.g, map.rgb.b)
-        } else {
-            result = rgbToHex(props.map.defaultNegativeMapColour.r, props.map.defaultNegativeMapColour.g, props.map.defaultNegativeMapColour.b)
-        }
-        return JSON.stringify(result)
-    })
+
     const positiveMapColourString = useSelector((state: moorhen.State) => {
         const map = state.mapContourSettings.positiveMapColours.find(item => item.molNo === props.map.molNo)
-        let result: {r: number, g: number, b: number}
-        if (map) {
-            result = map.rgb
-        } else {
-           result = {r: props.map.defaultPositiveMapColour.r * 255., g: props.map.defaultPositiveMapColour.g * 255., b: props.map.defaultPositiveMapColour.b * 255.}
-        }
-        return JSON.stringify(result)
+        return map ? JSON.stringify(map.rgb) : ""
     })
-    const positiveMapColourHex = useSelector((state: moorhen.State) => {
-        const map = state.mapContourSettings.positiveMapColours.find(item => item.molNo === props.map.molNo)
-        let result: string
-        if (map) {
-            result = rgbToHex(map.rgb.r, map.rgb.g, map.rgb.b)
+
+    const mapColour: {r: number; g: number; b: number;} = useMemo(() => {
+        if (mapColourString) {
+            return JSON.parse(mapColourString)
         } else {
-            result = rgbToHex(props.map.defaultPositiveMapColour.r, props.map.defaultPositiveMapColour.g, props.map.defaultPositiveMapColour.b)
+            return {r: props.map.defaultMapColour.r * 255., g: props.map.defaultMapColour.g * 255., b: props.map.defaultMapColour.b * 255.}
         }
-        return JSON.stringify(result)
-    })
+    }, [mapColourString])
+    
+    const mapColourHex: string  = useMemo(() => {
+        if (mapColourString) {
+            const rgb = JSON.parse(mapColourString)
+            return rgbToHex(rgb.r, rgb.g, rgb.b)
+        } else {
+            return rgbToHex(props.map.defaultMapColour.r, props.map.defaultMapColour.g, props.map.defaultMapColour.b)
+        }
+    }, [mapColourString])
+
+    const negativeMapColour: {r: number; g: number; b: number;} = useMemo(() => {
+        if (negativeMapColourString) {
+            return JSON.parse(negativeMapColourString)
+        } else {
+            return {r: props.map.defaultNegativeMapColour.r * 255., g: props.map.defaultNegativeMapColour.g * 255., b: props.map.defaultNegativeMapColour.b * 255.}
+        }
+    }, [negativeMapColourString])
+
+    const negativeMapColourHex: string  = useMemo(() => {
+        if (negativeMapColourString) {
+            const rgb = JSON.parse(negativeMapColourString)
+            return rgbToHex(rgb.r, rgb.g, rgb.b)
+        } else {
+            return rgbToHex(props.map.defaultNegativeMapColour.r, props.map.defaultNegativeMapColour.g, props.map.defaultNegativeMapColour.b)
+        }
+    }, [negativeMapColourString])
+
+    const positiveMapColour: {r: number; g: number; b: number;} = useMemo(() => {
+        if (positiveMapColourString) {
+            return JSON.parse(positiveMapColourString)
+        } else {
+            return {r: props.map.defaultPositiveMapColour.r * 255., g: props.map.defaultPositiveMapColour.g * 255., b: props.map.defaultPositiveMapColour.b * 255.}
+        }
+    }, [positiveMapColourString])
+
+    const positiveMapColourHex: string  = useMemo(() => {
+        if (positiveMapColourString) {
+            const rgb = JSON.parse(positiveMapColourString)
+            return rgbToHex(rgb.r, rgb.g, rgb.b)
+        } else {
+            return rgbToHex(props.map.defaultPositiveMapColour.r, props.map.defaultPositiveMapColour.g, props.map.defaultPositiveMapColour.b)
+        }
+    }, [positiveMapColourString])
+
     const activeMap = useSelector((state: moorhen.State) => state.generalStates.activeMap)
     const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
     const contourWheelSensitivityFactor = useSelector((state: moorhen.State) => state.mouseSettings.contourWheelSensitivityFactor)
@@ -153,10 +160,6 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     const isDirty = useRef<boolean>(false)
     const histogramRef = useRef(null)
     const intervalRef = useRef(null)
-
-    const mapColour: {r: number; g: number; b: number;} = JSON.parse(mapColourString)
-    const negativeMapColour: {r: number; g: number; b: number;} = JSON.parse(negativeMapColourString)
-    const positiveMapColour: {r: number; g: number; b: number;} = JSON.parse(positiveMapColourString)
 
     useImperativeHandle(cardRef, () => ({
         forceIsCollapsed: (value: boolean) => { 

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -509,6 +509,7 @@ export namespace moorhen {
         diffuseLight: [number, number, number, number];
         lightPosition: [number, number, number, number];
         specularLight: [number, number, number, number];
+        specularPower: number;
         fogStart: number;
         fogEnd: number;
         zoom: number;

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -251,6 +251,7 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
             diffuseLight: this.glRef.current.light_colours_diffuse,
             lightPosition: this.glRef.current.light_positions,
             specularLight: this.glRef.current.light_colours_specular,
+            specularPower: this.glRef.current.specularPower,
             fogStart: this.glRef.current.gl_fog_start,
             fogEnd: this.glRef.current.gl_fog_end,
             zoom: this.glRef.current.zoom,

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -278,7 +278,7 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
             moleculeData: moleculeData,
             mapData: mapData,
             viewData: viewData,
-            activeMapIndex: this.mapsRef.current.findIndex(map => map.molNo === this.activeMapRef.current.molNo),
+            activeMapIndex: this.mapsRef.current.findIndex(map => map.molNo === this.activeMapRef.current?.molNo),
             version: this.version
         }
 

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -8,7 +8,7 @@ import { moorhen } from "../types/moorhen";
 import { gemmi } from "../types/gemmi";
 import { webGL } from "../types/mgWebGL";
 import { AnyAction, Dispatch } from "@reduxjs/toolkit";
-import { addMolecule, emptyMolecules } from "../store/moleculesSlice";
+import { addCustomRepresentation, addMolecule, emptyMolecules } from "../store/moleculesSlice";
 import { addMap, emptyMaps } from "../store/mapsSlice";
 import { batch } from "react-redux";
 import { setActiveMap } from "../store/generalStatesSlice";
@@ -279,7 +279,8 @@ export async function loadSessionData(
         molecule.defaultColourRules = storedMoleculeData.defaultColourRules
         molecule.defaultBondOptions = storedMoleculeData.defaultBondOptions
         for (const item of storedMoleculeData.representations) {
-            await molecule.addRepresentation(item.style, item.cid, item.isCustom, item.colourRules, item.bondOptions, item.applyColoursToNonCarbonAtoms)
+            const representation = await molecule.addRepresentation(item.style, item.cid, item.isCustom, item.colourRules, item.bondOptions, item.applyColoursToNonCarbonAtoms)
+            dispatch( addCustomRepresentation(representation) )
         }
     }
     

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -349,6 +349,7 @@ export async function loadSessionData(
     glRef.current.doDrawClickedAtomLines = sessionData.viewData.doDrawClickedAtomLines
     glRef.current.setOrigin(sessionData.viewData.origin, false)
     glRef.current.setQuat(sessionData.viewData.quat4)
+    glRef.current.specularPower = sessionData.viewData.specularPower
     batch(() => {
         dispatch(setBackgroundColor(sessionData.viewData.backgroundColor))
         dispatch(setDoEdgeDetect(sessionData.viewData.edgeDetection))


### PR DESCRIPTION
This update includes:
- Fix for a bug causing the app to crash if attempted to create a session without an active map
- Include specular power in session data
- Fix restoring of custom representations within session data
- Better handling of map colours with `useMemo`