### PR TITLE
Use protobuf to store moorhen session files and other improvements to session handling

### DIFF
--- a/.github/workflows/tsc-compilation.yml
+++ b/.github/workflows/tsc-compilation.yml
@@ -20,10 +20,6 @@ jobs:
       run: | 
         sudo apt-get update -y   
         sudo apt-get install -y npm
-    - name: Create mock version file
-      working-directory: /home/runner/work/Moorhen/       
-      run: |    
-        echo "export const version = 0.1" > /home/runner/work/Moorhen/Moorhen/baby-gru/src/version.js
     - name: Restore cache node16 modules
       id: cache-node16-modules-load
       uses: actions/cache@v4
@@ -45,4 +41,6 @@ jobs:
       working-directory: /home/runner/work/Moorhen/Moorhen/baby-gru
       run: |             
         cd /home/runner/work/Moorhen/Moorhen/baby-gru/
+        npm run create-version
+        npm run transpile-protobuf 
         npx tsc

--- a/.gitignore
+++ b/.gitignore
@@ -585,3 +585,4 @@ baby-gru/public/baby-gru/CootWorker.js
 baby-gru/docs/
 baby-gru/src/version.js
 react-app/public/wasm/web_example.js
+baby-gru/src/protobuf/MoorhenSession.js

