### PR TITLE
Variable sized golden balls.

### DIFF
--- a/baby-gru/src/WebGLgComponents/webgl-2/edge-detect-fragment-shader.js
+++ b/baby-gru/src/WebGLgComponents/webgl-2/edge-detect-fragment-shader.js
@@ -13,6 +13,8 @@ uniform float depthThreshold;
 uniform float normalThreshold;
 uniform float scaleDepth;
 uniform float scaleNormal;
+uniform float xPixelOffset;
+uniform float yPixelOffset;
 
 in mediump mat4 pMatrix;
 in vec2 out_TexCoord0;
@@ -27,15 +29,16 @@ void main() {
     float halfScaleFloorNormal = floor(scaleNormal * 0.5);
     float halfScaleCeilNormal = ceil(scaleNormal * 0.5);
     
-    float depth0 = texture(gPosition, out_TexCoord0 - vec2(pixelFrac,pixelFrac)*halfScaleFloorDepth).z;
-    float depth1 = texture(gPosition, out_TexCoord0 + vec2(pixelFrac,pixelFrac)*halfScaleCeilDepth).z;
-    float depth2 = texture(gPosition, out_TexCoord0 + vec2( pixelFrac * halfScaleCeilDepth, -pixelFrac * halfScaleFloorDepth)).z;
-    float depth3 = texture(gPosition, out_TexCoord0 + vec2(-pixelFrac * halfScaleFloorDepth, pixelFrac * halfScaleCeilDepth)).z;
+    float depth0 = texture(gPosition, out_TexCoord0 - vec2(xPixelOffset,yPixelOffset)*halfScaleFloorDepth).z;
+    float depth1 = texture(gPosition, out_TexCoord0 + vec2(xPixelOffset,yPixelOffset)*halfScaleCeilDepth).z;
+    float depth2 = texture(gPosition, out_TexCoord0 + vec2( xPixelOffset * halfScaleCeilDepth, -yPixelOffset * halfScaleFloorDepth)).z;
+    float depth3 = texture(gPosition, out_TexCoord0 + vec2(-xPixelOffset * halfScaleFloorDepth, yPixelOffset * halfScaleCeilDepth)).z;
+    float depth4 = texture(gPosition, out_TexCoord0).z;
 
-    vec3 normal0 = normalize(texture(gNormal, out_TexCoord0 - vec2(pixelFrac,pixelFrac)*halfScaleFloorNormal)).xyz;
-    vec3 normal1 = normalize(texture(gNormal, out_TexCoord0 + vec2(pixelFrac,pixelFrac)*halfScaleCeilNormal)).xyz;
-    vec3 normal2 = normalize(texture(gNormal, out_TexCoord0 + vec2( pixelFrac * halfScaleCeilNormal, -pixelFrac * halfScaleFloorNormal))).xyz;
-    vec3 normal3 = normalize(texture(gNormal, out_TexCoord0 + vec2(-pixelFrac * halfScaleFloorNormal, pixelFrac * halfScaleCeilNormal))).xyz;
+    vec3 normal0 = normalize(texture(gNormal, out_TexCoord0 - vec2(xPixelOffset,yPixelOffset)*halfScaleFloorNormal)).xyz;
+    vec3 normal1 = normalize(texture(gNormal, out_TexCoord0 + vec2(xPixelOffset,yPixelOffset)*halfScaleCeilNormal)).xyz;
+    vec3 normal2 = normalize(texture(gNormal, out_TexCoord0 + vec2( xPixelOffset * halfScaleCeilNormal, -yPixelOffset * halfScaleFloorNormal))).xyz;
+    vec3 normal3 = normalize(texture(gNormal, out_TexCoord0 + vec2(-xPixelOffset * halfScaleFloorNormal, yPixelOffset * halfScaleCeilNormal))).xyz;
 
     float depthFiniteDifference0 = depth1 - depth0;
     float depthFiniteDifference1 = depth3 - depth2;

--- a/baby-gru/src/components/modal/MoorhenSceneSettingsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenSceneSettingsModal.tsx
@@ -56,7 +56,7 @@ const EdgeDetectPanel = (props: {}) => {
         <MoorhenSlider
                 isDisabled={!doEdgeDetect}
                 minVal={0.1}
-                maxVal={2.0}
+                maxVal={4.0}
                 logScale={false}
                 sliderTitle="Depth threshold"
                 initialValue={edgeDetectDepthThreshold}

--- a/baby-gru/src/types/mgWebGL.d.ts
+++ b/baby-gru/src/types/mgWebGL.d.ts
@@ -267,6 +267,8 @@ export namespace webGL {
         normalThreshold: number;
         scaleDepth: number;
         scaleNormal: number;
+        xPixelOffset: number;
+        yPixelOffset: number;
         occludeDiffuse: boolean;
         doShadowDepthDebug: boolean;
         doSpin: boolean;
@@ -433,6 +435,8 @@ export namespace webGL {
         drawingGBuffers: boolean;
         initializeShaders() : void;
         axesTexture: any;
+
+        hoverSize: number;
 
     }
 }

--- a/baby-gru/src/utils/MoorhenMoleculeRepresentation.ts
+++ b/baby-gru/src/utils/MoorhenMoleculeRepresentation.ts
@@ -617,17 +617,13 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
         const atomColours = {}
         selectedGemmiAtoms.forEach(atom => { atomColours[`${atom.serial}`] = colour })
         let sphere_size = 0.3
-        let click_tol = 0.65
-        if (this.parentMolecule.representations.some(item => item.style === 'VdwSpheres' && item.visible)) {
-            sphere_size = 1.8
-            click_tol = 3.7
-        }
         let objects = [
             gemmiAtomsToCirclesSpheresInfo(selectedGemmiAtoms, sphere_size, "PERFECT_SPHERES", atomColours)
         ]
         objects.forEach(object => {
-            object["clickTol"] = click_tol
+            object["clickTol"] = 1e-6
             object["doStencil"] = true
+            object["isHoverBuffer"] = true
         })
         return objects
     }


### PR DESCRIPTION
This change makes golden balls a size appropriate for the residue being highlighted. So now if there is a subset of the molecule drawn as Spheres, only hovering over the big spheres will result in big golden balls; residues represented as bonds will get small golden balls. Tested with Ramachandran plot and sequence viewer also.