### PR TITLE
Add MoorhenColourRule and other changes

### DIFF
--- a/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
+++ b/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
@@ -137,7 +137,7 @@ export const MoorhenModifyColourRulesCard = (props: {
 
     const applyRules = useCallback(async () => {
         if (props.molecule?.defaultColourRules) {
-            if (JSON.stringify(props.molecule.defaultColourRules.map(rule => rule.stringify())) === JSON.stringify(ruleList.map(rule => rule.stringify()))) {
+            if (JSON.stringify(props.molecule.defaultColourRules.map(rule => rule.objectify())) === JSON.stringify(ruleList.map(rule => rule.objectify()))) {
                 return
             }
             props.molecule.defaultColourRules = ruleList

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -685,7 +685,7 @@ const CustomRepresentationChip = (props: {
                     anchorEl={props.addColourRulesAnchorDivRef}
                     initialRepresentationStyleValue={props.representation.style}
                     initialRuleType='cid'
-                    initialApplyColourToNonCarbonAtoms={props.representation.applyColourToNonCarbonAtoms}
+                    initialApplyColourToNonCarbonAtoms={(!props.representation.useDefaultColourRules && props.representation.colourRules?.length !== 0) ? props.representation.colourRules[0].applyColourToNonCarbonAtoms : false}
                     initialColour={(!props.representation.useDefaultColourRules && !props.representation.colourRules[0]?.isMultiColourRule) ? props.representation.colourRules[0].color : '#47d65f'}
                     initialAtomRadiusBondRatio={props.representation.bondOptions?.atomRadiusBondRatio}
                     initialBondWidth={props.representation.bondOptions?.width}

--- a/baby-gru/src/components/form/MoorhenFetchOnlineSourcesForm.tsx
+++ b/baby-gru/src/components/form/MoorhenFetchOnlineSourcesForm.tsx
@@ -11,6 +11,7 @@ import { setActiveMap, setNotificationContent } from "../../store/generalStatesS
 import { addMolecule } from "../../store/moleculesSlice";
 import { addMap } from "../../store/mapsSlice";
 import { webGL } from "../../types/mgWebGL";
+import { MoorhenColourRule } from "../../utils/MoorhenColourRule";
 
 export const MoorhenFetchOnlineSourcesForm = (props: {
     monomerLibraryPath: string;
@@ -137,14 +138,14 @@ export const MoorhenFetchOnlineSourcesForm = (props: {
             if (newMolecule.molNo === -1) {
                 throw new Error("Cannot read the fetched molecule...")
             } else if (isAF2) {
+                const newColourRule = new MoorhenColourRule(
+                    'af2-plddt', "/*/*/*/*", "#ffffff", commandCentre, true
+                )
+                newColourRule.setLabel("PLDDT")
                 const ruleArgs = await getMultiColourRuleArgs(newMolecule, 'af2-plddt')
-                const newRule = {
-                    args: [ruleArgs],
-                    isMultiColourRule: true,
-                    ruleType: 'af2-plddt',
-                    label: `//*`
-                }
-                newMolecule.defaultColourRules = [newRule]
+                newColourRule.setArgs([ ruleArgs ])
+                newColourRule.setParentMolecule(newMolecule)
+                newMolecule.defaultColourRules = [ newColourRule ]
             }
             await newMolecule.fetchIfDirtyAndDraw(newMolecule.atomCount >= 50000 ? 'CRs' : 'CBs')
             await newMolecule.centreOn('/*/*/*/*', true)

--- a/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
+++ b/baby-gru/src/components/misc/MoorhenResidueSelectionActions.tsx
@@ -14,6 +14,7 @@ import { MoorhenCidInputForm } from "../form/MoorhenCidInputForm"
 import { MoorhenAcceptRejectRotateTranslate } from "./MoorhenAcceptRejectRotateTranslate"
 import { MoorhenAcceptRejectDragAtoms } from "./MoorhenAcceptRejectDragAtoms"
 import { triggerUpdate } from "../../store/moleculeMapUpdateSlice"
+import { MoorhenColourRule } from "../../utils/MoorhenColourRule"
 
 export const MoorhenResidueSelectionActions = (props) => {
 
@@ -286,31 +287,29 @@ export const MoorhenResidueSelectionActions = (props) => {
         let newColourRules: moorhen.ColourRule[] = []
 
         if (residueSelection.isMultiCid && Array.isArray(residueSelection.cid)) {
-            residueSelection.cid.forEach(cid => newColourRules.push({
-                args: [cid, selectedColour],
-                isMultiColourRule: false,
-                ruleType: 'cid',
-                color: selectedColour,
-                label: cid,
-            }))
-        } else if (residueSelection.molecule && residueSelection.cid) {
-            newColourRules.push({
-                args: [residueSelection.cid as string, selectedColour],
-                isMultiColourRule: false,
-                ruleType: 'cid',
-                color: selectedColour,
-                label: residueSelection.cid as string,
+            residueSelection.cid.forEach(cid => {
+                const newColourRule = new MoorhenColourRule(
+                    'cid', cid, selectedColour, residueSelection.molecule.commandCentre, false
+                )
+                newColourRule.setArgs([ cid, selectedColour ])
+                newColourRule.setParentMolecule(residueSelection.molecule)
+                newColourRules.push(newColourRule)
             })
+        } else if (residueSelection.molecule && residueSelection.cid) {
+            const newColourRule = new MoorhenColourRule(
+                'cid', residueSelection.cid as string, selectedColour, residueSelection.molecule.commandCentre, false
+            )
+            newColourRule.setArgs([ residueSelection.cid as string, selectedColour ])
+            newColourRule.setParentMolecule(residueSelection.molecule)
+            newColourRules.push(newColourRule)
         } else if (residueSelection.molecule && residueSelection.first) {
             const startResSpec = cidToSpec(residueSelection.first)
             const cid =`/${startResSpec.mol_no}/${startResSpec.chain_id}/${startResSpec.res_no}-${startResSpec.res_no}`
-            newColourRules.push({
-                args: [cid as string, selectedColour],
-                isMultiColourRule: false,
-                ruleType: 'cid',
-                color: selectedColour,
-                label: cid as string,
-            })
+            const newColourRule = new MoorhenColourRule(
+                'cid', cid as string, selectedColour, residueSelection.molecule.commandCentre, false
+            )
+            newColourRule.setArgs([ cid as string, selectedColour ])
+            newColourRule.setParentMolecule(residueSelection.molecule)
         }
 
         newColourRules.forEach((newColourRule, idx) => {

--- a/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
@@ -14,6 +14,7 @@ import { MoorhenNotification } from "../misc/MoorhenNotification";
 import { useSelector, useDispatch } from 'react-redux';
 import { addMolecule } from "../../store/moleculesSlice";
 import { setNotificationContent } from "../../store/generalStatesSlice";
+import { MoorhenColourRule } from "../../utils/MoorhenColourRule";
 
 export const MoorhenQuerySequenceModal = (props: {
     show: boolean;
@@ -135,14 +136,14 @@ export const MoorhenQuerySequenceModal = (props: {
             return
         }
         if (source === 'AFDB') {
-            let ruleArgs = await getMultiColourRuleArgs(newMolecule, 'af2-plddt')
-            const newRule = {
-                args: [ruleArgs],
-                isMultiColourRule: true,
-                ruleType: 'af2-plddt',
-                label: `//*`
-            }
-            newMolecule.defaultColourRules = [newRule]
+            const colourRule = new MoorhenColourRule(
+                'af2-plddt', "//*", "#ffffff", props.commandCentre, true
+            )
+            colourRule.setLabel("PLDDT")
+            const ruleArgs = await getMultiColourRuleArgs(newMolecule, 'af2-plddt')
+            colourRule.setArgs([ ruleArgs ])
+            colourRule.setParentMolecule(newMolecule)
+            newMolecule.defaultColourRules = [ colourRule ]
         } 
         await props.commandCentre.current.cootCommand({
             message: 'coot_command',

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -50,6 +50,7 @@ declare module 'moorhen' {
 
     class MoorhenMolecule implements _moorhen.Molecule {
         constructor(commandCentre: React.RefObject<_moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, monomerLibrary: string)
+        addColourRule(ruleType: string, cid: string, color: string, args: (string | number)[], isMultiColourRule?: boolean, applyColourToNonCarbonAtoms?: boolean, label?: string): void;
         splitMultiModels(draw?: boolean): Promise<_moorhen.Molecule[]>;
         exportAsGltf(representationId: string): Promise<ArrayBuffer>;
         getNonSelectedCids(cid: string): string[];
@@ -65,7 +66,7 @@ declare module 'moorhen' {
         fitLigand(mapMolNo: number, ligandMolNo: number, fitRightHere?: boolean, redraw?: boolean, useConformers?: boolean, conformerCount?: number): Promise<_moorhen.Molecule[]>;
         checkIsLigand(): boolean;
         removeRepresentation(representationId: string): void;
-        addRepresentation(style: string, cid: string, isCustom?: boolean, colour?: _moorhen.ColourRule[], bondOptions?: _moorhen.cootBondOptions, applyColourToNonCarbonAtoms?: boolean): Promise<_moorhen.MoleculeRepresentation>;
+        addRepresentation(style: string, cid: string, isCustom?: boolean, colour?: _moorhen.ColourRule[], bondOptions?: _moorhen.cootBondOptions): Promise<_moorhen.MoleculeRepresentation>;
         getNeighborResiduesCids(selectionCid: string, maxDist: number): Promise<string[]>;
         drawWithStyleFromMesh(style: string, meshObjects: any[], cid?: string): Promise<void>;
         updateWithMovedAtoms(movedResidues: _moorhen.AtomInfo[][]): Promise<void>;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -78,17 +78,48 @@ export namespace moorhen {
         atomRadiusBondRatio: number;
     }
     
-    type ColourRule = {
-        args: (string | number)[];
-        color?: string;
+    type ColourRuleObject = {
+        cid: string;
+        color: string;
+        applyColourToNonCarbonAtoms: boolean;
         isMultiColourRule: boolean;
         ruleType: string;
+        args: (string | number)[];
         label: string;
+        uniqueId: string;
+        parentMoleculeMolNo: number;
+        parentRepresentationUniqueId: string;
+    };
+
+    type ColourRule = {
+        ruleType: string;
+        cid: string;
+        color: string;
+        args: (string | number)[];
+        label: string;
+        isMultiColourRule: boolean;
+        commandCentre: React.RefObject<moorhen.CommandCentre>;
+        parentMolecule: moorhen.Molecule;
+        parentRepresentation: moorhen.MoleculeRepresentation;
+        applyColourToNonCarbonAtoms: boolean;
+        uniqueId: string;
+        static initFromDataObject(data: ColourRuleObject, commandCentre: React.RefObject<CommandCentre>, molecule: Molecule): ColourRule;
+        static initFromString(stringData: string, commandCentre: React.RefObject<CommandCentre>, molecule: Molecule): ColourRule;
+        objectify(): ColourRuleObject;
+        stringify(): string;
+        setLabel(label: string): void;
+        setArgs(args: (string | number)[]): void;
+        setParentMolecule(molecule: moorhen.Molecule): void;
+        setParentRepresentation(representation: moorhen.MoleculeRepresentation): void;    
+        setApplyColourToNonCarbonAtoms(newVal: boolean): void;
+        getUserDefinedColours(): { cid: string; rgb: [number, number, number]; applyColourToNonCarbonAtoms: boolean }[];
+        apply(style: string, ruleIndex: number): Promise<void>;
     }
 
     type coorFormats = 'pdb' | 'mmcif';
     
     interface Molecule {
+        addColourRule(ruleType: string, cid: string, color: string, args: (string | number)[], isMultiColourRule?: boolean, applyColourToNonCarbonAtoms?: boolean, label?: string): void;
         splitMultiModels(draw?: boolean): Promise<Molecule[]>;
         getActiveAtom(): Promise<string>;
         setDrawAdaptativeBonds(newValue: boolean): Promise<void>;
@@ -115,7 +146,7 @@ export namespace moorhen {
         fitLigand(mapMolNo: number, ligandMolNo: number, fitRightHere?: boolean, redraw?: boolean, useConformers?: boolean, conformerCount?: number): Promise<Molecule[]>;
         checkIsLigand(): boolean;
         removeRepresentation(representationId: string): void;
-        addRepresentation(style: string, cid: string, isCustom?: boolean, colour?: ColourRule[], bondOptions?: cootBondOptions, applyColourToNonCarbonAtoms?: boolean): Promise<MoleculeRepresentation>;
+        addRepresentation(style: string, cid: string, isCustom?: boolean, colour?: ColourRule[], bondOptions?: cootBondOptions): Promise<MoleculeRepresentation>;
         getNeighborResiduesCids(selectionCid: string, maxDist: number): Promise<string[]>;
         drawWithStyleFromMesh(style: string, meshObjects: any[], cid?: string): Promise<void>;
         updateWithMovedAtoms(movedResidues: AtomInfo[][]): Promise<void>;
@@ -222,10 +253,10 @@ export namespace moorhen {
     'residueSelection' | 'MetaBalls' | 'adaptativeBonds'
 
     interface MoleculeRepresentation {
+        addColourRule(ruleType: string, cid: string, color: string, args: (string | number)[], isMultiColourRule?: boolean, applyColourToNonCarbonAtoms?: boolean, label?: string): void;
         getBufferObjects(): Promise<any>;
         applyColourRules(): Promise<void>;
         exportAsGltf(): Promise<ArrayBuffer>;
-        setApplyColourToNonCarbonAtoms(newVal: boolean): void;
         setBondOptions(bondOptions: cootBondOptions): void;
         setStyle(style: string): void;
         setUseDefaultColourRules(arg0: boolean): void;
@@ -243,7 +274,6 @@ export namespace moorhen {
         bondOptions: cootBondOptions;
         useDefaultColourRules: boolean;
         useDefaultBondOptions: boolean;
-        applyColourToNonCarbonAtoms: boolean;
         uniqueId: string;
         style: string;
         cid: string;
@@ -470,12 +500,11 @@ export namespace moorhen {
             cid: string;
             style: strin;
             isCustom: boolean;
-            colourRules: ColourRule[];
+            colourRules: ColourRuleObject[];
             bondOptions: cootBondOptions;
-            applyColoursToNonCarbonAtoms: boolean;
          }[];
         defaultBondOptions: cootBondOptions;
-        defaultColourRules: ColourRule[];
+        defaultColourRules: ColourRuleObject[];
         connectedToMaps: number[];
         ligandDicts: {[comp_id: string]: string};
     }

--- a/baby-gru/src/utils/MoorhenColourRule.tsx
+++ b/baby-gru/src/utils/MoorhenColourRule.tsx
@@ -1,0 +1,120 @@
+import { moorhen } from '../types/moorhen';
+import { hexToRgb } from '@mui/material';
+import { guid } from './MoorhenUtils';
+
+export class MoorhenColourRule implements moorhen.ColourRule {
+    
+    ruleType: string;
+    cid: string;
+    color: string;
+    args: (string | number)[];
+    label: string;
+    isMultiColourRule: boolean;
+    commandCentre: React.RefObject<moorhen.CommandCentre>;
+    parentMolecule: moorhen.Molecule;
+    parentRepresentation: moorhen.MoleculeRepresentation;
+    applyColourToNonCarbonAtoms: boolean;
+    uniqueId: string;
+    initFromString: (stringifiedObject: string, commandCentre: React.RefObject<moorhen.CommandCentre>, molecule: moorhen.Molecule) => moorhen.ColourRule;
+    initFromDataObject: (data: moorhen.ColourRuleObject, commandCentre: React.RefObject<moorhen.CommandCentre>, molecule: moorhen.Molecule) => moorhen.ColourRule;
+
+    constructor(ruleType: string, cid: string, color: string, commandCentre: React.RefObject<moorhen.CommandCentre>, isMultiColourRule: boolean = false, applyColourToNonCarbonAtoms: boolean = false) {
+        this.cid = cid
+        this.color = color
+        this.commandCentre = commandCentre
+        this.applyColourToNonCarbonAtoms = applyColourToNonCarbonAtoms
+        this.isMultiColourRule = isMultiColourRule
+        this.ruleType = ruleType
+        this.args = []
+        this.label = cid
+        this.uniqueId = guid()
+    }
+
+    static initFromString(stringifiedObject: string, commandCentre: React.RefObject<moorhen.CommandCentre>, molecule: moorhen.Molecule) {
+        const data = JSON.parse(stringifiedObject)
+        return MoorhenColourRule.initFromDataObject(data, commandCentre, molecule)
+    }
+
+    static initFromDataObject(data: moorhen.ColourRuleObject, commandCentre: React.RefObject<moorhen.CommandCentre>, molecule: moorhen.Molecule) {
+        const colourRule = new MoorhenColourRule(data.ruleType, data.cid, data.color, commandCentre, data.isMultiColourRule, data.applyColourToNonCarbonAtoms)
+        colourRule.setArgs(data.args)
+        colourRule.setLabel(data.label)
+        colourRule.setParentMolecule(molecule)
+        return colourRule
+    }
+
+    objectify() {
+        return {
+            cid: this.cid,
+            color: this.color,
+            applyColourToNonCarbonAtoms: this.applyColourToNonCarbonAtoms,
+            isMultiColourRule: this.isMultiColourRule,
+            ruleType: this.ruleType,
+            args: this.args,
+            label: this.label,
+            uniqueId: this.uniqueId,
+            parentMoleculeMolNo: this.parentMolecule ? this.parentMolecule.molNo : null,
+            parentRepresentationUniqueId: this.parentRepresentation ? this.parentRepresentation.uniqueId : null
+        }
+    }
+
+    stringify() {
+        return JSON.stringify(this.objectify())
+    }
+    
+    setLabel(label: string) {
+        this.label = label
+    }
+
+    setArgs(args: (string | number)[]) {
+        this.args = args
+    }
+
+    setParentMolecule(molecule: moorhen.Molecule) {
+        this.parentMolecule = molecule
+    }
+
+    setParentRepresentation(representation: moorhen.MoleculeRepresentation) {
+        this.parentRepresentation = representation
+        this.parentMolecule = representation.parentMolecule
+    }
+
+    setApplyColourToNonCarbonAtoms(newVal: boolean) {
+        this.applyColourToNonCarbonAtoms = newVal
+    }
+
+    getUserDefinedColours(): { cid: string; rgb: [number, number, number]; applyColourToNonCarbonAtoms: boolean }[] {
+        if(this.isMultiColourRule) {
+            const allColours = this.args[0] as string
+            return allColours.split('|').map(colour => {
+                const [cid, hex] = colour.split('^')
+                const [r, g, b] = hexToRgb(hex).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+                return { cid: cid, rgb: [r / 255, g / 255, b / 255], applyColourToNonCarbonAtoms: this.applyColourToNonCarbonAtoms }
+            })
+        } else {
+            const [r, g, b] = hexToRgb(this.color).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+            return [{ cid: this.label, rgb: [r / 255, g / 255, b / 255], applyColourToNonCarbonAtoms: this.applyColourToNonCarbonAtoms}]
+        }
+    }
+
+    async apply(style: string) {
+        if (!this.parentMolecule || !this.commandCentre) {
+            console.warn('Cannot apply colour rule without a parent molecule, or a command centre assigned. Doing nothing...')
+        } else if (['CBs', 'VdwSpheres', 'ligands', 'CAs'].includes(style)) {
+            const userDefinedColours = this.getUserDefinedColours()
+            await this.commandCentre.current.cootCommand({
+                message: 'coot_command',
+                command: 'shim_set_bond_colours',
+                returnType: 'status',
+                commandArgs: [this.parentMolecule.molNo, userDefinedColours, this.applyColourToNonCarbonAtoms]
+            }, false)
+        } else {
+            await this.commandCentre.current.cootCommand({
+                message: 'coot_command',
+                command: this.isMultiColourRule ? 'add_colour_rules_multi' : 'add_colour_rule',
+                returnType: 'status',
+                commandArgs: [this.parentMolecule.molNo, ...this.args]
+            }, false)
+        }
+    }
+}

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -4,6 +4,7 @@ import {
     getRandomMoleculeColour, doDownload, formatLigandSVG, getCentreAtom, getAtomInfoLabel
  } from './MoorhenUtils'
 import { MoorhenMoleculeRepresentation } from "./MoorhenMoleculeRepresentation"
+import { MoorhenColourRule } from "./MoorhenColourRule"
 import { quatToMat4 } from '../WebGLgComponents/quatToMat4.js';
 import { isDarkBackground } from '../WebGLgComponents/mgWebGL'
 import { hideMolecule } from '../store/moleculesSlice';
@@ -1042,6 +1043,16 @@ export class MoorhenMolecule implements moorhen.Molecule {
         representation.show()
     }
 
+    addColourRule(ruleType: string, cid: string, color: string, args: (string | number)[], isMultiColourRule: boolean = false, applyColourToNonCarbonAtoms: boolean = false, label?: string) {
+        const newColourRule = new MoorhenColourRule(ruleType, cid, color, this.commandCentre, isMultiColourRule, applyColourToNonCarbonAtoms)
+        newColourRule.setParentMolecule(this)
+        newColourRule.setArgs(args)
+        if (label) {
+            newColourRule.setLabel(label)
+        }
+        this.defaultColourRules.push(newColourRule)
+    }
+
     /**
      * Add a representation to the molecule
      * @param {string} style - The style of the new representation
@@ -1051,7 +1062,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @param {moorhen.cootBondOptions} [bondOptions=undefined] - An object that describes bond width, atom/bond ratio and other bond settings.
      * @param {boolean} [applyColourToNonCarbonAtoms=undefined] - If true then colours are applied to non-carbon atoms also.
      */
-    async addRepresentation(style: moorhen.RepresentationStyles, cid: string = '/*/*/*/*', isCustom: boolean = false, colourRules?: moorhen.ColourRule[], bondOptions?: moorhen.cootBondOptions, applyColourToNonCarbonAtoms?: boolean) {
+    async addRepresentation(style: moorhen.RepresentationStyles, cid: string = '/*/*/*/*', isCustom: boolean = false, colourRules?: moorhen.ColourRule[], bondOptions?: moorhen.cootBondOptions) {
         if (!this.defaultColourRules) {
             await this.fetchDefaultColourRules()
         }
@@ -1060,7 +1071,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
         representation.setParentMolecule(this)
         representation.setColourRules(colourRules)
         representation.setBondOptions(bondOptions)
-        representation.setApplyColourToNonCarbonAtoms(applyColourToNonCarbonAtoms)
         await representation.draw()
         this.representations.push(representation)
         await this.drawSymmetry(false)
@@ -1491,13 +1501,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
             const newChains = currentChains.filter(chainName => !prevChainNames.includes(chainName))
             newChains.forEach(chainName => {
                 const selectedColour = getRandomMoleculeColour()
-                this.defaultColourRules.push({
-                    args: [`//${chainName}`, selectedColour],
-                    isMultiColourRule: false,
-                    ruleType: 'chain',
-                    color: selectedColour,
-                    label: `//${chainName}`,
-                })
+                this.addColourRule('chain', `//${chainName}`, selectedColour, [`//${chainName}`, selectedColour])
             })
 
             await this.redraw()
@@ -1704,8 +1708,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
             return
         }
 
-        let rules: moorhen.ColourRule[] = []
-
         const response = await this.commandCentre.current.cootCommand({
             message: 'coot_command',
             command: "get_colour_rules",
@@ -1713,17 +1715,10 @@ export class MoorhenMolecule implements moorhen.Molecule {
             commandArgs: [this.molNo],
         }, false) as moorhen.WorkerResponse<libcootApi.PairType<string, string>[]>
         
-        response.data.result.result.forEach(rule => {
-            rules.push({
-                args: [rule.first, rule.second],
-                isMultiColourRule: false,
-                ruleType: 'chain',
-                color: rule.second,
-                label: rule.first
-            })
-        })
-
-        this.defaultColourRules = rules
+        this.defaultColourRules = []
+        for (let rule of response.data.result.result) {
+            this.addColourRule('chain',  rule.first, rule.second, [rule.first, rule.second])
+        }
     }
 
     /**
@@ -2233,13 +2228,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
             this.setAtomsDirty(true)
             // If the chain is new, then we need to create a random colour rule for it...
             const selectedColour = getRandomMoleculeColour()
-            this.defaultColourRules.push({
-                args: [`//${newId}`, selectedColour],
-                isMultiColourRule: false,
-                ruleType: 'chain',
-                color: selectedColour,
-                label: `//${newId}`,
-            })
+            this.addColourRule('chain', `//${newId}`, selectedColour, [`//${newId}`, selectedColour])
             if (redraw) {
                 await this.redraw()
             }

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -50,7 +50,7 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
         this.modificationCount = 0
         this.modificationCountBackupThreshold = 5
         this.maxBackupCount = 10
-        this.version = 'v20'
+        this.version = 'v21'
         this.disableBackups = false
         this.storageInstance = null
         this.onIsBusyChange = null
@@ -209,11 +209,10 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
                     cid: item.cid,
                     style: item.style,
                     isCustom: item.isCustom,
-                    colourRules: item.useDefaultColourRules ? null : item.colourRules,
+                    colourRules: item.useDefaultColourRules ? null : item.colourRules.map(item => item.objectify()),
                     bondOptions: item.useDefaultBondOptions ? null : item.bondOptions,
-                    applyColoursToNonCarbonAtoms: item.applyColourToNonCarbonAtoms,
                 }}),
-                defaultColourRules: molecule.defaultColourRules,
+                defaultColourRules: molecule.defaultColourRules.map(item => item.objectify()),
                 defaultBondOptions: molecule.defaultBondOptions,
                 connectedToMaps: molecule.connectedToMaps,
                 ligandDicts: molecule.ligandDicts

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -4,6 +4,7 @@ import * as vec3 from 'gl-matrix/vec3';
 import * as mat3 from 'gl-matrix/mat3';
 import { MoorhenMolecule } from "./MoorhenMolecule";
 import { MoorhenMap } from "./MoorhenMap";
+import { MoorhenColourRule } from "./MoorhenColourRule";
 import { moorhen } from "../types/moorhen";
 import { gemmi } from "../types/gemmi";
 import { webGL } from "../types/mgWebGL";
@@ -279,11 +280,22 @@ export async function loadSessionData(
         const molecule = newMolecules[i]
         const storedMoleculeData = sessionData.moleculeData[i]
         await Promise.all(Object.keys(storedMoleculeData.ligandDicts).map(compId => molecule.addDict(storedMoleculeData.ligandDicts[compId])))
-        molecule.defaultColourRules = storedMoleculeData.defaultColourRules
+        molecule.defaultColourRules = storedMoleculeData.defaultColourRules.map(item => {
+            const colourRule = MoorhenColourRule.initFromDataObject(item, commandCentre, molecule)
+            return colourRule
+        })
         molecule.defaultBondOptions = storedMoleculeData.defaultBondOptions
         for (const item of storedMoleculeData.representations) {
-            const representation = await molecule.addRepresentation(item.style, item.cid, item.isCustom, item.colourRules, item.bondOptions, item.applyColoursToNonCarbonAtoms)
-            dispatch( addCustomRepresentation(representation) )
+            const colourRules = !item.colourRules ? null : item.colourRules.map(item => {
+                const colourRule = MoorhenColourRule.initFromDataObject(item, commandCentre, molecule)
+                return colourRule
+            })
+            const representation = await molecule.addRepresentation(
+                item.style, item.cid, item.isCustom, colourRules, item.bondOptions
+            )
+            if (item.isCustom) {
+                dispatch( addCustomRepresentation(representation) )
+            }
         }
     }
     

--- a/wasm_src/moorhen-wrappers.cc
+++ b/wasm_src/moorhen-wrappers.cc
@@ -1169,6 +1169,13 @@ EMSCRIPTEN_BINDINGS(my_module) {
     ;
     class_<molecules_container_t>("molecules_container_t")
     .constructor<bool>()
+    .function("set_use_rama_plot_restraints", &molecules_container_t::set_use_rama_plot_restraints)
+    .function("set_rama_plot_restraints_weight", &molecules_container_t::set_rama_plot_restraints_weight)
+    .function("get_rama_plot_restraints_weight", &molecules_container_t::get_rama_plot_restraints_weight)
+    .function("set_use_torsion_restraints", &molecules_container_t::set_use_torsion_restraints)
+    .function("set_torsion_restraints_weight", &molecules_container_t::set_torsion_restraints_weight)
+    .function("get_torsion_restraints_weight", &molecules_container_t::get_torsion_restraints_weight)
+    .function("minimize_energy", &molecules_container_t::minimize_energy)
     .function("set_refinement_is_verbose", &molecules_container_t::set_refinement_is_verbose)
     .function("split_multi_model_molecule", &molecules_container_t::split_multi_model_molecule)
     .function("print_non_drawn_bonds", &molecules_container_t::print_non_drawn_bonds)


### PR DESCRIPTION
This update includes changes to how colour rules are being handled internally by Moorhen. It introduces a new class `MoorhenColourRule` which is used to manage all colour related actions. Among other changes, now `applyColourToNonCarbonAtoms` is defined for each colour rule rather than at the representation level. These changes are required for the future adition of goodsell colour schemes, see #351 and #354.