### PR TITLE
Move doSpinTest out of preferences and out of dev mode

### DIFF
--- a/baby-gru/src/components/misc/MoorhenPreferencesContainer.tsx
+++ b/baby-gru/src/components/misc/MoorhenPreferencesContainer.tsx
@@ -7,7 +7,12 @@ import { setEnableTimeCapsule, setMakeBackups, setMaxBackupCount, setModificatio
 import { overwriteMapUpdatingScores, setShowScoresToast } from "../../store/moleculeMapUpdateSlice";
 import { setShortCuts, setShortcutOnHoveredAtom, setShowShortcutToast } from "../../store/shortCutsSlice";
 import { setAtomLabelDepthMode, setGLLabelsFontFamily, setGLLabelsFontSize } from "../../store/labelSettingsSlice";
-import { setClipCap, setDefaultBackgroundColor, setDefaultBondSmoothness, setDepthBlurDepth, setDepthBlurRadius, setDoOutline, setDoPerspectiveProjection, setDoSSAO, setDoShadow, setDoShadowDepthDebug, setDoSpinTest, setDrawAxes, setDrawCrosshairs, setDrawFPS, setDrawInteractions, setDrawMissingLoops, setResetClippingFogging, setSsaoBias, setSsaoRadius, setUseOffScreenBuffers, setDrawScaleBar, setDoEdgeDetect, setEdgeDetectDepthThreshold, setEdgeDetectNormalThreshold, setEdgeDetectDepthScale, setEdgeDetectNormalScale} from "../../store/sceneSettingsSlice";
+import { 
+    setClipCap, setDefaultBackgroundColor, setDefaultBondSmoothness, setDepthBlurDepth, setDepthBlurRadius, setDoOutline,
+    setDoPerspectiveProjection, setDoSSAO, setDoShadow, setDoShadowDepthDebug, setDrawAxes, setDrawCrosshairs, setUseOffScreenBuffers,
+    setDrawFPS, setDrawInteractions, setDrawMissingLoops, setResetClippingFogging, setSsaoBias, setSsaoRadius, setEdgeDetectNormalScale,
+    setDrawScaleBar, setDoEdgeDetect, setEdgeDetectDepthThreshold, setEdgeDetectNormalThreshold, setEdgeDetectDepthScale
+} from "../../store/sceneSettingsSlice";
 import { setAnimateRefine, setDefaultExpandDisplayCards, setEnableRefineAfterMod, setTransparentModalsOnMouseOut } from "../../store/miscAppSettingsSlice";
 import { setDevMode, setUserPreferencesMounted } from "../../store/generalStatesSlice";
 import { moorhen } from "../../types/moorhen"
@@ -76,7 +81,6 @@ export const MoorhenPreferencesContainer = (props: {
     const useOffScreenBuffers = useSelector((state: moorhen.State) => state.sceneSettings.useOffScreenBuffers)
     const doShadowDepthDebug = useSelector((state: moorhen.State) => state.sceneSettings.doShadowDepthDebug)
     const doShadow = useSelector((state: moorhen.State) => state.sceneSettings.doShadow)
-    const doSpinTest = useSelector((state: moorhen.State) => state.sceneSettings.doSpinTest)
     const doOutline = useSelector((state: moorhen.State) => state.sceneSettings.doOutline)
     const depthBlurRadius = useSelector((state: moorhen.State) => state.sceneSettings.depthBlurRadius)
     const depthBlurDepth = useSelector((state: moorhen.State) => state.sceneSettings.depthBlurDepth)
@@ -123,22 +127,21 @@ export const MoorhenPreferencesContainer = (props: {
         32: { label: "doShadow", value: doShadow, valueSetter: setDoShadow},
         33: { label: "GLLabelsFontFamily", value: GLLabelsFontFamily, valueSetter: setGLLabelsFontFamily},
         34: { label: "GLLabelsFontSize", value: GLLabelsFontSize, valueSetter: setGLLabelsFontSize},
-        35: { label: "doSpinTest", value: doSpinTest, valueSetter: setDoSpinTest},
-        36: { label: "doOutline", value: doOutline, valueSetter: setDoOutline},
-        37: { label: "depthBlurRadius", value: depthBlurRadius, valueSetter: setDepthBlurRadius},
-        38: { label: "depthBlurDepth", value: depthBlurDepth, valueSetter: setDepthBlurDepth},
-        39: { label: "transparentModalsOnMouseOut", value: transparentModalsOnMouseOut, valueSetter: setTransparentModalsOnMouseOut},
-        40: { label: "defaultMapSamplingRate", value: defaultMapSamplingRate, valueSetter: setDefaultMapSamplingRate},
-        41: { label: "doSSAO", value: doSSAO, valueSetter: setDoSSAO},
-        42: { label: "ssaoRadius", value: ssaoRadius, valueSetter: setSsaoRadius},
-        43: { label: "ssaoBias", value: ssaoBias, valueSetter: setSsaoBias},
-        44: { label: "drawScaleBar", value: drawScaleBar, valueSetter: setDrawScaleBar},
-        45: { label: "animateRefine", value: animateRefine, valueSetter: setAnimateRefine},
-        46: { label: "doEdgeDetect", value: doEdgeDetect, valueSetter: setDoEdgeDetect},
-        47: { label: "edgeDetectDepthThreshold", value: edgeDetectDepthThreshold, valueSetter: setEdgeDetectDepthThreshold},
-        48: { label: "edgeDetectNormalThreshold", value: edgeDetectNormalThreshold, valueSetter: setEdgeDetectNormalThreshold},
-        49: { label: "edgeDetectDepthScale", value: edgeDetectDepthScale, valueSetter: setEdgeDetectDepthScale},
-        50: { label: "edgeDetectNormalScale", value: edgeDetectNormalScale, valueSetter: setEdgeDetectNormalScale},
+        35: { label: "doOutline", value: doOutline, valueSetter: setDoOutline},
+        36: { label: "depthBlurRadius", value: depthBlurRadius, valueSetter: setDepthBlurRadius},
+        37: { label: "depthBlurDepth", value: depthBlurDepth, valueSetter: setDepthBlurDepth},
+        38: { label: "transparentModalsOnMouseOut", value: transparentModalsOnMouseOut, valueSetter: setTransparentModalsOnMouseOut},
+        39: { label: "defaultMapSamplingRate", value: defaultMapSamplingRate, valueSetter: setDefaultMapSamplingRate},
+        40: { label: "doSSAO", value: doSSAO, valueSetter: setDoSSAO},
+        41: { label: "ssaoRadius", value: ssaoRadius, valueSetter: setSsaoRadius},
+        42: { label: "ssaoBias", value: ssaoBias, valueSetter: setSsaoBias},
+        43: { label: "drawScaleBar", value: drawScaleBar, valueSetter: setDrawScaleBar},
+        44: { label: "animateRefine", value: animateRefine, valueSetter: setAnimateRefine},
+        45: { label: "doEdgeDetect", value: doEdgeDetect, valueSetter: setDoEdgeDetect},
+        46: { label: "edgeDetectDepthThreshold", value: edgeDetectDepthThreshold, valueSetter: setEdgeDetectDepthThreshold},
+        47: { label: "edgeDetectNormalThreshold", value: edgeDetectNormalThreshold, valueSetter: setEdgeDetectNormalThreshold},
+        48: { label: "edgeDetectDepthScale", value: edgeDetectDepthScale, valueSetter: setEdgeDetectDepthScale},
+        49: { label: "edgeDetectNormalScale", value: edgeDetectNormalScale, valueSetter: setEdgeDetectNormalScale},
     }
 
     const restoreDefaults = (preferences: moorhen.Preferences, defaultValues: moorhen.PreferencesValues)=> {
@@ -617,16 +620,6 @@ export const MoorhenPreferencesContainer = (props: {
         localForageInstanceRef.current?.localStorageInstance.setItem('GLLabelsFontSize', GLLabelsFontSize)
         .then(_ => props.onUserPreferencesChange('GLLabelsFontSize', GLLabelsFontSize));
     }, [GLLabelsFontSize]);
-
-    useMemo(() => {
-
-        if (doSpinTest === null) {
-            return
-        }
-
-        localForageInstanceRef.current?.localStorageInstance.setItem('doSpinTest', doSpinTest)
-        .then(_ => props.onUserPreferencesChange('doSpinTest', doSpinTest));
-    }, [doSpinTest]);
 
     useMemo(() => {
 

--- a/baby-gru/src/components/navbar-menus/MoorhenDevMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenDevMenu.tsx
@@ -13,7 +13,6 @@ export const MoorhenDevMenu = (props: MoorhenNavBarExtendedControlsInterface) =>
     const dispatch = useDispatch()
     const doShadow = useSelector((state: moorhen.State) => state.sceneSettings.doShadow)
     const doOutline = useSelector((state: moorhen.State) => state.sceneSettings.doOutline)
-    const doSpinTest = useSelector((state: moorhen.State) => state.sceneSettings.doSpinTest)
 
     const menuItemProps = {setPopoverIsShown, customCid, ...props}
 
@@ -42,13 +41,6 @@ export const MoorhenDevMenu = (props: MoorhenNavBarExtendedControlsInterface) =>
                             checked={doOutline}
                             onChange={() => {dispatch( setDoOutline(!doOutline) )}}
                             label="Outlines"/>
-                    </InputGroup>
-                    <InputGroup className='moorhen-input-group-check'>
-                        <Form.Check 
-                            type="switch"
-                            checked={doSpinTest}
-                            onChange={() => {dispatch( setDoSpinTest(!doSpinTest) )}}
-                            label="Spin test"/>
                     </InputGroup>
         </>
     }

--- a/baby-gru/src/components/navbar-menus/MoorhenViewMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenViewMenu.tsx
@@ -4,7 +4,7 @@ import { MoorhenNavBarExtendedControlsInterface } from "./MoorhenNavBar";
 import { MoorhenScenePresetMenuItem } from "../menu-item/MoorhenScenePresetMenuItem"
 import { moorhen } from "../../types/moorhen";
 import { useSelector, useDispatch } from "react-redux";
-import { setDoPerspectiveProjection, setDrawAxes, setDrawCrosshairs, setDrawFPS, setDrawInteractions, setDrawMissingLoops, setDrawScaleBar } from "../../store/sceneSettingsSlice";
+import { setDoPerspectiveProjection, setDoSpin, setDrawAxes, setDrawCrosshairs, setDrawFPS, setDrawInteractions, setDrawMissingLoops, setDrawScaleBar } from "../../store/sceneSettingsSlice";
 import { setEnableAtomHovering, setHoveredAtom } from "../../store/hoveringStatesSlice";
 import { convertViewtoPx } from "../../utils/MoorhenUtils";
 import { MenuItem } from "@mui/material";
@@ -21,6 +21,7 @@ export const MoorhenViewMenu = (props: MoorhenNavBarExtendedControlsInterface) =
     const drawInteractions = useSelector((state: moorhen.State) => state.sceneSettings.drawInteractions)
     const doPerspectiveProjection = useSelector((state: moorhen.State) => state.sceneSettings.doPerspectiveProjection)
     const height = useSelector((state: moorhen.State) => state.sceneSettings.height)
+    const doSpin = useSelector((state: moorhen.State) => state.sceneSettings.doSpin)
     const dispatch = useDispatch()
 
     const menuItemProps = {setPopoverIsShown, ...props}
@@ -87,6 +88,13 @@ export const MoorhenViewMenu = (props: MoorhenNavBarExtendedControlsInterface) =
                         checked={doPerspectiveProjection}
                         onChange={() => {dispatch( setDoPerspectiveProjection(!doPerspectiveProjection) )}}
                         label="Perspective projection"/>
+                </InputGroup>
+                <InputGroup className='moorhen-input-group-check'>
+                    <Form.Check 
+                        type="switch"
+                        checked={doSpin}
+                        onChange={() => {dispatch( setDoSpin(!doSpin) )}}
+                        label="Spin view"/>
                 </InputGroup>
                 <hr></hr>
                 <MoorhenScenePresetMenuItem {...menuItemProps} />

--- a/baby-gru/src/components/webMG/MoorhenWebMG.tsx
+++ b/baby-gru/src/components/webMG/MoorhenWebMG.tsx
@@ -70,7 +70,7 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
     const useOffScreenBuffers = useSelector((state: moorhen.State) => state.sceneSettings.useOffScreenBuffers)
     const doShadowDepthDebug = useSelector((state: moorhen.State) => state.sceneSettings.doShadowDepthDebug)
     const doShadow = useSelector((state: moorhen.State) => state.sceneSettings.doShadow)
-    const doSpinTest = useSelector((state: moorhen.State) => state.sceneSettings.doSpinTest)
+    const doSpin = useSelector((state: moorhen.State) => state.sceneSettings.doSpin)
     const doOutline = useSelector((state: moorhen.State) => state.sceneSettings.doOutline)
     const depthBlurRadius = useSelector((state: moorhen.State) => state.sceneSettings.depthBlurRadius)
     const depthBlurDepth = useSelector((state: moorhen.State) => state.sceneSettings.depthBlurDepth)
@@ -264,10 +264,10 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
 
     useEffect(() => {
         if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setSpinTestState(doSpinTest)
+            glRef.current.setSpinTestState(doSpin)
             glRef.current.drawScene()
         }
-    }, [doSpinTest])
+    }, [doSpin])
 
     useEffect(() => {
         if(glRef !== null && typeof glRef !== 'function') {

--- a/baby-gru/src/moorhen.ts
+++ b/baby-gru/src/moorhen.ts
@@ -16,7 +16,7 @@ import { loadSessionData } from "./utils/MoorhenUtils";
 import { MoorhenReduxProvider } from "./components/misc/MoorhenReduxProvider";
 import { setDefaultBackgroundColor, setDrawCrosshairs, setDrawFPS, setDrawMissingLoops, setDefaultBondSmoothness,
     setDrawInteractions, setDoSSAO, setSsaoRadius, setSsaoBias, setResetClippingFogging, setClipCap,  
-    setUseOffScreenBuffers, setDoShadowDepthDebug, setDoShadow, setDoSpinTest, setDoOutline, setDepthBlurRadius,
+    setUseOffScreenBuffers, setDoShadowDepthDebug, setDoShadow, setDoSpin, setDoOutline, setDepthBlurRadius,
     setDepthBlurDepth, setDrawAxes, setDoPerspectiveProjection, setHeight, setWidth, setIsDark, setBackgroundColor, setDrawScaleBar,
     setDoEdgeDetect, setEdgeDetectDepthThreshold, setEdgeDetectNormalThreshold, setEdgeDetectDepthScale, setEdgeDetectNormalScale
 } from './store/sceneSettingsSlice';
@@ -43,7 +43,7 @@ export {
     MoorhenCommandCentre, loadSessionData, MoorhenMapSelect, MoorhenDraggableModalBase, MoorhenReduxProvider, 
     setDefaultBackgroundColor, setDrawCrosshairs, setDrawScaleBar, setDrawFPS, setDrawMissingLoops, setDefaultBondSmoothness,
     setDrawInteractions, setDoSSAO, setSsaoRadius, setSsaoBias, setResetClippingFogging, setClipCap,  
-    setUseOffScreenBuffers, setDoShadowDepthDebug, setDoShadow, setDoSpinTest, setDoOutline, setDepthBlurRadius,
+    setUseOffScreenBuffers, setDoShadowDepthDebug, setDoShadow, setDoSpin, setDoOutline, setDepthBlurRadius,
     setDepthBlurDepth, setDrawAxes, setDoPerspectiveProjection, setEnableTimeCapsule, setMakeBackups, setMaxBackupCount, 
     setModificationCountBackupThreshold, setHeight, setWidth, setIsDark, setBackgroundColor, setNotificationContent, 
     setActiveMap, setCootInitialized, setAppTittle, setUserPreferencesMounted, setDevMode, setTheme, setViewOnly,

--- a/baby-gru/src/store/sceneSettingsSlice.ts
+++ b/baby-gru/src/store/sceneSettingsSlice.ts
@@ -25,7 +25,7 @@ export const sceneSettingsSlice = createSlice({
     useOffScreenBuffers: null,
     doShadowDepthDebug: null,
     doShadow: null,
-    doSpinTest: null,
+    doSpin: null,
     doOutline: null,
     depthBlurRadius: null,
     depthBlurDepth: null,
@@ -101,8 +101,8 @@ export const sceneSettingsSlice = createSlice({
     setDoShadow: (state, action: {payload: boolean, type: string}) => {
         return {...state, doShadow: action.payload}
     },
-    setDoSpinTest: (state, action: {payload: boolean, type: string}) => {
-        return {...state, doSpinTest: action.payload}
+    setDoSpin: (state, action: {payload: boolean, type: string}) => {
+        return {...state, doSpin: action.payload}
     },
     setDoOutline: (state, action: {payload: boolean, type: string}) => {
         return {...state, doOutline: action.payload}
@@ -130,7 +130,7 @@ export const sceneSettingsSlice = createSlice({
 export const {
     setDefaultBackgroundColor, setDrawCrosshairs, setDrawScaleBar, setDrawFPS, setDrawMissingLoops, setDefaultBondSmoothness,
     setDrawInteractions, setDoSSAO, setSsaoRadius, setSsaoBias, setResetClippingFogging, setClipCap,  
-    setUseOffScreenBuffers, setDoShadowDepthDebug, setDoShadow, setDoSpinTest, setDoOutline, setDepthBlurRadius,
+    setUseOffScreenBuffers, setDoShadowDepthDebug, setDoShadow, setDoSpin, setDoOutline, setDepthBlurRadius,
     setDepthBlurDepth, setDrawAxes, setDoPerspectiveProjection, setHeight, setWidth, setIsDark, setBackgroundColor,
     setDoEdgeDetect, setEdgeDetectDepthThreshold, setEdgeDetectNormalThreshold, setEdgeDetectDepthScale, setEdgeDetectNormalScale
 } = sceneSettingsSlice.actions

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -346,8 +346,8 @@ declare module 'moorhen' {
     function setDoShadow(arg0: boolean): any;
     module.exports = setDoShadow;
     
-    function setDoSpinTest(arg0: boolean): any;
-    module.exports = setDoSpinTest;
+    function setDoSpin(arg0: boolean): any;
+    module.exports = setDoSpin;
     
     function setDoOutline(arg0: boolean): any;
     module.exports = setDoOutline;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -627,7 +627,6 @@ export namespace moorhen {
         setEdgeDetectDepthScale: React.Dispatch<React.SetStateAction<number>>;
         setEdgeDetectNormalScale: React.Dispatch<React.SetStateAction<number>>;
         setDoOutline: React.Dispatch<React.SetStateAction<boolean>>;
-        setDoSpinTest: React.Dispatch<React.SetStateAction<boolean>>;
         setClipCap: React.Dispatch<React.SetStateAction<boolean>>;
         setResetClippingFogging: React.Dispatch<React.SetStateAction<boolean>>;
         setUseOffScreenBuffers: React.Dispatch<React.SetStateAction<boolean>>;
@@ -834,7 +833,7 @@ export namespace moorhen {
             edgeDetectDepthScale: number;
             edgeDetectNormalScale: number;
             doOutline: boolean; 
-            doSpinTest: boolean;
+            doSpin: boolean;
             defaultBondSmoothness: number,
             resetClippingFogging: boolean; 
             clipCap: boolean;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -519,7 +519,13 @@ export namespace moorhen {
         quat4: any[];
         shadows: boolean;
         ssao: {enabled: boolean; radius: number; bias: number};
-        edgeDetection: boolean;
+        edgeDetection: {
+            enabled: boolean;
+            depthScale: number;
+            normalScale: number;
+            depthThreshold: number;
+            normalThreshold: number;
+        };
         blur: {enabled: boolean; depth: number; radius: number};
     }
     

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -704,7 +704,6 @@ export namespace moorhen {
         doOutline: boolean; 
         GLLabelsFontFamily: string;
         GLLabelsFontSize: number;
-        doSpinTest: boolean;
         mouseSensitivity: number;
         zoomWheelSensitivityFactor: number;
         contourWheelSensitivityFactor: number;

--- a/baby-gru/src/utils/MoorhenPreferences.ts
+++ b/baby-gru/src/utils/MoorhenPreferences.ts
@@ -64,7 +64,6 @@ export class MoorhenPreferences implements moorhen.Preferences {
         doOutline: false,
         GLLabelsFontFamily: "Arial",
         GLLabelsFontSize: 18,
-        doSpinTest: false,
         mouseSensitivity: 0.3,
         zoomWheelSensitivityFactor: 1.0,
         contourWheelSensitivityFactor: 0.05,

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -50,7 +50,7 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
         this.modificationCount = 0
         this.modificationCountBackupThreshold = 5
         this.maxBackupCount = 10
-        this.version = 'v19'
+        this.version = 'v20'
         this.disableBackups = false
         this.storageInstance = null
         this.onIsBusyChange = null
@@ -259,7 +259,13 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
             clipStart: (this.glRef.current.gl_clipPlane0[3] + this.glRef.current.fogClipOffset) * -1,
             clipEnd: this.glRef.current.gl_clipPlane1[3] - this.glRef.current.fogClipOffset,
             quat4: this.glRef.current.myQuat,
-            edgeDetection: this.glRef.current.doEdgeDetect,
+            edgeDetection: {
+                enabled: this.glRef.current.doEdgeDetect,
+                depthScale: this.glRef.current.scaleDepth,
+                depthThreshold: this.glRef.current.depthThreshold,
+                normalScale: this.glRef.current.scaleNormal,
+                normalThreshold: this.glRef.current.normalThreshold
+            },
             shadows: this.glRef.current.doShadow,
             ssao: {
                 enabled: this.glRef.current.doSSAO,

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -15,7 +15,10 @@ import { setActiveMap } from "../store/generalStatesSlice";
 import { setContourLevel, setMapAlpha, setMapColours, setMapRadius, setMapStyle, setNegativeMapColours, setPositiveMapColours } from "../store/mapContourSettingsSlice";
 import { enableUpdatingMaps, setConnectedMoleculeMolNo, setFoFcMapMolNo, setReflectionMapMolNo, setTwoFoFcMapMolNo } from "../store/moleculeMapUpdateSlice";
 import { libcootApi } from "../types/libcoot";
-import { setBackgroundColor, setDepthBlurDepth, setDepthBlurRadius, setDoEdgeDetect, setDoSSAO, setDoShadow, setSsaoBias, setSsaoRadius, setUseOffScreenBuffers } from "../store/sceneSettingsSlice";
+import { 
+    setBackgroundColor, setDepthBlurDepth, setDepthBlurRadius, setDoEdgeDetect, setDoSSAO, setDoShadow, 
+    setEdgeDetectDepthScale, setEdgeDetectDepthThreshold, setEdgeDetectNormalScale, setEdgeDetectNormalThreshold, setSsaoBias, setSsaoRadius, setUseOffScreenBuffers 
+} from "../store/sceneSettingsSlice";
 
 export const getAtomInfoLabel = (atomInfo: moorhen.AtomInfo) => {
     return `/${atomInfo.mol_name}/${atomInfo.chain_id}/${atomInfo.res_no}(${atomInfo.res_name})/${atomInfo.name}${atomInfo.has_altloc ? `:${atomInfo.alt_loc}` : ""}`
@@ -352,7 +355,11 @@ export async function loadSessionData(
     glRef.current.specularPower = sessionData.viewData.specularPower
     batch(() => {
         dispatch(setBackgroundColor(sessionData.viewData.backgroundColor))
-        dispatch(setDoEdgeDetect(sessionData.viewData.edgeDetection))
+        dispatch(setEdgeDetectDepthScale(sessionData.viewData.edgeDetection.depthScale))
+        dispatch(setEdgeDetectDepthThreshold(sessionData.viewData.edgeDetection.depthThreshold))
+        dispatch(setEdgeDetectNormalScale(sessionData.viewData.edgeDetection.normalScale))
+        dispatch(setEdgeDetectNormalThreshold(sessionData.viewData.edgeDetection.normalThreshold))
+        dispatch(setDoEdgeDetect(sessionData.viewData.edgeDetection.enabled))
         dispatch(setDoShadow(sessionData.viewData.shadows))
         dispatch(setDoSSAO(sessionData.viewData.ssao.enabled))
         dispatch(setSsaoBias(sessionData.viewData.ssao.bias))


### PR DESCRIPTION
This update resolves #339. Also, the variable has been renamed from `doSpinTest` to `doSpin`.