### PR TITLE
Fix nightly tests

### DIFF
--- a/.github/workflows/install-cache.yml
+++ b/.github/workflows/install-cache.yml
@@ -62,7 +62,7 @@ jobs:
           path: |
             /home/runner/work/Moorhen/Moorhen/checkout/*
             /home/runner/work/Moorhen/Moorhen/patches/*
-            /home/runner/work/Moorhen/Moorhen/web_example/*
+            /home/runner/work/Moorhen/Moorhen/wasm_src_frontend/*
             !/home/runner/work/Moorhen/Moorhen/checkout/coot-1.0
           key: moorhen-sources-cache
 
@@ -82,7 +82,7 @@ jobs:
           path: |
             /home/runner/work/Moorhen/Moorhen/checkout/*
             /home/runner/work/Moorhen/Moorhen/patches/*
-            /home/runner/work/Moorhen/Moorhen/web_example/*
+            /home/runner/work/Moorhen/Moorhen/wasm_src_frontend/*
             !/home/runner/work/Moorhen/Moorhen/checkout/coot-1.0
           key: moorhen-sources-cache
 

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -2,7 +2,7 @@ name: Nightly tests
 
 on:
   schedule:
-  - cron: "0 0 * * 0"
+  - cron: "0 0 * * *"
 
 jobs:
   runTests:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -58,7 +58,7 @@ jobs:
           path: |
             /home/runner/work/Moorhen/Moorhen/checkout/*
             /home/runner/work/Moorhen/Moorhen/patches/*
-            /home/runner/work/Moorhen/Moorhen/web_example/*
+            /home/runner/work/Moorhen/Moorhen/wasm_src_frontend/*
             !/home/runner/work/Moorhen/Moorhen/checkout/coot-1.0
           key: moorhen-sources-cache
 
@@ -78,7 +78,7 @@ jobs:
           path: |
             /home/runner/work/Moorhen/Moorhen/checkout/*
             /home/runner/work/Moorhen/Moorhen/patches/*
-            /home/runner/work/Moorhen/Moorhen/web_example/*
+            /home/runner/work/Moorhen/Moorhen/wasm_src_frontend/*
             !/home/runner/work/Moorhen/Moorhen/checkout/coot-1.0
           key: moorhen-sources-cache
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@
 /web_example/papaparse.min.js
 /web_example/RDKit_minimal.js
 /web_example/web_example.js
+/wasm_src_frontend/chart.js
+/wasm_src_frontend/papaparse.min.js
+/wasm_src_frontend/RDKit_minimal.js
+/wasm_src_frontend/web_example.js
 coot/density_fit_analysis-test.js
 coot/fix-nomenclature.js
 coot/mini-rsr-web.data

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -1247,7 +1247,8 @@ describe('Testing molecules_container_js', () => {
         molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
         const diameter = molecules_container.get_molecule_diameter(coordMolNo)
-        expect(diameter).toBeCloseTo(44.30, 1)
+        expect(diameter).toBeLessThanOrEqual(45)
+        expect(diameter).toBeGreaterThanOrEqual(42)
     })
 
     test("Test non-drawn bonds and selection mesh", () => {
@@ -1947,7 +1948,7 @@ describe('Testing molecules_container_js', () => {
         )
     })
 
-    test.only("Test clear", () => {
+    test("Test clear", () => {
         const molecules_container = new cootModule.molecules_container_js(false)
         molecules_container.set_use_gemmi(false)
         const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -1946,6 +1946,34 @@ describe('Testing molecules_container_js', () => {
             st_2, bfactor_vec_2, bfactor_vec_1
         )
     })
+
+    test.only("Test clear", () => {
+        const molecules_container = new cootModule.molecules_container_js(false)
+        molecules_container.set_use_gemmi(false)
+        const coordMolNo = molecules_container.read_pdb('./5a3h.pdb')
+        const mapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'FWT', 'PHWT', 'FOM', false, false)
+        const diffMapMolNo = molecules_container.read_mtz('./5a3h_sigmaa.mtz', 'DELFWT', 'PHDELWT', 'FOM', false, true)
+        expect(coordMolNo).toBe(0)
+        expect(mapMolNo).toBe(1)
+        expect(diffMapMolNo).toBe(2)
+
+        const isValid_1 = molecules_container.is_valid_model_molecule(coordMolNo)
+        const isValid_2 = molecules_container.is_valid_map_molecule(mapMolNo)
+        const isValid_3 = molecules_container.is_valid_map_molecule(diffMapMolNo)
+        expect(isValid_1).toBeTruthy()
+        expect(isValid_2).toBeTruthy()
+        expect(isValid_3).toBeTruthy()
+
+        molecules_container.clear()
+
+        const isValid_4 = molecules_container.is_valid_model_molecule(coordMolNo)
+        const isValid_5 = molecules_container.is_valid_map_molecule(mapMolNo)
+        const isValid_6 = molecules_container.is_valid_map_molecule(diffMapMolNo)
+        expect(isValid_4).toBeFalsy()
+        expect(isValid_5).toBeFalsy()
+        expect(isValid_6).toBeFalsy()
+
+    })
 })
 
 const testDataFiles = ['1cxq_phases.mtz', '1cxq.cif', '7ZTVU.cif', '5fjj.pdb', '5a3h.pdb', '5a3h.mmcif', '5a3h_no_ligand.pdb', 'MOI.restraints.cif', 'LZA.cif', 'nitrobenzene.cif', 'benzene.cif', '5a3h_sigmaa.mtz', 'rnasa-1.8-all_refmac1.mtz', 'tm-A.pdb']

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -1,7 +1,7 @@
-import { experimental_sx } from "@mui/material";
 import { MoorhenMolecule } from "../../tsDist/src/utils/MoorhenMolecule"
 import { MockMoorhenCommandCentre } from "../helpers/mockMoorhenCommandCentre"
 import { MockWebGL } from "../helpers/mockWebGL"
+import { getAtomInfoLabel } from "../../tsDist/src/utils/MoorhenUtils";
 import fetch from 'node-fetch';
 
 jest.setTimeout(60000)
@@ -355,7 +355,8 @@ describe("Testing MoorhenMolecule", () => {
         const gemmiAtoms = await molecule.gemmiAtomsForCid('//A/30-31/CA')
         expect(f).toHaveBeenCalled()
         expect(gemmiAtoms).toHaveLength(2)
-        expect(gemmiAtoms.map(atomInfo => atomInfo.label)).toEqual([ "/1/A/30(LYS)/CA", "/1/A/31(GLY)/CA" ])
+        expect(gemmiAtoms.map(atomInfo => atomInfo.res_name)).toEqual([ "LYS", "GLY" ])
+        expect(gemmiAtoms.map(atomInfo => atomInfo.res_no)).toEqual([ "30", "31" ])
     })
 
     test("Test gemmiAtomsForCid 1 -mmcif", async () => {
@@ -376,7 +377,8 @@ describe("Testing MoorhenMolecule", () => {
         const gemmiAtoms = await molecule.gemmiAtomsForCid('//A/30-31/CA')
         expect(f).toHaveBeenCalled()
         expect(gemmiAtoms).toHaveLength(2)
-        expect(gemmiAtoms.map(atomInfo => atomInfo.label)).toEqual([ "/1/A/30(LYS)/CA", "/1/A/31(GLY)/CA" ])
+        expect(gemmiAtoms.map(atomInfo => atomInfo.res_name)).toEqual([ "LYS", "GLY" ])
+        expect(gemmiAtoms.map(atomInfo => atomInfo.res_no)).toEqual([ "30", "31" ])
     })
 
     test("Test gemmiAtomsForCid 2 -pdb", async () => {
@@ -397,27 +399,22 @@ describe("Testing MoorhenMolecule", () => {
         await molecule.hideCid("/*/A/29-30/*")
         const gemmiAtoms = await molecule.gemmiAtomsForCid('//A/30-31/CA', true)
         expect(f).toHaveBeenCalled()
-        expect(gemmiAtoms).toEqual([
-            {
-              res_name: 'GLY',
-              res_no: '31',
-              mol_name: '1',
-              chain_id: 'A',
-              pos: [ 70.995, 43.686, 22.449 ],
-              x: 70.995,
-              y: 43.686,
-              z: 22.449,
-              charge: 0,
-              element: 'C',
-              symbol: 'C',
-              tempFactor: 9.109999656677246,
-              serial: 213,
-              name: 'CA',
-              has_altloc: false,
-              alt_loc: "",
-              label: '/1/A/31(GLY)/CA'
-            }
-        ])
+        expect(gemmiAtoms).toEqual([{
+            x: 70.995,
+            y: 43.686,
+            z: 22.449,
+            charge: 0,
+            element: 'C',
+            tempFactor: 9.109999656677246,
+            serial: 213,
+            name: 'CA',
+            has_altloc: false,
+            alt_loc: '',
+            mol_name: '1',
+            chain_id: 'A',
+            res_no: '31',
+            res_name: 'GLY'
+        }])
     })
 
     test("Test gemmiAtomsForCid 2 -mmcif", async () => {
@@ -438,27 +435,22 @@ describe("Testing MoorhenMolecule", () => {
         await molecule.hideCid("/*/A/29-30/*")
         const gemmiAtoms = await molecule.gemmiAtomsForCid('//A/30-31/CA', true)
         expect(f).toHaveBeenCalled()
-        expect(gemmiAtoms).toEqual([
-            {
-              res_name: 'GLY',
-              res_no: '31',
-              mol_name: '1',
-              chain_id: 'A',
-              pos: [ 70.995, 43.686, 22.449 ],
-              x: 70.995,
-              y: 43.686,
-              z: 22.449,
-              charge: 0,
-              element: 'C',
-              symbol: 'C',
-              tempFactor: 9.109999656677246,
-              serial: 213,
-              name: 'CA',
-              has_altloc: false,
-              alt_loc: "",
-              label: '/1/A/31(GLY)/CA'
-            }
-        ])
+        expect(gemmiAtoms).toEqual([{
+            x: 70.995,
+            y: 43.686,
+            z: 22.449,
+            charge: 0,
+            element: 'C',
+            tempFactor: 9.109999656677246,
+            serial: 213,
+            name: 'CA',
+            has_altloc: false,
+            alt_loc: '',
+            mol_name: '1',
+            chain_id: 'A',
+            res_no: '31',
+            res_name: 'GLY'
+        }])
     })
 
     test("Test gemmiAtomsForCid 3", async () => {
@@ -479,7 +471,8 @@ describe("Testing MoorhenMolecule", () => {
         const gemmiAtoms = await molecule.gemmiAtomsForCid('//A/30-31/CA||//A/60-61/CA')
         expect(f).toHaveBeenCalled()
         expect(gemmiAtoms).toHaveLength(4)
-        expect(gemmiAtoms.map(atomInfo => atomInfo.label)).toEqual([ "/1/A/30(LYS)/CA", "/1/A/31(GLY)/CA", "/1/A/60(VAL)/CA", "/1/A/61(PHE)/CA" ])
+        expect(gemmiAtoms.map(atomInfo => atomInfo.res_no)).toEqual([ "30", "31", "60", "61" ])
+        expect(gemmiAtoms.map(atomInfo => atomInfo.res_name)).toEqual([ "LYS", "GLY", "VAL", "PHE" ])
     })
 
     test("Test gemmiAtomsForCid 4", async () => {
@@ -504,23 +497,20 @@ describe("Testing MoorhenMolecule", () => {
         expect(gemmiAtoms).toHaveLength(2)
         expect(gemmiAtoms).toEqual([
             {
-              res_name: 'GLY',
-              res_no: '31',
-              mol_name: '1',
-              chain_id: 'A',
-              pos: [ 70.995, 43.686, 22.449 ],
-              x: 70.995,
-              y: 43.686,
-              z: 22.449,
-              charge: 0,
-              element: 'C',
-              symbol: 'C',
-              tempFactor: 9.109999656677246,
-              serial: 213,
-              name: 'CA',
-              has_altloc: false,
-              alt_loc: "",
-              label: '/1/A/31(GLY)/CA'
+                x: 70.995,
+                y: 43.686,
+                z: 22.449,
+                charge: 0,
+                element: 'C',
+                tempFactor: 9.109999656677246,
+                serial: 213,
+                name: 'CA',
+                has_altloc: false,
+                alt_loc: '',
+                mol_name: '1',
+                chain_id: 'A',
+                res_no: '31',
+                res_name: 'GLY'
             },
             {
                 alt_loc: "",
@@ -528,18 +518,11 @@ describe("Testing MoorhenMolecule", () => {
                 charge: 0,
                 element: "C",
                 has_altloc: false,
-                label: "/1/A/61(PHE)/CA",
                 mol_name: "1",
                 name: "CA",
-                pos: [
-                    66.013,
-                    44.486,
-                    20.155,
-                ],
                 res_name: "PHE",
                 res_no: "61",
                 serial: 475,
-                symbol: "C",
                 tempFactor: 8.699999809265137,
                 x: 66.013,
                 y: 44.486,
@@ -566,7 +549,7 @@ describe("Testing MoorhenMolecule", () => {
         const gemmiAtoms = await molecule.gemmiAtomsForCid('//A/30-31/CA||//B')
         expect(f).toHaveBeenCalled()
         expect(gemmiAtoms).toHaveLength(25)
-        expect(gemmiAtoms.map(atomInfo => atomInfo.label)).toEqual([
+        expect(gemmiAtoms.map(atomInfo => getAtomInfoLabel(atomInfo))).toEqual([
             "/1/A/30(LYS)/CA",
             "/1/A/31(GLY)/CA",
             "/1/B/1(G2F)/C1",


### PR DESCRIPTION
Currently tests are outdated as they do not account for the changes in #333. Also the tests were scheduled to run on the first once a week instead of every night.