--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -64,12 +64,13 @@
   },
   "dependencies": {},
   "scripts": {
+    "transpile-protobuf": "npx pbjs -t static-module -w es6 -o ./src/protobuf/MoorhenSession.js ./src/protobuf/MoorhenSession.proto",
     "create-version": "npx genversion -e -p ./package.json -d -s ./src/version.js",
     "transpile-ts-worker": "npx tsc --module es2015 --lib webworker --skipLibCheck public/baby-gru/CootWorker.ts && sed -i.bak '/export {}/d' public/baby-gru/CootWorker.js && rm public/baby-gru/CootWorker.js.bak",
     "transpile-ts-worker-jest": "npx tsc --module es2015 --lib webworker --skipLibCheck public/baby-gru/CootWorker.ts && sed -i.bak 's/export {}/export { doCootCommand, setModules }/g' public/baby-gru/CootWorker.js && sed -i.bak '/importScripts.*;/d' public/baby-gru/CootWorker.js && sed -i.bak 's/onmessage/function setModules(arg0, arg1) { molecules_container = arg0; cootModule = arg1 }; let postMessage = () => {}; let onmessage/g' public/baby-gru/CootWorker.js && rm public/baby-gru/CootWorker.js.bak",
-    "prestart": "npm run create-version && npm run transpile-ts-worker",
+    "prestart": "npm run create-version && npm run transpile-ts-worker && npm run transpile-protobuf",
     "start": "vite",
-    "prebuild": "npm run create-version && npm run transpile-ts-worker",
+    "prebuild": "npm run create-version && npm run transpile-ts-worker && npm run transpile-protobuf",
     "build": "vite build",
     "build-release": "npm run prebuild && webpack --mode production --devtool inline-source-map",
     "dev": "concurrently -k \"BROWSER=none npm start\" \"npm:electron\"",
@@ -79,8 +80,8 @@
     "make-linux": "npm run build && electron-forge make --platform linux",
     "make-win32": "npm run build && electron-forge make --platform win32",
     "create-docs": "npm run create-version && npx jsdoc -c jsdoc.json",
-    "test": "npm run create-version && npx tsc && npm run transpile-ts-worker-jest && ln -s ./public/baby-gru/wasm/moorhen.data ./moorhen.data && ln -s ./public/baby-gru ./baby-gru && node --trace-warnings --experimental-vm-modules --experimental-wasm-threads node_modules/jest/bin/jest.js --forceExit",
-    "test-react": "npm run create-version && npx tsc && node --trace-warnings --experimental-vm-modules --experimental-wasm-threads node_modules/jest/bin/jest.js --forceExit --testPathIgnorePatterns=moorhenContainer.test.jsx --selectProjects react-components"
+    "test": "npm run create-version && npm run transpile-protobuf && npx tsc && npm run transpile-ts-worker-jest && ln -s ./public/baby-gru/wasm/moorhen.data ./moorhen.data && ln -s ./public/baby-gru ./baby-gru && node --trace-warnings --experimental-vm-modules --experimental-wasm-threads node_modules/jest/bin/jest.js --forceExit",
+    "test-react": "npm run create-version && npm run transpile-protobuf && npx tsc && node --trace-warnings --experimental-vm-modules --experimental-wasm-threads node_modules/jest/bin/jest.js --forceExit --testPathIgnorePatterns=moorhenContainer.test.jsx --selectProjects react-components"
   },
   "eslintConfig": {
     "extends": [

--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -162,6 +162,8 @@
     "plotly.js": "^2.12.1",
     "prismjs": "^1.29.0",
     "prop-types": "^15.8.1",
+    "protobufjs": "^7.2.6",
+    "protobufjs-cli": "^1.1.2",
     "protvista-manager": "^3.4.0",
     "protvista-navigation": "^3.5.1",
     "protvista-sequence": "^3.5.1",

--- a/baby-gru/src/components/navbar-menus/MoorhenHistoryMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenHistoryMenu.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 import { MoorhenNavBarExtendedControlsInterface } from "./MoorhenNavBar";
-import { convertViewtoPx, guid, loadSessionData } from "../../utils/MoorhenUtils";
+import { convertViewtoPx, guid, loadSessionFromJsonString } from "../../utils/MoorhenUtils";
 import { Stepper, Step, StepButton, StepLabel } from "@mui/material";
 import { moorhen } from "../../types/moorhen";
 import { SaveOutlined, WarningOutlined } from "@mui/icons-material";
@@ -28,7 +28,7 @@ export const MoorhenHistoryMenu = (props: MoorhenNavBarExtendedControlsInterface
 
     const loadSession = useCallback(async (sessionData: string) => {
         try {
-            const status = await loadSessionData(
+            const status = await loadSessionFromJsonString(
                 sessionData as string,
                 props.monomerLibraryPath,
                 molecules, 

--- a/baby-gru/src/moorhen.ts
+++ b/baby-gru/src/moorhen.ts
@@ -14,7 +14,7 @@ import { MoorhenMoleculeSelect } from "./components/select/MoorhenMoleculeSelect
 import { MoorhenMapSelect } from "./components/select/MoorhenMapSelect";
 import { MoorhenSlider } from "./components/misc/MoorhenSlider";
 import { MoorhenFetchOnlineSourcesForm } from "./components/form/MoorhenFetchOnlineSourcesForm";
-import { loadSessionData } from "./utils/MoorhenUtils";
+import { loadSessionFromJsonString, loadSessionData, loadSessionFromProtoMessage } from "./utils/MoorhenUtils";
 import { MoorhenReduxProvider } from "./components/misc/MoorhenReduxProvider";
 import MoorhenReduxStore from "./store/MoorhenReduxStore";
 import { setDefaultBackgroundColor, setDrawCrosshairs, setDrawFPS, setDrawMissingLoops, setDefaultBondSmoothness,
@@ -44,7 +44,7 @@ import { setShowScoresToast, addMapUpdatingScore, removeMapUpdatingScore, overwr
 
 export {
     ErrorBoundary, MoorhenApp, MoorhenContainer, MoorhenTimeCapsule, MoorhenMoleculeSelect, MoorhenMolecule, MoorhenMap,
-    MoorhenCommandCentre, loadSessionData, MoorhenMapSelect, MoorhenDraggableModalBase, MoorhenReduxProvider, 
+    MoorhenCommandCentre, loadSessionFromJsonString, MoorhenMapSelect, MoorhenDraggableModalBase, MoorhenReduxProvider, 
     setDefaultBackgroundColor, setDrawCrosshairs, setDrawScaleBar, setDrawFPS, setDrawMissingLoops, setDefaultBondSmoothness,
     setDrawInteractions, setDoSSAO, setSsaoRadius, setSsaoBias, setResetClippingFogging, setClipCap, MoorhenColourRule,
     setUseOffScreenBuffers, setDoShadowDepthDebug, setDoShadow, setDoSpin, setDoOutline, setDepthBlurRadius,
@@ -61,5 +61,6 @@ export {
     setMapRadius, setMapStyle, showMap, hideMap, setContourLevel, showMolecule, hideMolecule, MoorhenMoleculeRepresentation, 
     MoorhenQuerySequenceModal, MoorhenPreferences, setDoEdgeDetect, addCustomRepresentation, removeCustomRepresentation,
     setEdgeDetectDepthThreshold, setEdgeDetectNormalThreshold, setEdgeDetectDepthScale, setEdgeDetectNormalScale,
-    setUseRamaRefinementRestraints, setuseTorsionRefinementRestraints, setAnimateRefine, MoorhenReduxStore
+    setUseRamaRefinementRestraints, setuseTorsionRefinementRestraints, setAnimateRefine, MoorhenReduxStore, 
+    loadSessionData, loadSessionFromProtoMessage
 };

--- a/baby-gru/src/protobuf/MoorhenSession.proto
+++ b/baby-gru/src/protobuf/MoorhenSession.proto
@@ -121,7 +121,7 @@ message Blur {
   float radius = 3;
 }
 
-message BackupSession {
+message Session {
   string version = 1;
   bool includesAdditionalMapData = 2;
   repeated MoleculeSessionData moleculeData = 3;

--- a/baby-gru/src/protobuf/MoorhenSession.proto
+++ b/baby-gru/src/protobuf/MoorhenSession.proto
@@ -1,0 +1,131 @@
+package moorhensession;
+syntax = "proto3";
+
+message CootBondOptions {
+  float smoothness = 1;
+  float width = 2;
+  float atomRadiusBondRatio = 3;
+}
+
+message ColourRuleObject {
+  string cid = 1;
+  string color = 2;
+  bool applyColourToNonCarbonAtoms = 3;
+  bool isMultiColourRule = 4;
+  string ruleType = 5;
+  repeated string args = 6;
+  string label = 7;
+  string uniqueId = 8;
+  int32 parentMoleculeMolNo = 9;
+  string parentRepresentationUniqueId = 10;
+}
+
+message SelectedMtzColumns {
+  string F = 1;
+  string PHI = 2;
+  optional string Fobs = 3;
+  optional string SigFobs = 4;
+  optional string FreeR = 5;
+  optional bool isDifference = 6;
+  optional bool useWeight = 7;
+  optional bool calcStructFact = 8;
+}
+
+message Representation {
+    string cid = 1;
+    string style = 2;
+    bool isCustom = 3;
+    repeated ColourRuleObject colourRules = 4;
+    CootBondOptions bondOptions = 5;
+}
+
+message MoleculeSessionData {
+  string name = 1;
+  int32 molNo = 2;
+  string coordString = 3;
+  repeated Representation representations = 4;
+  CootBondOptions defaultBondOptions = 5;
+  repeated ColourRuleObject defaultColourRules = 6;
+  repeated int32 connectedToMaps = 7;
+  map<string, string> ligandDicts = 8;
+}
+
+message MapDataSession {
+  string name = 1;
+  int32 molNo = 2;
+  string uniqueId = 3;
+  bytes mapData = 4;
+  bytes reflectionData = 5;
+  bool showOnLoad = 6;
+  float contourLevel = 7;
+  float radius = 8;
+  MapRgba rgba = 9;
+  string style = 10;
+  bool isDifference = 11;
+  SelectedMtzColumns selectedColumns = 12;
+  bool hasReflectionData = 13;
+  string associatedReflectionFileName = 14;
+}
+
+message MapRgba {
+  MapColour mapColour = 1;
+  MapColour positiveDiffColour = 2;
+  MapColour negativeDiffColour = 3;
+  float a = 4;
+}
+
+message MapColour {
+  int32 r = 1;
+  int32 g = 2;
+  int32 b = 3;
+}
+
+message ViewDataSession {
+  repeated float origin = 1;
+  repeated float backgroundColor = 2;
+  repeated float ambientLight = 3;
+  repeated float diffuseLight = 4;
+  repeated float lightPosition = 5;
+  repeated float specularLight = 6;
+  float specularPower = 7;
+  float fogStart = 8;
+  float fogEnd = 9;
+  float zoom = 10;
+  bool doDrawClickedAtomLines = 11;
+  float clipStart = 12;
+  float clipEnd = 13;
+  repeated float quat4 = 14;
+  bool shadows = 15;
+  Ssao ssao = 16;
+  EdgeDetection edgeDetection = 17;
+  Blur blur = 18;
+}
+
+message Ssao {
+  bool enabled = 1;
+  float radius = 2;
+  float bias = 3;
+}
+
+message EdgeDetection {
+  bool enabled = 1;
+  float depthScale = 2;
+  float normalScale = 3;
+  float depthThreshold = 4;
+  float normalThreshold = 5;
+}
+
+message Blur {
+  bool enabled = 1;
+  float depth = 2;
+  float radius = 3;
+}
+
+message BackupSession {
+  string version = 1;
+  bool includesAdditionalMapData = 2;
+  repeated MoleculeSessionData moleculeData = 3;
+  repeated MapDataSession mapData = 4;
+  ViewDataSession viewData = 5;
+  int32 activeMapIndex = 6;
+}

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -316,8 +316,33 @@ declare module 'moorhen' {
     }
     module.exports.MoorhenMap = MoorhenMap
 
-    function loadSessionData(
+    function loadSessionFromJsonString(
         sessionDataString: string,
+        monomerLibraryPath: string,
+        molecules: _moorhen.Molecule[],
+        maps: _moorhen.Map[],
+        commandCentre: React.RefObject<_moorhen.CommandCentre>,
+        timeCapsuleRef: React.RefObject<_moorhen.TimeCapsule>,
+        glRef: React.RefObject<webGL.MGWebGL>,
+        dispatch: (reduxStoreAction: any) => void,
+    ): Promise<number>;
+    module.exports = loadSessionFromJsonString;
+
+    function loadSessionFromProtoMessage(
+        sessionProtoMessage: any,
+        monomerLibraryPath: string,
+        molecules: _moorhen.Molecule[],
+        maps: _moorhen.Map[],
+        commandCentre: React.RefObject<_moorhen.CommandCentre>,
+        timeCapsuleRef: React.RefObject<_moorhen.TimeCapsule>,
+        glRef: React.RefObject<webGL.MGWebGL>,
+        dispatch: (reduxStoreAction: any) => void,
+    ): Promise<number>;
+    module.exports = loadSessionFromProtoMessage;
+
+
+    function loadSessionData(
+        sessionData: _moorhen.backupSession,
         monomerLibraryPath: string,
         molecules: _moorhen.Molecule[],
         maps: _moorhen.Map[],

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -582,7 +582,7 @@ export namespace moorhen {
         removeBackup(key: string): Promise<void>;
         updateDataFiles(): Promise<(string | void)[]>;
         createBackup(keyString: string, sessionString: string): Promise<string>;
-        fetchSession(arg0: boolean): Promise<backupSession>;
+        fetchSession(includeAdditionalMapData: boolean): Promise<backupSession>;
         toggleDisableBackups(): void;
         moleculesRef: React.RefObject<Molecule[]>;
         mapsRef: React.RefObject<Map[]>;

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -369,6 +369,7 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
                 return key
             } catch (err) {
                 console.log(err)
+                console.log('Unable to create backup, something went wrong...')
             }   
         }
     }

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -101,7 +101,7 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
 
     /**
      * Update metadata files currently stored in the local storage. It might be required to call this function before
-     * using {@link MoorhenTimeCapsule.fetchSession}
+     * using MoorhenTimeCapsule.fetchSession
      * @returns {Promise<string[]>} Backup keys for the new metadata files that were created if any
      */
     async updateDataFiles(): Promise<(string | void)[]> {
@@ -246,10 +246,10 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
         const viewData: moorhen.viewDataSession = {
             origin: this.glRef.current.origin,
             backgroundColor: this.glRef.current.background_colour,
-            ambientLight: this.glRef.current.light_colours_ambient,
-            diffuseLight: this.glRef.current.light_colours_diffuse,
-            lightPosition: this.glRef.current.light_positions,
-            specularLight: this.glRef.current.light_colours_specular,
+            ambientLight: Array.from(this.glRef.current.light_colours_ambient) as [number, number, number, number],
+            diffuseLight: Array.from(this.glRef.current.light_colours_diffuse) as [number, number, number, number],
+            lightPosition: Array.from(this.glRef.current.light_positions) as [number, number, number, number],
+            specularLight: Array.from(this.glRef.current.light_colours_specular) as [number, number, number, number],
             specularPower: this.glRef.current.specularPower,
             fogStart: this.glRef.current.gl_fog_start,
             fogEnd: this.glRef.current.gl_fog_end,
@@ -257,7 +257,7 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
             doDrawClickedAtomLines: this.glRef.current.doDrawClickedAtomLines,
             clipStart: (this.glRef.current.gl_clipPlane0[3] + this.glRef.current.fogClipOffset) * -1,
             clipEnd: this.glRef.current.gl_clipPlane1[3] - this.glRef.current.fogClipOffset,
-            quat4: this.glRef.current.myQuat,
+            quat4: Array.from(this.glRef.current.myQuat),
             edgeDetection: {
                 enabled: this.glRef.current.doEdgeDetect,
                 depthScale: this.glRef.current.scaleDepth,

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -20,6 +20,7 @@ import {
     setBackgroundColor, setDepthBlurDepth, setDepthBlurRadius, setDoEdgeDetect, setDoSSAO, setDoShadow, 
     setEdgeDetectDepthScale, setEdgeDetectDepthThreshold, setEdgeDetectNormalScale, setEdgeDetectNormalThreshold, setSsaoBias, setSsaoRadius, setUseOffScreenBuffers 
 } from "../store/sceneSettingsSlice";
+import { moorhensession } from "../protobuf/MoorhenSession";
 
 export const getAtomInfoLabel = (atomInfo: moorhen.AtomInfo) => {
     return `/${atomInfo.mol_name}/${atomInfo.chain_id}/${atomInfo.res_no}(${atomInfo.res_name})/${atomInfo.name}${atomInfo.has_altloc ? `:${atomInfo.alt_loc}` : ""}`
@@ -209,9 +210,10 @@ export function sequenceIsValid(sequence: moorhen.ResidueInfo[]): boolean {
     }
     return true
 }
+
 /**
- * A function to load session data
- * @param {string} sessionDataString - A JSON string representation of the object containing session data
+ * A function to load session data 
+ * @param {moorhen.backupSession} sessionData - An object containing session data
  * @param {string} monomerLibraryPath - Path to the monomer library
  * @param {moorhen.Molecule[]} molecules - State containing current molecules loaded in the session
  * @param {moorhen.Map[]} maps - State containing current maps loaded in the session
@@ -222,7 +224,7 @@ export function sequenceIsValid(sequence: moorhen.ResidueInfo[]): boolean {
  * @returns {number} Returns -1 if there was an error loading the session otherwise 0
  */
 export async function loadSessionData(
-    sessionDataString: string,
+    sessionData: moorhen.backupSession,
     monomerLibraryPath: string,
     molecules: moorhen.Molecule[],
     maps: moorhen.Map[],
@@ -231,9 +233,6 @@ export async function loadSessionData(
     glRef: React.RefObject<webGL.MGWebGL>,
     dispatch: Dispatch<AnyAction>
 ): Promise<number> {
-
-    timeCapsuleRef.current.setBusy(true)
-    const sessionData: moorhen.backupSession = JSON.parse(sessionDataString)
 
     if (!sessionData) {
         return -1
@@ -296,7 +295,9 @@ export async function loadSessionData(
     for (let i = 0; i < newMolecules.length; i++) {
         const molecule = newMolecules[i]
         const storedMoleculeData = sessionData.moleculeData[i]
-        await Promise.all(Object.keys(storedMoleculeData.ligandDicts).map(compId => molecule.addDict(storedMoleculeData.ligandDicts[compId])))
+        if (storedMoleculeData.ligandDicts) {
+            await Promise.all(Object.keys(storedMoleculeData.ligandDicts).map(compId => molecule.addDict(storedMoleculeData.ligandDicts[compId])))
+        }
         molecule.defaultColourRules = storedMoleculeData.defaultColourRules.map(item => {
             const colourRule = MoorhenColourRule.initFromDataObject(item, commandCentre, molecule)
             return colourRule
@@ -400,7 +401,7 @@ export async function loadSessionData(
     })
 
     // Set connected maps and molecules if any
-    const connectedMoleculeIndex = sessionData.moleculeData.findIndex(molecule => molecule.connectedToMaps !== null)
+    const connectedMoleculeIndex = sessionData.moleculeData.findIndex(molecule => molecule.connectedToMaps?.length > 0)
     if (connectedMoleculeIndex !== -1) {
         const oldConnectedMolecule = sessionData.moleculeData[connectedMoleculeIndex]        
         const molecule = newMolecules[connectedMoleculeIndex].molNo
@@ -429,8 +430,67 @@ export async function loadSessionData(
         })
     }
     
-    timeCapsuleRef.current.setBusy(false)
     return 0
+}
+
+/**
+ * A function to load session data
+ * @param {string} sessionProtoMessage - A protobuf message for the object containing session data
+ * @param {string} monomerLibraryPath - Path to the monomer library
+ * @param {moorhen.Molecule[]} molecules - State containing current molecules loaded in the session
+ * @param {moorhen.Map[]} maps - State containing current maps loaded in the session
+ * @param {React.RefObject<moorhen.CommandCentre>} commandCentre - React reference to the command centre
+ * @param {React.RefObject<moorhen.TimeCapsule>} timeCapsuleRef - React reference to the time capsule
+ * @param {React.RefObject<webGL.MGWebGL>} glRef - React reference to the webGL renderer
+ * @param {Dispatch<AnyAction>} dispatch - Dispatch method for the MoorhenReduxStore
+ * @returns {number} Returns -1 if there was an error loading the session otherwise 0
+ */
+export async function loadSessionFromProtoMessage(
+    sessionProtoMessage: any,
+    monomerLibraryPath: string,
+    molecules: moorhen.Molecule[],
+    maps: moorhen.Map[],
+    commandCentre: React.RefObject<moorhen.CommandCentre>,
+    timeCapsuleRef: React.RefObject<moorhen.TimeCapsule>,
+    glRef: React.RefObject<webGL.MGWebGL>,
+    dispatch: Dispatch<AnyAction>
+): Promise<number> {
+
+    timeCapsuleRef.current.setBusy(true)
+    const sessionData = moorhensession.BackupSession.toObject(sessionProtoMessage) as moorhen.backupSession
+    const status = await loadSessionData(sessionData, monomerLibraryPath, molecules, maps, commandCentre, timeCapsuleRef, glRef, dispatch)
+    timeCapsuleRef.current.setBusy(false)
+    return status
+}
+
+/**
+ * A function to load session data from a JSON string representation
+ * @param {string} sessionDataString - A JSON string representation of the object containing session data
+ * @param {string} monomerLibraryPath - Path to the monomer library
+ * @param {moorhen.Molecule[]} molecules - State containing current molecules loaded in the session
+ * @param {moorhen.Map[]} maps - State containing current maps loaded in the session
+ * @param {React.RefObject<moorhen.CommandCentre>} commandCentre - React reference to the command centre
+ * @param {React.RefObject<moorhen.TimeCapsule>} timeCapsuleRef - React reference to the time capsule
+ * @param {React.RefObject<webGL.MGWebGL>} glRef - React reference to the webGL renderer
+ * @param {Dispatch<AnyAction>} dispatch - Dispatch method for the MoorhenReduxStore
+ * @returns {number} Returns -1 if there was an error loading the session otherwise 0
+ */
+export async function loadSessionFromJsonString(
+    sessionDataString: string,
+    monomerLibraryPath: string,
+    molecules: moorhen.Molecule[],
+    maps: moorhen.Map[],
+    commandCentre: React.RefObject<moorhen.CommandCentre>,
+    timeCapsuleRef: React.RefObject<moorhen.TimeCapsule>,
+    glRef: React.RefObject<webGL.MGWebGL>,
+    dispatch: Dispatch<AnyAction>
+): Promise<number> {
+
+    timeCapsuleRef.current.setBusy(true)
+    const sessionData: moorhen.backupSession = JSON.parse(sessionDataString)
+    const status = await loadSessionData(sessionData, monomerLibraryPath, molecules, maps, commandCentre, timeCapsuleRef, glRef, dispatch)
+    timeCapsuleRef.current.setBusy(false)
+    return status
 }
 
 export function convertRemToPx(rem: number): number {

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -266,7 +266,7 @@ export async function loadSessionData(
         const newMap = new MoorhenMap(commandCentre, glRef)
         if (sessionData.includesAdditionalMapData) {
             return newMap.loadToCootFromMapData(
-                Uint8Array.from(Object.values(storedMapData.mapData)).buffer, 
+                storedMapData.mapData, 
                 storedMapData.name, 
                 storedMapData.isDifference
                 )
@@ -324,7 +324,7 @@ export async function loadSessionData(
             if (sessionData.includesAdditionalMapData && storedMapData.reflectionData) {
                 return map.associateToReflectionData(
                     storedMapData.selectedColumns, 
-                    Uint8Array.from(Object.values(storedMapData.reflectionData))
+                    storedMapData.reflectionData
                 )
             } else if(storedMapData.associatedReflectionFileName && storedMapData.selectedColumns) {
                 return timeCapsuleRef.current.retrieveBackup(
@@ -335,7 +335,7 @@ export async function loadSessionData(
                     ).then(reflectionData => {
                         return map.associateToReflectionData(
                             storedMapData.selectedColumns, 
-                            Uint8Array.from(Object.values(reflectionData))
+                            reflectionData as ArrayBuffer
                         )
                     })
             }

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -611,15 +611,11 @@ export const readDataFile = (source: File): Promise<ArrayBuffer> => {
 }
 
 export const doDownload = (data: BlobPart[], targetName: string) => {
-    const url = window.URL.createObjectURL(
-        new Blob(data),
-    );
+    const file = new File(data, targetName, { type: 'application/octet-stream' });
+    const url = window.URL.createObjectURL(file);
     const link = document.createElement('a');
+    link.download = targetName;
     link.href = url;
-    link.setAttribute(
-        'download',
-        targetName,
-    );
 
     // Append to html link element page
     document.body.appendChild(link);
@@ -629,6 +625,7 @@ export const doDownload = (data: BlobPart[], targetName: string) => {
 
     // Clean up and remove the link
     link.parentNode.removeChild(link);
+    window.URL.revokeObjectURL(url);
 }
 
 export const doDownloadText = (text: string, filename: string) => {

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -457,7 +457,7 @@ export async function loadSessionFromProtoMessage(
 ): Promise<number> {
 
     timeCapsuleRef.current.setBusy(true)
-    const sessionData = moorhensession.BackupSession.toObject(sessionProtoMessage) as moorhen.backupSession
+    const sessionData = moorhensession.Session.toObject(sessionProtoMessage) as moorhen.backupSession
     const status = await loadSessionData(sessionData, monomerLibraryPath, molecules, maps, commandCentre, timeCapsuleRef, glRef, dispatch)
     timeCapsuleRef.current.setBusy(false)
     return status
@@ -670,35 +670,29 @@ export const readDataFile = (source: File): Promise<ArrayBuffer> => {
     })
 }
 
-export const doDownload = (data: BlobPart[], targetName: string) => {
-    const file = new File(data, targetName, { type: 'application/octet-stream' });
+const downloadFile = (file: File, fileName: string) => {
     const url = window.URL.createObjectURL(file);
+    
     const link = document.createElement('a');
-    link.download = targetName;
+    link.download = fileName;
     link.href = url;
 
-    // Append to html link element page
     document.body.appendChild(link);
 
-    // Start download
     link.click();
 
-    // Clean up and remove the link
     link.parentNode.removeChild(link);
     window.URL.revokeObjectURL(url);
 }
 
-export const doDownloadText = (text: string, filename: string) => {
-    var element = document.createElement('a');
-    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
-    element.setAttribute('download', filename);
+export const doDownload = (data: BlobPart[], fileName: string) => {
+    const file = new File(data, fileName, { type: 'application/octet-stream' });
+    downloadFile(file, fileName)
+}
 
-    element.style.display = 'none';
-    document.body.appendChild(element);
-
-    element.click();
-
-    document.body.removeChild(element);
+export const doDownloadText = (text: string, fileName: string) => {
+    const file = new File([text], fileName, { type: 'text/plain' });
+    downloadFile(file, fileName)
 }
 
 export const readGemmiStructure = (coordData: ArrayBuffer | string, molName: string): gemmi.Structure => {


### PR DESCRIPTION
This update makes use of `protobuf` to serialize session data instead of `JSON.stringify`. At the moment this is only possible for files downloaded and uploaded from the "File" menu, backups stored in the browser's local storage are still being stored with `JSON.stringify`. This resolves #377. Other improvements to download and upload of session files have been made:
- Improved speed of `doDownload`  by using `new File` instead of `new Blob`.
- Reduced the memory consumption in `loadSessionData` at `utils/MoorhenUtils.ts` by avoiding unnecessary copying of map and reflection data into equivalent data types.