### PR TITLE
Add screenshot manager

### DIFF
--- a/baby-gru/src/components/MoorhenContainer.tsx
+++ b/baby-gru/src/components/MoorhenContainer.tsx
@@ -32,6 +32,7 @@ import { MoorhenModelTrajectorySnackBar } from './snack-bar/MoorhenModelTrajecto
 import { MoorhenTomogramSnackBar } from './snack-bar/MoorhenTomogramSnackBar';
 import { MoorhenMapContourLevelSnackBar } from './snack-bar/MoorhenMapContourLevelSnackBar';
 import { MoorhenRotamerChangeSnackBar } from './snack-bar/MoorhenRotamerChangeSnackbar';
+import { MoorhenScreenshotSnackBar } from './snack-bar/MoorhenScreenshotSnackBar';
 
 declare module "notistack" {
     interface VariantOverrides {
@@ -100,6 +101,10 @@ declare module "notistack" {
             commandCentre: React.RefObject<moorhen.CommandCentre>;
             glRef: React.RefObject<webGL.MGWebGL>;
         }
+        screenshot: {
+            videoRecorderRef: React.RefObject<moorhen.ScreenRecorder>;
+            glRef: React.RefObject<webGL.MGWebGL>;    
+        };
     }
 }
   
@@ -458,7 +463,8 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
             modelTrajectory: MoorhenModelTrajectorySnackBar,
             tomogram: MoorhenTomogramSnackBar,
             mapContourLevel: MoorhenMapContourLevelSnackBar,
-            rotamerChange: MoorhenRotamerChangeSnackBar
+            rotamerChange: MoorhenRotamerChangeSnackBar,
+            screenshot: MoorhenScreenshotSnackBar
         }}
         preventDuplicate={true}>
     <div>

--- a/baby-gru/src/components/menu-item/MoorhenGetMonomerMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenGetMonomerMenuItem.tsx
@@ -9,7 +9,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { addMolecule } from "../../store/moleculesSlice";
 import { ToolkitStore } from "@reduxjs/toolkit/dist/configureStore";
 import { useSnackbar } from "notistack";
-import { Autocomplete, CircularProgress, createFilterOptions, MenuItem, selectClasses, Skeleton, TextField } from "@mui/material";
+import { Autocomplete, CircularProgress, createFilterOptions, MenuItem, Skeleton, TextField } from "@mui/material";
 import { libcootApi } from "../../types/libcoot";
 import parse from 'html-react-parser';
 

--- a/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
@@ -236,10 +236,14 @@ export const MoorhenFileMenu = (props: MoorhenNavBarExtendedControlsInterface) =
                     <MoorhenBackupsMenuItem {...menuItemProps} disabled={!enableTimeCapsule} loadSession={loadSession} />
 
                     <MenuItem id='screenshot-menu-item' onClick={() =>  {
-                        dispatch(setHoveredAtom({ molecule: null, cid: null }))
-                        molecules.forEach(molecule => molecule.clearBuffersOfStyle('hover'))
-                        props.videoRecorderRef.current?.takeScreenShot("moorhen.png")}
-                        }>
+                        enqueueSnackbar("screenshot", {
+                            variant: "screenshot",
+                            persist: true,
+                            glRef: props.glRef,
+                            videoRecorderRef: props.videoRecorderRef 
+                        })
+                        document.body.click()
+                    }}>
                         Screenshot
                     </MenuItem>
 

