### PR TITLE
Update MoorhenContainer and other utils so that it can be embedded within an external redux store

### DIFF
--- a/baby-gru/src/ErrorBoundary.tsx
+++ b/baby-gru/src/ErrorBoundary.tsx
@@ -41,7 +41,7 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryPropsType, Error
     }
     
     async handleBackupDownload() {
-        const timeCapsule = new MoorhenTimeCapsule(null, null, null, null)
+        const timeCapsule = new MoorhenTimeCapsule(null, null, null, null, null)
         timeCapsule.storageInstance = createLocalStorageInstance('Moorhen-TimeCapsule') 
         await timeCapsule.init()
         const backup = await timeCapsule.retrieveLastBackup() as string

--- a/baby-gru/src/components/MoorhenApp.tsx
+++ b/baby-gru/src/components/MoorhenApp.tsx
@@ -1,8 +1,9 @@
 import { useRef } from 'react';
 import { MoorhenContainer } from "./MoorhenContainer";
-import { MoorhenReduxProvider } from './misc/MoorhenReduxProvider'
 import { moorhen } from '../types/moorhen';
 import { webGL } from '../types/mgWebGL';
+import { Provider } from 'react-redux';
+import store from '../store/MoorhenReduxStore';
 
 export const MoorhenApp = (props) => {
     const glRef = useRef<null | webGL.MGWebGL>(null)
@@ -15,11 +16,11 @@ export const MoorhenApp = (props) => {
     const prevActiveMoleculeRef = useRef<null | moorhen.Molecule>(null)
 
     const collectedProps = {
-        glRef, timeCapsuleRef, commandCentre, moleculesRef, 
-        mapsRef, activeMapRef, lastHoveredAtom, prevActiveMoleculeRef,
+        glRef, timeCapsuleRef, commandCentre, moleculesRef, mapsRef, activeMapRef,
+        lastHoveredAtom, prevActiveMoleculeRef
     }
 
-    return  <MoorhenReduxProvider>
+    return  <Provider store={store}> 
                 <MoorhenContainer {...collectedProps}/>
-            </MoorhenReduxProvider>
+            </Provider>
 }

--- a/baby-gru/src/components/MoorhenContainer.tsx
+++ b/baby-gru/src/components/MoorhenContainer.tsx
@@ -21,6 +21,7 @@ import { setDefaultBackgroundColor, setBackgroundColor, setHeight, setIsDark, se
 import { setCootInitialized, setNotificationContent, setTheme, toggleCootCommandExit, toggleCootCommandStart } from '../store/generalStatesSlice';
 import { setEnableAtomHovering, setHoveredAtom } from '../store/hoveringStatesSlice';
 import { setRefinementSelection } from '../store/refinementSettingsSlice';
+import MoorhenReduxStore from '../store/MoorhenReduxStore';
 
 // import { MoorhenSharedSessionManager } from './misc/MoorhenSharedSessionManager';
 
@@ -120,7 +121,7 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
     })
 
     const { 
-        glRef, timeCapsuleRef, commandCentre, moleculesRef, mapsRef, activeMapRef, videoRecorderRef, lastHoveredAtomRef, 
+        glRef, timeCapsuleRef, commandCentre, moleculesRef, mapsRef, activeMapRef, videoRecorderRef, lastHoveredAtomRef
     } = refs
 
     activeMapRef.current = activeMap
@@ -131,14 +132,14 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
         disableFileUploads, urlPrefix, extraNavBarMenus, viewOnly, extraDraggableModals, 
         monomerLibraryPath, extraFileMenuItems, allowScripting, backupStorageInstance,
         extraEditMenuItems, aceDRGInstance, extraCalculateMenuItems, setMoorhenDimensions,
-        onUserPreferencesChange, extraNavBarModals, includeNavBarMenuNames
+        onUserPreferencesChange, extraNavBarModals, includeNavBarMenuNames, store
     } = props
 
     const collectedProps: moorhen.CollectedProps = {
         glRef, commandCentre, timeCapsuleRef, disableFileUploads, extraDraggableModals, aceDRGInstance, 
         urlPrefix, viewOnly, mapsRef, allowScripting, extraCalculateMenuItems, extraEditMenuItems,
         extraNavBarMenus, monomerLibraryPath, moleculesRef, extraFileMenuItems, activeMapRef,
-        videoRecorderRef, lastHoveredAtomRef, onUserPreferencesChange, extraNavBarModals, 
+        videoRecorderRef, lastHoveredAtomRef, onUserPreferencesChange, extraNavBarModals, store,
         includeNavBarMenuNames
     }
     
@@ -175,7 +176,7 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
     useEffect(() => {
         const initTimeCapsule = async () => {
             if (userPreferencesMounted) {
-                timeCapsuleRef.current = new MoorhenTimeCapsule(moleculesRef, mapsRef, activeMapRef, glRef)
+                timeCapsuleRef.current = new MoorhenTimeCapsule(moleculesRef, mapsRef, activeMapRef, glRef, store)
                 timeCapsuleRef.current.storageInstance = backupStorageInstance
                 timeCapsuleRef.current.maxBackupCount = maxBackupCount
                 timeCapsuleRef.current.modificationCountBackupThreshold = modificationCountBackupThreshold
@@ -476,5 +477,6 @@ MoorhenContainer.defaultProps = {
     viewOnly: false,
     allowScripting: true,
     backupStorageInstance: createLocalStorageInstance('Moorhen-TimeCapsule'),
-    aceDRGInstance: null
+    aceDRGInstance: null,
+    store: MoorhenReduxStore
 }

--- a/baby-gru/src/components/card/MoorhenMapCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMapCard.tsx
@@ -49,7 +49,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
             return props.initialRadius
         }
     })
-    const contourLevel = useSelector((state: moorhen.State) => {
+    const mapContourLevel = useSelector((state: moorhen.State) => {
         const map = state.mapContourSettings.contourLevels.find(item => item.molNo === props.map.molNo)
         if (map) {
             return map.contourLevel
@@ -65,7 +65,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
             return state.mapContourSettings.defaultMapSurface ? "solid" : state.mapContourSettings.defaultMapLitLines ? "lit-lines" : "lines"
         }
     })
-    const mapAlpha = useSelector((state: moorhen.State) => {
+    const mapOpacity = useSelector((state: moorhen.State) => {
         const map = state.mapContourSettings.mapAlpha.find(item => item.molNo === props.map.molNo)
         if (map) {
             return map.alpha
@@ -94,7 +94,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
         if (mapColourString) {
             return JSON.parse(mapColourString)
         } else {
-            return {r: props.map.contourParams.mapColour.r * 255., g: props.map.contourParams.mapColour.g * 255., b: props.map.contourParams.mapColour.b * 255.}
+            return {r: props.map.defaultMapColour.r * 255., g: props.map.defaultMapColour.g * 255., b: props.map.defaultMapColour.b * 255.}
         }
     }, [mapColourString])
     
@@ -103,7 +103,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
             const rgb = JSON.parse(mapColourString)
             return rgbToHex(rgb.r, rgb.g, rgb.b)
         } else {
-            return rgbToHex(props.map.contourParams.mapColour.r, props.map.contourParams.mapColour.g, props.map.contourParams.mapColour.b)
+            return rgbToHex(props.map.defaultMapColour.r, props.map.defaultMapColour.g, props.map.defaultMapColour.b)
         }
     }, [mapColourString])
 
@@ -111,7 +111,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
         if (negativeMapColourString) {
             return JSON.parse(negativeMapColourString)
         } else {
-            return {r: props.map.contourParams.negativeMapColour.r * 255., g: props.map.contourParams.negativeMapColour.g * 255., b: props.map.contourParams.negativeMapColour.b * 255.}
+            return {r: props.map.defaultNegativeMapColour.r * 255., g: props.map.defaultNegativeMapColour.g * 255., b: props.map.defaultNegativeMapColour.b * 255.}
         }
     }, [negativeMapColourString])
 
@@ -120,7 +120,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
             const rgb = JSON.parse(negativeMapColourString)
             return rgbToHex(rgb.r, rgb.g, rgb.b)
         } else {
-            return rgbToHex(props.map.contourParams.negativeMapColour.r, props.map.contourParams.negativeMapColour.g, props.map.contourParams.negativeMapColour.b)
+            return rgbToHex(props.map.defaultNegativeMapColour.r, props.map.defaultNegativeMapColour.g, props.map.defaultNegativeMapColour.b)
         }
     }, [negativeMapColourString])
 
@@ -128,7 +128,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
         if (positiveMapColourString) {
             return JSON.parse(positiveMapColourString)
         } else {
-            return {r: props.map.contourParams.positiveMapColour.r * 255., g: props.map.contourParams.positiveMapColour.g * 255., b: props.map.contourParams.positiveMapColour.b * 255.}
+            return {r: props.map.defaultPositiveMapColour.r * 255., g: props.map.defaultPositiveMapColour.g * 255., b: props.map.defaultPositiveMapColour.b * 255.}
         }
     }, [positiveMapColourString])
 
@@ -137,7 +137,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
             const rgb = JSON.parse(positiveMapColourString)
             return rgbToHex(rgb.r, rgb.g, rgb.b)
         } else {
-            return rgbToHex(props.map.contourParams.positiveMapColour.r, props.map.contourParams.positiveMapColour.g, props.map.contourParams.positiveMapColour.b)
+            return rgbToHex(props.map.defaultPositiveMapColour.r, props.map.defaultPositiveMapColour.g, props.map.defaultPositiveMapColour.b)
         }
     }, [positiveMapColourString])
 
@@ -171,7 +171,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     const handlePositiveMapColorChange = (color: { r: number; g: number; b: number; }) => {
         try {
             dispatch( setPositiveMapColours({ molNo: props.map.molNo, rgb: color}) )
-            props.map.setDiffMapColourAndRedraw('positiveDiffColour', {r: color.r / 255., g: color.g / 255., b: color.b / 255.})
+            props.map.fetchDiffMapColourAndRedraw('positiveDiffColour')
         }
         catch (err) {
             console.log('err', err)
@@ -181,7 +181,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     const handleNegativeMapColorChange = (color: { r: number; g: number; b: number; }) => {
         try {
             dispatch( setNegativeMapColours({ molNo: props.map.molNo, rgb: color}) )
-            props.map.setDiffMapColourAndRedraw('negativeDiffColour', {r: color.r / 255., g: color.g / 255., b: color.b / 255.})
+            props.map.fetchDiffMapColourAndRedraw('negativeDiffColour')
         }
         catch (err) {
             console.log('err', err)
@@ -191,7 +191,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     const handleColorChange = (color: { r: number; g: number; b: number; }) => {
         try {
             dispatch( setMapColours({ molNo: props.map.molNo, rgb: color}) )
-            props.map.setColourAndRedraw({r: color.r / 255., g: color.g / 255., b: color.b / 255.})
+            props.map.fetchColourAndRedraw()
         }
         catch (err) {
             console.log('err', err)
@@ -199,7 +199,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     }
 
     const mapSettingsProps = {
-        setPopoverIsShown, mapOpacity: mapAlpha, mapStyle, glRef: props.glRef, map: props.map
+        setPopoverIsShown, mapOpacity, mapStyle, glRef: props.glRef, map: props.map
     }
 
     const handleDownload = async () => {
@@ -324,23 +324,23 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
                 doContourIfDirty()
             })
         }
-    }, [])
+    }, [mapRadius, mapContourLevel, mapIsVisible, mapStyle])
 
     const handleOriginUpdate = useCallback((evt: moorhen.OriginUpdateEvent) => {
         nextOrigin.current = [...evt.detail.origin.map((coord: number) => -coord)]
         isDirty.current = true
         if (mapIsVisible && !busyContouring.current) {
-            doContourIfDirty()
+                doContourIfDirty()
         }
-    }, [doContourIfDirty, mapIsVisible])
+    }, [doContourIfDirty])
 
     const handleWheelContourLevelCallback = useCallback((evt: moorhen.WheelContourLevelEvent) => {
         let newMapContourLevel: number
         if (mapIsVisible && props.map.molNo === activeMap.molNo) {
             if (evt.detail.factor > 1) {
-                newMapContourLevel = contourLevel + contourWheelSensitivityFactor
+                newMapContourLevel = mapContourLevel + contourWheelSensitivityFactor
             } else {
-                newMapContourLevel = contourLevel - contourWheelSensitivityFactor
+                newMapContourLevel = mapContourLevel - contourWheelSensitivityFactor
             }
             batch(() => {
                 dispatch( setContourLevel({ molNo: props.map.molNo, contourLevel: newMapContourLevel }) )
@@ -355,7 +355,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
                 ))
             })
         }
-    }, [contourLevel, mapRadius, activeMap?.molNo, props.map.molNo, mapIsVisible])
+    }, [mapContourLevel, mapRadius, activeMap?.molNo, props.map.molNo, mapIsVisible])
 
     useMemo(() => {
         if (currentName === "") {
@@ -380,28 +380,18 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     }, [handleWheelContourLevelCallback])
 
     useEffect(() => {
-        props.map.setMapAlphaAndRedraw(mapAlpha)
-    }, [mapAlpha])
+        props.map.fetchMapAlphaAndRedraw()
+    }, [mapOpacity])
 
     useEffect(() => {
         // This looks stupid but it is important otherwise the map is first drawn with the default contour and radius. Probably there's a problem somewhere...
-        dispatch(setMapAlpha({molNo: props.map.molNo, alpha: mapAlpha}))
+        dispatch(setMapAlpha({molNo: props.map.molNo, alpha: mapOpacity}))
         dispatch(setMapStyle({molNo: props.map.molNo, style: mapStyle}))
         dispatch(setMapRadius({molNo: props.map.molNo, radius: mapRadius}))
-        dispatch(setContourLevel({molNo: props.map.molNo, contourLevel: contourLevel}))
+        dispatch(setContourLevel({molNo: props.map.molNo, contourLevel: mapContourLevel}))
         dispatch(setMapColours({molNo: props.map.molNo, rgb: mapColour}))
         dispatch(setNegativeMapColours({molNo: props.map.molNo, rgb: negativeMapColour}))
         dispatch(setPositiveMapColours({molNo: props.map.molNo, rgb: positiveMapColour}))
-        // Update attribute in MoorhenMap
-        props.map.contourParams = {
-            mapRadius, 
-            contourLevel, 
-            mapAlpha, 
-            mapStyle,
-            mapColour: {r: mapColour.r / 255., g: mapColour.g / 255., b: mapColour.b / 255.},
-            positiveMapColour: {r: positiveMapColour.r / 255., g: positiveMapColour.g / 255., b: positiveMapColour.b / 255.},
-            negativeMapColour: {r: negativeMapColour.r / 255., g: negativeMapColour.g / 255., b: negativeMapColour.b / 255.}
-        }
         // Show map only if specified
         if (props.map.showOnLoad) {
             dispatch(showMap(props.map))
@@ -411,9 +401,6 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     useEffect(() => {
         if (mapIsVisible) {
             nextOrigin.current = props.glRef.current.origin.map(coord => -coord)
-            props.map.contourParams.mapRadius = mapRadius
-            props.map.contourParams.contourLevel = contourLevel
-            props.map.contourParams.mapStyle = mapStyle    
             isDirty.current = true
             if (!busyContouring.current) {
                 doContourIfDirty()
@@ -422,7 +409,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
             props.map.hideMapContour()
         }
 
-    }, [mapRadius, contourLevel, mapIsVisible, mapStyle, doContourIfDirty])
+    }, [doContourIfDirty])
 
     const increaseLevelButton = <IconButton 
         style={{padding: 0, color: isDark ? 'white' : 'black'}}
@@ -618,7 +605,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
                 </ToggleButton>
                 <Col>
                     <Form.Group controlId="contouringLevel" className="mb-3">
-                        <span>{`Lvl: ${contourLevel.toFixed(2)} ${props.map.mapRmsd ? '(' + (contourLevel / props.map.mapRmsd).toFixed(2) + ' rmsd)' : ''}`}</span>
+                        <span>{`Lvl: ${mapContourLevel.toFixed(2)} ${props.map.mapRmsd ? '(' + (mapContourLevel / props.map.mapRmsd).toFixed(2) + ' rmsd)' : ''}`}</span>
                         <MoorhenSlider
                             minVal={0.001}
                             maxVal={props.map.isEM ? 15 : 5}
@@ -630,7 +617,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
                             showSliderTitle={false}
                             isDisabled={!mapIsVisible}
                             initialValue={props.initialContour}
-                            externalValue={contourLevel}
+                            externalValue={mapContourLevel}
                             setExternalValue={(newVal) => dispatch( setContourLevel({molNo: props.map.molNo, contourLevel: newVal}) )}
                         />
                     </Form.Group>

--- a/baby-gru/src/components/card/MoorhenMapCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMapCard.tsx
@@ -145,7 +145,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
     const contourWheelSensitivityFactor = useSelector((state: moorhen.State) => state.mouseSettings.contourWheelSensitivityFactor)
     const defaultExpandDisplayCards = useSelector((state: moorhen.State) => state.miscAppSettings.defaultExpandDisplayCards)
-    const isVisible = useSelector((state: moorhen.State) => state.mapContourSettings.visibleMaps.includes(props.map.molNo))
+    const mapIsVisible = useSelector((state: moorhen.State) => state.mapContourSettings.visibleMaps.includes(props.map.molNo))
     const dispatch = useDispatch()
 
     const [isCollapsed, setIsCollapsed] = useState<boolean>(!defaultExpandDisplayCards);
@@ -209,10 +209,9 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     }
 
     const handleVisibility = useCallback(() => {
-        dispatch( isVisible ? hideMap(props.map) : showMap(props.map) )
-        props.map.contourParams.isVisible = !isVisible
+        dispatch( mapIsVisible ? hideMap(props.map) : showMap(props.map) )
         props.setCurrentDropdownMolNo(-1)
-    }, [isVisible])
+    }, [mapIsVisible])
 
     const handleCopyMap = async () => {
         const newMap = await props.map.copyMap()
@@ -221,11 +220,11 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
 
     const actionButtons: { [key: number] : ActionButtonType } = {
         1: {
-            label: isVisible ? "Hide map" : "Show map",
-            compressed: () => { return (<MenuItem key='hide-show-map' onClick={handleVisibility}>{isVisible ? "Hide map" : "Show map"}</MenuItem>) },
+            label: mapIsVisible ? "Hide map" : "Show map",
+            compressed: () => { return (<MenuItem key='hide-show-map' onClick={handleVisibility}>{mapIsVisible ? "Hide map" : "Show map"}</MenuItem>) },
             expanded: () => {
                 return (<Button key='hide-show-map' size="sm" variant="outlined" onClick={handleVisibility}>
-                    {isVisible ? <VisibilityOutlined /> : <VisibilityOffOutlined />}
+                    {mapIsVisible ? <VisibilityOutlined /> : <VisibilityOffOutlined />}
                 </Button>)
             },
         },
@@ -245,7 +244,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
         },
         4: {
             label: "Map draw settings",
-            compressed: () => { return (<MoorhenMapSettingsMenuItem key='map-draw-settings' disabled={!isVisible} {...mapSettingsProps} />) },
+            compressed: () => { return (<MoorhenMapSettingsMenuItem key='map-draw-settings' disabled={!mapIsVisible} {...mapSettingsProps} />) },
             expanded: null
         },
         5: {
@@ -264,7 +263,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
         },
         7: {
             label: "Set map weight...",
-            compressed: () => { return (<MoorhenSetMapWeight key='set-map-weight' disabled={!isVisible} map={props.map} setPopoverIsShown={setPopoverIsShown} />) },
+            compressed: () => { return (<MoorhenSetMapWeight key='set-map-weight' disabled={!mapIsVisible} map={props.map} setPopoverIsShown={setPopoverIsShown} />) },
             expanded: null
         },
     }
@@ -330,14 +329,14 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     const handleOriginUpdate = useCallback((evt: moorhen.OriginUpdateEvent) => {
         nextOrigin.current = [...evt.detail.origin.map((coord: number) => -coord)]
         isDirty.current = true
-        if (isVisible && !busyContouring.current) {
+        if (mapIsVisible && !busyContouring.current) {
             doContourIfDirty()
         }
-    }, [doContourIfDirty, isVisible])
+    }, [doContourIfDirty, mapIsVisible])
 
     const handleWheelContourLevelCallback = useCallback((evt: moorhen.WheelContourLevelEvent) => {
         let newMapContourLevel: number
-        if (isVisible && props.map.molNo === activeMap.molNo) {
+        if (mapIsVisible && props.map.molNo === activeMap.molNo) {
             if (evt.detail.factor > 1) {
                 newMapContourLevel = contourLevel + contourWheelSensitivityFactor
             } else {
@@ -356,7 +355,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
                 ))
             })
         }
