### PR TITLE
Fix bug with "Find ligand" and long ligand names

### DIFF
--- a/baby-gru/src/components/modal/MoorhenFindLigandModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenFindLigandModal.tsx
@@ -20,6 +20,8 @@ const LigandHitCard = (props: {
     setLigandResults: React.Dispatch<React.SetStateAction<moorhen.Molecule[]>>;
 }) => {
 
+    const representationRef = useRef<moorhen.MoleculeRepresentation>(null)
+
     const dispatch = useDispatch()
     const animateRefine = useSelector((state: moorhen.State) => state.refinementSettings.animateRefine)
     const activeMap = useSelector((state: moorhen.State) => state.generalStates.activeMap)
@@ -27,16 +29,16 @@ const LigandHitCard = (props: {
 
     const handleShow = useCallback(async () => {
         if (props.ligandMolecule.representations.length > 0) {
-            props.ligandMolecule.show('ligands')
+            props.ligandMolecule.show('CBs')
         } else {
-            await props.ligandMolecule.fetchIfDirtyAndDraw('ligands')
+            await props.ligandMolecule.fetchIfDirtyAndDraw('CBs')
         }
         await props.ligandMolecule.centreOn('/*/*/*/*', true, true)
     }, [])
 
     useEffect(() => {
         if (props.ligandCardMolNoFocus !== props.ligandMolecule.molNo) {
-            props.ligandMolecule.hide('ligands')
+            props.ligandMolecule.hide('CBs')
         } else {
             handleShow()
         }

--- a/baby-gru/src/components/modal/MoorhenFindLigandModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenFindLigandModal.tsx
@@ -20,8 +20,6 @@ const LigandHitCard = (props: {
     setLigandResults: React.Dispatch<React.SetStateAction<moorhen.Molecule[]>>;
 }) => {
 
-    const representationRef = useRef<moorhen.MoleculeRepresentation>(null)
-
     const dispatch = useDispatch()
     const animateRefine = useSelector((state: moorhen.State) => state.refinementSettings.animateRefine)
     const activeMap = useSelector((state: moorhen.State) => state.generalStates.activeMap)

--- a/baby-gru/src/moorhen.ts
+++ b/baby-gru/src/moorhen.ts
@@ -16,6 +16,7 @@ import { MoorhenSlider } from "./components/misc/MoorhenSlider";
 import { MoorhenFetchOnlineSourcesForm } from "./components/form/MoorhenFetchOnlineSourcesForm";
 import { loadSessionData } from "./utils/MoorhenUtils";
 import { MoorhenReduxProvider } from "./components/misc/MoorhenReduxProvider";
+import MoorhenReduxStore from "./store/MoorhenReduxStore";
 import { setDefaultBackgroundColor, setDrawCrosshairs, setDrawFPS, setDrawMissingLoops, setDefaultBondSmoothness,
     setDrawInteractions, setDoSSAO, setSsaoRadius, setSsaoBias, setResetClippingFogging, setClipCap,  
     setUseOffScreenBuffers, setDoShadowDepthDebug, setDoShadow, setDoSpin, setDoOutline, setDepthBlurRadius,
@@ -60,5 +61,5 @@ export {
     setMapRadius, setMapStyle, showMap, hideMap, setContourLevel, showMolecule, hideMolecule, MoorhenMoleculeRepresentation, 
     MoorhenQuerySequenceModal, MoorhenPreferences, setDoEdgeDetect, addCustomRepresentation, removeCustomRepresentation,
     setEdgeDetectDepthThreshold, setEdgeDetectNormalThreshold, setEdgeDetectDepthScale, setEdgeDetectNormalScale,
-    setUseRamaRefinementRestraints, setuseTorsionRefinementRestraints, setAnimateRefine
+    setUseRamaRefinementRestraints, setuseTorsionRefinementRestraints, setAnimateRefine, MoorhenReduxStore
 };

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -6,6 +6,9 @@ import { privateer } from "./privateer";
 
 declare module 'moorhen' {
 
+    let MoorhenReduxStore: any;
+    module.exports = MoorhenReduxStore
+
     let MoorhenContainer: any;
     module.exports = MoorhenContainer;
 

--- a/wasm_src/moorhen-wrappers.cc
+++ b/wasm_src/moorhen-wrappers.cc
@@ -190,7 +190,7 @@ class molecules_container_js : public molecules_container_t {
             
         }
 
-        std::vector<std::pair<std::string,int>> slicendice_slice(int imol, int nclusters, const std::string &clustering_method, const std::string &input_pae){
+        std::vector<std::pair<std::string,int>> slicendice_slice(int imol, int nclusters, const std::string &clustering_method, const std::string &pae_contents_string){
 
             std::vector<std::pair<std::string,int>> cid_label_pair;
             mmdb::Manager *mol = get_mol(imol);
@@ -255,7 +255,10 @@ class molecules_container_js : public molecules_container_t {
                     birch.fit(atomic_matrix);
                     labels = birch.labels_;
                 } else if (clustering_method == "pae") {
-                    PAE pae(nclusters, input_pae);
+                    std::string pae_file_name = generate_rand_str(32);
+                    pae_file_name += ".json";
+                    write_text_file(pae_file_name, pae_contents_string);
+                    PAE pae(nclusters, pae_file_name);
                     pae.fit(atomic_matrix);
                     labels = pae.labels_;
                 } else {


### PR DESCRIPTION
This update:
- Resolves #372
- Adds `MoorhenReduxStore` to exported variables in the npm module
- Updates PAE wrapper to take file contents rather than a file name