--- a/baby-gru/src/components/snack-bar/MoorhenScreenshotSnackBar.tsx
+++ b/baby-gru/src/components/snack-bar/MoorhenScreenshotSnackBar.tsx
@@ -1,0 +1,61 @@
+import { SnackbarContent, useSnackbar } from "notistack"
+import { forwardRef, useCallback, useRef, useState } from "react"
+import { useDispatch, useSelector } from "react-redux"
+import { moorhen } from "../../types/moorhen"
+import { IconButton, Tooltip } from "@mui/material"
+import { CameraAltOutlined, CloseOutlined, Photo, PhotoOutlined } from "@mui/icons-material"
+import { setHoveredAtom } from "../../store/hoveringStatesSlice"
+import { webGL } from "../../types/mgWebGL"
+
+export const MoorhenScreenshotSnackBar = forwardRef<
+    HTMLDivElement,
+    { 
+        id: string;
+        videoRecorderRef: React.RefObject<moorhen.ScreenRecorder>;
+        glRef: React.RefObject<webGL.MGWebGL>;
+    }
+>((props, ref) => {
+    
+    const molecules = useSelector((state: moorhen.State) => state.molecules.moleculeList)
+    const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
+
+    const [doTransparentBackground, setDoTransparentBackground] = useState<boolean>(false)
+
+    const doTransparentBackgroundRef = useRef<boolean>(false)
+
+    const dispatch = useDispatch()
+
+    const { closeSnackbar } = useSnackbar()
+
+    const handleScreenShot = useCallback(() => {
+        dispatch(setHoveredAtom({ molecule: null, cid: null }))
+        molecules.forEach(molecule => molecule.clearBuffersOfStyle('hover'))
+        props.videoRecorderRef.current?.takeScreenShot("moorhen.png", doTransparentBackgroundRef.current)
+        closeSnackbar(props.id)
+    }, [molecules, props.id])
+
+    return <SnackbarContent ref={ref} className="moorhen-notification-div" style={{ justifyContent: 'space-between', backgroundColor: isDark ? 'grey' : 'white', color: isDark ? 'white' : 'grey' }}>
+            <Tooltip title={'Take screenshot'}>
+                <IconButton onClick={handleScreenShot}>
+                    <CameraAltOutlined/>
+                </IconButton>
+            </Tooltip>
+            <Tooltip title={doTransparentBackground ? 'Use opaque background' : 'Use transparent background'}>
+                <IconButton onClick={() => {
+                    doTransparentBackgroundRef.current = !doTransparentBackgroundRef.current
+                    setDoTransparentBackground((prev) => !prev)
+                }}>
+                    {doTransparentBackground ? 
+                    <PhotoOutlined/>
+                    :
+                    <Photo/>
+                }
+                </IconButton>
+            </Tooltip>
+            <Tooltip title={'Do transparent background'}>
+                <IconButton onClick={() => closeSnackbar(props.id)}>
+                    <CloseOutlined/>
+                </IconButton>
+            </Tooltip>
+    </SnackbarContent>
+})

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -427,7 +427,7 @@ export namespace moorhen {
         startRecording: () => void;
         isRecording: () => boolean;
         downloadVideo: (blob: Blob) => Promise<void>;
-        takeScreenShot: (fileName: string) => void;
+        takeScreenShot: (fileName: string, doTransparentBackground?: boolean) => void;
     }
 
     interface Map {

--- a/baby-gru/src/utils/MoorhenKeyboardPress.ts
+++ b/baby-gru/src/utils/MoorhenKeyboardPress.ts
@@ -293,9 +293,12 @@ export const moorhenKeyPress = (
     }
 
     else if (action === 'take_screenshot') {
-        dispatch(setHoveredAtom({ molecule: null, cid: null }))
-        molecules.forEach(molecule => molecule.clearBuffersOfStyle('hover'))
-        videoRecorderRef.current?.takeScreenShot("moorhen.png")
+        enqueueSnackbar("screenshot", {
+            variant: "screenshot",
+            persist: true,
+            glRef: glRef,
+            videoRecorderRef: videoRecorderRef 
+        })
     }
 
     else if (action === 'show_shortcuts') {

--- a/baby-gru/src/utils/MoorhenScreenRecorder.ts
+++ b/baby-gru/src/utils/MoorhenScreenRecorder.ts
@@ -63,7 +63,8 @@ export class MoorhenScreenRecorder implements moorhen.ScreenRecorder {
         link.click();
     }
 
-    takeScreenShot = (filename: string) => {
+    takeScreenShot = (filename: string, doTransparentBackground: boolean = false) => {
+        this.glRef.current.setDoTransparentScreenshotBackground(doTransparentBackground)
         const oldOrigin = [this.glRef.current.origin[0], this.glRef.current.origin[1], this.glRef.current.origin[2]];
 
         // Getting up and right for doing tiling (in future?)


### PR DESCRIPTION
This update adds a screenshot manager that lets the user set opaque/transparent background used on the screenshots via the new method `MGWebGL.setDoTransparentScreenshotBackground(newVal: boolean)`. More settings might be exposed in the future through this manager.