-    }, [contourLevel, mapRadius, activeMap?.molNo, props.map.molNo, isVisible])
+    }, [contourLevel, mapRadius, activeMap?.molNo, props.map.molNo, mapIsVisible])
 
     useMemo(() => {
         if (currentName === "") {
@@ -396,7 +395,6 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
         // Update attribute in MoorhenMap
         props.map.contourParams = {
             mapRadius, 
-            isVisible,
             contourLevel, 
             mapAlpha, 
             mapStyle,
@@ -411,7 +409,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     }, [])
 
     useEffect(() => {
-        if (isVisible) {
+        if (mapIsVisible) {
             nextOrigin.current = props.glRef.current.origin.map(coord => -coord)
             props.map.contourParams.mapRadius = mapRadius
             props.map.contourParams.contourLevel = contourLevel
@@ -424,7 +422,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
             props.map.hideMapContour()
         }
 
-    }, [mapRadius, contourLevel, isVisible, mapStyle, doContourIfDirty])
+    }, [mapRadius, contourLevel, mapIsVisible, mapStyle, doContourIfDirty])
 
     const increaseLevelButton = <IconButton 
         style={{padding: 0, color: isDark ? 'white' : 'black'}}
@@ -630,7 +628,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
                             allowExternalFeedback={true}
                             logScale={true}
                             showSliderTitle={false}
-                            isDisabled={!isVisible}
+                            isDisabled={!mapIsVisible}
                             initialValue={props.initialContour}
                             externalValue={contourLevel}
                             setExternalValue={(newVal) => dispatch( setContourLevel({molNo: props.map.molNo, contourLevel: newVal}) )}
@@ -647,7 +645,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
                             logScale={false} 
                             sliderTitle="Radius" 
                             decimalPlaces={2} 
-                            isDisabled={!isVisible} 
+                            isDisabled={!mapIsVisible} 
                             initialValue={props.initialRadius} 
                             externalValue={mapRadius} 
                             setExternalValue={(newVal) => dispatch( setMapRadius({molNo: props.map.molNo, radius: newVal}) )}

--- a/baby-gru/src/components/card/MoorhenMapCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMapCard.tsx
@@ -49,7 +49,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
             return props.initialRadius
         }
     })
-    const mapContourLevel = useSelector((state: moorhen.State) => {
+    const contourLevel = useSelector((state: moorhen.State) => {
         const map = state.mapContourSettings.contourLevels.find(item => item.molNo === props.map.molNo)
         if (map) {
             return map.contourLevel
@@ -65,7 +65,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
             return state.mapContourSettings.defaultMapSurface ? "solid" : state.mapContourSettings.defaultMapLitLines ? "lit-lines" : "lines"
         }
     })
-    const mapOpacity = useSelector((state: moorhen.State) => {
+    const mapAlpha = useSelector((state: moorhen.State) => {
         const map = state.mapContourSettings.mapAlpha.find(item => item.molNo === props.map.molNo)
         if (map) {
             return map.alpha
@@ -94,7 +94,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
         if (mapColourString) {
             return JSON.parse(mapColourString)
         } else {
-            return {r: props.map.defaultMapColour.r * 255., g: props.map.defaultMapColour.g * 255., b: props.map.defaultMapColour.b * 255.}
+            return {r: props.map.contourParams.mapColour.r * 255., g: props.map.contourParams.mapColour.g * 255., b: props.map.contourParams.mapColour.b * 255.}
         }
     }, [mapColourString])
     
@@ -103,7 +103,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
             const rgb = JSON.parse(mapColourString)
             return rgbToHex(rgb.r, rgb.g, rgb.b)
         } else {
-            return rgbToHex(props.map.defaultMapColour.r, props.map.defaultMapColour.g, props.map.defaultMapColour.b)
+            return rgbToHex(props.map.contourParams.mapColour.r, props.map.contourParams.mapColour.g, props.map.contourParams.mapColour.b)
         }
     }, [mapColourString])
 
@@ -111,7 +111,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
         if (negativeMapColourString) {
             return JSON.parse(negativeMapColourString)
         } else {
-            return {r: props.map.defaultNegativeMapColour.r * 255., g: props.map.defaultNegativeMapColour.g * 255., b: props.map.defaultNegativeMapColour.b * 255.}
+            return {r: props.map.contourParams.negativeMapColour.r * 255., g: props.map.contourParams.negativeMapColour.g * 255., b: props.map.contourParams.negativeMapColour.b * 255.}
         }
     }, [negativeMapColourString])
 
@@ -120,7 +120,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
             const rgb = JSON.parse(negativeMapColourString)
             return rgbToHex(rgb.r, rgb.g, rgb.b)
         } else {
-            return rgbToHex(props.map.defaultNegativeMapColour.r, props.map.defaultNegativeMapColour.g, props.map.defaultNegativeMapColour.b)
+            return rgbToHex(props.map.contourParams.negativeMapColour.r, props.map.contourParams.negativeMapColour.g, props.map.contourParams.negativeMapColour.b)
         }
     }, [negativeMapColourString])
 
@@ -128,7 +128,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
         if (positiveMapColourString) {
             return JSON.parse(positiveMapColourString)
         } else {
-            return {r: props.map.defaultPositiveMapColour.r * 255., g: props.map.defaultPositiveMapColour.g * 255., b: props.map.defaultPositiveMapColour.b * 255.}
+            return {r: props.map.contourParams.positiveMapColour.r * 255., g: props.map.contourParams.positiveMapColour.g * 255., b: props.map.contourParams.positiveMapColour.b * 255.}
         }
     }, [positiveMapColourString])
 
@@ -137,7 +137,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
             const rgb = JSON.parse(positiveMapColourString)
             return rgbToHex(rgb.r, rgb.g, rgb.b)
         } else {
-            return rgbToHex(props.map.defaultPositiveMapColour.r, props.map.defaultPositiveMapColour.g, props.map.defaultPositiveMapColour.b)
+            return rgbToHex(props.map.contourParams.positiveMapColour.r, props.map.contourParams.positiveMapColour.g, props.map.contourParams.positiveMapColour.b)
         }
     }, [positiveMapColourString])
 
@@ -171,7 +171,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     const handlePositiveMapColorChange = (color: { r: number; g: number; b: number; }) => {
         try {
             dispatch( setPositiveMapColours({ molNo: props.map.molNo, rgb: color}) )
-            props.map.fetchDiffMapColourAndRedraw('positiveDiffColour')
+            props.map.setDiffMapColourAndRedraw('positiveDiffColour', {r: color.r / 255., g: color.g / 255., b: color.b / 255.})
         }
         catch (err) {
             console.log('err', err)
@@ -181,7 +181,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     const handleNegativeMapColorChange = (color: { r: number; g: number; b: number; }) => {
         try {
             dispatch( setNegativeMapColours({ molNo: props.map.molNo, rgb: color}) )
-            props.map.fetchDiffMapColourAndRedraw('negativeDiffColour')
+            props.map.setDiffMapColourAndRedraw('negativeDiffColour', {r: color.r / 255., g: color.g / 255., b: color.b / 255.})
         }
         catch (err) {
             console.log('err', err)
@@ -191,7 +191,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     const handleColorChange = (color: { r: number; g: number; b: number; }) => {
         try {
             dispatch( setMapColours({ molNo: props.map.molNo, rgb: color}) )
-            props.map.fetchColourAndRedraw()
+            props.map.setColourAndRedraw({r: color.r / 255., g: color.g / 255., b: color.b / 255.})
         }
         catch (err) {
             console.log('err', err)
@@ -199,7 +199,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     }
 
     const mapSettingsProps = {
-        setPopoverIsShown, mapOpacity, mapStyle, glRef: props.glRef, map: props.map
+        setPopoverIsShown, mapOpacity: mapAlpha, mapStyle, glRef: props.glRef, map: props.map
     }
 
     const handleDownload = async () => {
@@ -324,23 +324,23 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
                 doContourIfDirty()
             })
         }
-    }, [mapRadius, mapContourLevel, mapIsVisible, mapStyle])
+    }, [])
 
     const handleOriginUpdate = useCallback((evt: moorhen.OriginUpdateEvent) => {
         nextOrigin.current = [...evt.detail.origin.map((coord: number) => -coord)]
         isDirty.current = true
         if (mapIsVisible && !busyContouring.current) {
-                doContourIfDirty()
+            doContourIfDirty()
         }
-    }, [doContourIfDirty])
+    }, [doContourIfDirty, mapIsVisible])
 
     const handleWheelContourLevelCallback = useCallback((evt: moorhen.WheelContourLevelEvent) => {
         let newMapContourLevel: number
         if (mapIsVisible && props.map.molNo === activeMap.molNo) {
             if (evt.detail.factor > 1) {
-                newMapContourLevel = mapContourLevel + contourWheelSensitivityFactor
+                newMapContourLevel = contourLevel + contourWheelSensitivityFactor
             } else {
-                newMapContourLevel = mapContourLevel - contourWheelSensitivityFactor
+                newMapContourLevel = contourLevel - contourWheelSensitivityFactor
             }
             batch(() => {
                 dispatch( setContourLevel({ molNo: props.map.molNo, contourLevel: newMapContourLevel }) )
@@ -355,7 +355,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
                 ))
             })
         }
