### PR TITLE
Add `reContourMapOnlyOnMouseUp` to preferences

### DIFF
--- a/baby-gru/src/WebGLgComponents/mgWebGL.tsx
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.tsx
@@ -2035,6 +2035,7 @@ interface ShaderOverlay extends MGWebGLShader {
 }
 
 interface MGWebGLPropsInterface {
+                    reContourMapOnlyOnMouseUp: boolean | null;
                     onAtomHovered : (identifier: { buffer: { id: string; }; atom: moorhen.AtomInfo; }) => void;
                     onKeyPress : (event: KeyboardEvent) =>  boolean | Promise<boolean>;
                     messageChanged : ((d:Dictionary<string>) => void);
@@ -2352,6 +2353,9 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
         this.reContourMapOnlyOnMouseUp = true;
         this.mapLineWidth = 1.0
 
+        if (this.props.reContourMapOnlyOnMouseUp !== null) {
+            this.reContourMapOnlyOnMouseUp = this.props.reContourMapOnlyOnMouseUp
+        }
         if (this.props.showAxes !== null) {
             this.showAxes = this.props.showAxes
         }
@@ -2538,6 +2542,9 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
             this.mapLineWidth = this.props.mapLineWidth
             this.setOrigin(this.origin, true)
             this.drawScene()
+        }
+        if (oldProps.reContourMapOnlyOnMouseUp !== this.props.reContourMapOnlyOnMouseUp) {
+            this.reContourMapOnlyOnMouseUp = this.props.reContourMapOnlyOnMouseUp
         }
     }
 

--- a/baby-gru/src/components/misc/MoorhenPreferencesContainer.tsx
+++ b/baby-gru/src/components/misc/MoorhenPreferencesContainer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from "react";
 import { MoorhenPreferences } from "../../utils/MoorhenPreferences";
-import { setDefaultMapLitLines, setDefaultMapSamplingRate, setDefaultMapSurface, setMapLineWidth } from "../../store/mapContourSettingsSlice";
+import { setDefaultMapLitLines, setDefaultMapSamplingRate, setDefaultMapSurface, setMapLineWidth, setReContourMapOnlyOnMouseUp } from "../../store/mapContourSettingsSlice";
 import { useSelector, useDispatch } from "react-redux"
 import { setContourWheelSensitivityFactor, setMouseSensitivity, setZoomWheelSensitivityFactor } from "../../store/mouseSettings";
 import { setEnableTimeCapsule, setMakeBackups, setMaxBackupCount, setModificationCountBackupThreshold } from "../../store/backupSettingsSlice";
