### PR TITLE
Handle transparent colour rules

### DIFF
--- a/baby-gru/public/baby-gru/CootWorker.ts
+++ b/baby-gru/public/baby-gru/CootWorker.ts
@@ -974,12 +974,12 @@ const read_ccp4_map = (mapData: ArrayBufferLike, name: string, isDiffMap: boolea
     return molNo
 }
 
-const setUserDefinedBondColours = (imol: number, colours: { cid: string; rgb: [number, number, number] }[], applyColourToNonCarbonAtoms: boolean = false) => {
-    let colourMap = new cootModule.MapIntFloat3()
+const setUserDefinedBondColours = (imol: number, colours: { cid: string; rgba: [number, number, number, number] }[], applyColourToNonCarbonAtoms: boolean = false) => {
+    let colourMap = new cootModule.MapIntFloat4()
     let indexedResiduesVec = new cootModule.VectorStringUInt_pair()
     
     colours.forEach((colour, index) => {
-        colourMap.set(index + 51, colour.rgb)
+        colourMap.set(index + 51, colour.rgba)
         const i = { first: colour.cid, second: index + 51 }
         indexedResiduesVec.push_back(i)
     })
@@ -1090,7 +1090,7 @@ const doCootCommand = (messageData: {
                 cootResult = replace_map_by_mtz_from_file(...commandArgs as [number, ArrayBufferLike, { F: string; PHI: string; }])
                 break
             case 'shim_set_bond_colours':
-                cootResult = setUserDefinedBondColours(...commandArgs as [number, { cid: string; rgb: [number, number, number] }[], boolean])
+                cootResult = setUserDefinedBondColours(...commandArgs as [number, { cid: string; rgba: [number, number, number, number] }[], boolean])
                 break
             case 'shim_export_map_as_gltf':
                 cootResult = export_map_as_gltf(...commandArgs as [number, number, number, number, number, number])

--- a/baby-gru/src/components/card/MoorhenColourRuleCard.tsx
+++ b/baby-gru/src/components/card/MoorhenColourRuleCard.tsx
@@ -1,11 +1,12 @@
 import { useRef, useState } from "react";
 import { Row, Button, Card, Col, OverlayTrigger, Tooltip, Form, FormSelect } from "react-bootstrap";
 import { ArrowUpwardOutlined, ArrowDownwardOutlined, DeleteOutlined, GrainOutlined } from '@mui/icons-material';
-import { HexColorInput, RgbColorPicker } from "react-colorful";
+import { HexAlphaColorPicker, HexColorInput, RgbColorPicker } from "react-colorful";
 import { rgbToHex } from "../../utils/MoorhenUtils";
 import { moorhen } from "../../types/moorhen";
-import { Popover, hexToRgb } from "@mui/material";
+import { Popover } from "@mui/material";
 import { useSelector } from "react-redux";
+import { MoorhenColourRule } from "../../utils/MoorhenColourRule";
 
 const ColourSwatch = (props: {
     rule: moorhen.ColourRule;
@@ -17,14 +18,7 @@ const ColourSwatch = (props: {
 
     const { rule, applyColourChange } = props
     
-    let [r, g, b]: number[] = []
-    if (!rule.isMultiColourRule) {
-        [r, g, b] = hexToRgb(rule.color).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
-    } else {
-        [r, g, b] = [100, 100, 100]
-    }
-
-    const [rgb, setRgb] = useState<{r: number, g: number, b: number}>({r, g, b})
+    const [hex, setHex] = useState<string>(rule.color)
     const [showColourPicker, setShowColourPicker] = useState<boolean>(false)
 
     const handleClick = () => {
@@ -32,6 +26,16 @@ const ColourSwatch = (props: {
             rule.color = newHexValueRef.current
             if (!rule.isMultiColourRule) rule.args[1] = rule.color 
             applyColourChange()
+        }
+        catch (err) {
+            console.log('err', err)
+        }
+    }
+
+    const handleColorChange = (color: string) => {
+        try {
+            newHexValueRef.current = color
+            setHex(color)
         }
         catch (err) {
             console.log('err', err)
@@ -64,17 +68,10 @@ const ColourSwatch = (props: {
             }}
         >
         <div style={{ padding: '0.5rem', width: '100%', margin: 0, justifyContent: 'center', display: 'flex', flexDirection: 'column'}}>
-            <RgbColorPicker color={rgb} onChange={(color: { r: number; g: number; b: number; }) => {
-                newHexValueRef.current = rgbToHex(color.r, color.g, color.b)
-                setRgb(color)
-            }}/>
+            <HexAlphaColorPicker color={hex} onChange={handleColorChange}/>
             <div style={{width: '100%', display: 'flex', justifyContent: 'center'}}>
                 <div className="moorhen-hex-input-decorator">#</div>
-                <HexColorInput className="moorhen-hex-input" color={rgbToHex(rgb.r, rgb.g, rgb.b)} onChange={(hex) => {
-                    const [r, g, b] = hexToRgb(hex).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
-                    newHexValueRef.current = rgbToHex(r, g, b)
-                    setRgb({r, g, b})
-                }}/>
+                <HexColorInput className="moorhen-hex-input" color={hex} onChange={handleColorChange}/>
             </div>
             <Button style={{marginTop: '0.2rem'}} onClick={handleClick}>
                 Apply
@@ -116,7 +113,7 @@ const NcsColourSwatch = (props: {
         <GrainOutlined ref={ncsSwatchRef} onClick={() => {
             setShowColourPicker(true)
             const hex = (rule.args[0] as string).split('|')[0].split('^')[1]
-            const [_r, _g, _b] = hexToRgb(hex).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+            const [_r, _g, _b, _a] = MoorhenColourRule.parseHexToRgba(hex)
             setRgb({r: _r, g: _g, b: _b})
         }} style={{ cursor: 'pointer', height:'23px', width:'23px', marginLeft: '0.5rem', marginRight: '0.5rem', borderStyle: 'solid', borderColor: '#ced4da', borderWidth: '3px', borderRadius: '8px' }}/>
         <Popover 
@@ -137,7 +134,7 @@ const NcsColourSwatch = (props: {
                     setNcsCopyValue(evt.target.value)
                     const chainNames = JSON.parse(evt.target.value)
                     const hex = (rule.args[0] as string).split('|').find(item => item.includes(chainNames[0]))?.split('^')[1]
-                    const [_r, _g, _b] = hexToRgb(hex).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+                    const [_r, _g, _b, _a] = MoorhenColourRule.parseHexToRgba(hex)
                     setRgb({r: _r, g: _g, b: _b})
                 }}>
                     {[...new Set((rule.args[0] as string).split('|').map(item => item.split('^')[1]))].map((hex, index) => {
@@ -153,8 +150,8 @@ const NcsColourSwatch = (props: {
             <div style={{width: '100%', display: 'flex', justifyContent: 'center'}}>
                 <div className="moorhen-hex-input-decorator">#</div>
                 <HexColorInput className="moorhen-hex-input" color={rgbToHex(rgb.r, rgb.g, rgb.b)} onChange={(hex) => {
-                    const [r, g, b] = hexToRgb(hex).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
-                    newNcsHexValueRef.current = rgbToHex(r, g, b)
+                    const [r, g, b, _a] = MoorhenColourRule.parseHexToRgba(hex)
+                    newNcsHexValueRef.current = hex
                     setRgb({r, g, b})
                 }}/>
             </div>
@@ -180,11 +177,6 @@ export const MoorhenColourRuleCard = (props: {
     const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
 
     const { index, molecule, rule, urlPrefix, setRuleList } = props
-    
-    let [r, g, b]: number[] = []
-    if (!rule.isMultiColourRule) {
-        [r, g, b] = hexToRgb(rule.color).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
-    }
     
     const redrawIfDirty = () => {
         if (isDirty.current) {

--- a/baby-gru/src/components/card/MoorhenMapCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMapCard.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useImperativeHandle, useEffect, useState, useRef, useCallback, useMemo, Fragment } from "react"
 import { Card, Form, Button, Col, DropdownButton, Stack, OverlayTrigger, ToggleButton, Spinner } from "react-bootstrap"
-import { doDownload, guid, rgbToHex } from '../../utils/MoorhenUtils'
+import { doDownload, rgbToHex } from '../../utils/MoorhenUtils'
 import { getNameLabel } from "./cardUtils"
 import { VisibilityOffOutlined, VisibilityOutlined, ExpandMoreOutlined, ExpandLessOutlined, DownloadOutlined, Settings, FileCopyOutlined, RadioButtonCheckedOutlined, RadioButtonUncheckedOutlined, AddCircleOutline, RemoveCircleOutline } from '@mui/icons-material';
 import { MoorhenMapSettingsMenuItem } from "../menu-item/MoorhenMapSettingsMenuItem";
@@ -17,6 +17,7 @@ import { setActiveMap } from "../../store/generalStatesSlice";
 import { addMap } from "../../store/mapsSlice";
 import { hideMap, setContourLevel, changeContourLevel, setMapAlpha, setMapColours, setMapRadius, setMapStyle, setNegativeMapColours, setPositiveMapColours, showMap, changeMapRadius } from "../../store/mapContourSettingsSlice";
 import { useSnackbar } from "notistack";
+import { MoorhenColourRule } from "../../utils/MoorhenColourRule";
 
 type ActionButtonType = {
     label: string;
@@ -497,7 +498,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
                         <div style={{width: '100%', display: 'flex', justifyContent: 'center'}}>
                             <div className="moorhen-hex-input-decorator">#</div>
                             <HexColorInput className="moorhen-hex-input" color={positiveMapColourHex} onChange={(hex) => {
-                                const [r, g, b] = hexToRgb(hex).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+                                const [r, g, b] = MoorhenColourRule.parseHexToRgba(hex)
                                 handlePositiveMapColorChange({r, g, b})
                             }}/>
                         </div>
@@ -508,7 +509,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
                         <div style={{width: '100%', display: 'flex', justifyContent: 'center'}}>
                             <div className="moorhen-hex-input-decorator">#</div>
                             <HexColorInput className="moorhen-hex-input" color={negativeMapColourHex} onChange={(hex) => {
-                                const [r, g, b] = hexToRgb(hex).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+                                const [r, g, b] = MoorhenColourRule.parseHexToRgba(hex)
                                 handleNegativeMapColorChange({r, g, b})
                             }}/>
                         </div>
@@ -546,7 +547,7 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
                         <div style={{width: '100%', display: 'flex', justifyContent: 'center', marginBottom: '0.1rem'}}>
                             <div className="moorhen-hex-input-decorator">#</div>
                             <HexColorInput className="moorhen-hex-input" color={mapColourHex} onChange={(hex) => {
-                                const [r, g, b] = hexToRgb(hex).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+                                const [r, g, b, a] = MoorhenColourRule.parseHexToRgba(hex)
                                 handleColorChange({r, g, b})
                             }}/>
                         </div>

--- a/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
+++ b/baby-gru/src/components/card/MoorhenModifyColourRulesCard.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState, useReducer } from "react";
 import { Button, Stack, Form, FormSelect } from "react-bootstrap";
 import { CirclePicker } from "react-color";
-import { HexColorPicker, HexColorInput } from "react-colorful";
+import { HexColorInput, HexAlphaColorPicker } from "react-colorful";
 import { MoorhenChainSelect } from "../select/MoorhenChainSelect";
 import { MoorhenColourRuleCard } from "./MoorhenColourRuleCard"
 import { convertRemToPx, convertViewtoPx, getMultiColourRuleArgs } from "../../utils/MoorhenUtils";
@@ -276,7 +276,7 @@ export const MoorhenModifyColourRulesCard = (props: {
                 {ruleType !== 'property' &&
                 <Stack direction='vertical' style={{display: 'flex', justifyContent: 'center'}} gap={2}>
                     <div style={{padding: 0, margin: 0, justifyContent: 'center', display: 'flex'}}>
-                        <HexColorPicker color={selectedColour} onChange={handleColorChange}/>
+                        <HexAlphaColorPicker color={selectedColour} onChange={handleColorChange}/>
                     </div>
                     <div style={{padding: '0.5rem', margin: 0, justifyContent: 'center', display: 'flex', backgroundColor: '#e3e1e1', borderRadius: '8px'}}>
                         <CirclePicker width={convertRemToPx(15)} circleSize={convertRemToPx(15)/20} color={selectedColour} onChange={handleColourCircleClick}/>

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -6,7 +6,7 @@ import { isDarkBackground } from '../../WebGLgComponents/mgWebGL'
 import { MoorhenSequenceList } from "../list/MoorhenSequenceList";
 import { MoorhenMoleculeCardButtonBar } from "../button-bar/MoorhenMoleculeCardButtonBar"
 import { MoorhenLigandList } from "../list/MoorhenLigandList"
-import { Chip, FormGroup, hexToRgb } from "@mui/material";
+import { Chip, FormGroup } from "@mui/material";
 import { getNameLabel } from "./cardUtils"
 import { AddOutlined, DeleteOutlined, FormatColorFillOutlined, SettingsOutlined, EditOutlined, ExpandMoreOutlined } from '@mui/icons-material';
 import { MoorhenAddCustomRepresentationCard } from "./MoorhenAddCustomRepresentationCard"
@@ -19,6 +19,7 @@ import { addMolecule, removeCustomRepresentation, showMolecule } from '../../sto
 import { triggerUpdate } from '../../store/moleculeMapUpdateSlice';
 import { MoorhenHeaderInfoCard } from './MoorhenHeaderInfoCard';
 import { MoorhenCarbohydrateList } from "../list/MoorhenCarbohydrateList";
+import { MoorhenColourRule } from '../../utils/MoorhenColourRule';
 
 const allRepresentations = [ 'CBs', 'adaptativeBonds', 'CAs', 'CRs', 'ligands', 'gaussian', 'MolecularSurface', 'DishyBases', 'VdwSpheres', 'rama', 'rotamer', 'CDs', 'allHBonds','glycoBlocks', 'restraints' ]
 
@@ -563,13 +564,13 @@ const getChipStyle = (colourRules: moorhen.ColourRule[], repIsVisible: boolean, 
         chipStyle['color'] = 'white'
     }
 
-    let [r, g, b]: number[] = [214, 214, 214]
+    let [r, g, b, _a]: number[] = [214, 214, 214, 1]
     if (colourRules?.length > 0) {
         if (colourRules[0].isMultiColourRule) {
             const alphaHex = repIsVisible ? '99' : '33'
             chipStyle['background'] = `linear-gradient( to right, #264CFF${alphaHex}, #3FA0FF${alphaHex}, #72D8FF${alphaHex}, #AAF7FF${alphaHex}, #E0FFFF${alphaHex}, #FFFFBF${alphaHex}, #FFE099${alphaHex}, #FFAD72${alphaHex}, #F76D5E${alphaHex}, #D82632${alphaHex}, #A50021${alphaHex} )`
         } else {
-            [r, g, b] = hexToRgb(colourRules[0].color).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+            [r, g, b, _a] = MoorhenColourRule.parseHexToRgba(colourRules[0].color)
             chipStyle['backgroundColor'] = `rgba(${r}, ${g}, ${b}, ${repIsVisible ? 0.5 : 0.1})`
         }        
     } else {

--- a/baby-gru/src/components/modal/MoorhenSceneSettingsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenSceneSettingsModal.tsx
@@ -14,9 +14,10 @@ import { HexColorInput, RgbColorPicker } from "react-colorful";
 import { CirclePicker } from "react-color"
 import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
-import { Tooltip, hexToRgb } from "@mui/material";
+import { Tooltip } from "@mui/material";
 import { useSnackbar } from "notistack";
 import { LastPageOutlined } from "@mui/icons-material";
+import { MoorhenColourRule } from "../../utils/MoorhenColourRule";
 
 const EdgeDetectPanel = (props: {}) => {
     const dispatch = useDispatch()
@@ -163,7 +164,7 @@ const BackgroundColorPanel = (props: {}) => {
             <HexColorInput className='moorhen-hex-input'
                 color={rgbToHex(innerBackgroundColor.r, innerBackgroundColor.g, innerBackgroundColor.b)}
                 onChange={(hex) => {
-                    const [r, g, b] = hexToRgb(hex).replace('rgb(', '').replace(')', '').split(', ').map(item => parseFloat(item))
+                    const [r, g, b, a] = MoorhenColourRule.parseHexToRgba(hex)
                     handleColorChange({r, g, b})
             }}/>
         </div>

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -497,6 +497,7 @@ export namespace libcootApi {
         moved_residue_t: { new(arg0: string, arg1: number, arg2: string): MovedResidueT};
         moved_atom_t: { new(arg0: string, arg1: string, arg2: number, arg3: number, arg4: number, arg5: number): MovedAtomT};
         MapIntFloat3: { new(): emscriptem.map<[number, number, number], number>};
+        MapIntFloat4: { new(): emscriptem.map<[number, number, number, number], number>};
         VectorStringUInt_pair: { new(): emscriptem.vector<{ first: string, second: number }>};
     }
     interface MoleculesContainerJS {
@@ -517,7 +518,7 @@ export namespace libcootApi {
         set_map_sampling_rate(arg0: number): void;
         fill_rotamer_probability_tables(): void;
         set_user_defined_atom_colour_by_selection(imol: number, indexedResiduesVec: emscriptem.vector<{ first: string; second: number; }>, nonCarbon: boolean): void;
-        set_user_defined_bond_colours(imol: number, colourMap: emscriptem.map<[number, number, number], number>): void;
+        set_user_defined_bond_colours(imol: number, colourMap: emscriptem.map<[number, number, number, number], number>): void;
         read_ccp4_map(arg0: string, arg2: boolean): number;
         associate_data_mtz_file_with_map(arg0: number, arg1: string, arg2: string, arg3: string, arg5: string): void;
         read_mtz(arg0: string, arg1: string, arg2: string, arg3: string, arg4: boolean, arg5: boolean): number;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -109,6 +109,7 @@ export namespace moorhen {
         uniqueId: string;
         static initFromDataObject(data: ColourRuleObject, commandCentre: React.RefObject<CommandCentre>, molecule: Molecule): ColourRule;
         static initFromString(stringData: string, commandCentre: React.RefObject<CommandCentre>, molecule: Molecule): ColourRule;
+        static parseHexToRgba(hex: string): [number, number, number, number];
         objectify(): ColourRuleObject;
         stringify(): string;
         setLabel(label: string): void;
@@ -116,7 +117,7 @@ export namespace moorhen {
         setParentMolecule(molecule: Molecule): void;
         setParentRepresentation(representation: MoleculeRepresentation): void;    
         setApplyColourToNonCarbonAtoms(newVal: boolean): void;
-        getUserDefinedColours(): { cid: string; rgb: [number, number, number]; applyColourToNonCarbonAtoms: boolean }[];
+        getUserDefinedColours(): { cid: string; rgba: [number, number, number, number]; applyColourToNonCarbonAtoms: boolean }[];
         apply(style: string, ruleIndex: number): Promise<void>;
     }
 

--- a/baby-gru/src/utils/MoorhenMoleculeRepresentation.ts
+++ b/baby-gru/src/utils/MoorhenMoleculeRepresentation.ts
@@ -857,7 +857,7 @@ export class MoorhenMoleculeRepresentation implements moorhen.MoleculeRepresenta
 
         if (this.colourRules?.length > 0) {
             if (['CBs', 'VdwSpheres', 'ligands', 'CAs'].includes(this.style)) {
-                let colourObjectList: {cid: string; rgb: number[]; applyColourToNonCarbonAtoms: boolean}[] = []
+                let colourObjectList: {cid: string; rgba: number[]; applyColourToNonCarbonAtoms: boolean}[] = []
                 this.colourRules.forEach(rule => {
                     colourObjectList.push(...rule.getUserDefinedColours())
                 })


### PR DESCRIPTION
This update adds support for transparent colour rules in the UI. This is currently not working for M2T representations.