### PR TITLE
Add LSQKB superpose to the UI

### DIFF
--- a/baby-gru/src/components/menu-item/MoorhenChangeChainIdMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenChangeChainIdMenuItem.tsx
@@ -13,7 +13,7 @@ export const MoorhenChangeChainIdMenuItem = (props) => {
     const chainSelectRef = useRef<null | HTMLSelectElement>(null)
     const moleculeSelectRef = useRef<null | HTMLSelectElement>(null)
     const newChainIdFormRef = useRef<null |HTMLInputElement>(null)
-    const minMaxValueRef = useRef<[number, number]>([1, 100])
+    const residueRangeRef = useRef<[number, number]>([1, 100])
 
     const [invalidNewId, setInvalidNewId] = useState<boolean>(false)
     const [selectedChain, setSelectedChain] = useState<string>(null)
@@ -74,8 +74,8 @@ export const MoorhenChangeChainIdMenuItem = (props) => {
             return
         }
         
-        const startResNum = sequence.sequence[minMaxValueRef.current[0] - 1]?.resNum
-        const endResNum = sequence.sequence[minMaxValueRef.current[1] - 1]?.resNum
+        const startResNum = sequence.sequence[residueRangeRef.current[0] - 1]?.resNum
+        const endResNum = sequence.sequence[residueRangeRef.current[1] - 1]?.resNum
 
         try {
             setInvalidNewId(false)
@@ -109,7 +109,7 @@ export const MoorhenChangeChainIdMenuItem = (props) => {
             selectedCoordMolNo={selectedModel} 
             onChange={handleChainChange}
             ref={chainSelectRef}/>
-        <MoorhenSequenceRangeSlider ref={minMaxValueRef} selectedChainId={selectedChain} selectedMolNo={selectedModel} />
+        <MoorhenSequenceRangeSlider ref={residueRangeRef} selectedChainId={selectedChain} selectedMolNo={selectedModel} />
         <Form.Group style={{ width: "95%", margin: "0.5rem", height: "4rem" }}>
             <Form.Label>New chain ID</Form.Label>
             <Form.Control

--- a/baby-gru/src/components/menu-item/MoorhenChangeChainIdMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenChangeChainIdMenuItem.tsx
@@ -15,7 +15,6 @@ export const MoorhenChangeChainIdMenuItem = (props) => {
     const newChainIdFormRef = useRef<null |HTMLInputElement>(null)
     const minMaxValueRef = useRef<[number, number]>([1, 100])
 
-    const [sequenceLength, setSequenceLength] = useState<null | number>(null)
     const [invalidNewId, setInvalidNewId] = useState<boolean>(false)
     const [selectedChain, setSelectedChain] = useState<string>(null)
     const [selectedModel, setSelectedModel] = useState<number | null>(null)
@@ -33,21 +32,13 @@ export const MoorhenChangeChainIdMenuItem = (props) => {
             if (!sequence) {
                 sequence = molecule.sequences[0]
             }
-            setSequenceLength(sequence.sequence.length)
             setSelectedChain(sequence.chain)
         }
     }, [molecules])
 
     const handleChainChange = useCallback((evt) => {
         setSelectedChain(evt.target.value)
-        const molecule = molecules.find(molecule => molecule.molNo === parseInt(moleculeSelectRef.current?.value))
-        if (molecule) {
-            const sequence = molecule.sequences.find(sequence => sequence.chain === evt.target.value)
-            if (sequence) {
-                setSequenceLength(sequence.sequence.length)
-            }
-        }
-    }, [molecules])
+    }, [ ])
 
     useEffect(() => {
         let selectedMolecule: moorhen.Molecule
@@ -62,14 +53,7 @@ export const MoorhenChangeChainIdMenuItem = (props) => {
             setSelectedModel(molecules[0].molNo)
             setSelectedChain(molecules[0].sequences[0]?.chain)
             selectedMolecule = molecules[0]
-        }
-        
-        if (selectedMolecule) {
-            const sequence = selectedMolecule.sequences[0]
-            if (sequence) {
-                setSequenceLength(sequence.sequence.length)
-            }
-        }
+        }        
     }, [molecules])
 
     const changeChainId = useCallback(async () => {
@@ -125,7 +109,7 @@ export const MoorhenChangeChainIdMenuItem = (props) => {
             selectedCoordMolNo={selectedModel} 
             onChange={handleChainChange}
             ref={chainSelectRef}/>
-        <MoorhenSequenceRangeSlider ref={minMaxValueRef} sequenceLength={sequenceLength} selectedChainId={selectedChain} selectedMolNo={selectedModel} />
+        <MoorhenSequenceRangeSlider ref={minMaxValueRef} selectedChainId={selectedChain} selectedMolNo={selectedModel} />
         <Form.Group style={{ width: "95%", margin: "0.5rem", height: "4rem" }}>
             <Form.Label>New chain ID</Form.Label>
             <Form.Control

--- a/baby-gru/src/components/menu-item/MoorhenDeleteDisplayObjectMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenDeleteDisplayObjectMenuItem.tsx
@@ -6,6 +6,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { setActiveMap } from "../../store/generalStatesSlice";
 import { removeMap } from "../../store/mapsSlice";
 import { removeMolecule } from "../../store/moleculesSlice";
+import { useCallback } from "react";
 
 export const MoorhenDeleteDisplayObjectMenuItem = (props: {
     item: moorhen.Map | moorhen.Molecule;
@@ -14,6 +15,8 @@ export const MoorhenDeleteDisplayObjectMenuItem = (props: {
 }) => {
 
     const activeMap = useSelector((state: moorhen.State) => state.generalStates.activeMap)
+    const maps = useSelector((state: moorhen.State) => state.maps)
+
     const dispatch = useDispatch()
 
     const panelContent = <>
@@ -22,20 +25,25 @@ export const MoorhenDeleteDisplayObjectMenuItem = (props: {
         </Form.Group>
     </>
 
-    const onCompleted = () => {
+    const onCompleted = useCallback(() => {
         props.item.delete()
         props.setPopoverIsShown(false)
         if (props.item.type === "map") {
-            dispatch( removeMap(props.item as moorhen.Map) )
             if (activeMap?.molNo === props.item.molNo) {
-                dispatch( setActiveMap(null) )
+                if (maps.length > 1) {
+                    const newActiveMap = maps.find(map => map.molNo !== props.item.molNo)
+                    dispatch( setActiveMap(newActiveMap) )
+                } else {
+                    dispatch( setActiveMap(null) )
+                }
             }
+            dispatch( removeMap(props.item as moorhen.Map) )
         } else if(props.item.type === "molecule") {
             dispatch( removeMolecule(props.item as moorhen.Molecule) )
         } else {
             console.warn('Attempted to delete item of unknown type ', props.item.type)
         }
-    }
+    }, [activeMap, maps])
 
     return <MoorhenBaseMenuItem
         textClassName="text-danger"

--- a/baby-gru/src/components/misc/MoorhenSequenceRangeSlider.tsx
+++ b/baby-gru/src/components/misc/MoorhenSequenceRangeSlider.tsx
@@ -1,0 +1,167 @@
+import { AddCircleOutline, RemoveCircleOutline } from "@mui/icons-material";
+import { IconButton, Slider } from "@mui/material";
+import { forwardRef, useCallback, useEffect, useRef, useState } from "react";
+import { Stack } from "react-bootstrap";
+import { useSelector } from "react-redux";
+import { moorhen } from "../../types/moorhen";
+
+export const MoorhenSequenceRangeSlider = forwardRef<
+    any,
+    {
+        selectedMolNo: number;
+        selectedChainId: string;
+        sequenceLength: number;
+    }
+>((props, ref) => {
+
+    const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
+    const molecules = useSelector((state: moorhen.State) => state.molecules.moleculeList)
+
+    const intervalRef = useRef(null)
+
+    const [minMaxValue, setMinMaxValue]  = useState<[number, number]>([1, 100])
+
+    useEffect(() => {
+        setMinMaxValue([1, props.sequenceLength])
+    }, [props.sequenceLength])
+
+    const convertValue = useCallback((value: number) => {
+        if (!props.selectedChainId || props.selectedMolNo === null) {
+            return ''
+        }
+    
+        const molecule = molecules.find(molecule => molecule.molNo === props.selectedMolNo)
+        if (!molecule) {
+            return ''
+        }
+        
+        const sequence = molecule.sequences.find(sequence => sequence.chain === props.selectedChainId)
+        if (!sequence) {
+            return ''
+        }
+        
+        const resNum = Math.floor(value)
+        
+        return sequence.sequence[resNum - 1]?.cid
+    
+    }, [molecules, props.selectedMolNo, props.selectedChainId])
+
+    const handleMinMaxChange = (_event: any, newValue: [number, number]) => {
+        setMinMaxValue(newValue)
+        if (ref !== null && typeof ref !== 'function') ref.current = newValue
+    }
+
+    return <>
+        <span style={{margin: '0.5rem'}}>Residue range</span>
+        <Stack direction='horizontal' gap={1} style={{ }}>
+            <Stack direction='vertical' gap={0} style={{justifyContent: 'center'}}>
+                <IconButton onMouseDown={() => {
+                    intervalRef.current = setInterval(() => {
+                        if (ref !== null && typeof ref !== 'function') {
+                            const newValue = [ref.current[0] + 1, ref.current[1]] as [number, number]
+                            handleMinMaxChange(null, newValue)
+                        }      
+                    }, 100)
+                }} onMouseUp={() => {
+                    clearInterval(intervalRef.current)                   
+                }} onClick={() => {
+                    if (ref !== null && typeof ref !== 'function') {
+                        const newValue = [ref.current[0] + 1, ref.current[1]] as [number, number]
+                        handleMinMaxChange(null, newValue)    
+                    }
+                }} style={{padding: 0, color: isDark ? 'white' : 'grey'}}>
+                    <AddCircleOutline/>
+                </IconButton>
+                <IconButton onMouseDown={() => {
+                    intervalRef.current = setInterval(() => {
+                        if (ref !== null && typeof ref !== 'function') {
+                            const newValue = [ref.current[0] - 1, ref.current[1]] as [number, number]
+                            handleMinMaxChange(null, newValue)
+                        }          
+                    }, 100)
+                }} onMouseUp={() => {
+                    clearInterval(intervalRef.current)                   
+                }} onClick={() => {
+                    if (ref !== null && typeof ref !== 'function') {
+                        const newValue = [ref.current[0] - 1, ref.current[1]] as [number, number]
+                        handleMinMaxChange(null, newValue)
+                    }
+                }} style={{padding: 0, color: isDark ? 'white' : 'grey'}}>
+                    <RemoveCircleOutline/>
+                </IconButton>
+            </Stack>
+            <div style={{ width: '80%', paddingLeft: '1rem', paddingRight: '1rem', paddingTop: '0.1rem', paddingBottom: '0.1rem' }}>
+            <Slider
+                getAriaLabel={() => 'Residue range'}
+                value={minMaxValue}
+                onChange={handleMinMaxChange}
+                getAriaValueText={convertValue}
+                valueLabelFormat={convertValue}
+                valueLabelDisplay="on"
+                min={1}
+                max={props.sequenceLength ? props.sequenceLength : 100}
+                step={1}
+                marks={true}
+                sx={{
+                    marginTop: '1.7rem',
+                    marginBottom: '0.8rem',
+                    '& .MuiSlider-thumb[data-index="1"]': {
+                        '& .MuiSlider-valueLabel': {
+                            top: '-0.7rem',
+                            fontSize: 14,
+                            fontWeight: 'bold',
+                            color: 'grey',
+                            backgroundColor: 'unset',
+                        },
+                    },
+                    '& .MuiSlider-thumb[data-index="0"]': {
+                        '& .MuiSlider-valueLabel': {
+                            top:'3.5rem',
+                            fontSize: 14,
+                            fontWeight: 'bold',
+                            color: 'grey',
+                            backgroundColor: 'unset',
+                        },
+                    }
+                }}
+            />
+            </div>
+            <Stack direction='vertical' gap={0} style={{display: 'flex', verticalAlign: 'center', justifyContent: 'center'}}>
+                <IconButton onMouseDown={() => {
+                    intervalRef.current = setInterval(() => {
+                        if (ref !== null && typeof ref !== 'function') {
+                            const newValue = [ref.current[0], ref.current[1] + 1] as [number, number]
+                            handleMinMaxChange(null, newValue)
+                        }
+                    }, 100)
+                }} onMouseUp={() => {
+                    clearInterval(intervalRef.current)
+                }} onClick={() => {
+                    if (ref !== null && typeof ref !== 'function') {
+                        const newValue = [ref.current[0], ref.current[1] + 1] as [number, number]
+                        handleMinMaxChange(null, newValue)
+                    }      
+                }} style={{padding: 0, color: isDark ? 'white' : 'grey'}}>
+                    <AddCircleOutline/>
+                </IconButton>
+                <IconButton onMouseDown={() => {
+                    intervalRef.current = setInterval(() => {
+                        if (ref !== null && typeof ref !== 'function') {
+                            const newValue = [ref.current[0], ref.current[1] - 1] as [number, number]
+                            handleMinMaxChange(null, newValue)
+                        }
+                    }, 100)
+                }} onMouseUp={() => {
+                    clearInterval(intervalRef.current)                   
+                }} onClick={() => {
+                    if (ref !== null && typeof ref !== 'function') {
+                        const newValue = [ref.current[0], ref.current[1] - 1] as [number, number]
+                        handleMinMaxChange(null, newValue)
+                    }
+                }} style={{padding: 0, color: isDark ? 'white' : 'grey'}}>
+                    <RemoveCircleOutline/>
+                </IconButton>
+            </Stack>
+        </Stack>
+    </>
+})

--- a/baby-gru/src/components/misc/MoorhenSequenceRangeSlider.tsx
+++ b/baby-gru/src/components/misc/MoorhenSequenceRangeSlider.tsx
@@ -6,11 +6,10 @@ import { useSelector } from "react-redux";
 import { moorhen } from "../../types/moorhen";
 
 export const MoorhenSequenceRangeSlider = forwardRef<
-    any,
+    [number, number],
     {
         selectedMolNo: number;
         selectedChainId: string;
-        sequenceLength: number;
     }
 >((props, ref) => {
 
@@ -20,10 +19,20 @@ export const MoorhenSequenceRangeSlider = forwardRef<
     const intervalRef = useRef(null)
 
     const [minMaxValue, setMinMaxValue]  = useState<[number, number]>([1, 100])
+    const [sequenceLength, setSequenceLength]  = useState<number | null>(null)
 
     useEffect(() => {
-        setMinMaxValue([1, props.sequenceLength])
-    }, [props.sequenceLength])
+        const molecule = molecules.find(molecule => molecule.molNo === props.selectedMolNo)
+        if (molecule) {
+            let sequence = molecule.sequences.find(sequence => sequence.chain === props.selectedChainId)
+            if (!sequence) {
+                sequence = molecule.sequences[0]
+            }
+            setSequenceLength(sequence.sequence.length)
+            setMinMaxValue([1, sequence.sequence.length])
+            if (ref !== null && typeof ref !== 'function') ref.current = [1, sequence.sequence.length]
+        }
+    }, [props.selectedMolNo, props.selectedChainId])
 
     const convertValue = useCallback((value: number) => {
         if (!props.selectedChainId || props.selectedMolNo === null) {
@@ -99,7 +108,7 @@ export const MoorhenSequenceRangeSlider = forwardRef<
                 valueLabelFormat={convertValue}
                 valueLabelDisplay="on"
                 min={1}
-                max={props.sequenceLength ? props.sequenceLength : 100}
+                max={sequenceLength ? sequenceLength : 100}
                 step={1}
                 marks={true}
                 sx={{

--- a/baby-gru/src/components/modal/MoorhenSuperposeStructuresModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenSuperposeStructuresModal.tsx
@@ -1,18 +1,112 @@
 import { MoorhenDraggableModalBase } from "./MoorhenDraggableModalBase"
 import { moorhen } from "../../types/moorhen";
-import { useCallback, useEffect, useRef, useState } from "react";
-import { Button, Form, FormSelect, Spinner, Stack } from "react-bootstrap";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import { Button, Card, Col, Form, FormSelect, Row, Spinner, Stack } from "react-bootstrap";
 import { convertViewtoPx } from '../../utils/MoorhenUtils';
 import { useDispatch, useSelector } from "react-redux";
 import { MoorhenMoleculeSelect } from "../select/MoorhenMoleculeSelect";
 import { MoorhenChainSelect } from "../select/MoorhenChainSelect";
 import { libcootApi } from "../../types/libcoot";
-import { Backdrop } from "@mui/material";
+import { Backdrop, IconButton, Tooltip } from "@mui/material";
 import { useSnackbar } from "notistack";
 import { addMolecule } from "../../moorhen";
+import { MoorhenSequenceRangeSlider } from "../misc/MoorhenSequenceRangeSlider";
+import { DeleteOutlined, WarningAmberOutlined } from "@mui/icons-material";
 
+const lsqkbResidueRangesReducer = (oldList: moorhen.lskqbResidueRangeMatch[], change: {action: string; item?: moorhen.lskqbResidueRangeMatch}) => {
+    let newState: moorhen.lskqbResidueRangeMatch[]
+    
+    switch (change.action) {
+        case "add":
+            newState = [ ...oldList.filter(item => JSON.stringify(item) !== JSON.stringify(change.item)), change.item ]
+            break
+        case "remove":
+            newState = [ ...oldList.filter(item => JSON.stringify(item) !== JSON.stringify(change.item)) ]
+            break
+        case "empty":
+            newState = [ ]
+            break
+        default:
+            console.warn(`Unrecognised lsqkb residue range reducer action type ${change.action}`)
+            newState = [ ...oldList ]
+            break
+    }
+    
+    return newState
+}
+
+const initialLsqkbResidueRanges: moorhen.lskqbResidueRangeMatch[] = []
+
+const LskqbResidueRangeMatchCard = (props: { 
+    item: moorhen.lskqbResidueRangeMatch;
+    removeItem: () => void;
+    refMolNo: number;
+    movMolNo: number;
+}) => {
+    
+    const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
+    const molecules = useSelector((state: moorhen.State) => state.molecules.moleculeList)
+
+    const [warning, setWarning] = useState<string | null>(null)
+
+    useEffect(() => {
+        const doSanityCheck = async () => {
+            const refMolecule = molecules.find(molecule => molecule.molNo === props.refMolNo)
+            const movMolecule = molecules.find(molecule => molecule.molNo === props.movMolNo)
+            if (refMolecule && movMolecule) {
+                const atomsRef = await refMolecule.gemmiAtomsForCid(`//${props.item.refChainId}/${props.item.refResidueRange[0]}-${props.item.refResidueRange[1]}/CA`)
+                const atomsMov = await movMolecule.gemmiAtomsForCid(`//${props.item.movChainId}/${props.item.movResidueRange[0]}-${props.item.movResidueRange[1]}/CA`)
+                if (atomsMov.length !== atomsRef.length) {
+                    setWarning(
+                        `Unequal number of residues selected in the reference (${atomsRef.length} res.) and moving (${atomsMov.length} res.) structures.
+                        Only first ${atomsRef.length < atomsMov.length ? atomsRef.length : atomsMov.length} res. will be used.`
+                    )
+                }
+            }    
+        }
+        doSanityCheck()
+    }, [])
+    
+    return <Card style={{marginTop: '0.5rem', borderStyle: 'solid', borderColor: isDark ? 'white' : 'grey', borderWidth: '1px'}}>
+        <Card.Body style={{padding:'0.5rem'}}>
+            <Row style={{display:'flex', justifyContent:'between'}}>
+                <Col style={{alignItems:'center', justifyContent:'left', display:'flex', flexDirection: "column"}}>
+                    <Row>
+                        Reference
+                    </Row>
+                    <Row>
+                        {`//${props.item.refChainId}/${props.item.refResidueRange[0]}-${props.item.refResidueRange[1]}`}
+                    </Row>
+                </Col>
+                <Col style={{alignItems:'center', justifyContent:'left', display:'flex', flexDirection: "column"}}>
+                    <Row>
+                        Moving
+                    </Row>
+                    <Row>
+                        {`//${props.item.movChainId}/${props.item.movResidueRange[0]}-${props.item.movResidueRange[1]}`}
+                    </Row>
+                </Col>
+                {warning &&
+                <Col style={{margin: '0', padding:'0', justifyContent: 'center', display:'flex', alignItems: "center"}}>
+                    <Tooltip title={warning}>
+                        <WarningAmberOutlined style={{ marginRight:'0.5rem', color: isDark ? 'white' : 'grey' }}/>
+                    </Tooltip>
+                </Col>
+                }
+                <Col className='col-3' style={{margin: '0', padding:'0', justifyContent: 'right', display:'flex'}}>
+                    <Tooltip title="Delete">
+                    <IconButton style={{ marginRight:'0.5rem', color: isDark ? 'white' : 'grey' }} onClick={props.removeItem}>
+                        <DeleteOutlined/>
+                    </IconButton>
+                    </Tooltip>
+                </Col>
+            </Row>
+        </Card.Body>
+    </Card>
+}
 
 export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: React.Dispatch<React.SetStateAction<boolean>>; commandCentre: React.RefObject<moorhen.CommandCentre> }) => {    
+
     const molecules = useSelector((state: moorhen.State) => state.molecules.moleculeList)
     const width = useSelector((state: moorhen.State) => state.sceneSettings.width)
     const height = useSelector((state: moorhen.State) => state.sceneSettings.height)
@@ -24,7 +118,10 @@ export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: 
     const makeCopyOfMovStructCheckRef = useRef<null | HTMLInputElement>(null)
     const algorithmSelectRef = useRef<null | HTMLSelectElement>(null)
     const lsqkbModeRef = useRef<string>("all-atoms")
+    const movResidueRangeRef = useRef<[number, number]>([1, 100])
+    const refResidueRangeRef = useRef<[number, number]>([1, 100])
 
+    const [lsqkbResidueRanges, setLsqkbResidueRanges] = useReducer(lsqkbResidueRangesReducer, initialLsqkbResidueRanges)
     const [selectedRefModel, setSelectedRefModel] = useState<null | number>(null)
     const [selectedRefChain, setSelectedRefChain] = useState<null | string>(null)
     const [selectedMovModel, setSelectedMovModel] = useState<null | number>(null)
@@ -63,23 +160,12 @@ export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: 
         }
 
         setBusy(true)
-
-        await props.commandCentre.current.cootCommand({
-            message: 'coot_command',
-            command: 'SSM_superpose',
-            returnType: 'superpose_results',
-            commandArgs: [
-                refMolecule.molNo,
-                refChainSelectRef.current.value,
-                movMolecule.molNo,
-                movChainSelectRef.current.value
-            ],
-            changesMolecules: [movMolecule.molNo]
-        }, true) as moorhen.WorkerResponse<libcootApi.SuperposeResultsJS>
-
-        movMolecule.setAtomsDirty(true)
-        await movMolecule.redraw()
-        movMolecule.centreOn('/*/*/*/*', true)
+        
+        if (algorithmSelectRef.current.value === "ssm") {
+            await movMolecule.SSMSuperpose(movChainSelectRef.current.value, refMolecule.molNo, refChainSelectRef.current.value)
+        } else {
+            await movMolecule.lsqkbSuperpose(refMolecule.molNo, lsqkbResidueRanges, parseInt(lsqkbModeRef.current))
+        }
 
         if (makeCopyOfMovStructCheckRef.current.checked) {
             dispatch( addMolecule(movMolecule) )
@@ -88,7 +174,7 @@ export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: 
         setBusy(false)
         props.setShow(false)
 
-    }, [molecules, props.commandCentre])
+    }, [molecules, props.commandCentre, lsqkbResidueRanges])
 
 
     const handleModelChange = (evt: React.ChangeEvent<HTMLSelectElement>, isReferenceModel: boolean) => {
@@ -100,6 +186,7 @@ export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: 
             setSelectedMovModel(parseInt(evt.target.value))
             setSelectedMovChain(selectedMolecule.sequences[0].chain)
         }
+        setLsqkbResidueRanges({ action: "empty" })
     }
 
     const handleChainChange = (evt: React.ChangeEvent<HTMLSelectElement>, isReferenceModel: boolean) => {
@@ -108,21 +195,52 @@ export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: 
         } else {
             setSelectedMovChain(evt.target.value)
         }
+        setLsqkbResidueRanges({ action: "empty" })
     }
+
+    const handleAddLsqkbMatch = useCallback(() => {
+        const refMolecule = molecules.find(molecule => molecule.molNo === parseInt(refMoleculeSelectRef.current.value))
+        const movMolecule = molecules.find(molecule => molecule.molNo === parseInt(movMoleculeSelectRef.current.value))
+        if (refMolecule && movMolecule) {
+            const refSequence = refMolecule.sequences.find(sequence => sequence.chain === refChainSelectRef.current.value)
+            const movSequence = movMolecule.sequences.find(sequence => sequence.chain === movChainSelectRef.current.value)
+            if (refSequence && movSequence) {
+                const refStartResNum = refSequence.sequence[refResidueRangeRef.current[0] - 1]?.resNum
+                const refEndResNum = refSequence.sequence[refResidueRangeRef.current[1] - 1]?.resNum
+                const movStartResNum = movSequence.sequence[movResidueRangeRef.current[0] - 1]?.resNum
+                const movEndResNum = movSequence.sequence[movResidueRangeRef.current[1] - 1]?.resNum
+                const newMatch = {
+                    refChainId: refChainSelectRef.current.value,
+                    movChainId: movChainSelectRef.current.value,
+                    refResidueRange: [refStartResNum, refEndResNum] as [number, number],
+                    movResidueRange: [movStartResNum, movEndResNum] as [number, number]
+                }
+                setLsqkbResidueRanges({ action: "add", item: newMatch })        
+            } else {
+                enqueueSnackbar("Something went wrong...", { variant: "warning" })
+            }
+        } else {
+            enqueueSnackbar("Something went wrong...", { variant: "warning" })
+        }
+    }, [molecules])
 
     useEffect(() => {
         if (molecules.length === 0) {
             setSelectedRefModel(null)
             setSelectedMovModel(null)
+            setSelectedRefChain(null)
+            setSelectedMovChain(null)
             return
         }
 
         if (selectedRefModel === null || !molecules.map(molecule => molecule.molNo).includes(selectedRefModel)) {
             setSelectedRefModel(molecules[0].molNo)
+            setSelectedRefChain(molecules[0].sequences[0].chain)
         }
 
         if (selectedMovModel === null || !molecules.map(molecule => molecule.molNo).includes(selectedMovModel)) {
             setSelectedMovModel(molecules[0].molNo)
+            setSelectedMovChain(molecules[0].sequences[0].chain)
         }
 
     }, [molecules.length])
@@ -143,6 +261,9 @@ export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: 
                 </Form.Label>
                 <MoorhenMoleculeSelect width="100%" molecules={molecules} ref={refMoleculeSelectRef} onChange={(evt) => handleModelChange(evt, true)} />
                 <MoorhenChainSelect width="100%" molecules={molecules} onChange={(evt) => handleChainChange(evt, true)} selectedCoordMolNo={selectedRefModel} allowedTypes={[1, 2]} ref={refChainSelectRef} />
+                {algortihm === 'lsqkb' && 
+                <MoorhenSequenceRangeSlider ref={refResidueRangeRef} selectedMolNo={selectedRefModel} selectedChainId={selectedRefChain}/>
+                }
             </Form.Group>
             <Form.Group key="moving-model-select" style={{ margin: '0.5rem', width: '100%' }} controlId="movModelSelect" className="mb-3">
                 <Form.Label>
@@ -150,9 +271,23 @@ export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: 
                 </Form.Label>
                 <MoorhenMoleculeSelect width="100%" molecules={molecules} ref={movMoleculeSelectRef} onChange={(evt) => handleModelChange(evt, false)} />
                 <MoorhenChainSelect width="100%" molecules={molecules} onChange={(evt) => handleChainChange(evt, false)} selectedCoordMolNo={selectedMovModel} allowedTypes={[1, 2]} ref={movChainSelectRef} />
+                {algortihm === 'lsqkb' && 
+                <MoorhenSequenceRangeSlider ref={movResidueRangeRef} selectedMolNo={selectedMovModel} selectedChainId={selectedMovChain}/>
+                }
             </Form.Group>
         </Stack>
         {algortihm === "lsqkb" && <>
+        <Button onClick={handleAddLsqkbMatch}>
+            Add match
+        </Button>
+        <hr></hr>
+        {lsqkbResidueRanges.length > 0 ? 
+            lsqkbResidueRanges.map(item => {
+                return <LskqbResidueRangeMatchCard key={JSON.stringify(item)} refMolNo={selectedRefModel} movMolNo={selectedMovModel} item={item} removeItem={() => setLsqkbResidueRanges({ action: "remove", item: item })}/>
+            })
+            :
+            <span>No matches defined for alignment...</span>
+        }
         <hr></hr>
         <Form.Label style={{ margin: '0.5rem' }}>
             Match atoms

--- a/baby-gru/src/components/modal/MoorhenSuperposeStructuresModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenSuperposeStructuresModal.tsx
@@ -175,7 +175,7 @@ export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: 
                     lsqkbModeRef.current = "mainchain"
                     setLsqkbMode("mainchain")
                 }}
-                label="Mainchain"/>
+                label="Main Chain"/>
             <Form.Check
                 style={{ margin: "0.5rem", justifyContent: "inherit", display: "flex", gap: "0.5rem"}} 
                 type="radio"

--- a/baby-gru/src/components/modal/MoorhenSuperposeStructuresModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenSuperposeStructuresModal.tsx
@@ -22,11 +22,15 @@ export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: 
     const movChainSelectRef = useRef<null | HTMLSelectElement>(null)
     const movMoleculeSelectRef = useRef<null | HTMLSelectElement>(null)
     const makeCopyOfMovStructCheckRef = useRef<null | HTMLInputElement>(null)
+    const algorithmSelectRef = useRef<null | HTMLSelectElement>(null)
+    const lsqkbModeRef = useRef<string>("all-atoms")
 
     const [selectedRefModel, setSelectedRefModel] = useState<null | number>(null)
     const [selectedRefChain, setSelectedRefChain] = useState<null | string>(null)
     const [selectedMovModel, setSelectedMovModel] = useState<null | number>(null)
     const [selectedMovChain, setSelectedMovChain] = useState<null | string>(null)
+    const [algortihm, setAlgorithm] = useState<null | string>("ssm")
+    const [lsqkbMode, setLsqkbMode] = useState<string>("all-atoms")
     const [busy, setBusy] = useState<boolean>(false)
 
     const dispatch = useDispatch()
@@ -126,7 +130,7 @@ export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: 
     const bodyContent = <Stack direction="vertical" gap={1} style={{ display: 'flex' }}>
         <Form.Group style={{  margin: '0.5rem' }}>
             <Form.Label>Algorithm</Form.Label>
-            <FormSelect>
+            <FormSelect ref={algorithmSelectRef} value={algortihm} onChange={(evt) => setAlgorithm(evt.target.value)}>
                 <option value={"ssm"}>SSM</option>
                 <option value={"lsqkb"}>LSQKB</option>
             </FormSelect>
@@ -148,6 +152,42 @@ export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: 
                 <MoorhenChainSelect width="100%" molecules={molecules} onChange={(evt) => handleChainChange(evt, false)} selectedCoordMolNo={selectedMovModel} allowedTypes={[1, 2]} ref={movChainSelectRef} />
             </Form.Group>
         </Stack>
+        {algortihm === "lsqkb" && <>
+        <hr></hr>
+        <Form.Label style={{ margin: '0.5rem' }}>
+            Match atoms
+        </Form.Label>
+        <Form.Group style={{ margin: '0.5rem', display: "flex", width: '100%', flexDirection: 'row', justifyContent: 'space-around' }} controlId="lsqkb-settings" className="mb-3">
+            <Form.Check
+                style={{ margin: "0.5rem", justifyContent: "inherit", display: "flex", gap: "0.5rem"}} 
+                type="radio"
+                checked={lsqkbMode === 'all-atoms'}
+                onChange={() => { 
+                    lsqkbModeRef.current = "all-atoms"
+                    setLsqkbMode("all-atoms")
+                }}
+                label="All Atoms"/>
+            <Form.Check
+                style={{ margin: "0.5rem", justifyContent: "inherit", display: "flex", gap: "0.5rem"}} 
+                type="radio"
+                checked={lsqkbMode === 'mainchain'}
+                onChange={() => { 
+                    lsqkbModeRef.current = "mainchain"
+                    setLsqkbMode("mainchain")
+                }}
+                label="Mainchain"/>
+            <Form.Check
+                style={{ margin: "0.5rem", justifyContent: "inherit", display: "flex", gap: "0.5rem"}} 
+                type="radio"
+                checked={lsqkbMode === 'c-alphas'}
+                onChange={() => { 
+                    lsqkbModeRef.current = "c-alphas"
+                    setLsqkbMode("c-alphas")
+                }}
+                label="C-Alphas"/>
+        </Form.Group>
+        <hr></hr>
+        </>}
         <Form.Check
             style={{ margin: "0.5rem", justifyContent: "inherit", display: "flex", gap: "0.5rem"}} 
             type="switch"
@@ -181,7 +221,7 @@ export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: 
                 defaultWidth={convertViewtoPx(10, width)}
                 minHeight={convertViewtoPx(15, height)}
                 minWidth={convertViewtoPx(25, width)}
-                maxHeight={convertViewtoPx(30, height)}
+                maxHeight={convertViewtoPx(50, height)}
                 maxWidth={convertViewtoPx(50, width)}
                 headerTitle='Superpose structures'
                 footer={footerContent}

--- a/baby-gru/src/components/snack-bar/MoorhenResidueSelectionSnackBar.tsx
+++ b/baby-gru/src/components/snack-bar/MoorhenResidueSelectionSnackBar.tsx
@@ -368,10 +368,10 @@ export const MoorhenResidueSelectionSnackBar = forwardRef<HTMLDivElement, {id: s
                 <hr style={{margin: 0, padding: 0}}></hr>
                 <Stack gap={2} direction="vertical" style={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
                     <Stack gap={2} direction='horizontal' style={{ width: '100%', display: 'flex', justifyContent: 'center' }}>
-                        <IconButton onClick={handleRefinement} onMouseEnter={() => setTooltipContents('Refine')}>
+                        <IconButton disabled={activeMap === null} onClick={handleRefinement} onMouseEnter={() => setTooltipContents('Refine')}>
                             <CrisisAlertOutlined/>
                         </IconButton>
-                        <IconButton onClick={handleDragAtoms} onMouseEnter={() => setTooltipContents('Drag atoms')}>
+                        <IconButton disabled={activeMap === null} onClick={handleDragAtoms} onMouseEnter={() => setTooltipContents('Drag atoms')}>
                             <AdsClickOutlined/>
                         </IconButton>
                         <IconButton onClick={handleSelectionCopy} onMouseEnter={() => setTooltipContents('Copy fragment')}>

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -144,7 +144,8 @@ export namespace moorhen {
         getNcsRelatedChains(): Promise<string[][]>;
         animateRefine(n_cyc: number, n_iteration: number, final_n_cyc?: number): Promise<void>;
         refineResidueRange(chainId: string, start: number, stop: number, ncyc?: number, redraw?: boolean): Promise<void>;
-        SSMSuperpose(movChainId: string, refMolNo: number, refChainId: string): Promise<WorkerResponse>;
+        SSMSuperpose(movChainId: string, refMolNo: number, refChainId: string, redraw?: boolean): Promise<void>;
+        lsqkbSuperpose(refMolNo: number, residueMatches: moorhen.lskqbResidueRangeMatch[], matchType?: number, redraw?: boolean): Promise<void>;
         refineResiduesUsingAtomCid(cid: string, mode: string, ncyc?: number, redraw?: boolean): Promise<void>;
         deleteCid(cid: string, redraw?: boolean): Promise<{first: number, second: number}>;
         getNumberOfAtoms(): Promise<number>;
@@ -256,6 +257,13 @@ export namespace moorhen {
         coordsFormat: coorFormats;
         moleculeDiameter: number;
         headerInfo: libcootApi.headerInfoJS;
+    }
+
+    type lskqbResidueRangeMatch = {
+        refChainId: string;
+        movChainId: string;
+        refResidueRange: [number, number];
+        movResidueRange: [number, number];
     }
 
     type RepresentationStyles = 'VdwSpheres' | 'ligands' | 'CAs' | 'CBs' | 'CDs' | 'gaussian' | 'allHBonds' | 'rama' | 

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1978,14 +1978,56 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @param {string} movChainId - Chain ID for the moving structure
      * @param {string} refMolNo - Molecule number for the reference structure
      * @param {string} refChainId - Chain ID for the reference structure
+     * @param {boolean} [redraw=true] - Indicates if the molecule should be redrawn
      */
-    SSMSuperpose(movChainId: string, refMolNo: number, refChainId: string): Promise<moorhen.WorkerResponse> {
-        return this.commandCentre.current.cootCommand({
+    async SSMSuperpose(movChainId: string, refMolNo: number, refChainId: string, redraw: boolean = true): Promise<void> {
+        this.commandCentre.current.cootCommand({
             command: "SSM_superpose",
             returnType: 'superpose_results',
             commandArgs: [refMolNo, refChainId, this.molNo, movChainId],
             changesMolecules: [this.molNo]
         }, true)
+        
+        this.setAtomsDirty(true)
+        if (redraw) {
+            await this.redraw()
+            await this.centreOn('/*/*/*/*', true)
+        }
+    }
+
+    /**
+     * Use LSQKB to superpose this molecule (as the moving structure) with another molecule isntance
+     * @param {string} refMolNo - Molecule number for the reference structure
+     * @param {moorhen.lskqbResidueRangeMatch[]} residueMatches - A list of objects describing the residue matches for LSQKB
+     * @param {number} [matchType=1] - The match type for LSQKB: 0 - all | 1 - main | 2 - CAs 
+     * @param {boolean} [redraw=true] - Indicates if the molecule should be redrawn
+     */
+    async lsqkbSuperpose(refMolNo: number, residueMatches: moorhen.lskqbResidueRangeMatch[], matchType: number = 1, redraw: boolean = true): Promise<void> {
+        await this.commandCentre.current.cootCommand({
+            command: 'clear_lsq_matches',
+            commandArgs: [ ],
+            returnType: 'status'
+        }, false)
+        
+        await Promise.all(residueMatches.map(item => {
+            return this.commandCentre.current.cootCommand({
+                command: 'add_lsq_superpose_match',
+                commandArgs: [item.refChainId, ...item.refResidueRange, item.movChainId, ...item.movResidueRange, matchType],
+                returnType: 'status'
+            }, false)
+        }))
+        
+        await this.commandCentre.current.cootCommand({
+            command: 'lsq_superpose',
+            commandArgs: [refMolNo, this.molNo],
+            returnType: 'status'
+        }, false)
+        
+        this.setAtomsDirty(true)
+        if (redraw) {
+            await this.redraw()
+            await this.centreOn('/*/*/*/*', true)
+        }
     }
 
     /**


### PR DESCRIPTION
This update resolves #393. It also includes the following fixes:
- Whenever the active map is deleted, the next available map is made active in order to prevent situations where refinement is attempted without an active map.
- Refinement buttons in the residue selection menu are disabled if no active map is available.