@@ -32,6 +32,7 @@ export const MoorhenPreferencesContainer = (props: {
     const defaultMapSamplingRate = useSelector((state: moorhen.State) => state.mapContourSettings.defaultMapSamplingRate)
     const mapLineWidth = useSelector((state: moorhen.State) => state.mapContourSettings.mapLineWidth)
     const defaultMapSurface = useSelector((state: moorhen.State) => state.mapContourSettings.defaultMapSurface)
+    const reContourMapOnlyOnMouseUp = useSelector((state: moorhen.State) => state.mapContourSettings.reContourMapOnlyOnMouseUp)
 
     // Backup settings
     const enableTimeCapsule = useSelector((state: moorhen.State) => state.backupSettings.enableTimeCapsule)
@@ -142,6 +143,7 @@ export const MoorhenPreferencesContainer = (props: {
         47: { label: "edgeDetectNormalThreshold", value: edgeDetectNormalThreshold, valueSetter: setEdgeDetectNormalThreshold},
         48: { label: "edgeDetectDepthScale", value: edgeDetectDepthScale, valueSetter: setEdgeDetectDepthScale},
         49: { label: "edgeDetectNormalScale", value: edgeDetectNormalScale, valueSetter: setEdgeDetectNormalScale},
+        50: { label: "reContourMapOnlyOnMouseUp", value: reContourMapOnlyOnMouseUp, valueSetter: setReContourMapOnlyOnMouseUp},
     }
 
     const restoreDefaults = (preferences: moorhen.Preferences, defaultValues: moorhen.PreferencesValues)=> {
@@ -199,6 +201,16 @@ export const MoorhenPreferencesContainer = (props: {
         fetchStoredContext();
 
     }, [])
+
+    useMemo(() => {
+
+        if (reContourMapOnlyOnMouseUp === null) {
+            return
+        }
+       
+        localForageInstanceRef.current?.localStorageInstance.setItem('reContourMapOnlyOnMouseUp', reContourMapOnlyOnMouseUp)
+        .then(_ => props.onUserPreferencesChange('reContourMapOnlyOnMouseUp', reContourMapOnlyOnMouseUp));
+    }, [reContourMapOnlyOnMouseUp]);
 
     useMemo(() => {
 

--- a/baby-gru/src/components/navbar-menus/MoorhenPreferencesMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenPreferencesMenu.tsx
@@ -14,7 +14,7 @@ import { MoorhenNavBarExtendedControlsInterface } from "./MoorhenNavBar";
 import { useSelector, useDispatch } from "react-redux";
 import { setAnimateRefine, setDefaultExpandDisplayCards, setEnableRefineAfterMod, setTransparentModalsOnMouseOut } from "../../store/miscAppSettingsSlice";
 import { setAtomLabelDepthMode } from "../../store/labelSettingsSlice";
-import { setDefaultMapLitLines, setDefaultMapSurface } from "../../store/mapContourSettingsSlice";
+import { setDefaultMapLitLines, setDefaultMapSurface, setReContourMapOnlyOnMouseUp } from "../../store/mapContourSettingsSlice";
 import { setShortcutOnHoveredAtom, setShowShortcutToast } from "../../store/shortCutsSlice";
 import { setMakeBackups } from "../../store/backupSettingsSlice";
 import { setDevMode } from "../../store/generalStatesSlice";
@@ -27,6 +27,7 @@ export const MoorhenPreferencesMenu = (props: MoorhenNavBarExtendedControlsInter
     const devMode = useSelector((state: moorhen.State) => state.generalStates.devMode)
     const defaultMapLitLines = useSelector((state: moorhen.State) => state.mapContourSettings.defaultMapLitLines)
     const defaultMapSurface = useSelector((state: moorhen.State) => state.mapContourSettings.defaultMapSurface)
+    const reContourMapOnlyOnMouseUp = useSelector((state: moorhen.State) => state.mapContourSettings.reContourMapOnlyOnMouseUp)
     const enableTimeCapsule = useSelector((state: moorhen.State) => state.backupSettings.enableTimeCapsule)
     const makeBackups = useSelector((state: moorhen.State) => state.backupSettings.makeBackups)
     const maxBackupCount = useSelector((state: moorhen.State) => state.backupSettings.maxBackupCount)
@@ -91,6 +92,13 @@ export const MoorhenPreferencesMenu = (props: MoorhenNavBarExtendedControlsInter
                             checked={defaultMapSurface}
                             onChange={() => {dispatch( setDefaultMapSurface(!defaultMapSurface) )}}
                             label="Show maps as surface by default"/>
+                    </InputGroup>
+                    <InputGroup className='moorhen-input-group-check'>
+                        <Form.Check 
+                            type="switch"
+                            checked={reContourMapOnlyOnMouseUp}
+                            onChange={() => {dispatch( setReContourMapOnlyOnMouseUp(!reContourMapOnlyOnMouseUp) )}}
+                            label="Recontour maps only on mouse up"/>
                     </InputGroup>
                     <InputGroup className='moorhen-input-group-check'>
                         <Form.Check 

--- a/baby-gru/src/components/webMG/MoorhenWebMG.tsx
+++ b/baby-gru/src/components/webMG/MoorhenWebMG.tsx
@@ -43,6 +43,7 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
     const [showContextMenu, setShowContextMenu] = useState<false | moorhen.AtomRightClickEventInfo>(false)
     const [defaultActionButtonSettings, setDefaultActionButtonSettings] = useReducer(actionButtonSettingsReducer, intialDefaultActionButtonSettings)
 
+    const reContourMapOnlyOnMouseUp = useSelector((state: moorhen.State) => state.mapContourSettings.reContourMapOnlyOnMouseUp)
     const visibleMolecules = useSelector((state: moorhen.State) => state.molecules.visibleMolecules)
     const residueSelection = useSelector((state: moorhen.State) => state.generalStates.residueSelection)
     const isChangingRotamers = useSelector((state: moorhen.State) => state.generalStates.isChangingRotamers)
@@ -439,6 +440,7 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
                     showFPS={drawFPS}
                     mapLineWidth={innerMapLineWidth}
                     drawMissingLoops={drawMissingLoops}
+                    reContourMapOnlyOnMouseUp={reContourMapOnlyOnMouseUp}
                     drawInteractions={drawInteractions} />
 
                 {showContextMenu &&

--- a/baby-gru/src/store/mapContourSettingsSlice.ts
+++ b/baby-gru/src/store/mapContourSettingsSlice.ts
@@ -16,8 +16,13 @@ export const mapContourSettingsSlice = createSlice({
     defaultMapLitLines: null,
     mapLineWidth: null,
     defaultMapSurface: null,
+    reContourMapOnlyOnMouseUp: null
   },
   reducers: {
+    setReContourMapOnlyOnMouseUp: (state, action: {payload: boolean, type: string}) => {
+      state = { ...state, reContourMapOnlyOnMouseUp: action.payload }
+      return state
+  },
     showMap: (state, action: {payload: moorhen.Map, type: string}) => {
         if (!state.visibleMaps.includes(action.payload.molNo)) state = { ...state, visibleMaps: [...state.visibleMaps, action.payload.molNo] }
         return state
@@ -82,7 +87,8 @@ export const mapContourSettingsSlice = createSlice({
 export const {
   showMap, hideMap, setContourLevel, setMapRadius, setMapAlpha, setMapStyle, changeMapRadius,
   setDefaultMapSamplingRate, setDefaultMapLitLines, setMapLineWidth, setDefaultMapSurface,
-  setMapColours, setNegativeMapColours, setPositiveMapColours, changeContourLevel
+  setMapColours, setNegativeMapColours, setPositiveMapColours, changeContourLevel,
+  setReContourMapOnlyOnMouseUp
 } = mapContourSettingsSlice.actions
 
 export default mapContourSettingsSlice.reducer

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -703,6 +703,7 @@ export namespace moorhen {
     
     interface PreferencesValues {
         version?: string;
+        reContourMapOnlyOnMouseUp: boolean;
         isMounted?: boolean;
         defaultMapSamplingRate: number;
         transparentModalsOnMouseOut: boolean;
@@ -944,6 +945,7 @@ export namespace moorhen {
             mapColours: { molNo: number; rgb: {r: number, g: number, b: number} }[];
             negativeMapColours: { molNo: number; rgb: {r: number, g: number, b: number} }[];
             positiveMapColours: { molNo: number; rgb: {r: number, g: number, b: number} }[];
+            reContourMapOnlyOnMouseUp: boolean;
         };
         moleculeMapUpdate: {
             updatingMapsIsEnabled: boolean;

--- a/baby-gru/src/utils/MoorhenPreferences.ts
+++ b/baby-gru/src/utils/MoorhenPreferences.ts
@@ -32,7 +32,8 @@ export class MoorhenPreferences implements moorhen.Preferences {
     }
 
     static defaultPreferencesValues: moorhen.PreferencesValues = {
-        version: 'v35',
+        version: 'v36',
+        reContourMapOnlyOnMouseUp: false,
         transparentModalsOnMouseOut: false,
         defaultBackgroundColor: [1, 1, 1, 1],
         atomLabelDepthMode: true,


### PR DESCRIPTION
Added `reContourMapOnlyOnMouseUp` as a user-defined preference which controls whether maps should only be redrawn on mouse up.