-    }, [mapContourLevel, mapRadius, activeMap?.molNo, props.map.molNo, mapIsVisible])
+    }, [contourLevel, mapRadius, activeMap?.molNo, props.map.molNo, mapIsVisible])
 
     useMemo(() => {
         if (currentName === "") {
@@ -380,18 +380,28 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     }, [handleWheelContourLevelCallback])
 
     useEffect(() => {
-        props.map.fetchMapAlphaAndRedraw()
-    }, [mapOpacity])
+        props.map.setMapAlphaAndRedraw(mapAlpha)
+    }, [mapAlpha])
 
     useEffect(() => {
         // This looks stupid but it is important otherwise the map is first drawn with the default contour and radius. Probably there's a problem somewhere...
-        dispatch(setMapAlpha({molNo: props.map.molNo, alpha: mapOpacity}))
+        dispatch(setMapAlpha({molNo: props.map.molNo, alpha: mapAlpha}))
         dispatch(setMapStyle({molNo: props.map.molNo, style: mapStyle}))
         dispatch(setMapRadius({molNo: props.map.molNo, radius: mapRadius}))
-        dispatch(setContourLevel({molNo: props.map.molNo, contourLevel: mapContourLevel}))
+        dispatch(setContourLevel({molNo: props.map.molNo, contourLevel: contourLevel}))
         dispatch(setMapColours({molNo: props.map.molNo, rgb: mapColour}))
         dispatch(setNegativeMapColours({molNo: props.map.molNo, rgb: negativeMapColour}))
         dispatch(setPositiveMapColours({molNo: props.map.molNo, rgb: positiveMapColour}))
+        // Update attribute in MoorhenMap
+        props.map.contourParams = {
+            mapRadius, 
+            contourLevel, 
+            mapAlpha, 
+            mapStyle,
+            mapColour: {r: mapColour.r / 255., g: mapColour.g / 255., b: mapColour.b / 255.},
+            positiveMapColour: {r: positiveMapColour.r / 255., g: positiveMapColour.g / 255., b: positiveMapColour.b / 255.},
+            negativeMapColour: {r: negativeMapColour.r / 255., g: negativeMapColour.g / 255., b: negativeMapColour.b / 255.}
+        }
         // Show map only if specified
         if (props.map.showOnLoad) {
             dispatch(showMap(props.map))
@@ -401,6 +411,9 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
     useEffect(() => {
         if (mapIsVisible) {
             nextOrigin.current = props.glRef.current.origin.map(coord => -coord)
+            props.map.contourParams.mapRadius = mapRadius
+            props.map.contourParams.contourLevel = contourLevel
+            props.map.contourParams.mapStyle = mapStyle    
             isDirty.current = true
             if (!busyContouring.current) {
                 doContourIfDirty()
@@ -409,7 +422,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
             props.map.hideMapContour()
         }
 
-    }, [doContourIfDirty])
+    }, [mapRadius, contourLevel, mapIsVisible, mapStyle, doContourIfDirty])
 
     const increaseLevelButton = <IconButton 
         style={{padding: 0, color: isDark ? 'white' : 'black'}}
@@ -605,7 +618,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
                 </ToggleButton>
                 <Col>
                     <Form.Group controlId="contouringLevel" className="mb-3">
-                        <span>{`Lvl: ${mapContourLevel.toFixed(2)} ${props.map.mapRmsd ? '(' + (mapContourLevel / props.map.mapRmsd).toFixed(2) + ' rmsd)' : ''}`}</span>
+                        <span>{`Lvl: ${contourLevel.toFixed(2)} ${props.map.mapRmsd ? '(' + (contourLevel / props.map.mapRmsd).toFixed(2) + ' rmsd)' : ''}`}</span>
                         <MoorhenSlider
                             minVal={0.001}
                             maxVal={props.map.isEM ? 15 : 5}
@@ -617,7 +630,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
                             showSliderTitle={false}
                             isDisabled={!mapIsVisible}
                             initialValue={props.initialContour}
-                            externalValue={mapContourLevel}
+                            externalValue={contourLevel}
                             setExternalValue={(newVal) => dispatch( setContourLevel({molNo: props.map.molNo, contourLevel: newVal}) )}
                         />
                     </Form.Group>

--- a/baby-gru/src/components/form/MoorhenFetchOnlineSourcesForm.tsx
+++ b/baby-gru/src/components/form/MoorhenFetchOnlineSourcesForm.tsx
@@ -12,9 +12,11 @@ import { addMolecule } from "../../store/moleculesSlice";
 import { addMap } from "../../store/mapsSlice";
 import { webGL } from "../../types/mgWebGL";
 import { MoorhenColourRule } from "../../utils/MoorhenColourRule";
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore";
 
 export const MoorhenFetchOnlineSourcesForm = (props: {
     monomerLibraryPath: string;
+    store: ToolkitStore;
     commandCentre: React.RefObject<moorhen.CommandCentre>;
     glRef: React.RefObject<webGL.MGWebGL>;
     setBusy: React.Dispatch<React.SetStateAction<boolean>>;
@@ -33,7 +35,7 @@ export const MoorhenFetchOnlineSourcesForm = (props: {
     const defaultBondSmoothness = useSelector((state: moorhen.State) => state.sceneSettings.defaultBondSmoothness)
     const backgroundColor = useSelector((state: moorhen.State) => state.sceneSettings.backgroundColor)
 
-    const { commandCentre, glRef, monomerLibraryPath } = props;
+    const { commandCentre, glRef, monomerLibraryPath, store } = props;
 
     const getWarningToast = (message: string) => <MoorhenNotification key={guid()} hideDelay={3000} width={20}>
         <><WarningOutlined style={{ margin: 0 }} />
@@ -130,7 +132,7 @@ export const MoorhenFetchOnlineSourcesForm = (props: {
     }
 
     const fetchMoleculeFromURL = async (url: RequestInfo | URL, molName: string, isAF2?: boolean): Promise<moorhen.Molecule> => {
-        const newMolecule = new MoorhenMolecule(commandCentre, glRef, monomerLibraryPath)
+        const newMolecule = new MoorhenMolecule(commandCentre, glRef, monomerLibraryPath, store)
         newMolecule.setBackgroundColour(backgroundColor)
         newMolecule.defaultBondOptions.smoothness = defaultBondSmoothness
         try {
@@ -161,7 +163,7 @@ export const MoorhenFetchOnlineSourcesForm = (props: {
     }
 
     const fetchMapFromURL = async (url: RequestInfo | URL, mapName: string, isDiffMap: boolean = false, contourLevel?: number): Promise<moorhen.Map> => {
-        const newMap = new MoorhenMap(commandCentre, glRef)
+        const newMap = new MoorhenMap(commandCentre, glRef, store)
         try {
             try {
                 await newMap.loadToCootFromMapURL(url, mapName, isDiffMap)
@@ -190,7 +192,7 @@ export const MoorhenFetchOnlineSourcesForm = (props: {
     }
 
     const fetchMtzFromURL = async (url: RequestInfo | URL, mapName: string, selectedColumns: moorhen.selectedMtzColumns): Promise<moorhen.Map> => {
-        const newMap = new MoorhenMap(commandCentre, glRef)
+        const newMap = new MoorhenMap(commandCentre, glRef, store)
         try {
             await newMap.loadToCootFromMtzURL(url, mapName, selectedColumns)
             if (newMap.molNo === -1) throw new Error("Cannot read the fetched mtz...")

--- a/baby-gru/src/components/form/MoorhenFetchOnlineSourcesForm.tsx
+++ b/baby-gru/src/components/form/MoorhenFetchOnlineSourcesForm.tsx
@@ -132,7 +132,7 @@ export const MoorhenFetchOnlineSourcesForm = (props: {
     }
 
     const fetchMoleculeFromURL = async (url: RequestInfo | URL, molName: string, isAF2?: boolean): Promise<moorhen.Molecule> => {
-        const newMolecule = new MoorhenMolecule(commandCentre, glRef, monomerLibraryPath, store)
+        const newMolecule = new MoorhenMolecule(commandCentre, glRef, store, monomerLibraryPath)
         newMolecule.setBackgroundColour(backgroundColor)
         newMolecule.defaultBondOptions.smoothness = defaultBondSmoothness
         try {

--- a/baby-gru/src/components/menu-item/MoorhenAutoOpenMtzMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenAutoOpenMtzMenuItem.tsx
@@ -9,8 +9,10 @@ import { libcootApi } from "../../types/libcoot"
 import { useDispatch } from 'react-redux';
 import { setActiveMap, setNotificationContent } from "../../store/generalStatesSlice"
 import { addMap } from "../../store/mapsSlice"
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore"
 
 export const MoorhenAutoOpenMtzMenuItem = (props: {
+    store: ToolkitStore;
     commandCentre: React.RefObject<moorhen.CommandCentre>;
     glRef: React.RefObject<webGL.MGWebGL>;
     setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>;
@@ -63,7 +65,7 @@ export const MoorhenAutoOpenMtzMenuItem = (props: {
 
         await Promise.all(
             response.data.result.result.filter(item => item.idx !== -1).map(async (autoReadInfo, index) => {
-                const newMap = new MoorhenMap(props.commandCentre, props.glRef)
+                const newMap = new MoorhenMap(props.commandCentre, props.glRef, props.store)
                 newMap.molNo = autoReadInfo.idx
                 newMap.name = `${file.name.replace('mtz', '')}-map-${index}`
                 newMap.isDifference = isDiffMapResponses[index].data.result.result

--- a/baby-gru/src/components/menu-item/MoorhenFlipMapHandMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenFlipMapHandMenuItem.tsx
@@ -42,7 +42,7 @@ export const MoorhenFlipMapHandMenuItem = (props: {
             newMap.name = `Flipped map ${mapNo}`
             await newMap.getSuggestedSettings()
             newMap.isDifference = selectedMap.isDifference
-            const { mapRadius, contourLevel, mapAlpha, mapStyle } = selectedMap.getMapContourParams()
+            const { mapRadius, contourLevel, mapAlpha, mapStyle } = selectedMap.contourParams
             batch(() => {
                 dispatch( setMapRadius({ molNo: newMap.molNo, radius: mapRadius }) )
                 dispatch( setContourLevel({ molNo: newMap.molNo, contourLevel: contourLevel }) )

--- a/baby-gru/src/components/menu-item/MoorhenFlipMapHandMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenFlipMapHandMenuItem.tsx
@@ -7,11 +7,13 @@ import { webGL } from "../../types/mgWebGL";
 import { batch, useDispatch, useSelector } from "react-redux";
 import { addMap } from "../../store/mapsSlice";
 import { hideMap, setContourLevel, setMapAlpha, setMapRadius, setMapStyle } from "../../store/mapContourSettingsSlice";
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore";
 
 export const MoorhenFlipMapHandMenuItem = (props: {
     setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>
     commandCentre: React.RefObject<moorhen.CommandCentre>;
     glRef: React.RefObject<webGL.MGWebGL>;
+    store: ToolkitStore;
 }) => {
 
     const dispatch = useDispatch()
@@ -24,7 +26,7 @@ export const MoorhenFlipMapHandMenuItem = (props: {
         }
 
         const mapNo = parseInt(selectRef.current.value)
-        const newMap = new MoorhenMap(props.commandCentre, props.glRef)
+        const newMap = new MoorhenMap(props.commandCentre, props.glRef, props.store)
         const selectedMap = maps.find(map => map.molNo === mapNo)
 
         if (!selectedMap) {

--- a/baby-gru/src/components/menu-item/MoorhenFlipMapHandMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenFlipMapHandMenuItem.tsx
@@ -42,7 +42,7 @@ export const MoorhenFlipMapHandMenuItem = (props: {
             newMap.name = `Flipped map ${mapNo}`
             await newMap.getSuggestedSettings()
             newMap.isDifference = selectedMap.isDifference
-            const { mapRadius, contourLevel, mapAlpha, mapStyle } = selectedMap.contourParams
+            const { mapRadius, contourLevel, mapAlpha, mapStyle } = selectedMap.getMapContourParams()
             batch(() => {
                 dispatch( setMapRadius({ molNo: newMap.molNo, radius: mapRadius }) )
                 dispatch( setContourLevel({ molNo: newMap.molNo, contourLevel: contourLevel }) )

--- a/baby-gru/src/components/menu-item/MoorhenGetMonomerMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenGetMonomerMenuItem.tsx
@@ -7,12 +7,14 @@ import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
 import { useSelector, useDispatch } from 'react-redux';
 import { addMolecule } from "../../store/moleculesSlice";
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore";
 
 export const MoorhenGetMonomerMenuItem = (props: {
     glRef: React.RefObject<webGL.MGWebGL>
     popoverPlacement?: 'left' | 'right'
     commandCentre: React.RefObject<moorhen.CommandCentre>;
     monomerLibraryPath: string;
+    store: ToolkitStore;
     setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
 
@@ -35,7 +37,7 @@ export const MoorhenGetMonomerMenuItem = (props: {
     const onCompleted = async () => {
         const fromMolNo = parseInt(selectRef.current.value)
         const newTlc = tlcRef.current.value.toUpperCase()
-        const newMolecule = new MoorhenMolecule(props.commandCentre, props.glRef, props.monomerLibraryPath)
+        const newMolecule = new MoorhenMolecule(props.commandCentre, props.glRef, props.monomerLibraryPath, props.store)
 
         if (!newTlc || !selectRef.current.value) {
             return

--- a/baby-gru/src/components/menu-item/MoorhenGetMonomerMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenGetMonomerMenuItem.tsx
@@ -37,7 +37,7 @@ export const MoorhenGetMonomerMenuItem = (props: {
     const onCompleted = async () => {
         const fromMolNo = parseInt(selectRef.current.value)
         const newTlc = tlcRef.current.value.toUpperCase()
-        const newMolecule = new MoorhenMolecule(props.commandCentre, props.glRef, props.monomerLibraryPath, props.store)
+        const newMolecule = new MoorhenMolecule(props.commandCentre, props.glRef, props.store, props.monomerLibraryPath)
 
         if (!newTlc || !selectRef.current.value) {
             return

--- a/baby-gru/src/components/menu-item/MoorhenImportFSigFMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenImportFSigFMenuItem.tsx
@@ -76,7 +76,7 @@ export const MoorhenImportFSigFMenuItem = (props:{
                 uniqueMaps.map(async (imol, index) => {
                     const currentMap = maps.find(map => map.molNo === imol)
                     const postRmsd = await currentMap.fetchMapRmsd()
-                    const { contourLevel } = currentMap.contourParams
+                    const { contourLevel } = currentMap.getMapContourParams()
                     let newContourLevel = contourLevel * postRmsd / prevRmsd[index]
                     if (currentMap.isDifference) {
                         newContourLevel -= newContourLevel * 0.3

--- a/baby-gru/src/components/menu-item/MoorhenImportFSigFMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenImportFSigFMenuItem.tsx
@@ -76,7 +76,7 @@ export const MoorhenImportFSigFMenuItem = (props:{
                 uniqueMaps.map(async (imol, index) => {
                     const currentMap = maps.find(map => map.molNo === imol)
                     const postRmsd = await currentMap.fetchMapRmsd()
-                    const { contourLevel } = currentMap.getMapContourParams()
+                    const { contourLevel } = currentMap.contourParams
                     let newContourLevel = contourLevel * postRmsd / prevRmsd[index]
                     if (currentMap.isDifference) {
                         newContourLevel -= newContourLevel * 0.3

--- a/baby-gru/src/components/menu-item/MoorhenImportLigandDictionary.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenImportLigandDictionary.tsx
@@ -11,6 +11,7 @@ import { libcootApi } from "../../types/libcoot"
 import { useSelector, useDispatch } from 'react-redux';
 import { addMolecule } from "../../store/moleculesSlice"
 import { triggerUpdate } from "../../store/moleculeMapUpdateSlice"
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore"
 
 const MoorhenImportLigandDictionary = (props: { 
     id: string;
@@ -20,6 +21,7 @@ const MoorhenImportLigandDictionary = (props: {
     glRef: React.RefObject<webGL.MGWebGL>;
     commandCentre: React.RefObject<moorhen.CommandCentre>;
     monomerLibraryPath: string;
+    store: ToolkitStore;
     panelContent: JSX.Element;
     fetchLigandDict: () => Promise<string>;
     addToMoleculeValueRef: React.MutableRefObject<number>;
@@ -42,7 +44,7 @@ const MoorhenImportLigandDictionary = (props: {
         createInstance, setCreateInstance, addToMolecule, fetchLigandDict, panelContent,
         setAddToMolecule, tlcValueRef, createRef, moleculeSelectRef, addToRef,moleculeSelectValueRef,
         addToMoleculeValueRef, setPopoverIsShown, glRef, commandCentre, menuItemText,
-        monomerLibraryPath, id
+        monomerLibraryPath, id, store
     } = props
 
     const handleFileContent = useCallback(async (fileContent: string) => {
@@ -81,7 +83,7 @@ const MoorhenImportLigandDictionary = (props: {
                     ...glRef.current.origin.map(coord => -coord)]
             }, true) as moorhen.WorkerResponse<number> 
             if (result.data.result.status === "Completed") {
-                newMolecule = new MoorhenMolecule(commandCentre, glRef, monomerLibraryPath)
+                newMolecule = new MoorhenMolecule(commandCentre, glRef, monomerLibraryPath, store)
                 newMolecule.molNo = result.data.result.result
                 newMolecule.name = instanceName
                 newMolecule.setBackgroundColour(backgroundColor)
@@ -167,6 +169,7 @@ export const MoorhenSMILESToLigandMenuItem = (props: {
     glRef: React.RefObject<webGL.MGWebGL>;
     commandCentre: React.RefObject<moorhen.CommandCentre>;
     monomerLibraryPath: string;
+    store: ToolkitStore;
 }) => {
 
     const [smile, setSmile] = useState<string>('')
@@ -283,6 +286,7 @@ export const MoorhenImportDictionaryMenuItem = (props: {
     glRef: React.RefObject<webGL.MGWebGL>;
     commandCentre: React.RefObject<moorhen.CommandCentre>;
     monomerLibraryPath: string;
+    store: ToolkitStore;
  }) => {
     
     const fileOrLibraryRef = useRef<string>("Library")

--- a/baby-gru/src/components/menu-item/MoorhenImportLigandDictionary.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenImportLigandDictionary.tsx
@@ -83,7 +83,7 @@ const MoorhenImportLigandDictionary = (props: {
                     ...glRef.current.origin.map(coord => -coord)]
             }, true) as moorhen.WorkerResponse<number> 
             if (result.data.result.status === "Completed") {
-                newMolecule = new MoorhenMolecule(commandCentre, glRef, monomerLibraryPath, store)
+                newMolecule = new MoorhenMolecule(commandCentre, glRef, store, monomerLibraryPath)
                 newMolecule.molNo = result.data.result.result
                 newMolecule.name = instanceName
                 newMolecule.setBackgroundColour(backgroundColor)

--- a/baby-gru/src/components/menu-item/MoorhenImportMapCoefficientsMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenImportMapCoefficientsMenuItem.tsx
@@ -8,10 +8,12 @@ import { webGL } from "../../types/mgWebGL"
 import { batch, useDispatch, useSelector } from 'react-redux';
 import { setActiveMap, setNotificationContent } from "../../store/generalStatesSlice"
 import { addMap } from "../../store/mapsSlice"
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore"
 
 export const MoorhenImportMapCoefficientsMenuItem = (props: {
     commandCentre: RefObject<moorhen.CommandCentre>;
     glRef: React.RefObject<webGL.MGWebGL>;
+    store: ToolkitStore;
     setPopoverIsShown: Dispatch<SetStateAction<boolean>>;
     getWarningToast: (arg0: string) => JSX.Element;
 }) => {
@@ -54,7 +56,7 @@ export const MoorhenImportMapCoefficientsMenuItem = (props: {
                 Fobs: fobsSelectRef.current.value, SigFobs: sigFobsSelectRef.current.value,
                 FreeR: freeRSelectRef.current.value, calcStructFact: calcStructFactRef.current.checked
             }
-            const newMap = new MoorhenMap(props.commandCentre, props.glRef)
+            const newMap = new MoorhenMap(props.commandCentre, props.glRef, props.store)
             try {
                 await newMap.loadToCootFromMtzFile(file, selectedColumns)
                 if (newMap.molNo === -1) {

--- a/baby-gru/src/components/menu-item/MoorhenImportMapMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenImportMapMenuItem.tsx
@@ -7,10 +7,12 @@ import { webGL } from "../../types/mgWebGL";
 import { setActiveMap, setNotificationContent } from "../../store/generalStatesSlice";
 import { batch, useDispatch, useSelector } from 'react-redux';
 import { addMap } from "../../store/mapsSlice";
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore";
 
 export const MoorhenImportMapMenuItem = (props: { 
     commandCentre: React.RefObject<moorhen.CommandCentre>;
     glRef: React.RefObject<webGL.MGWebGL>;
+    store: ToolkitStore;
     setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>;
     getWarningToast: (arg0: string) => JSX.Element;
 }) => {
@@ -25,7 +27,7 @@ export const MoorhenImportMapMenuItem = (props: {
     const readMap = useCallback(async () => {
         if (filesRef.current.files.length > 0) {
             const file = filesRef.current.files[0]
-            const newMap = new MoorhenMap(props.commandCentre, props.glRef)
+            const newMap = new MoorhenMap(props.commandCentre, props.glRef, props.store)
             try {
                 try {
                     await newMap.loadToCootFromMapFile(file, isDiffRef.current.checked)

--- a/baby-gru/src/components/menu-item/MoorhenLoadScriptMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenLoadScriptMenuItem.tsx
@@ -5,10 +5,12 @@ import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem";
 import { MoorhenScriptModal } from "../modal/MoorhenScriptModal";
 import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore";
 
 export const MoorhenLoadScriptMenuItem = (props: {
      setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>;
      glRef: React.RefObject<webGL.MGWebGL>;
+     store: ToolkitStore;
      commandCentre: React.RefObject<moorhen.CommandCentre>;
 }) => {
     

--- a/baby-gru/src/components/menu-item/MoorhenLoadTutorialDataMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenLoadTutorialDataMenuItem.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import { useRef } from "react";
 import { Form } from "react-bootstrap";
 import { MoorhenMap } from "../../utils/MoorhenMap";
 import { MoorhenMolecule } from "../../utils/MoorhenMolecule";
@@ -49,7 +49,7 @@ export const MoorhenLoadTutorialDataMenuItem = (props: {
             return
         }
         const tutorialNumber = tutorialNumberSelectorRef.current.value
-        const newMolecule = new MoorhenMolecule(props.commandCentre, props.glRef, props.monomerLibraryPath, props.store)
+        const newMolecule = new MoorhenMolecule(props.commandCentre, props.glRef, props.store, props.monomerLibraryPath)
         newMolecule.setBackgroundColour(backgroundColor)
         newMolecule.defaultBondOptions.smoothness = defaultBondSmoothness
         const newMap = new MoorhenMap(props.commandCentre, props.glRef, props.store)

--- a/baby-gru/src/components/menu-item/MoorhenLoadTutorialDataMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenLoadTutorialDataMenuItem.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import React, { useRef } from "react";
 import { Form } from "react-bootstrap";
 import { MoorhenMap } from "../../utils/MoorhenMap";
 import { MoorhenMolecule } from "../../utils/MoorhenMolecule";
@@ -9,12 +9,14 @@ import { useSelector, useDispatch, batch } from 'react-redux';
 import { setActiveMap } from "../../store/generalStatesSlice";
 import { addMolecule } from "../../store/moleculesSlice";
 import { addMapList } from "../../store/mapsSlice";
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore";
 
 export const MoorhenLoadTutorialDataMenuItem = (props: {
     commandCentre: React.RefObject<moorhen.CommandCentre>;
     monomerLibraryPath: string;
     urlPrefix: string;
     glRef: React.RefObject<webGL.MGWebGL>;
+    store: ToolkitStore;
     setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
 
@@ -47,11 +49,11 @@ export const MoorhenLoadTutorialDataMenuItem = (props: {
             return
         }
         const tutorialNumber = tutorialNumberSelectorRef.current.value
-        const newMolecule = new MoorhenMolecule(props.commandCentre, props.glRef, props.monomerLibraryPath)
+        const newMolecule = new MoorhenMolecule(props.commandCentre, props.glRef, props.monomerLibraryPath, props.store)
         newMolecule.setBackgroundColour(backgroundColor)
         newMolecule.defaultBondOptions.smoothness = defaultBondSmoothness
-        const newMap = new MoorhenMap(props.commandCentre, props.glRef)
-        const newDiffMap = new MoorhenMap(props.commandCentre, props.glRef)
+        const newMap = new MoorhenMap(props.commandCentre, props.glRef, props.store)
+        const newDiffMap = new MoorhenMap(props.commandCentre, props.glRef, props.store)
         await newMolecule.loadToCootFromURL(`${props.urlPrefix}/baby-gru/tutorials/moorhen-tutorial-structure-number-${tutorialNumber}.pdb`, `mol-${tutorialNumber}`)
         await newMolecule.fetchIfDirtyAndDraw('CBs')
         await newMolecule.centreOn('/*/*/*/*', true)

--- a/baby-gru/src/components/menu-item/MoorhenMakeMaskedMapsSplitByChainMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenMakeMaskedMapsSplitByChainMenuItem.tsx
@@ -52,7 +52,7 @@ export const MoorhenMakeMaskedMapsSplitByChainMenuItem = (props: {
                     newMap.name = `Chain ${listIndex} of ${selectedMap.name}`
                     newMap.isDifference = selectedMap.isDifference
                     await newMap.getSuggestedSettings()
-                    const { mapRadius, contourLevel, mapAlpha, mapStyle } = selectedMap.getMapContourParams()
+                    const { mapRadius, contourLevel, mapAlpha, mapStyle } = selectedMap.contourParams
                     batch(() => {
                         dispatch( setMapRadius({ molNo: newMap.molNo, radius: mapRadius }) )
                         dispatch( setContourLevel({ molNo: newMap.molNo, contourLevel: contourLevel }) )

--- a/baby-gru/src/components/menu-item/MoorhenMakeMaskedMapsSplitByChainMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenMakeMaskedMapsSplitByChainMenuItem.tsx
@@ -8,11 +8,13 @@ import { webGL } from "../../types/mgWebGL";
 import { batch, useDispatch, useSelector } from 'react-redux';
 import { addMap } from "../../store/mapsSlice";
 import { hideMap, setContourLevel, setMapAlpha, setMapRadius, setMapStyle } from "../../store/mapContourSettingsSlice";
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore";
 
 export const MoorhenMakeMaskedMapsSplitByChainMenuItem = (props: {
     setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>
     commandCentre: React.RefObject<moorhen.CommandCentre>;
     glRef: React.RefObject<webGL.MGWebGL>;
+    store: ToolkitStore;
 }) => {
 
     const moleculeSelectRef = useRef<HTMLSelectElement>(null)
@@ -47,7 +49,7 @@ export const MoorhenMakeMaskedMapsSplitByChainMenuItem = (props: {
         if (result.data.result.result.length > 0 && selectedMap && selectedMolecule) {
             await Promise.all(
                 result.data.result.result.map(async (iNewMap, listIndex) =>{
-                    const newMap = new MoorhenMap(props.commandCentre, props.glRef)
+                    const newMap = new MoorhenMap(props.commandCentre, props.glRef, props.store)
                     newMap.molNo = iNewMap
                     newMap.name = `Chain ${listIndex} of ${selectedMap.name}`
                     newMap.isDifference = selectedMap.isDifference

--- a/baby-gru/src/components/menu-item/MoorhenMakeMaskedMapsSplitByChainMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenMakeMaskedMapsSplitByChainMenuItem.tsx
@@ -52,7 +52,7 @@ export const MoorhenMakeMaskedMapsSplitByChainMenuItem = (props: {
                     newMap.name = `Chain ${listIndex} of ${selectedMap.name}`
                     newMap.isDifference = selectedMap.isDifference
                     await newMap.getSuggestedSettings()
-                    const { mapRadius, contourLevel, mapAlpha, mapStyle } = selectedMap.contourParams
+                    const { mapRadius, contourLevel, mapAlpha, mapStyle } = selectedMap.getMapContourParams()
                     batch(() => {
                         dispatch( setMapRadius({ molNo: newMap.molNo, radius: mapRadius }) )
                         dispatch( setContourLevel({ molNo: newMap.molNo, contourLevel: contourLevel }) )

--- a/baby-gru/src/components/menu-item/MoorhenMapMaskingMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenMapMaskingMenuItem.tsx
@@ -13,11 +13,13 @@ import { batch, useDispatch, useSelector } from 'react-redux';
 import { addMap } from "../../store/mapsSlice";
 import { hideMap, setContourLevel, setMapAlpha, setMapRadius, setMapStyle } from "../../store/mapContourSettingsSlice";
 import { MoorhenNumberForm } from "../select/MoorhenNumberForm";
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore";
 
 export const MoorhenMapMaskingMenuItem = (props: {
     setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>
     commandCentre: React.RefObject<moorhen.CommandCentre>;
     glRef: React.RefObject<webGL.MGWebGL>;
+    store: ToolkitStore;
 }) => {
 
     const dispatch = useDispatch()
@@ -38,7 +40,7 @@ export const MoorhenMapMaskingMenuItem = (props: {
     const ligandSelectRef = useRef<null | HTMLSelectElement>(null)
     const cidInputRef = useRef<null | HTMLInputElement>(null)
 
-    const { commandCentre, glRef } = props
+    const { commandCentre, glRef, store } = props
 
     const panelContent = <>
         <Form.Group style={{ margin: '0.5rem', width: '20rem' }}>
@@ -123,7 +125,7 @@ export const MoorhenMapMaskingMenuItem = (props: {
         }, false) as moorhen.WorkerResponse<number>
         
         if (result.data.result.result !== -1) {
-            const newMap = new MoorhenMap(commandCentre, glRef)
+            const newMap = new MoorhenMap(commandCentre, glRef, store)
             newMap.molNo = result.data.result.result
             newMap.name = `Map ${mapNo} masked`
             await newMap.getSuggestedSettings()

--- a/baby-gru/src/components/menu-item/MoorhenMapMaskingMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenMapMaskingMenuItem.tsx
@@ -128,7 +128,7 @@ export const MoorhenMapMaskingMenuItem = (props: {
             newMap.name = `Map ${mapNo} masked`
             await newMap.getSuggestedSettings()
             newMap.isDifference = selectedMap.isDifference
-            const { mapRadius, contourLevel, mapAlpha, mapStyle } = selectedMap.contourParams
+            const { mapRadius, contourLevel, mapAlpha, mapStyle } = selectedMap.getMapContourParams()
             batch(() => {
                 dispatch( setMapRadius({ molNo: newMap.molNo, radius: mapRadius }) )
                 dispatch( setContourLevel({ molNo: newMap.molNo, contourLevel: contourLevel }) )

--- a/baby-gru/src/components/menu-item/MoorhenMapMaskingMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenMapMaskingMenuItem.tsx
@@ -128,7 +128,7 @@ export const MoorhenMapMaskingMenuItem = (props: {
             newMap.name = `Map ${mapNo} masked`
             await newMap.getSuggestedSettings()
             newMap.isDifference = selectedMap.isDifference
-            const { mapRadius, contourLevel, mapAlpha, mapStyle } = selectedMap.getMapContourParams()
+            const { mapRadius, contourLevel, mapAlpha, mapStyle } = selectedMap.contourParams
             batch(() => {
                 dispatch( setMapRadius({ molNo: newMap.molNo, radius: mapRadius }) )
                 dispatch( setContourLevel({ molNo: newMap.molNo, contourLevel: contourLevel }) )

--- a/baby-gru/src/components/menu-item/MoorhenSharpenBlurMapMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenSharpenBlurMapMenuItem.tsx
@@ -76,7 +76,7 @@ export const MoorhenSharpenBlurMapMenuItem = (props: {
             newMap.name = `Map ${mapNo} ${bFactor < 0 ? "sharpened" : "blurred"} by ${bFactor}`
             await newMap.getSuggestedSettings()
             newMap.isDifference = selectedMap.isDifference
-            const { mapRadius, contourLevel, mapAlpha, mapStyle } = selectedMap.getMapContourParams()
+            const { mapRadius, contourLevel, mapAlpha, mapStyle } = selectedMap.contourParams
             batch(() => {
                 dispatch( setMapRadius({ molNo: newMap.molNo, radius: mapRadius }) )
                 dispatch( setContourLevel({ molNo: newMap.molNo, contourLevel: contourLevel }) )

--- a/baby-gru/src/components/menu-item/MoorhenSharpenBlurMapMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenSharpenBlurMapMenuItem.tsx
@@ -76,7 +76,7 @@ export const MoorhenSharpenBlurMapMenuItem = (props: {
             newMap.name = `Map ${mapNo} ${bFactor < 0 ? "sharpened" : "blurred"} by ${bFactor}`
             await newMap.getSuggestedSettings()
             newMap.isDifference = selectedMap.isDifference
-            const { mapRadius, contourLevel, mapAlpha, mapStyle } = selectedMap.contourParams
+            const { mapRadius, contourLevel, mapAlpha, mapStyle } = selectedMap.getMapContourParams()
             batch(() => {
                 dispatch( setMapRadius({ molNo: newMap.molNo, radius: mapRadius }) )
                 dispatch( setContourLevel({ molNo: newMap.molNo, contourLevel: contourLevel }) )

--- a/baby-gru/src/components/menu-item/MoorhenSharpenBlurMapMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenSharpenBlurMapMenuItem.tsx
@@ -9,11 +9,13 @@ import { webGL } from "../../types/mgWebGL";
 import { batch, useDispatch, useSelector } from "react-redux";
 import { addMap } from "../../store/mapsSlice";
 import { hideMap, setContourLevel, setMapAlpha, setMapRadius, setMapStyle } from "../../store/mapContourSettingsSlice";
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore";
 
 export const MoorhenSharpenBlurMapMenuItem = (props: {
     setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>
     commandCentre: React.RefObject<moorhen.CommandCentre>;
     glRef: React.RefObject<webGL.MGWebGL>;
+    store: ToolkitStore;
 }) => {
 
     const dispatch = useDispatch()
@@ -48,7 +50,7 @@ export const MoorhenSharpenBlurMapMenuItem = (props: {
         
         const mapNo = parseInt(selectRef.current.value)
         const bFactor = parseFloat(factorRef.current)
-        const newMap = new MoorhenMap(props.commandCentre, props.glRef)
+        const newMap = new MoorhenMap(props.commandCentre, props.glRef, props.store)
         const selectedMap = maps.find(map => map.molNo === mapNo)
 
         if (!selectedMap) {

--- a/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
@@ -15,6 +15,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { addMolecule } from "../../store/moleculesSlice";
 import { setNotificationContent } from "../../store/generalStatesSlice";
 import { MoorhenColourRule } from "../../utils/MoorhenColourRule";
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore";
 
 export const MoorhenQuerySequenceModal = (props: {
     show: boolean;
@@ -22,6 +23,7 @@ export const MoorhenQuerySequenceModal = (props: {
     commandCentre: React.RefObject<moorhen.CommandCentre>;
     glRef: React.RefObject<webGL.MGWebGL>;
     monomerLibraryPath: string;
+    store: ToolkitStore;
 }) => {
 
     const [selectedModel, setSelectedModel] = useState<null | number>(null)
@@ -49,7 +51,7 @@ export const MoorhenQuerySequenceModal = (props: {
     const backgroundColor = useSelector((state: moorhen.State) => state.sceneSettings.backgroundColor)
 
     const fetchMoleculeFromURL = async (url: RequestInfo | URL, molName: string): Promise<moorhen.Molecule> => {
-        const newMolecule = new MoorhenMolecule(props.commandCentre, props.glRef, props.monomerLibraryPath)
+        const newMolecule = new MoorhenMolecule(props.commandCentre, props.glRef, props.monomerLibraryPath, props.store)
         newMolecule.setBackgroundColour(backgroundColor)
         newMolecule.defaultBondOptions.smoothness = defaultBondSmoothness
         try {

--- a/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenQuerySequenceModal.tsx
@@ -51,7 +51,7 @@ export const MoorhenQuerySequenceModal = (props: {
     const backgroundColor = useSelector((state: moorhen.State) => state.sceneSettings.backgroundColor)
 
     const fetchMoleculeFromURL = async (url: RequestInfo | URL, molName: string): Promise<moorhen.Molecule> => {
-        const newMolecule = new MoorhenMolecule(props.commandCentre, props.glRef, props.monomerLibraryPath, props.store)
+        const newMolecule = new MoorhenMolecule(props.commandCentre, props.glRef, props.store, props.monomerLibraryPath)
         newMolecule.setBackgroundColour(backgroundColor)
         newMolecule.defaultBondOptions.smoothness = defaultBondSmoothness
         try {

--- a/baby-gru/src/components/modal/MoorhenScriptModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenScriptModal.tsx
@@ -12,10 +12,12 @@ import 'prismjs/components/prism-clike';
 import 'prismjs/components/prism-javascript';
 import { useSelector } from "react-redux";
 import { convertRemToPx, convertViewtoPx } from "../../utils/MoorhenUtils";
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore";
 
 export const MoorhenScriptModal = (props: {
     glRef: React.RefObject<webGL.MGWebGL>;
     commandCentre: React.RefObject<moorhen.CommandCentre>;
+    store: ToolkitStore;
     show: boolean;
     setShow: React.Dispatch<React.SetStateAction<boolean>>;
     code?: string;
@@ -31,7 +33,7 @@ export const MoorhenScriptModal = (props: {
 
     const handleScriptExe = useCallback(async () => {
         try {
-            const scriptApi = new MoorhenScriptApi(props.commandCentre, props.glRef, molecules, maps)
+            const scriptApi = new MoorhenScriptApi(props.commandCentre, props.glRef, props.store, molecules, maps)
             scriptApi.exe(code)
         }
         catch (err) {

--- a/baby-gru/src/components/modal/MoorhenScriptModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenScriptModal.tsx
@@ -10,7 +10,7 @@ import Editor from 'react-simple-code-editor';
 import 'prismjs/themes/prism.css';
 import 'prismjs/components/prism-clike';
 import 'prismjs/components/prism-javascript';
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { convertRemToPx, convertViewtoPx } from "../../utils/MoorhenUtils";
 
 export const MoorhenScriptModal = (props: {
@@ -23,6 +23,7 @@ export const MoorhenScriptModal = (props: {
 
     const [code, setCode] = useState<string>("")
     
+    const dispatch = useDispatch()
     const width = useSelector((state: moorhen.State) => state.sceneSettings.width)
     const height = useSelector((state: moorhen.State) => state.sceneSettings.height)
     const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
@@ -32,7 +33,7 @@ export const MoorhenScriptModal = (props: {
     const handleScriptExe = useCallback(async () => {
         try {
             const scriptApi = new MoorhenScriptApi(props.commandCentre, props.glRef, molecules, maps)
-            scriptApi.exe(code)
+            scriptApi.exe(code, dispatch)
         }
         catch (err) {
             console.error(err)

--- a/baby-gru/src/components/modal/MoorhenScriptModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenScriptModal.tsx
@@ -10,7 +10,7 @@ import Editor from 'react-simple-code-editor';
 import 'prismjs/themes/prism.css';
 import 'prismjs/components/prism-clike';
 import 'prismjs/components/prism-javascript';
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { convertRemToPx, convertViewtoPx } from "../../utils/MoorhenUtils";
 
 export const MoorhenScriptModal = (props: {
@@ -23,7 +23,6 @@ export const MoorhenScriptModal = (props: {
 
     const [code, setCode] = useState<string>("")
     
-    const dispatch = useDispatch()
     const width = useSelector((state: moorhen.State) => state.sceneSettings.width)
     const height = useSelector((state: moorhen.State) => state.sceneSettings.height)
     const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
@@ -33,7 +32,7 @@ export const MoorhenScriptModal = (props: {
     const handleScriptExe = useCallback(async () => {
         try {
             const scriptApi = new MoorhenScriptApi(props.commandCentre, props.glRef, molecules, maps)
-            scriptApi.exe(code, dispatch)
+            scriptApi.exe(code)
         }
         catch (err) {
             console.error(err)

--- a/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
@@ -223,7 +223,7 @@ export const MoorhenFileMenu = (props: MoorhenNavBarExtendedControlsInterface) =
                     {!props.disableFileUploads && 
                     <Form.Group className='moorhen-form-group' controlId="upload-session-form">
                         <Form.Label>Load from stored session</Form.Label>
-                        <Form.Control type="file" accept=".pb" multiple={false} onChange={handleSessionUpload}/>
+                        <Form.Control type="file" accept=".pb," multiple={false} onChange={handleSessionUpload}/>
                     </Form.Group>}
                     
                     <hr></hr>

--- a/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
@@ -76,7 +76,7 @@ export const MoorhenFileMenu = (props: MoorhenNavBarExtendedControlsInterface) =
     }
 
     const readPdbFile = async (file: File): Promise<moorhen.Molecule> => {
-        const newMolecule = new MoorhenMolecule(commandCentre, glRef, monomerLibraryPath, store)
+        const newMolecule = new MoorhenMolecule(commandCentre, glRef, store, monomerLibraryPath)
         newMolecule.setBackgroundColour(backgroundColor)
         newMolecule.defaultBondOptions.smoothness = defaultBondSmoothness
         await newMolecule.loadToCootFromFile(file)        

--- a/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
@@ -36,7 +36,7 @@ export const MoorhenFileMenu = (props: MoorhenNavBarExtendedControlsInterface) =
     const backgroundColor = useSelector((state: moorhen.State) => state.sceneSettings.backgroundColor)
     const molecules = useSelector((state: moorhen.State) => state.molecules.moleculeList)
 
-    const { commandCentre, glRef, monomerLibraryPath, setBusy } = props;
+    const { commandCentre, glRef, monomerLibraryPath, setBusy, store } = props;
 
     const getWarningToast = (message: string) => <MoorhenNotification key={guid()} hideDelay={3000} width={20}>
             <><WarningOutlined style={{margin: 0}}/>
@@ -76,7 +76,7 @@ export const MoorhenFileMenu = (props: MoorhenNavBarExtendedControlsInterface) =
     }
 
     const readPdbFile = async (file: File): Promise<moorhen.Molecule> => {
-        const newMolecule = new MoorhenMolecule(commandCentre, glRef, monomerLibraryPath)
+        const newMolecule = new MoorhenMolecule(commandCentre, glRef, monomerLibraryPath, store)
         newMolecule.setBackgroundColour(backgroundColor)
         newMolecule.defaultBondOptions.smoothness = defaultBondSmoothness
         await newMolecule.loadToCootFromFile(file)        
@@ -129,6 +129,7 @@ export const MoorhenFileMenu = (props: MoorhenNavBarExtendedControlsInterface) =
                     props.commandCentre,
                     props.timeCapsuleRef,
                     props.glRef,
+                    store,
                     dispatch
                 )
             } else {
@@ -140,6 +141,7 @@ export const MoorhenFileMenu = (props: MoorhenNavBarExtendedControlsInterface) =
                     props.commandCentre,
                     props.timeCapsuleRef,
                     props.glRef,
+                    store,
                     dispatch
                 )
             }
@@ -218,7 +220,7 @@ export const MoorhenFileMenu = (props: MoorhenNavBarExtendedControlsInterface) =
                         <Form.Control type="file" accept=".pdb, .mmcif, .cif, .ent" multiple={true} onChange={(e: React.ChangeEvent<HTMLInputElement>) => { loadPdbFiles(e.target.files) }}/>
                     </Form.Group>}
                     
-                    <MoorhenFetchOnlineSourcesForm commandCentre={commandCentre} glRef={glRef} setBusy={setBusy} monomerLibraryPath={monomerLibraryPath} />
+                    <MoorhenFetchOnlineSourcesForm commandCentre={commandCentre} glRef={glRef} setBusy={setBusy} monomerLibraryPath={monomerLibraryPath} store={store} />
                     
                     {!props.disableFileUploads && 
                     <Form.Group className='moorhen-form-group' controlId="upload-session-form">

--- a/baby-gru/src/components/navbar-menus/MoorhenHistoryMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenHistoryMenu.tsx
@@ -36,6 +36,7 @@ export const MoorhenHistoryMenu = (props: MoorhenNavBarExtendedControlsInterface
                 props.commandCentre,
                 props.timeCapsuleRef,
                 props.glRef,
+                props.store,
                 dispatch
             )
             if (status === -1) {

--- a/baby-gru/src/moorhen.ts
+++ b/baby-gru/src/moorhen.ts
@@ -21,26 +21,29 @@ import { setDefaultBackgroundColor, setDrawCrosshairs, setDrawFPS, setDrawMissin
     setDrawInteractions, setDoSSAO, setSsaoRadius, setSsaoBias, setResetClippingFogging, setClipCap,  
     setUseOffScreenBuffers, setDoShadowDepthDebug, setDoShadow, setDoSpin, setDoOutline, setDepthBlurRadius,
     setDepthBlurDepth, setDrawAxes, setDoPerspectiveProjection, setHeight, setWidth, setIsDark, setBackgroundColor, setDrawScaleBar,
-    setDoEdgeDetect, setEdgeDetectDepthThreshold, setEdgeDetectNormalThreshold, setEdgeDetectDepthScale, setEdgeDetectNormalScale
+    setDoEdgeDetect, setEdgeDetectDepthThreshold, setEdgeDetectNormalThreshold, setEdgeDetectDepthScale, setEdgeDetectNormalScale, resetSceneSettings
 } from './store/sceneSettingsSlice';
-import { setEnableTimeCapsule, setMakeBackups, setMaxBackupCount, setModificationCountBackupThreshold } from './store/backupSettingsSlice';
+import { setEnableTimeCapsule, setMakeBackups, setMaxBackupCount, setModificationCountBackupThreshold, resetBackupSettings } from './store/backupSettingsSlice';
 import { 
     setNotificationContent, setActiveMap, setCootInitialized, setAppTittle, 
-    setUserPreferencesMounted, setDevMode, setTheme, setViewOnly
+    setUserPreferencesMounted, setDevMode, setTheme, setViewOnly, resetGeneralStates
  } from './store/generalStatesSlice';
 import { addMap, addMapList, removeMap, emptyMaps } from "./store/mapsSlice";
-import { setCursorStyle, setEnableAtomHovering, setHoveredAtom } from './store/hoveringStatesSlice';
-import { addAvailableFontList, setAtomLabelDepthMode, setGLLabelsFontFamily, setGLLabelsFontSize } from './store/labelSettingsSlice';
+import { setCursorStyle, setEnableAtomHovering, setHoveredAtom, resetHoveringStates } from './store/hoveringStatesSlice';
+import { addAvailableFontList, setAtomLabelDepthMode, setGLLabelsFontFamily, setGLLabelsFontSize, resetLabelSettings } from './store/labelSettingsSlice';
 import { 
     showMap, hideMap, setPositiveMapColours, setNegativeMapColours, setMapAlpha, setMapColours, setMapRadius, 
-    setMapStyle, setDefaultMapSamplingRate, setDefaultMapLitLines, setMapLineWidth, setDefaultMapSurface, setContourLevel
+    setMapStyle, setDefaultMapSamplingRate, setDefaultMapLitLines, setMapLineWidth, setDefaultMapSurface, setContourLevel, resetMapContourSettings
 } from './store/mapContourSettingsSlice';
-import { setDefaultExpandDisplayCards, setTransparentModalsOnMouseOut } from './store/miscAppSettingsSlice';
-import { setEnableRefineAfterMod, setUseRamaRefinementRestraints, setuseTorsionRefinementRestraints, setAnimateRefine } from './store/refinementSettingsSlice';
+import { setDefaultExpandDisplayCards, setTransparentModalsOnMouseOut, resetMiscAppSettings } from './store/miscAppSettingsSlice';
+import { setEnableRefineAfterMod, setUseRamaRefinementRestraints, setuseTorsionRefinementRestraints, setAnimateRefine, resetRefinementSettings } from './store/refinementSettingsSlice';
 import { addMolecule, removeMolecule, emptyMolecules, addMoleculeList, showMolecule, hideMolecule, addCustomRepresentation, removeCustomRepresentation } from './store/moleculesSlice';
-import { setContourWheelSensitivityFactor, setZoomWheelSensitivityFactor, setMouseSensitivity } from './store/mouseSettings';
-import { setShowShortcutToast, setShortcutOnHoveredAtom, setShortCuts } from './store/shortCutsSlice';
-import { setShowScoresToast, addMapUpdatingScore, removeMapUpdatingScore, overwriteMapUpdatingScores } from './store/moleculeMapUpdateSlice'
+import { setContourWheelSensitivityFactor, setZoomWheelSensitivityFactor, setMouseSensitivity, resetDefaultMouseSettings } from './store/mouseSettings';
+import { setShowShortcutToast, setShortcutOnHoveredAtom, setShortCuts, resetShortcutSettings } from './store/shortCutsSlice';
+import { setShowScoresToast, addMapUpdatingScore, removeMapUpdatingScore, overwriteMapUpdatingScores, resetMoleculeMapUpdates } from './store/moleculeMapUpdateSlice'
+import { resetActiveModals, focusOnModal, unFocusModal } from './store/activeModalsSlice'
+import { resetActivePopUps } from './store/activePopUpsSlice'
+import { resetSharedSession } from './store/sharedSessionSlice'
 import moleculesReducer from './store/moleculesSlice'
 import mapsReducer from './store/mapsSlice'
 import mouseSettingsReducer from './store/mouseSettings'
@@ -81,5 +84,8 @@ export {
     loadSessionData, loadSessionFromProtoMessage, moleculesReducer, mapsReducer, mouseSettingsReducer, backupSettingsReducer,
     shortcutSettingsReducer, labelSettingsReducer, sceneSettingsReducer, miscAppSettingsReducer, generalStatesReducer,
     activeModalsReducer, hoveringStatesReducer, activePopUpsReducer, mapContourSettingsReducer, moleculeMapUpdateReducer,
-    sharedSessionReducer, refinementSettingsReducer
+    sharedSessionReducer, refinementSettingsReducer, resetSceneSettings, resetBackupSettings, resetDefaultMouseSettings, 
+    resetGeneralStates, resetHoveringStates, resetLabelSettings, resetMapContourSettings, resetMiscAppSettings, resetMoleculeMapUpdates,
+    resetRefinementSettings, resetShortcutSettings, resetActiveModals, focusOnModal, unFocusModal, resetActivePopUps,
+    resetSharedSession
 };

--- a/baby-gru/src/store/activeModalsSlice.ts
+++ b/baby-gru/src/store/activeModalsSlice.ts
@@ -1,30 +1,35 @@
 import { createSlice } from '@reduxjs/toolkit'
 
+const initialState = {
+  showModelsModal: false,
+  showMapsModal: false,
+  showCreateAcedrgLinkModal: false,
+  showQuerySequenceModal: false,
+  showScriptingModal: false,
+  showControlsModal: false,
+  showFitLigandModal: false,
+  showRamaPlotModal: false,
+  showDiffMapPeaksModal: false,
+  showValidationPlotModal: false,
+  showLigandValidationModal: false,
+  showCarbohydrateModal: false,
+  showPepFlipsValidationModal: false,
+  showFillPartialResValidationModal: false,
+  showUnmodelledBlobsModal: false,
+  showMmrrccModal: false,
+  showWaterValidationModal: false,
+  showSceneSettingsModal: false,
+  showSliceNDiceModal: false,
+  focusHierarchy: [],
+}
+
 export const activeModalsSlice = createSlice({
   name: 'activeModals',
-  initialState: {
-    showModelsModal: false,
-    showMapsModal: false,
-    showCreateAcedrgLinkModal: false,
-    showQuerySequenceModal: false,
-    showScriptingModal: false,
-    showControlsModal: false,
-    showFitLigandModal: false,
-    showRamaPlotModal: false,
-    showDiffMapPeaksModal: false,
-    showValidationPlotModal: false,
-    showLigandValidationModal: false,
-    showCarbohydrateModal: false,
-    showPepFlipsValidationModal: false,
-    showFillPartialResValidationModal: false,
-    showUnmodelledBlobsModal: false,
-    showMmrrccModal: false,
-    showWaterValidationModal: false,
-    showSceneSettingsModal: false,
-    showSliceNDiceModal: false,
-    focusHierarchy: [],
-  },
+  initialState: initialState,
   reducers: {
+    resetActiveModals: (state) => {
+      return initialState
+    },
     setShowSliceNDiceModal: (state, action: { payload: boolean, type: string }) => {
       return {...state, showSliceNDiceModal: action.payload }
     },
@@ -98,7 +103,7 @@ export const {
   setShowLigandValidationModal, setShowPepFlipsValidationModal, setShowMmrrccModal,
   setShowWaterValidationModal, setShowValidationPlotModal, setShowCarbohydrateValidationModal, 
   setShowUnmodelledBlobsModal, setShowDiffMapPeaksModal, setShowFillPartialResValidationModal, 
-  setShowSceneSettingsModal, setShowSliceNDiceModal
+  setShowSceneSettingsModal, setShowSliceNDiceModal, resetActiveModals
 } = activeModalsSlice.actions
 
 export default activeModalsSlice.reducer

--- a/baby-gru/src/store/activePopUpsSlice.ts
+++ b/baby-gru/src/store/activePopUpsSlice.ts
@@ -1,20 +1,25 @@
 import { createSlice } from '@reduxjs/toolkit'
 
+const initialState = {
+  goToResiduePopUp: {
+    show: false
+  },
+  matchingLigandPopUp: {
+    show: false,
+    refMolNo: null,
+    movingMolNo: null,
+    refLigandCid: null,
+    movingLigandCid: null
+  }
+}
+
 export const activePopUpsSlice = createSlice({
   name: 'activePopUps',
-  initialState: {
-    goToResiduePopUp: {
-      show: false
-    },
-    matchingLigandPopUp: {
-      show: false,
-      refMolNo: null,
-      movingMolNo: null,
-      refLigandCid: null,
-      movingLigandCid: null
-    }
-  },
+  initialState: initialState,
   reducers: {
+    resetActivePopUps: (state) => {
+      return initialState
+    },
     setShowGoToResiduePopUp: (state, action: { payload: boolean, type: string }) => {
       return {...state, goToResiduePopUp: {...state.goToResiduePopUp, show: action.payload} }
     },
@@ -44,7 +49,7 @@ export const activePopUpsSlice = createSlice({
 
 export const {
     setShowAcceptMatchingLigandPopUp, setMatchinLigandPopUpParams, hideAcceptMatchingLigandPopUp,
-    showGoToResiduePopUp, hideGoToResiduePopUp, setShowGoToResiduePopUp
+    showGoToResiduePopUp, hideGoToResiduePopUp, setShowGoToResiduePopUp, resetActivePopUps
 } = activePopUpsSlice.actions
 
 export default activePopUpsSlice.reducer

--- a/baby-gru/src/store/backupSettingsSlice.ts
+++ b/baby-gru/src/store/backupSettingsSlice.ts
@@ -1,14 +1,19 @@
 import { createSlice } from '@reduxjs/toolkit'
 
+const initialState = {
+  enableTimeCapsule: null,
+  makeBackups: null,
+  maxBackupCount: null,
+  modificationCountBackupThreshold: null
+}
+
 export const backupSettingsSlice = createSlice({
   name: 'backupSettings',
-  initialState: {
-    enableTimeCapsule: null,
-    makeBackups: null,
-    maxBackupCount: null,
-    modificationCountBackupThreshold: null
-  },
+  initialState: initialState,
   reducers: {
+    resetBackupSettings: (state) => {
+      return initialState
+    },
     setEnableTimeCapsule: (state, action: {payload: boolean, type: string}) => {
       return {...state, enableTimeCapsule: action.payload}
     },
@@ -23,6 +28,8 @@ export const backupSettingsSlice = createSlice({
     }
 }})
 
-export const { setEnableTimeCapsule, setMakeBackups, setMaxBackupCount, setModificationCountBackupThreshold } = backupSettingsSlice.actions
+export const { 
+  setEnableTimeCapsule, setMakeBackups, setMaxBackupCount, setModificationCountBackupThreshold, resetBackupSettings
+ } = backupSettingsSlice.actions
 
 export default backupSettingsSlice.reducer

--- a/baby-gru/src/store/generalStatesSlice.ts
+++ b/baby-gru/src/store/generalStatesSlice.ts
@@ -1,29 +1,34 @@
 import { createSlice } from '@reduxjs/toolkit'
 import { moorhen } from '../types/moorhen'
 
+const initialState = {
+  devMode: null,
+  userPreferencesMounted: false,
+  appTitle: 'Moorhen',
+  cootInitialized: false,
+  notificationContent: null,
+  activeMap: null,
+  theme: 'flatly',
+  viewOnly: false,
+  residueSelection: { molecule: null, first: null, second: null, cid: null, isMultiCid: false, label: null } as moorhen.ResidueSelection,
+  showResidueSelection: false,
+  isAnimatingTrajectory: false,
+  isChangingRotamers: false,
+  isDraggingAtoms: false,
+  isRotatingAtoms: false,
+  newCootCommandExit: false,
+  newCootCommandStart: false,
+  useRamaRefinementRestraints: false,
+  useTorsionRefinementRestraints: false,
+}
+
 export const generalStatesSlice = createSlice({
   name: 'generalStates',
-  initialState: {
-    devMode: null,
-    userPreferencesMounted: false,
-    appTitle: 'Moorhen',
-    cootInitialized: false,
-    notificationContent: null,
-    activeMap: null,
-    theme: 'flatly',
-    viewOnly: false,
-    residueSelection: { molecule: null, first: null, second: null, cid: null, isMultiCid: false, label: null } as moorhen.ResidueSelection,
-    showResidueSelection: false,
-    isAnimatingTrajectory: false,
-    isChangingRotamers: false,
-    isDraggingAtoms: false,
-    isRotatingAtoms: false,
-    newCootCommandExit: false,
-    newCootCommandStart: false,
-    useRamaRefinementRestraints: false,
-    useTorsionRefinementRestraints: false,
-  },
+  initialState: initialState,
   reducers: {
+    resetGeneralStates: (state) => {
+      return initialState
+    },
     setIsAnimatingTrajectory: (state, action: {payload: boolean, type: string}) => {
       return {...state, isAnimatingTrajectory: action.payload}
     },
@@ -100,6 +105,7 @@ export const {
   setMoleculeResidueSelection, setResidueSelection, setCidResidueSelection,
   setIsRotatingAtoms, setIsChangingRotamers, setShowResidueSelection,
   toggleCootCommandExit, toggleCootCommandStart, setIsAnimatingTrajectory,
+  resetGeneralStates
 } = generalStatesSlice.actions
 
 export default generalStatesSlice.reducer

--- a/baby-gru/src/store/hoveringStatesSlice.ts
+++ b/baby-gru/src/store/hoveringStatesSlice.ts
@@ -1,14 +1,19 @@
 import { createSlice } from '@reduxjs/toolkit'
 import { moorhen } from '../types/moorhen'
 
+const initialState = {
+  enableAtomHovering: true,
+  hoveredAtom: { molecule: null, cid: null } as moorhen.HoveredAtom,
+  cursorStyle: 'default'
+}
+
 export const hoveringStatesSlice = createSlice({
   name: 'hoveringStates',
-  initialState: {
-    enableAtomHovering: true,
-    hoveredAtom: { molecule: null, cid: null } as moorhen.HoveredAtom,
-    cursorStyle: 'default'
-  },
+  initialState: initialState,
   reducers: {
+    resetHoveringStates: (state) => {
+      return initialState
+    },
     setHoveredAtom: (state, action: {payload: moorhen.HoveredAtom, type: string}) => {
         return {...state, hoveredAtom: action.payload}
     },
@@ -20,6 +25,6 @@ export const hoveringStatesSlice = createSlice({
     },
 }})
 
-export const { setCursorStyle, setEnableAtomHovering, setHoveredAtom } = hoveringStatesSlice.actions
+export const { setCursorStyle, setEnableAtomHovering, setHoveredAtom, resetHoveringStates } = hoveringStatesSlice.actions
 
 export default hoveringStatesSlice.reducer

--- a/baby-gru/src/store/labelSettingsSlice.ts
+++ b/baby-gru/src/store/labelSettingsSlice.ts
@@ -1,14 +1,19 @@
 import { createSlice } from '@reduxjs/toolkit'
 
+const initialState = {
+  atomLabelDepthMode: null,
+  GLLabelsFontFamily: null,
+  GLLabelsFontSize: null,
+  availableFonts: []
+}
+
 export const labelSettingsSlice = createSlice({
   name: 'labelSettings',
-  initialState: {
-    atomLabelDepthMode: null,
-    GLLabelsFontFamily: null,
-    GLLabelsFontSize: null,
-    availableFonts: []
-  },
+  initialState: initialState,
   reducers: {
+    resetLabelSettings: (state) => {
+      return initialState
+    },
     addAvailableFont: (state, action: {payload: string, type: string}) => {
       return {...state, availableFonts: [...state.availableFonts, action.payload]}
     },
@@ -33,6 +38,6 @@ export const labelSettingsSlice = createSlice({
   }
 })
 
-export const { addAvailableFontList, setAtomLabelDepthMode, setGLLabelsFontFamily, setGLLabelsFontSize } = labelSettingsSlice.actions
+export const { addAvailableFontList, setAtomLabelDepthMode, setGLLabelsFontFamily, setGLLabelsFontSize, resetLabelSettings } = labelSettingsSlice.actions
 
 export default labelSettingsSlice.reducer

--- a/baby-gru/src/store/mapContourSettingsSlice.ts
+++ b/baby-gru/src/store/mapContourSettingsSlice.ts
@@ -1,24 +1,29 @@
 import { createSlice } from '@reduxjs/toolkit'
 import { moorhen } from "../types/moorhen"
 
+const initialState = {
+  visibleMaps: [],
+  contourLevels: [],
+  mapRadii: [],
+  mapStyles: [],
+  mapAlpha: [],
+  mapColours: [],
+  negativeMapColours: [],
+  positiveMapColours: [],
+  defaultMapSamplingRate: null,
+  defaultMapLitLines: null,
+  mapLineWidth: null,
+  defaultMapSurface: null,
+  reContourMapOnlyOnMouseUp: null
+}
+
 export const mapContourSettingsSlice = createSlice({
   name: 'mapContourSettings',
-  initialState: {
-    visibleMaps: [],
-    contourLevels: [],
-    mapRadii: [],
-    mapStyles: [],
-    mapAlpha: [],
-    mapColours: [],
-    negativeMapColours: [],
-    positiveMapColours: [],
-    defaultMapSamplingRate: null,
-    defaultMapLitLines: null,
-    mapLineWidth: null,
-    defaultMapSurface: null,
-    reContourMapOnlyOnMouseUp: null
-  },
+  initialState: initialState,
   reducers: {
+    resetMapContourSettings: (state) => {
+      return initialState
+    },
     setReContourMapOnlyOnMouseUp: (state, action: {payload: boolean, type: string}) => {
       state = { ...state, reContourMapOnlyOnMouseUp: action.payload }
       return state
@@ -88,7 +93,7 @@ export const {
   showMap, hideMap, setContourLevel, setMapRadius, setMapAlpha, setMapStyle, changeMapRadius,
   setDefaultMapSamplingRate, setDefaultMapLitLines, setMapLineWidth, setDefaultMapSurface,
   setMapColours, setNegativeMapColours, setPositiveMapColours, changeContourLevel,
-  setReContourMapOnlyOnMouseUp
+  setReContourMapOnlyOnMouseUp, resetMapContourSettings
 } = mapContourSettingsSlice.actions
 
 export default mapContourSettingsSlice.reducer

--- a/baby-gru/src/store/miscAppSettingsSlice.ts
+++ b/baby-gru/src/store/miscAppSettingsSlice.ts
@@ -1,12 +1,17 @@
 import { createSlice } from '@reduxjs/toolkit'
 
-export const miscAppSettings = createSlice({
+const initialState = {
+  defaultExpandDisplayCards: null,
+  transparentModalsOnMouseOut: null,
+}
+
+export const miscAppSettingsSlice = createSlice({
   name: 'miscAppSettings',
-  initialState: {
-    defaultExpandDisplayCards: null,
-    transparentModalsOnMouseOut: null,
-  },
+  initialState: initialState,
   reducers: {
+    resetMiscAppSettings: (state) => {
+      return initialState
+    },
     setDefaultExpandDisplayCards: (state, action: {payload: boolean, type: string}) => {
       return {...state, defaultExpandDisplayCards: action.payload}
     },
@@ -16,7 +21,7 @@ export const miscAppSettings = createSlice({
 }})
 
 export const { 
-  setDefaultExpandDisplayCards, setTransparentModalsOnMouseOut, 
-} = miscAppSettings.actions
+  setDefaultExpandDisplayCards, setTransparentModalsOnMouseOut, resetMiscAppSettings
+} = miscAppSettingsSlice.actions
 
-export default miscAppSettings.reducer
+export default miscAppSettingsSlice.reducer

--- a/baby-gru/src/store/moleculeMapUpdateSlice.ts
+++ b/baby-gru/src/store/moleculeMapUpdateSlice.ts
@@ -1,9 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit'
 import { moorhen } from '../types/moorhen'
 
-export const moleculeMapUpdateSlice = createSlice({
-  name: 'moleculeMapUpdateSlice',
-  initialState: {
+const initialState = {
     updatingMapsIsEnabled: false,
     connectedMolecule: null,
     reflectionMap: null,
@@ -13,8 +11,15 @@ export const moleculeMapUpdateSlice = createSlice({
     defaultUpdatingScores: null,
     showScoresToast: null,
     moleculeUpdate: { switch: false, molNo: null },
-  },
+}
+
+export const moleculeMapUpdateSlice = createSlice({
+  name: 'moleculeMapUpdateSlice',
+  initialState: initialState,
   reducers: {
+    resetMoleculeMapUpdates: (state) => {
+        return initialState
+    },
     triggerUpdate: (state, action: {payload: number, type: string}) => {
         return {
             ...state, 
@@ -102,7 +107,7 @@ export const {
     setConnectedMolecule, enableUpdatingMaps, disableUpdatingMaps, setReflectionMap,
     setFoFcMap, setTwoFoFcMap, setReflectionMapMolNo, overwriteMapUpdatingScores,
     setConnectedMoleculeMolNo, setFoFcMapMolNo, setTwoFoFcMapMolNo, removeMapUpdatingScore,
-    setShowScoresToast, addMapUpdatingScore, triggerUpdate
+    setShowScoresToast, addMapUpdatingScore, triggerUpdate, resetMoleculeMapUpdates
 } = moleculeMapUpdateSlice.actions
 
 export default moleculeMapUpdateSlice.reducer

--- a/baby-gru/src/store/moleculesSlice.ts
+++ b/baby-gru/src/store/moleculesSlice.ts
@@ -1,13 +1,15 @@
 import { createSlice } from '@reduxjs/toolkit'
 import { moorhen } from "../types/moorhen"
 
+const initialState = {
+  visibleMolecules: [],
+  customRepresentations: [],
+  moleculeList: [],
+}
+
 export const moleculesSlice = createSlice({
   name: 'molecules',
-  initialState: {
-    visibleMolecules: [],
-    customRepresentations: [],
-    moleculeList: [],
-  },
+  initialState: initialState,
   reducers: {
     addMolecule: (state, action: {payload: moorhen.Molecule, type: string}) => {
       state = { ...state, moleculeList: [...state.moleculeList, action.payload] }
@@ -23,12 +25,7 @@ export const moleculesSlice = createSlice({
       return state
     },
     emptyMolecules: (state) => {
-      state = {
-        visibleMolecules: [],
-        customRepresentations: [],
-        moleculeList: [],
-      }
-      return state
+      return initialState
     },
     addMoleculeList: (state, action: {payload: moorhen.Molecule[], type: string}) => {
       state = { ...state, moleculeList: [...state.moleculeList, ...action.payload] }

--- a/baby-gru/src/store/mouseSettings.ts
+++ b/baby-gru/src/store/mouseSettings.ts
@@ -1,13 +1,18 @@
 import { createSlice } from '@reduxjs/toolkit'
 
+const initialState = {
+  zoomWheelSensitivityFactor: null,
+  mouseSensitivity: null,
+  contourWheelSensitivityFactor: null
+}
+
 export const defaultMouseSettingsSlice = createSlice({
   name: 'mouseSettings',
-  initialState: {
-    zoomWheelSensitivityFactor: null,
-    mouseSensitivity: null,
-    contourWheelSensitivityFactor: null
-  },
+  initialState: initialState,
   reducers: {
+    resetDefaultMouseSettings: (state) => {
+      return initialState
+    },
     setZoomWheelSensitivityFactor: (state, action: {payload: number, type: string}) => {
       return {...state, zoomWheelSensitivityFactor: action.payload}
     },
@@ -19,6 +24,6 @@ export const defaultMouseSettingsSlice = createSlice({
     }
 }})
 
-export const { setContourWheelSensitivityFactor, setZoomWheelSensitivityFactor, setMouseSensitivity } = defaultMouseSettingsSlice.actions
+export const { setContourWheelSensitivityFactor, setZoomWheelSensitivityFactor, setMouseSensitivity, resetDefaultMouseSettings } = defaultMouseSettingsSlice.actions
 
 export default defaultMouseSettingsSlice.reducer

--- a/baby-gru/src/store/refinementSettingsSlice.ts
+++ b/baby-gru/src/store/refinementSettingsSlice.ts
@@ -1,15 +1,20 @@
 import { createSlice } from '@reduxjs/toolkit'
 
+const initialState = {
+  enableRefineAfterMod: null,
+  animateRefine: null,
+  useRamaRefinementRestraints: false,
+  useTorsionRefinementRestraints: false,
+  refinementSelection: 'TRIPLE',
+}
+
 export const refinementSettings = createSlice({
   name: 'refinementSettings',
-  initialState: {
-    enableRefineAfterMod: null,
-    animateRefine: null,
-    useRamaRefinementRestraints: false,
-    useTorsionRefinementRestraints: false,
-    refinementSelection: 'TRIPLE',
-  },
+  initialState: initialState,
   reducers: {
+    resetRefinementSettings: (state) => {
+      return initialState
+    },
     setRefinementSelection: (state, action: {payload: 'SINGLE' | 'TRIPLE' | 'SPHERE', type: string}) => {
       return {...state, refinementSelection: action.payload}
     },
@@ -29,7 +34,7 @@ export const refinementSettings = createSlice({
 
 export const { 
   setAnimateRefine, setEnableRefineAfterMod, setUseRamaRefinementRestraints, 
-  setuseTorsionRefinementRestraints, setRefinementSelection
+  setuseTorsionRefinementRestraints, setRefinementSelection, resetRefinementSettings
 } = refinementSettings.actions
 
 export default refinementSettings.reducer

--- a/baby-gru/src/store/sceneSettingsSlice.ts
+++ b/baby-gru/src/store/sceneSettingsSlice.ts
@@ -1,8 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit'
 
-export const sceneSettingsSlice = createSlice({
-  name: 'sceneSettings',
-  initialState: {
+const initialState = {
     defaultBackgroundColor: null,
     drawScaleBar: null,
     drawCrosshairs: null,
@@ -33,8 +31,15 @@ export const sceneSettingsSlice = createSlice({
     width: 0,
     isDark: false,
     backgroundColor: [1, 1, 1, 1],
-  },
+}
+
+export const sceneSettingsSlice = createSlice({
+  name: 'sceneSettings',
+  initialState: initialState,
   reducers: {
+    resetSceneSettings: (state) => {
+        return initialState
+    },
     setDefaultBackgroundColor: (state, action: {payload: [number, number, number, number], type: string}) => {
         return {...state, defaultBackgroundColor: action.payload}
     },
@@ -132,7 +137,8 @@ export const {
     setDrawInteractions, setDoSSAO, setSsaoRadius, setSsaoBias, setResetClippingFogging, setClipCap,  
     setUseOffScreenBuffers, setDoShadowDepthDebug, setDoShadow, setDoSpin, setDoOutline, setDepthBlurRadius,
     setDepthBlurDepth, setDrawAxes, setDoPerspectiveProjection, setHeight, setWidth, setIsDark, setBackgroundColor,
-    setDoEdgeDetect, setEdgeDetectDepthThreshold, setEdgeDetectNormalThreshold, setEdgeDetectDepthScale, setEdgeDetectNormalScale
+    setDoEdgeDetect, setEdgeDetectDepthThreshold, setEdgeDetectNormalThreshold, setEdgeDetectDepthScale, setEdgeDetectNormalScale,
+    resetSceneSettings
 } = sceneSettingsSlice.actions
 
 export default sceneSettingsSlice.reducer

--- a/baby-gru/src/store/sharedSessionSlice.ts
+++ b/baby-gru/src/store/sharedSessionSlice.ts
@@ -1,13 +1,18 @@
 import { createSlice } from '@reduxjs/toolkit'
 
+const initialState = {
+  isInSharedSession: false,
+  sharedSessionToken: null,
+  showSharedSessionManager: false,
+}
+
 export const sharedSessionSlice = createSlice({
   name: 'sharedSession',
-  initialState: {
-    isInSharedSession: false,
-    sharedSessionToken: null,
-    showSharedSessionManager: false,
-  },
+  initialState: initialState,
   reducers: {
+    resetSharedSession: (state) => {
+      return initialState
+    },
     setIsInSharedSession: (state, action: { payload: boolean, type: string }) => {
         return {...state, isInSharedSession: action.payload }
     },
@@ -21,7 +26,7 @@ export const sharedSessionSlice = createSlice({
 })
 
 export const {
-  setIsInSharedSession, setSharedSessionToken, setShowSharedSessionManager
+  setIsInSharedSession, setSharedSessionToken, setShowSharedSessionManager, resetSharedSession
 } = sharedSessionSlice.actions
 
 export default sharedSessionSlice.reducer

--- a/baby-gru/src/store/shortCutsSlice.ts
+++ b/baby-gru/src/store/shortCutsSlice.ts
@@ -1,13 +1,18 @@
 import { createSlice } from '@reduxjs/toolkit'
 
+const initialState = {
+  shortcutOnHoveredAtom: null,
+  showShortcutToast: null,
+  shortCuts: null,
+}
+
 export const shortcutSettingsSlice = createSlice({
   name: 'shortcutSettings',
-  initialState: {
-    shortcutOnHoveredAtom: null,
-    showShortcutToast: null,
-    shortCuts: null,
-  },
+  initialState: initialState,
   reducers: {
+    resetShortcutSettings: (state) => {
+      return initialState
+    },
     setShortcutOnHoveredAtom: (state, action: {payload: boolean, type: string}) => {
       return {...state, shortcutOnHoveredAtom: action.payload}
     },
@@ -19,6 +24,6 @@ export const shortcutSettingsSlice = createSlice({
     }    
 }})
 
-export const { setShowShortcutToast, setShortcutOnHoveredAtom, setShortCuts } = shortcutSettingsSlice.actions
+export const { setShowShortcutToast, setShortcutOnHoveredAtom, setShortCuts, resetShortcutSettings } = shortcutSettingsSlice.actions
 
 export default shortcutSettingsSlice.reducer

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -654,4 +654,52 @@ declare module 'moorhen' {
 
     function addMapList(arg0: _moorhen.Map[]): any;
     module.exports = addMapList;
+
+    function resetSceneSettings(): any;
+    module.exports = resetSceneSettings;
+
+    function resetBackupSettings(): any;
+    module.exports = resetBackupSettings;
+    
+    function resetDefaultMouseSettings(): any;
+    module.exports = resetDefaultMouseSettings;
+    
+    function resetGeneralStates(): any;
+    module.exports = resetGeneralStates;
+    
+    function resetHoveringStates(): any;
+    module.exports = resetHoveringStates;
+    
+    function resetLabelSettings(): any;
+    module.exports = resetLabelSettings;
+    
+    function resetMapContourSettings(): any;
+    module.exports = resetMapContourSettings;
+    
+    function resetMiscAppSettings(): any;
+    module.exports = resetMiscAppSettings;
+    
+    function resetMoleculeMapUpdates(): any;
+    module.exports = resetMoleculeMapUpdates;
+    
+    function resetRefinementSettings(): any;
+    module.exports = resetRefinementSettings;
+    
+    function resetShortcutSettings(): any;
+    module.exports = resetShortcutSettings;
+    
+    function resetActiveModals(): any;
+    module.exports = resetActiveModals;
+    
+    function focusOnModal(): any;
+    module.exports = focusOnModal;
+    
+    function unFocusModal(): any;
+    module.exports = unFocusModal;
+    
+    function resetActivePopUps(): any;
+    module.exports = resetActivePopUps;
+    
+    function resetSharedSession(): any;
+    module.exports = resetSharedSession;
 }

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -168,7 +168,7 @@ declare module 'moorhen' {
     module.exports.MoorhenMoleculeRepresentation = MoorhenMoleculeRepresentation
 
     class MoorhenMolecule implements _moorhen.Molecule {
-        constructor(commandCentre: React.RefObject<_moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, monomerLibrary?: string, store?: any)
+        constructor(commandCentre: React.RefObject<_moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, store?: any, monomerLibrary?: string)
         transferLigandDicts(toMolecule: _moorhen.Molecule, override?: boolean): Promise<void>;
         minimizeEnergyUsingCidAnimated(cid: string, ncyc: number, nIterations: number, useRamaRestraints: boolean, ramaWeight: number, useTorsionRestraints: boolean, torsionWeight: number): Promise<void>;
         addColourRule(ruleType: string, cid: string, color: string, args: (string | number)[], isMultiColourRule?: boolean, applyColourToNonCarbonAtoms?: boolean, label?: string): void;

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -306,23 +306,14 @@ declare module 'moorhen' {
         getHistogram(nBins?: number, zoomFactor?: number): Promise<libcootApi.HistogramInfoJS>;
         setMapWeight(weight?: number): Promise<_moorhen.WorkerResponse>;
         estimateMapWeight(): Promise<void>;
-        fetchMapAlphaAndRedraw(): Promise<void>;
+        setMapAlphaAndRedraw(alpha: number): void;
         centreOnMap(): Promise<void>;
         getSuggestedSettings(): Promise<void>;
         copyMap(): Promise<_moorhen.Map>;
         hideMapContour(): void;
         drawMapContour(): Promise<void>;
-        getMapContourParams(): { 
-            mapRadius: number; 
-            contourLevel: number; 
-            mapAlpha: number; 
-            mapStyle: "lines" | "solid" | "lit-lines"; 
-            mapColour: {r: number; g: number; b: number}; 
-            positiveMapColour: {r: number; g: number; b: number}; 
-            negativeMapColour: {r: number; g: number; b: number}
-        };
-        fetchColourAndRedraw(): Promise<void> ;
-        fetchDiffMapColourAndRedraw(type: 'positiveDiffColour' | 'negativeDiffColour'): Promise<void> ;
+        setColourAndRedraw(mapColour: {r: number, g: number, b: number}): void;
+        setDiffMapColourAndRedraw(type: 'positiveDiffColour' | 'negativeDiffColour', mapColour: {r: number, g: number, b: number}): void;
         fetchMapRmsd(): Promise<number>;
         fetchSuggestedLevel(): Promise<number>;
         fetchMapCentre(): Promise<[number, number, number]>;
@@ -357,9 +348,15 @@ declare module 'moorhen' {
         otherMapForColouring: {molNo: number, min: number, max: number};
         mapRmsd: number;
         suggestedMapWeight: number;
-        defaultMapColour: {r: number, g: number, b: number};
-        defaultPositiveMapColour: {r: number, g: number, b: number};
-        defaultNegativeMapColour: {r: number, g: number, b: number};
+        contourParams: { 
+            mapRadius: number; 
+            contourLevel: number; 
+            mapAlpha: number; 
+            mapStyle: "lines" | "solid" | "lit-lines"; 
+            mapColour: {r: number; g: number; b: number}; 
+            positiveMapColour: {r: number; g: number; b: number}; 
+            negativeMapColour: {r: number; g: number; b: number}
+        };    
     }
     module.exports.MoorhenMap = MoorhenMap
 

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -306,14 +306,23 @@ declare module 'moorhen' {
         getHistogram(nBins?: number, zoomFactor?: number): Promise<libcootApi.HistogramInfoJS>;
         setMapWeight(weight?: number): Promise<_moorhen.WorkerResponse>;
         estimateMapWeight(): Promise<void>;
-        setMapAlphaAndRedraw(alpha: number): void;
+        fetchMapAlphaAndRedraw(): Promise<void>;
         centreOnMap(): Promise<void>;
         getSuggestedSettings(): Promise<void>;
         copyMap(): Promise<_moorhen.Map>;
         hideMapContour(): void;
         drawMapContour(): Promise<void>;
-        setColourAndRedraw(mapColour: {r: number, g: number, b: number}): void;
-        setDiffMapColourAndRedraw(type: 'positiveDiffColour' | 'negativeDiffColour', mapColour: {r: number, g: number, b: number}): void;
+        getMapContourParams(): { 
+            mapRadius: number; 
+            contourLevel: number; 
+            mapAlpha: number; 
+            mapStyle: "lines" | "solid" | "lit-lines"; 
+            mapColour: {r: number; g: number; b: number}; 
+            positiveMapColour: {r: number; g: number; b: number}; 
+            negativeMapColour: {r: number; g: number; b: number}
+        };
+        fetchColourAndRedraw(): Promise<void> ;
+        fetchDiffMapColourAndRedraw(type: 'positiveDiffColour' | 'negativeDiffColour'): Promise<void> ;
         fetchMapRmsd(): Promise<number>;
         fetchSuggestedLevel(): Promise<number>;
         fetchMapCentre(): Promise<[number, number, number]>;
@@ -348,15 +357,9 @@ declare module 'moorhen' {
         otherMapForColouring: {molNo: number, min: number, max: number};
         mapRmsd: number;
         suggestedMapWeight: number;
-        contourParams: { 
-            mapRadius: number; 
-            contourLevel: number; 
-            mapAlpha: number; 
-            mapStyle: "lines" | "solid" | "lit-lines"; 
-            mapColour: {r: number; g: number; b: number}; 
-            positiveMapColour: {r: number; g: number; b: number}; 
-            negativeMapColour: {r: number; g: number; b: number}
-        };    
+        defaultMapColour: {r: number, g: number, b: number};
+        defaultPositiveMapColour: {r: number, g: number, b: number};
+        defaultNegativeMapColour: {r: number, g: number, b: number};
     }
     module.exports.MoorhenMap = MoorhenMap
 

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -168,7 +168,7 @@ declare module 'moorhen' {
     module.exports.MoorhenMoleculeRepresentation = MoorhenMoleculeRepresentation
 
     class MoorhenMolecule implements _moorhen.Molecule {
-        constructor(commandCentre: React.RefObject<_moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, monomerLibrary: string)
+        constructor(commandCentre: React.RefObject<_moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, monomerLibrary?: string, store?: any)
         transferLigandDicts(toMolecule: _moorhen.Molecule, override?: boolean): Promise<void>;
         minimizeEnergyUsingCidAnimated(cid: string, ncyc: number, nIterations: number, useRamaRestraints: boolean, ramaWeight: number, useTorsionRestraints: boolean, torsionWeight: number): Promise<void>;
         addColourRule(ruleType: string, cid: string, color: string, args: (string | number)[], isMultiColourRule?: boolean, applyColourToNonCarbonAtoms?: boolean, label?: string): void;
@@ -259,6 +259,7 @@ declare module 'moorhen' {
         excludedCids: string[];
         commandCentre: React.RefObject<_moorhen.CommandCentre>;
         glRef: React.RefObject<webGL.MGWebGL>;
+        store: any;
         atomsDirty: boolean;
         name: string;
         molNo: number;
@@ -301,7 +302,7 @@ declare module 'moorhen' {
     module.exports.MoorhenMolecule = MoorhenMolecule
     
     class MoorhenMap implements _moorhen.Map {
-        constructor(commandCentre: React.RefObject<_moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>)
+        constructor(commandCentre: React.RefObject<_moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, store?: any)
         exportAsGltf(): Promise<ArrayBuffer>;
         getHistogram(nBins?: number, zoomFactor?: number): Promise<libcootApi.HistogramInfoJS>;
         setMapWeight(weight?: number): Promise<_moorhen.WorkerResponse>;
@@ -337,6 +338,7 @@ declare module 'moorhen' {
         setActive(): Promise<void>;
         setupContourBuffers(objects: any[], keepCootColours?: boolean): void;
         setOtherMapForColouring(molNo: number, min?: number, max?: number): void;
+        store: any;
         isEM: boolean;
         suggestedContourLevel: number;
         suggestedRadius: number;
@@ -371,6 +373,7 @@ declare module 'moorhen' {
         commandCentre: React.RefObject<_moorhen.CommandCentre>,
         timeCapsuleRef: React.RefObject<_moorhen.TimeCapsule>,
         glRef: React.RefObject<webGL.MGWebGL>,
+        store: any,
         dispatch: (reduxStoreAction: any) => void,
     ): Promise<number>;
     module.exports = loadSessionFromJsonString;
@@ -383,6 +386,7 @@ declare module 'moorhen' {
         commandCentre: React.RefObject<_moorhen.CommandCentre>,
         timeCapsuleRef: React.RefObject<_moorhen.TimeCapsule>,
         glRef: React.RefObject<webGL.MGWebGL>,
+        store: any,
         dispatch: (reduxStoreAction: any) => void,
     ): Promise<number>;
     module.exports = loadSessionFromProtoMessage;
@@ -396,6 +400,7 @@ declare module 'moorhen' {
         commandCentre: React.RefObject<_moorhen.CommandCentre>,
         timeCapsuleRef: React.RefObject<_moorhen.TimeCapsule>,
         glRef: React.RefObject<webGL.MGWebGL>,
+        store: any,
         dispatch: (reduxStoreAction: any) => void,
     ): Promise<number>;
     module.exports = loadSessionData;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -475,7 +475,6 @@ export namespace moorhen {
         mapRmsd: number;
         suggestedMapWeight: number;
         contourParams: { 
-            isVisible: boolean;
             mapRadius: number; 
             contourLevel: number; 
             mapAlpha: number; 

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -431,23 +431,14 @@ export namespace moorhen {
         getHistogram(nBins?: number, zoomFactor?: number): Promise<libcootApi.HistogramInfoJS>;
         setMapWeight(weight?: number): Promise<WorkerResponse>;
         estimateMapWeight(): Promise<void>;
-        fetchMapAlphaAndRedraw(): Promise<void>;
+        setMapAlphaAndRedraw(alpha: number): void;
         centreOnMap(): Promise<void>;
         getSuggestedSettings(): Promise<void>;
         copyMap(): Promise<Map>;
-        getMapContourParams(): { 
-            mapRadius: number; 
-            contourLevel: number; 
-            mapAlpha: number; 
-            mapStyle: "lines" | "solid" | "lit-lines"; 
-            mapColour: {r: number; g: number; b: number}; 
-            positiveMapColour: {r: number; g: number; b: number}; 
-            negativeMapColour: {r: number; g: number; b: number}
-        };
         hideMapContour(): void;
         drawMapContour(): Promise<void>;
-        fetchColourAndRedraw(): Promise<void> ;
-        fetchDiffMapColourAndRedraw(type: 'positiveDiffColour' | 'negativeDiffColour'): Promise<void> ;
+        setColourAndRedraw(mapColour: {r: number, g: number, b: number}): void;
+        setDiffMapColourAndRedraw(type: 'positiveDiffColour' | 'negativeDiffColour', mapColour: {r: number, g: number, b: number}): void;
         fetchMapRmsd(): Promise<number>;
         fetchSuggestedLevel(): Promise<number>;
         fetchMapCentre(): Promise<[number, number, number]>;
@@ -483,9 +474,15 @@ export namespace moorhen {
         otherMapForColouring: {molNo: number, min: number, max: number};
         mapRmsd: number;
         suggestedMapWeight: number;
-        defaultMapColour: {r: number, g: number, b: number};
-        defaultPositiveMapColour: {r: number, g: number, b: number};
-        defaultNegativeMapColour: {r: number, g: number, b: number};
+        contourParams: { 
+            mapRadius: number; 
+            contourLevel: number; 
+            mapAlpha: number; 
+            mapStyle: "lines" | "solid" | "lit-lines"; 
+            mapColour: {r: number; g: number; b: number}; 
+            positiveMapColour: {r: number; g: number; b: number}; 
+            negativeMapColour: {r: number; g: number; b: number}
+        };    
     }
     
     interface backupKey {

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -475,6 +475,7 @@ export namespace moorhen {
         mapRmsd: number;
         suggestedMapWeight: number;
         contourParams: { 
+            isVisible: boolean;
             mapRadius: number; 
             contourLevel: number; 
             mapAlpha: number; 

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -431,14 +431,23 @@ export namespace moorhen {
         getHistogram(nBins?: number, zoomFactor?: number): Promise<libcootApi.HistogramInfoJS>;
         setMapWeight(weight?: number): Promise<WorkerResponse>;
         estimateMapWeight(): Promise<void>;
-        setMapAlphaAndRedraw(alpha: number): void;
+        fetchMapAlphaAndRedraw(): Promise<void>;
         centreOnMap(): Promise<void>;
         getSuggestedSettings(): Promise<void>;
         copyMap(): Promise<Map>;
+        getMapContourParams(): { 
+            mapRadius: number; 
+            contourLevel: number; 
+            mapAlpha: number; 
+            mapStyle: "lines" | "solid" | "lit-lines"; 
+            mapColour: {r: number; g: number; b: number}; 
+            positiveMapColour: {r: number; g: number; b: number}; 
+            negativeMapColour: {r: number; g: number; b: number}
+        };
         hideMapContour(): void;
         drawMapContour(): Promise<void>;
-        setColourAndRedraw(mapColour: {r: number, g: number, b: number}): void;
-        setDiffMapColourAndRedraw(type: 'positiveDiffColour' | 'negativeDiffColour', mapColour: {r: number, g: number, b: number}): void;
+        fetchColourAndRedraw(): Promise<void> ;
+        fetchDiffMapColourAndRedraw(type: 'positiveDiffColour' | 'negativeDiffColour'): Promise<void> ;
         fetchMapRmsd(): Promise<number>;
         fetchSuggestedLevel(): Promise<number>;
         fetchMapCentre(): Promise<[number, number, number]>;
@@ -474,15 +483,9 @@ export namespace moorhen {
         otherMapForColouring: {molNo: number, min: number, max: number};
         mapRmsd: number;
         suggestedMapWeight: number;
-        contourParams: { 
-            mapRadius: number; 
-            contourLevel: number; 
-            mapAlpha: number; 
-            mapStyle: "lines" | "solid" | "lit-lines"; 
-            mapColour: {r: number; g: number; b: number}; 
-            positiveMapColour: {r: number; g: number; b: number}; 
-            negativeMapColour: {r: number; g: number; b: number}
-        };    
+        defaultMapColour: {r: number, g: number, b: number};
+        defaultPositiveMapColour: {r: number, g: number, b: number};
+        defaultNegativeMapColour: {r: number, g: number, b: number};
     }
     
     interface backupKey {

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -3,6 +3,7 @@ import { emscriptem } from "./emscriptem";
 import { gemmi } from "./gemmi";
 import { webGL } from "./mgWebGL";
 import { MoorhenMolecule } from "../moorhen";
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore";
 
 export namespace moorhen {
 
@@ -212,6 +213,7 @@ export namespace moorhen {
         excludedCids: string[];
         commandCentre: React.RefObject<CommandCentre>;
         glRef: React.RefObject<webGL.MGWebGL>;
+        store: ToolkitStore;
         atomsDirty: boolean;
         name: string;
         molNo: number;
@@ -463,6 +465,7 @@ export namespace moorhen {
         setupContourBuffers(objects: any[], keepCootColours?: boolean): void;
         setOtherMapForColouring(molNo: number, min?: number, max?: number): void;
         exportAsGltf(): Promise<ArrayBuffer>;
+        store: ToolkitStore;
         isEM: boolean;
         suggestedContourLevel: number;
         suggestedRadius: number;
@@ -584,6 +587,7 @@ export namespace moorhen {
         createBackup(keyString: string, sessionString: string): Promise<string>;
         fetchSession(includeAdditionalMapData: boolean): Promise<backupSession>;
         toggleDisableBackups(): void;
+        store: ToolkitStore;
         moleculesRef: React.RefObject<Molecule[]>;
         mapsRef: React.RefObject<Map[]>;
         glRef: React.RefObject<webGL.MGWebGL>;
@@ -811,7 +815,8 @@ export namespace moorhen {
         extraEditMenuItems: JSX.Element[];
         extraCalculateMenuItems: JSX.Element[];
         aceDRGInstance: AceDRGInstance | null; 
-        includeNavBarMenuNames: string[]
+        includeNavBarMenuNames: string[];
+        store: ToolkitStore;
     }
     
     interface ContainerProps extends Partial<ContainerRefs>, Partial<ContainerOptionalProps> { }

--- a/baby-gru/src/utils/MoorhenMap.ts
+++ b/baby-gru/src/utils/MoorhenMap.ts
@@ -3,7 +3,6 @@ import { moorhen } from "../types/moorhen";
 import { webGL } from "../types/mgWebGL";
 import { libcootApi } from "../types/libcoot";
 import pako from "pako"
-import MoorhenReduxStore from "../store/MoorhenReduxStore";
 
 const _DEFAULT_CONTOUR_LEVEL = 0.8
 const _DEFAULT_RADIUS = 13
@@ -66,9 +65,15 @@ export class MoorhenMap implements moorhen.Map {
     suggestedMapWeight: number
     otherMapForColouring: {molNo: number, min: number, max: number};
     diffMapColourBuffers: { positiveDiffColour: number[], negativeDiffColour: number[] }
-    defaultMapColour: {r: number, g: number, b: number};
-    defaultPositiveMapColour: {r: number, g: number, b: number};
-    defaultNegativeMapColour: {r: number, g: number, b: number};
+    contourParams: { 
+        mapRadius: number; 
+        contourLevel: number; 
+        mapAlpha: number; 
+        mapStyle: "lines" | "solid" | "lit-lines"; 
+        mapColour: {r: number; g: number; b: number}; 
+        positiveMapColour: {r: number; g: number; b: number}; 
+        negativeMapColour: {r: number; g: number; b: number}
+    }
 
     constructor(commandCentre: React.RefObject<moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>) {
         this.type = 'map'
@@ -92,9 +97,15 @@ export class MoorhenMap implements moorhen.Map {
         this.mapCentre = null
         this.otherMapForColouring = null
         this.diffMapColourBuffers = { positiveDiffColour: [], negativeDiffColour: [] }
-        this.defaultMapColour = _DEFAULT_MAP_COLOUR
-        this.defaultPositiveMapColour = _DEFAULT_POSITIVE_MAP_COLOUR
-        this.defaultNegativeMapColour = _DEFAULT_NEGATIVE_MAP_COLOUR
+        this.contourParams = {
+            mapRadius: _DEFAULT_RADIUS, 
+            contourLevel: _DEFAULT_CONTOUR_LEVEL,
+            mapAlpha: _DEFAULT_ALPHA,
+            mapStyle: _DEFAULT_STYLE,
+            mapColour: _DEFAULT_MAP_COLOUR,
+            negativeMapColour: _DEFAULT_NEGATIVE_MAP_COLOUR,
+            positiveMapColour:   _DEFAULT_POSITIVE_MAP_COLOUR,
+        }
     }
 
     /**
@@ -378,42 +389,10 @@ export class MoorhenMap implements moorhen.Map {
     }
 
     /**
-     * Get map contour parameters from the redux store
-     * @returns {object} A description of map contour parameters as described in the redux store
-     */
-    getMapContourParams(): { 
-        mapRadius: number; 
-        contourLevel: number; 
-        mapAlpha: number; 
-        mapStyle: "lines" | "solid" | "lit-lines"; 
-        mapColour: {r: number; g: number; b: number}; 
-        positiveMapColour: {r: number; g: number; b: number}; 
-        negativeMapColour: {r: number; g: number; b: number}
-    } {
-        const state = MoorhenReduxStore.getState()
-        const radius = state.mapContourSettings.mapRadii.find(item => item.molNo === this.molNo)?.radius
-        const level = state.mapContourSettings.contourLevels.find(item => item.molNo === this.molNo)?.contourLevel
-        const alpha = state.mapContourSettings.mapAlpha.find(item => item.molNo === this.molNo)?.alpha
-        const style = state.mapContourSettings.mapStyles.find(item => item.molNo === this.molNo)?.style
-        const mapColour = state.mapContourSettings.mapColours.find(item => item.molNo === this.molNo)?.rgb
-        const negativeMapColour = state.mapContourSettings.negativeMapColours.find(item => item.molNo === this.molNo)?.rgb
-        const positiveMapColour = state.mapContourSettings.positiveMapColours.find(item => item.molNo === this.molNo)?.rgb
-        return {
-            mapRadius: radius ? radius : _DEFAULT_RADIUS, 
-            contourLevel: level ? level : _DEFAULT_CONTOUR_LEVEL,
-            mapAlpha: alpha ? alpha : _DEFAULT_ALPHA,
-            mapStyle: style ? style : _DEFAULT_STYLE,
-            mapColour: mapColour ? {r: mapColour.r / 255., g: mapColour.g / 255., b: mapColour.b / 255.} : this.defaultMapColour,
-            negativeMapColour: negativeMapColour ? {r: negativeMapColour.r / 255., g: negativeMapColour.g / 255., b: negativeMapColour.b / 255.} : this.defaultNegativeMapColour,
-            positiveMapColour: positiveMapColour ? {r: positiveMapColour.r / 255., g: positiveMapColour.g / 255., b: positiveMapColour.b / 255.} : this.defaultPositiveMapColour  
-        }
-    }
-
-    /**
      * Contour the map with parameters from the redux store
      */
     drawMapContour(): Promise<void> {
-        const { mapRadius, contourLevel, mapStyle } = this.getMapContourParams()
+        const { mapRadius, contourLevel, mapStyle } = this.contourParams
         return this.doCootContour(...this.glRef.current.origin.map(coord => -coord) as [number, number, number], mapRadius, contourLevel, mapStyle)
     }
 
@@ -440,7 +419,7 @@ export class MoorhenMap implements moorhen.Map {
     }
 
     setupContourBuffers(objects: any[], keepCootColours: boolean = false) {
-        const { mapAlpha, mapColour, positiveMapColour, negativeMapColour } = this.getMapContourParams()
+        const { mapAlpha, mapColour, positiveMapColour, negativeMapColour } = this.contourParams
         const print_timing = false;
         const t1 = performance.now();
         try {
@@ -623,16 +602,21 @@ export class MoorhenMap implements moorhen.Map {
     /**
      * Fetch the colours for a difference map using values from redux store and redraw the map
      * @param {'positiveDiffColour' | 'negativeDiffColour'} type - Indicates whether the negative or positive colours will be set
-     * @returns {Promise<void>}
+     * @param {object} mapColour - The new colour for the difference map
      */
-    async fetchDiffMapColourAndRedraw(type: 'positiveDiffColour' | 'negativeDiffColour'): Promise<void> {
+    setDiffMapColourAndRedraw(type: 'positiveDiffColour' | 'negativeDiffColour', mapColour: {r: number, g: number, b: number}): void {
         if (!this.isDifference) {
-            console.error('Cannot use moorhen.Map.fetchDiffMapColourAndRedraw to change non-diff map colour. Use moorhen.Map.fetchColourAndRedraw instead...')
+            console.error('Cannot use moorhen.Map.setDiffMapColourAndRedraw to change non-diff map colour. Use moorhen.Map.setColourAndRedraw instead...')
             return
         }
         
-        const { mapAlpha, positiveMapColour, negativeMapColour } = this.getMapContourParams()
-        const mapColour = type === 'positiveDiffColour' ? positiveMapColour : negativeMapColour
+        if (type === 'positiveDiffColour') {
+            this.contourParams.positiveMapColour = mapColour
+        } else {
+            this.contourParams.negativeMapColour = mapColour
+        }
+
+        const { mapAlpha } = this.contourParams
        
         if (mapAlpha < 0.99) {
             this.displayObjects['Coot'].forEach((buffer, bufferIdx) => {
@@ -669,18 +653,21 @@ export class MoorhenMap implements moorhen.Map {
 
     /**
      * Set the colours for a non-difference map using values from redux store
+     * @param {object} mapColour - The new colour for the difference map
      */
-    async fetchColourAndRedraw(): Promise<void> {
+    setColourAndRedraw(mapColour: {r: number, g: number, b: number}): void {
         if (this.isDifference) {
-            console.error('Cannot use moorhen.Map.fetchColourAndRedraw to change difference map colour. Use moorhen.Map.fetchDiffMapColourAndRedraw instead...')
+            console.error('Cannot use moorhen.Map.setColourAndRedraw to change difference map colour. Use moorhen.Map.setDiffMapColourAndRedraw instead...')
             return
         }
+
+        this.contourParams.mapColour = mapColour
 
         if (this.otherMapForColouring !== null) {
             this.otherMapForColouring = null
         }
         
-        const { mapAlpha, mapColour } = this.getMapContourParams()
+        const { mapAlpha } = this.contourParams
         
         this.displayObjects['Coot'].forEach(buffer => {
             if (mapAlpha < 0.99) {
@@ -696,7 +683,7 @@ export class MoorhenMap implements moorhen.Map {
                 buffer.isDirty = true;
                 buffer.alphaChanged = true;
             } else {
-                buffer.setCustomColour([mapColour.r,mapColour.g,mapColour.b,1.0])
+                buffer.setCustomColour([mapColour.r, mapColour.g, mapColour.b, 1.0])
                 buffer.transparent = false
             }
         })
@@ -710,9 +697,11 @@ export class MoorhenMap implements moorhen.Map {
 
     /**
      * Fetch the map alpha (transparency) for this map using values from redux store and redraw the map
+     * @param {number} mapAlpha - The new map alpha
      */
-    async fetchMapAlphaAndRedraw(): Promise<void> {
-        const { mapAlpha, mapColour } = this.getMapContourParams()
+    setMapAlphaAndRedraw(mapAlpha: number): void {
+        this.contourParams.mapAlpha = mapAlpha
+        const { mapColour } = this.contourParams
         this.displayObjects['Coot'].forEach(buffer => {
             buffer.triangleColours.forEach(colbuffer => {
                 if (this.isDifference) {
@@ -809,7 +798,7 @@ export class MoorhenMap implements moorhen.Map {
         const reply = await this.getMap()
         const newMap = new MoorhenMap(this.commandCentre, this.glRef)
         await newMap.loadToCootFromMapData(reply.data.result.mapData, `Copy of ${this.name}`, this.isDifference)
-        const { mapRadius, contourLevel } = this.getMapContourParams()
+        const { mapRadius, contourLevel } = this.contourParams
         newMap.suggestedContourLevel = contourLevel
         newMap.suggestedRadius = mapRadius
         return newMap
@@ -997,7 +986,7 @@ export class MoorhenMap implements moorhen.Map {
             h -= 360
         }
         const [r, g, b] = hsvToRgb(h, s, v)
-        this.defaultMapColour = { r, g, b }
+        this.contourParams.mapColour = { r, g, b }
     }
 
     /**
@@ -1005,7 +994,7 @@ export class MoorhenMap implements moorhen.Map {
      * @returns {ArrayBuffer} - The contents of the gltf file (binary format)
      */
     async exportAsGltf(): Promise<ArrayBuffer> {
-        const { mapRadius, contourLevel } = this.getMapContourParams()
+        const { mapRadius, contourLevel } = this.contourParams
         const result = await this.commandCentre.current.cootCommand({
             returnType: "arrayBuffer",
             command: 'shim_export_map_as_gltf',

--- a/baby-gru/src/utils/MoorhenMap.ts
+++ b/baby-gru/src/utils/MoorhenMap.ts
@@ -669,8 +669,6 @@ export class MoorhenMap implements moorhen.Map {
 
     /**
      * Set the colours for a non-difference map using values from redux store
-     * @param {boolean} [redraw=true] - Indicates whether the map needs to be redrawn after setting the new colours
-     * @returns {Promise<void>}
      */
     async fetchColourAndRedraw(): Promise<void> {
         if (this.isDifference) {

--- a/baby-gru/src/utils/MoorhenMap.ts
+++ b/baby-gru/src/utils/MoorhenMap.ts
@@ -66,6 +66,7 @@ export class MoorhenMap implements moorhen.Map {
     otherMapForColouring: {molNo: number, min: number, max: number};
     diffMapColourBuffers: { positiveDiffColour: number[], negativeDiffColour: number[] }
     contourParams: { 
+        isVisible: boolean;
         mapRadius: number; 
         contourLevel: number; 
         mapAlpha: number; 
@@ -98,6 +99,7 @@ export class MoorhenMap implements moorhen.Map {
         this.otherMapForColouring = null
         this.diffMapColourBuffers = { positiveDiffColour: [], negativeDiffColour: [] }
         this.contourParams = {
+            isVisible: true,
             mapRadius: _DEFAULT_RADIUS, 
             contourLevel: _DEFAULT_CONTOUR_LEVEL,
             mapAlpha: _DEFAULT_ALPHA,

--- a/baby-gru/src/utils/MoorhenMap.ts
+++ b/baby-gru/src/utils/MoorhenMap.ts
@@ -4,6 +4,7 @@ import { webGL } from "../types/mgWebGL";
 import { libcootApi } from "../types/libcoot";
 import pako from "pako"
 import MoorhenReduxStore from "../store/MoorhenReduxStore";
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore";
 
 const _DEFAULT_CONTOUR_LEVEL = 0.8
 const _DEFAULT_RADIUS = 13
@@ -49,6 +50,7 @@ export class MoorhenMap implements moorhen.Map {
     name: string
     isEM: boolean
     molNo: number
+    store: ToolkitStore
     commandCentre: React.RefObject<moorhen.CommandCentre>
     glRef: React.RefObject<webGL.MGWebGL>
     mapCentre: [number, number, number]
@@ -70,13 +72,14 @@ export class MoorhenMap implements moorhen.Map {
     defaultPositiveMapColour: {r: number, g: number, b: number};
     defaultNegativeMapColour: {r: number, g: number, b: number};
 
-    constructor(commandCentre: React.RefObject<moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>) {
+    constructor(commandCentre: React.RefObject<moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, store: ToolkitStore = MoorhenReduxStore) {
         this.type = 'map'
         this.name = "unnamed"
         this.isEM = false
         this.molNo = null
         this.commandCentre = commandCentre
         this.glRef = glRef
+        this.store = store
         this.webMGContour = false
         this.showOnLoad = true
         this.displayObjects = { Coot: [] }
@@ -390,7 +393,7 @@ export class MoorhenMap implements moorhen.Map {
         positiveMapColour: {r: number; g: number; b: number}; 
         negativeMapColour: {r: number; g: number; b: number}
     } {
-        const state = MoorhenReduxStore.getState()
+        const state = this.store.getState()
         const radius = state.mapContourSettings.mapRadii.find(item => item.molNo === this.molNo)?.radius
         const level = state.mapContourSettings.contourLevels.find(item => item.molNo === this.molNo)?.contourLevel
         const alpha = state.mapContourSettings.mapAlpha.find(item => item.molNo === this.molNo)?.alpha
@@ -807,7 +810,7 @@ export class MoorhenMap implements moorhen.Map {
      */
     async copyMap(): Promise<moorhen.Map> {
         const reply = await this.getMap()
-        const newMap = new MoorhenMap(this.commandCentre, this.glRef)
+        const newMap = new MoorhenMap(this.commandCentre, this.glRef, this.store)
         await newMap.loadToCootFromMapData(reply.data.result.mapData, `Copy of ${this.name}`, this.isDifference)
         const { mapRadius, contourLevel } = this.getMapContourParams()
         newMap.suggestedContourLevel = contourLevel

--- a/baby-gru/src/utils/MoorhenMap.ts
+++ b/baby-gru/src/utils/MoorhenMap.ts
@@ -66,7 +66,6 @@ export class MoorhenMap implements moorhen.Map {
     otherMapForColouring: {molNo: number, min: number, max: number};
     diffMapColourBuffers: { positiveDiffColour: number[], negativeDiffColour: number[] }
     contourParams: { 
-        isVisible: boolean;
         mapRadius: number; 
         contourLevel: number; 
         mapAlpha: number; 
@@ -99,7 +98,6 @@ export class MoorhenMap implements moorhen.Map {
         this.otherMapForColouring = null
         this.diffMapColourBuffers = { positiveDiffColour: [], negativeDiffColour: [] }
         this.contourParams = {
-            isVisible: true,
             mapRadius: _DEFAULT_RADIUS, 
             contourLevel: _DEFAULT_CONTOUR_LEVEL,
             mapAlpha: _DEFAULT_ALPHA,

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -104,7 +104,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
     adaptativeBondsEnabled: boolean;
     store: ToolkitStore;
 
-    constructor(commandCentre: React.RefObject<moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, monomerLibraryPath = "./baby-gru/monomers", store: ToolkitStore = MoorhenReduxStore) {
+    constructor(commandCentre: React.RefObject<moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, store: ToolkitStore = MoorhenReduxStore, monomerLibraryPath = "./baby-gru/monomers") {
         this.type = 'molecule'
         this.commandCentre = commandCentre
         this.glRef = glRef
@@ -497,7 +497,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
      */
     async copyMolecule(): Promise<moorhen.Molecule> {
         let coordString = await this.getAtoms()
-        let newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath, this.store)
+        let newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.store, this.monomerLibraryPath)
         newMolecule.name = `${this.name}-placeholder`
         newMolecule.defaultBondOptions = this.defaultBondOptions
         newMolecule.coordsFormat = this.coordsFormat
@@ -533,7 +533,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
             command: "copy_fragment_using_cid",
             commandArgs: [this.molNo, cid],
         }, true) as moorhen.WorkerResponse<number>
-        const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath, this.store)
+        const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.store, this.monomerLibraryPath)
         newMolecule.name = `${this.name} fragment`
         newMolecule.molNo = response.data.result.result
         newMolecule.isDarkBackground = this.isDarkBackground
@@ -558,7 +558,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @returns {moorhen.Molecule} A new molecule instance that can be used for refinement
      */
     async copyFragmentForRefinement(cid: string[], refinementMap: moorhen.Map, redraw: boolean = true, redrawFragmentFirst: boolean = true): Promise<moorhen.Molecule> {
-        const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath, this.store)
+        const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.store, this.monomerLibraryPath)
         const copyResult = await this.commandCentre.current.cootCommand({
             returnType: 'int',
             command: 'copy_fragment_for_refinement_using_cid',
@@ -1556,7 +1556,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
             result = await getMonomer()
         }
         if (result.data.result.status === "Completed" && result.data.result.result !== -1) {
-            const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath, this.store)
+            const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.store, this.monomerLibraryPath)
             newMolecule.setAtomsDirty(true)
             newMolecule.molNo = result.data.result.result
             newMolecule.name = resType.toUpperCase()
@@ -2017,7 +2017,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         if (result.data.result.status === "Completed") {
             newMolecules = await Promise.all(
                 result.data.result.result.map(async (fitLigandResult: (number | libcootApi.fitLigandInfo), idx: number) => {
-                    const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath, this.store)
+                    const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.store, this.monomerLibraryPath)
                     newMolecule.molNo = fitRightHere ? fitLigandResult as number : (fitLigandResult as libcootApi.fitLigandInfo).imol 
                     newMolecule.name = `Fit. lig. #${idx + 1}`
                     newMolecule.isDarkBackground = this.isDarkBackground
@@ -2283,7 +2283,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
             }
             return await Promise.all(
                 result.data.result.result.map(async (molNo, index) => {
-                    const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath, this.store)
+                    const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.store, this.monomerLibraryPath)
                     newMolecule.name = `${this.name}-${index+1}`
                     newMolecule.molNo = molNo
                     newMolecule.isDarkBackground = this.isDarkBackground

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -17,6 +17,7 @@ import { gemmi } from "../types/gemmi"
 import { libcootApi } from '../types/libcoot';
 import { privateer } from '../types/privateer';
 import MoorhenReduxStore from "../store/MoorhenReduxStore";
+import { ToolkitStore } from '@reduxjs/toolkit/dist/configureStore';
 
 /**
  * Represents a molecule
@@ -101,11 +102,13 @@ export class MoorhenMolecule implements moorhen.Molecule {
     cachedLigandSVGs: {[key: string]: string};
     moleculeDiameter: number;
     adaptativeBondsEnabled: boolean;
+    store: ToolkitStore;
 
-    constructor(commandCentre: React.RefObject<moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, monomerLibraryPath = "./baby-gru/monomers") {
+    constructor(commandCentre: React.RefObject<moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, monomerLibraryPath = "./baby-gru/monomers", store: ToolkitStore = MoorhenReduxStore) {
         this.type = 'molecule'
         this.commandCentre = commandCentre
         this.glRef = glRef
+        this.store = store
         this.atomsDirty = true
         this.name = "unnamed"
         this.molNo = null
@@ -494,7 +497,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
      */
     async copyMolecule(): Promise<moorhen.Molecule> {
         let coordString = await this.getAtoms()
-        let newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath)
+        let newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath, this.store)
         newMolecule.name = `${this.name}-placeholder`
         newMolecule.defaultBondOptions = this.defaultBondOptions
         newMolecule.coordsFormat = this.coordsFormat
@@ -530,7 +533,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
             command: "copy_fragment_using_cid",
             commandArgs: [this.molNo, cid],
         }, true) as moorhen.WorkerResponse<number>
-        const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath)
+        const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath, this.store)
         newMolecule.name = `${this.name} fragment`
         newMolecule.molNo = response.data.result.result
         newMolecule.isDarkBackground = this.isDarkBackground
@@ -555,7 +558,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @returns {moorhen.Molecule} A new molecule instance that can be used for refinement
      */
     async copyFragmentForRefinement(cid: string[], refinementMap: moorhen.Map, redraw: boolean = true, redrawFragmentFirst: boolean = true): Promise<moorhen.Molecule> {
-        const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath)
+        const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath, this.store)
         const copyResult = await this.commandCentre.current.cootCommand({
             returnType: 'int',
             command: 'copy_fragment_for_refinement_using_cid',
@@ -571,7 +574,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
             }, false)
             newMolecule.setAtomsDirty(true)
             if (redraw) {
-                const drawMissingLoops = MoorhenReduxStore.getState().sceneSettings.drawMissingLoops
+                const drawMissingLoops = this.store.getState().sceneSettings.drawMissingLoops
                 if (drawMissingLoops) {
                     await this.commandCentre.current.cootCommand({
                         command: "set_draw_missing_residue_loops",
@@ -605,7 +608,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @param {boolean} [refineAfterMerge=false] - Indicates whether another cycle of refinement should be run after merging the fragment
      */
     async mergeFragmentFromRefinement(cid: string, fragmentMolecule: moorhen.Molecule, acceptTransform: boolean = true, refineAfterMerge: boolean = false) {
-        const drawMissingLoops = MoorhenReduxStore.getState().sceneSettings.drawMissingLoops
+        const drawMissingLoops = this.store.getState().sceneSettings.drawMissingLoops
         if (drawMissingLoops) {
             await this.commandCentre.current.cootCommand({
                 command: "set_draw_missing_residue_loops",
@@ -1510,7 +1513,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
 
             await Promise.all(otherMolecules.map(molecule => {
                 if (doHide) {
-                    MoorhenReduxStore.dispatch(hideMolecule(molecule))
+                    this.store.dispatch(hideMolecule(molecule))
                 }
                 return molecule.transferLigandDicts(this, false)
             }))
@@ -1553,7 +1556,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
             result = await getMonomer()
         }
         if (result.data.result.status === "Completed" && result.data.result.result !== -1) {
-            const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath)
+            const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath, this.store)
             newMolecule.setAtomsDirty(true)
             newMolecule.molNo = result.data.result.result
             newMolecule.name = resType.toUpperCase()
@@ -1714,7 +1717,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @returns {boolean} True if the molecule has any visible buffers
      */
     isVisible(excludeStyles: string[] = ['hover', 'unitCell', 'originNeighbours', 'selection', 'transformation', 'contact_dots', 'chemical_features', 'VdWSurface']): boolean {
-        const state = MoorhenReduxStore.getState()
+        const state = this.store.getState()
         const isVisible = state.molecules.visibleMolecules.some(molNo => molNo === this.molNo)
         const hasVisibleBuffers = this.representations
             .filter(item => !excludeStyles.includes(item.style))
@@ -2014,7 +2017,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         if (result.data.result.status === "Completed") {
             newMolecules = await Promise.all(
                 result.data.result.result.map(async (fitLigandResult: (number | libcootApi.fitLigandInfo), idx: number) => {
-                    const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath)
+                    const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath, this.store)
                     newMolecule.molNo = fitRightHere ? fitLigandResult as number : (fitLigandResult as libcootApi.fitLigandInfo).imol 
                     newMolecule.name = `Fit. lig. #${idx + 1}`
                     newMolecule.isDarkBackground = this.isDarkBackground
@@ -2214,7 +2217,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
             return this.cachedLigandSVGs[resName]
         }
 
-        const state = MoorhenReduxStore.getState()
+        const state = this.store.getState()
         const isDark = state.sceneSettings.isDark
 
         const result = await this.commandCentre.current.cootCommand({
@@ -2276,11 +2279,11 @@ export class MoorhenMolecule implements moorhen.Molecule {
         
         if (result.data.result.status === 'Completed') {
             if (draw) {
-                MoorhenReduxStore.dispatch(hideMolecule(this))
+                this.store.dispatch(hideMolecule(this))
             }
             return await Promise.all(
                 result.data.result.result.map(async (molNo, index) => {
-                    const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath)
+                    const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.monomerLibraryPath, this.store)
                     newMolecule.name = `${this.name}-${index+1}`
                     newMolecule.molNo = molNo
                     newMolecule.isDarkBackground = this.isDarkBackground

--- a/baby-gru/src/utils/MoorhenMoleculeRepresentation.ts
+++ b/baby-gru/src/utils/MoorhenMoleculeRepresentation.ts
@@ -2,7 +2,6 @@ import { moorhen } from '../types/moorhen';
 import { webGL } from '../types/mgWebGL';
 import { cidToSpec, gemmiAtomPairsToCylindersInfo, gemmiAtomsToCirclesSpheresInfo, getCubeLines, guid, countResiduesInSelection, copyStructureSelection } from './MoorhenUtils';
 import { libcootApi } from '../types/libcoot';
-import MoorhenReduxStore from "../store/MoorhenReduxStore";
 import { MoorhenColourRule } from './MoorhenColourRule';
 
 // TODO: It might be better to do this.glRef.current.drawScene() in the molecule... 
@@ -319,7 +318,7 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
             console.warn(`Cannot find neighboring residues for ${cid}, defaulting to active atom ${currentActiveAtom}`)
         }
 
-        const drawMissingLoops = MoorhenReduxStore.getState().sceneSettings.drawMissingLoops
+        const drawMissingLoops = this.parentMolecule.store.getState().sceneSettings.drawMissingLoops
         
         if (drawMissingLoops) {
             await this.commandCentre.current.cootCommand({
@@ -881,7 +880,7 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
         
         await this.applyColourRules()
         const bondSettings = this.getBondSettings(this.style)
-        const state = MoorhenReduxStore.getState()
+        const state = this.parentMolecule.store.getState()
         const drawMissingLoops = state.sceneSettings.drawMissingLoops
         const drawHydrogens = false
 

--- a/baby-gru/src/utils/MoorhenScriptAPI.ts
+++ b/baby-gru/src/utils/MoorhenScriptAPI.ts
@@ -2,9 +2,9 @@ import { moorhen } from "../types/moorhen"
 import { webGL } from "../types/mgWebGL";
 import { MoorhenMolecule } from "./MoorhenMolecule";
 import { MoorhenMap } from "./MoorhenMap";
+import MoorhenReduxStore from "../store/MoorhenReduxStore";
 import { addMolecule } from "../store/moleculesSlice";
 import { addMap } from "../store/mapsSlice";
-import { Dispatch } from "@reduxjs/toolkit";
 
 interface MoorhenScriptApiInterface {
     molecules: moorhen.Molecule[];
@@ -88,7 +88,7 @@ export class MoorhenScriptApi implements MoorhenScriptApiInterface {
           }))
     }
 
-    exe(src: string, dispatch: Dispatch<any>) {
+    exe(src: string) {
         // This env defines the variables accesible within the user-defined code
         let env = {
             molecules: this.molecules.reduce((obj, molecule) => {
@@ -103,7 +103,7 @@ export class MoorhenScriptApi implements MoorhenScriptApiInterface {
             commandCentre: this.commandCentre,
             MoorhenMolecule: MoorhenMolecule,
             MoorhenMap: MoorhenMap,
-            dispatch: dispatch,
+            dispatch: (arg) => MoorhenReduxStore.dispatch( arg ),
             addMolecule: addMolecule,
             addMap: addMap, 
             run_command: this.runCommand,

--- a/baby-gru/src/utils/MoorhenScriptAPI.ts
+++ b/baby-gru/src/utils/MoorhenScriptAPI.ts
@@ -2,9 +2,9 @@ import { moorhen } from "../types/moorhen"
 import { webGL } from "../types/mgWebGL";
 import { MoorhenMolecule } from "./MoorhenMolecule";
 import { MoorhenMap } from "./MoorhenMap";
-import MoorhenReduxStore from "../store/MoorhenReduxStore";
 import { addMolecule } from "../store/moleculesSlice";
 import { addMap } from "../store/mapsSlice";
+import { Dispatch } from "@reduxjs/toolkit";
 
 interface MoorhenScriptApiInterface {
     molecules: moorhen.Molecule[];
@@ -88,7 +88,7 @@ export class MoorhenScriptApi implements MoorhenScriptApiInterface {
           }))
     }
 
-    exe(src: string) {
+    exe(src: string, dispatch: Dispatch<any>) {
         // This env defines the variables accesible within the user-defined code
         let env = {
             molecules: this.molecules.reduce((obj, molecule) => {
@@ -103,7 +103,7 @@ export class MoorhenScriptApi implements MoorhenScriptApiInterface {
             commandCentre: this.commandCentre,
             MoorhenMolecule: MoorhenMolecule,
             MoorhenMap: MoorhenMap,
-            dispatch: (arg) => MoorhenReduxStore.dispatch( arg ),
+            dispatch: dispatch,
             addMolecule: addMolecule,
             addMap: addMap, 
             run_command: this.runCommand,

--- a/baby-gru/src/utils/MoorhenScriptAPI.ts
+++ b/baby-gru/src/utils/MoorhenScriptAPI.ts
@@ -2,15 +2,16 @@ import { moorhen } from "../types/moorhen"
 import { webGL } from "../types/mgWebGL";
 import { MoorhenMolecule } from "./MoorhenMolecule";
 import { MoorhenMap } from "./MoorhenMap";
-import MoorhenReduxStore from "../store/MoorhenReduxStore";
 import { addMolecule } from "../store/moleculesSlice";
 import { addMap } from "../store/mapsSlice";
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore";
 
 interface MoorhenScriptApiInterface {
     molecules: moorhen.Molecule[];
     maps: moorhen.Map[];
     glRef: React.RefObject<webGL.MGWebGL>;
     commandCentre: React.RefObject<moorhen.CommandCentre>;
+    store: ToolkitStore;
 }
 
 export class MoorhenScriptApi implements MoorhenScriptApiInterface {
@@ -19,10 +20,12 @@ export class MoorhenScriptApi implements MoorhenScriptApiInterface {
     maps: moorhen.Map[];
     glRef: React.RefObject<webGL.MGWebGL>;
     commandCentre: React.RefObject<moorhen.CommandCentre>;
+    store: ToolkitStore;
 
-    constructor(commandCentre: React.RefObject<moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, molecules: moorhen.Molecule[], maps: moorhen.Map[]) {
+    constructor(commandCentre: React.RefObject<moorhen.CommandCentre>, glRef: React.RefObject<webGL.MGWebGL>, store: ToolkitStore, molecules: moorhen.Molecule[], maps: moorhen.Map[]) {
         this.molecules = molecules
         this.maps = maps
+        this.store = store
         this.glRef = glRef
         this.commandCentre = commandCentre
     }
@@ -103,7 +106,7 @@ export class MoorhenScriptApi implements MoorhenScriptApiInterface {
             commandCentre: this.commandCentre,
             MoorhenMolecule: MoorhenMolecule,
             MoorhenMap: MoorhenMap,
-            dispatch: (arg) => MoorhenReduxStore.dispatch( arg ),
+            dispatch: (arg) => this.store.dispatch( arg ),
             addMolecule: addMolecule,
             addMap: addMap, 
             run_command: this.runCommand,

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -1,7 +1,6 @@
 import { moorhen } from "../types/moorhen";
 import { webGL } from "../types/mgWebGL";
 import { guid } from "./MoorhenUtils";
-import MoorhenReduxStore from "../store/MoorhenReduxStore";
 
 export const getBackupLabel = (key: moorhen.backupKey): string => {
     const dateOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' } as const
@@ -144,7 +143,6 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
         const keyStrings = await this.storageInstance.keys()
         const mtzFileNames = keyStrings.map((keyString: string) => JSON.parse(keyString)).filter((key: moorhen.backupKey) => key.type === 'mtzData').map((key: moorhen.backupKey) => key.name)
         const mapNames = keyStrings.map((keyString: string) => JSON.parse(keyString)).filter((key: moorhen.backupKey) => key.type === 'mapData').map((key: moorhen.backupKey) => key.name)
-        const state = MoorhenReduxStore.getState()
 
         const promises = await Promise.all([
             ...this.moleculesRef.current.map(molecule => {
@@ -226,16 +224,16 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
                 uniqueId: map.uniqueId,
                 mapData: mapDataPromises[index],
                 reflectionData: reflectionDataPromises[index],
-                showOnLoad: state.mapContourSettings.visibleMaps.includes(map.molNo),
-                contourLevel: state.mapContourSettings.contourLevels.find(item => item.molNo === map.molNo)?.contourLevel,
-                radius: state.mapContourSettings.mapRadii.find(item => item.molNo === map.molNo)?.radius,
+                showOnLoad: map.contourParams.isVisible,
+                contourLevel: map.contourParams.contourLevel,
+                radius: map.contourParams.mapRadius,
                 rgba: {
-                    a: state.mapContourSettings.mapAlpha.find(item => item.molNo === map.molNo)?.alpha,
-                    mapColour: state.mapContourSettings.mapColours.find(item => item.molNo === map.molNo)?.rgb,
-                    positiveDiffColour: state.mapContourSettings.positiveMapColours.find(item => item.molNo === map.molNo)?.rgb,
-                    negativeDiffColour: state.mapContourSettings.negativeMapColours.find(item => item.molNo === map.molNo)?.rgb
+                    a: map.contourParams.mapAlpha,
+                    mapColour: {r: map.contourParams.mapColour.r * 255., g: map.contourParams.mapColour.g * 255., b: map.contourParams.mapColour.b * 255.},
+                    positiveDiffColour: {r: map.contourParams.positiveMapColour.r * 255., g: map.contourParams.positiveMapColour.g * 255., b: map.contourParams.positiveMapColour.b * 255.},
+                    negativeDiffColour: {r: map.contourParams.negativeMapColour.r * 255., g: map.contourParams.negativeMapColour.g * 255., b: map.contourParams.negativeMapColour.b * 255.}
                 },
-                style: state.mapContourSettings.mapStyles.find(item => item.molNo === map.molNo)?.style,
+                style: map.contourParams.mapStyle,
                 isDifference: map.isDifference,
                 selectedColumns: map.selectedColumns,
                 hasReflectionData: map.hasReflectionData,

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -1,6 +1,7 @@
 import { moorhen } from "../types/moorhen";
 import { webGL } from "../types/mgWebGL";
 import { guid } from "./MoorhenUtils";
+import MoorhenReduxStore from "../store/MoorhenReduxStore";
 
 export const getBackupLabel = (key: moorhen.backupKey): string => {
     const dateOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' } as const
@@ -143,6 +144,7 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
         const keyStrings = await this.storageInstance.keys()
         const mtzFileNames = keyStrings.map((keyString: string) => JSON.parse(keyString)).filter((key: moorhen.backupKey) => key.type === 'mtzData').map((key: moorhen.backupKey) => key.name)
         const mapNames = keyStrings.map((keyString: string) => JSON.parse(keyString)).filter((key: moorhen.backupKey) => key.type === 'mapData').map((key: moorhen.backupKey) => key.name)
+        const state = MoorhenReduxStore.getState()
 
         const promises = await Promise.all([
             ...this.moleculesRef.current.map(molecule => {
@@ -224,16 +226,16 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
                 uniqueId: map.uniqueId,
                 mapData: mapDataPromises[index],
                 reflectionData: reflectionDataPromises[index],
-                showOnLoad: map.contourParams.isVisible,
-                contourLevel: map.contourParams.contourLevel,
-                radius: map.contourParams.mapRadius,
+                showOnLoad: state.mapContourSettings.visibleMaps.includes(map.molNo),
+                contourLevel: state.mapContourSettings.contourLevels.find(item => item.molNo === map.molNo)?.contourLevel,
+                radius: state.mapContourSettings.mapRadii.find(item => item.molNo === map.molNo)?.radius,
                 rgba: {
-                    a: map.contourParams.mapAlpha,
-                    mapColour: {r: map.contourParams.mapColour.r * 255., g: map.contourParams.mapColour.g * 255., b: map.contourParams.mapColour.b * 255.},
-                    positiveDiffColour: {r: map.contourParams.positiveMapColour.r * 255., g: map.contourParams.positiveMapColour.g * 255., b: map.contourParams.positiveMapColour.b * 255.},
-                    negativeDiffColour: {r: map.contourParams.negativeMapColour.r * 255., g: map.contourParams.negativeMapColour.g * 255., b: map.contourParams.negativeMapColour.b * 255.}
+                    a: state.mapContourSettings.mapAlpha.find(item => item.molNo === map.molNo)?.alpha,
+                    mapColour: state.mapContourSettings.mapColours.find(item => item.molNo === map.molNo)?.rgb,
+                    positiveDiffColour: state.mapContourSettings.positiveMapColours.find(item => item.molNo === map.molNo)?.rgb,
+                    negativeDiffColour: state.mapContourSettings.negativeMapColours.find(item => item.molNo === map.molNo)?.rgb
                 },
-                style: map.contourParams.mapStyle,
+                style: state.mapContourSettings.mapStyles.find(item => item.molNo === map.molNo)?.style,
                 isDifference: map.isDifference,
                 selectedColumns: map.selectedColumns,
                 hasReflectionData: map.hasReflectionData,

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -1,7 +1,7 @@
 import { moorhen } from "../types/moorhen";
 import { webGL } from "../types/mgWebGL";
 import { guid } from "./MoorhenUtils";
-import MoorhenReduxStore from "../store/MoorhenReduxStore";
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore";
 
 export const getBackupLabel = (key: moorhen.backupKey): string => {
     const dateOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' } as const
@@ -39,9 +39,11 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
     version: string;
     disableBackups: boolean;
     storageInstance: moorhen.LocalStorageInstance;
+    store: ToolkitStore;
     onIsBusyChange: (arg0: boolean) => void;
     
-    constructor(moleculesRef: React.RefObject<moorhen.Molecule[]>, mapsRef: React.RefObject<moorhen.Map[]>, activeMapRef: React.RefObject<moorhen.Map>, glRef: React.RefObject<webGL.MGWebGL>) {
+    constructor(moleculesRef: React.RefObject<moorhen.Molecule[]>, mapsRef: React.RefObject<moorhen.Map[]>, activeMapRef: React.RefObject<moorhen.Map>, glRef: React.RefObject<webGL.MGWebGL>, store: ToolkitStore) {
+        this.store = store
         this.moleculesRef = moleculesRef
         this.mapsRef = mapsRef
         this.glRef = glRef
@@ -144,7 +146,7 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
         const keyStrings = await this.storageInstance.keys()
         const mtzFileNames = keyStrings.map((keyString: string) => JSON.parse(keyString)).filter((key: moorhen.backupKey) => key.type === 'mtzData').map((key: moorhen.backupKey) => key.name)
         const mapNames = keyStrings.map((keyString: string) => JSON.parse(keyString)).filter((key: moorhen.backupKey) => key.type === 'mapData').map((key: moorhen.backupKey) => key.name)
-        const state = MoorhenReduxStore.getState()
+        const state = this.store.getState()
 
         const promises = await Promise.all([
             ...this.moleculesRef.current.map(molecule => {

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -259,7 +259,7 @@ export async function loadSessionData(
 
     // Load molecules stored in session from coords string
     const newMoleculePromises = sessionData.moleculeData?.map(storedMoleculeData => {
-        const newMolecule = new MoorhenMolecule(commandCentre, glRef, monomerLibraryPath, store)
+        const newMolecule = new MoorhenMolecule(commandCentre, glRef, store, monomerLibraryPath)
         return newMolecule.loadToCootFromString(storedMoleculeData.coordString, storedMoleculeData.name)
     }) || []
     

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -21,6 +21,7 @@ import {
     setEdgeDetectDepthScale, setEdgeDetectDepthThreshold, setEdgeDetectNormalScale, setEdgeDetectNormalThreshold, setSsaoBias, setSsaoRadius, setUseOffScreenBuffers 
 } from "../store/sceneSettingsSlice";
 import { moorhensession } from "../protobuf/MoorhenSession";
+import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore";
 
 export const getAtomInfoLabel = (atomInfo: moorhen.AtomInfo) => {
     return `/${atomInfo.mol_name}/${atomInfo.chain_id}/${atomInfo.res_no}(${atomInfo.res_name})/${atomInfo.name}${atomInfo.has_altloc ? `:${atomInfo.alt_loc}` : ""}`
@@ -231,6 +232,7 @@ export async function loadSessionData(
     commandCentre: React.RefObject<moorhen.CommandCentre>,
     timeCapsuleRef: React.RefObject<moorhen.TimeCapsule>,
     glRef: React.RefObject<webGL.MGWebGL>,
+    store: ToolkitStore,
     dispatch: Dispatch<AnyAction>
 ): Promise<number> {
 
@@ -257,13 +259,13 @@ export async function loadSessionData(
 
     // Load molecules stored in session from coords string
     const newMoleculePromises = sessionData.moleculeData?.map(storedMoleculeData => {
-        const newMolecule = new MoorhenMolecule(commandCentre, glRef, monomerLibraryPath)
+        const newMolecule = new MoorhenMolecule(commandCentre, glRef, monomerLibraryPath, store)
         return newMolecule.loadToCootFromString(storedMoleculeData.coordString, storedMoleculeData.name)
     }) || []
     
     // Load maps stored in session
     const newMapPromises = sessionData.mapData?.map(storedMapData => {
-        const newMap = new MoorhenMap(commandCentre, glRef)
+        const newMap = new MoorhenMap(commandCentre, glRef, store)
         if (sessionData.includesAdditionalMapData) {
             return newMap.loadToCootFromMapData(
                 storedMapData.mapData, 
@@ -453,12 +455,13 @@ export async function loadSessionFromProtoMessage(
     commandCentre: React.RefObject<moorhen.CommandCentre>,
     timeCapsuleRef: React.RefObject<moorhen.TimeCapsule>,
     glRef: React.RefObject<webGL.MGWebGL>,
+    store: ToolkitStore,
     dispatch: Dispatch<AnyAction>
 ): Promise<number> {
 
     timeCapsuleRef.current.setBusy(true)
     const sessionData = moorhensession.Session.toObject(sessionProtoMessage) as moorhen.backupSession
-    const status = await loadSessionData(sessionData, monomerLibraryPath, molecules, maps, commandCentre, timeCapsuleRef, glRef, dispatch)
+    const status = await loadSessionData(sessionData, monomerLibraryPath, molecules, maps, commandCentre, timeCapsuleRef, glRef, store, dispatch)
     timeCapsuleRef.current.setBusy(false)
     return status
 }
@@ -483,12 +486,13 @@ export async function loadSessionFromJsonString(
     commandCentre: React.RefObject<moorhen.CommandCentre>,
     timeCapsuleRef: React.RefObject<moorhen.TimeCapsule>,
     glRef: React.RefObject<webGL.MGWebGL>,
+    store: ToolkitStore,
     dispatch: Dispatch<AnyAction>
 ): Promise<number> {
 
     timeCapsuleRef.current.setBusy(true)
     const sessionData: moorhen.backupSession = JSON.parse(sessionDataString)
-    const status = await loadSessionData(sessionData, monomerLibraryPath, molecules, maps, commandCentre, timeCapsuleRef, glRef, dispatch)
+    const status = await loadSessionData(sessionData, monomerLibraryPath, molecules, maps, commandCentre, timeCapsuleRef, glRef, store, dispatch)
     timeCapsuleRef.current.setBusy(false)
     return status
 }


### PR DESCRIPTION
This includes an update to `MoorhenContainer` `MoorhenMap` `MoorhenMolecule` and other components so that Moorhen can be rendered within another app that uses its redux store. This store needs to be passed via props to `MoorhenContainer` and to `MoorhenMap` and `MoorhenMolecule` during instantiation.