### PR TITLE
Enable mol. symm. colouring in custom representations and other fixes

### DIFF
--- a/baby-gru/src/components/card/MoorhenColourRuleCard.tsx
+++ b/baby-gru/src/components/card/MoorhenColourRuleCard.tsx
@@ -81,16 +81,17 @@ const ColourSwatch = (props: {
     </>
 }
 
-const NcsColourSwatch = (props: {
+export const NcsColourSwatch = (props: {
     rule: moorhen.ColourRule;
     applyColourChange: () => void;
+    style?: {[key: string]: string}
 }) => {
 
     const ncsSwatchRef = useRef(null)
     const newNcsHexValueRef = useRef<string>('')
     const ncsCopySelectRef = useRef<null | HTMLSelectElement>(null)
 
-    const [rgb, setRgb] = useState<{r: number, g: number, b: number}>({r: 100, g: 100, b: 100})
+    const [hex, setHex] = useState<string>("#ffffff")
     const [ncsCopyValue, setNcsCopyValue] = useState<string>('')
     const [showColourPicker, setShowColourPicker] = useState<boolean>(false)
 
@@ -113,9 +114,8 @@ const NcsColourSwatch = (props: {
         <GrainOutlined ref={ncsSwatchRef} onClick={() => {
             setShowColourPicker(true)
             const hex = (rule.args[0] as string).split('|')[0].split('^')[1]
-            const [_r, _g, _b, _a] = MoorhenColourRule.parseHexToRgba(hex)
-            setRgb({r: _r, g: _g, b: _b})
-        }} style={{ cursor: 'pointer', height:'23px', width:'23px', marginLeft: '0.5rem', marginRight: '0.5rem', borderStyle: 'solid', borderColor: '#ced4da', borderWidth: '3px', borderRadius: '8px' }}/>
+            setHex(hex)
+        }} style={props.style ? props.style : { cursor: 'pointer', height:'23px', width:'23px', marginLeft: '0.5rem', marginRight: '0.5rem', borderStyle: 'solid', borderColor: '#ced4da', borderWidth: '3px', borderRadius: '8px' }}/>
         <Popover 
             anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
             transformOrigin={{ vertical: 'top', horizontal: 'left' }}
@@ -134,8 +134,7 @@ const NcsColourSwatch = (props: {
                     setNcsCopyValue(evt.target.value)
                     const chainNames = JSON.parse(evt.target.value)
                     const hex = (rule.args[0] as string).split('|').find(item => item.includes(chainNames[0]))?.split('^')[1]
-                    const [_r, _g, _b, _a] = MoorhenColourRule.parseHexToRgba(hex)
-                    setRgb({r: _r, g: _g, b: _b})
+                    setHex(hex)
                 }}>
                     {[...new Set((rule.args[0] as string).split('|').map(item => item.split('^')[1]))].map((hex, index) => {
                         const chainNames = JSON.stringify((rule.args[0] as string).split('|').filter(item => item.includes(hex)).map(item => item.split('^')[0]))
@@ -143,16 +142,15 @@ const NcsColourSwatch = (props: {
                     })}
                 </FormSelect>
             </Form.Group>
-            <RgbColorPicker color={rgb} onChange={(color: { r: number; g: number; b: number; }) => {
-                newNcsHexValueRef.current = rgbToHex(color.r, color.g, color.b)
-                setRgb(color)
+            <HexAlphaColorPicker color={hex} onChange={(color: string) => {
+                newNcsHexValueRef.current = color
+                setHex(color)
             }}/>
             <div style={{width: '100%', display: 'flex', justifyContent: 'center'}}>
                 <div className="moorhen-hex-input-decorator">#</div>
-                <HexColorInput className="moorhen-hex-input" color={rgbToHex(rgb.r, rgb.g, rgb.b)} onChange={(hex) => {
-                    const [r, g, b, _a] = MoorhenColourRule.parseHexToRgba(hex)
+                <HexColorInput className="moorhen-hex-input" color={hex} onChange={(hex) => {
                     newNcsHexValueRef.current = hex
-                    setRgb({r, g, b})
+                    setHex(hex)
                 }}/>
             </div>
             <Button style={{marginTop: '0.2rem'}} onClick={applyNcsColourChange}>

--- a/baby-gru/src/components/modal/MoorhenSuperposeStructuresModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenSuperposeStructuresModal.tsx
@@ -117,7 +117,7 @@ export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: 
     const movMoleculeSelectRef = useRef<null | HTMLSelectElement>(null)
     const makeCopyOfMovStructCheckRef = useRef<null | HTMLInputElement>(null)
     const algorithmSelectRef = useRef<null | HTMLSelectElement>(null)
-    const lsqkbModeRef = useRef<string>("all-atoms")
+    const lsqkbModeRef = useRef<number>(0)
     const movResidueRangeRef = useRef<[number, number]>([1, 100])
     const refResidueRangeRef = useRef<[number, number]>([1, 100])
 
@@ -164,7 +164,7 @@ export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: 
         if (algorithmSelectRef.current.value === "ssm") {
             await movMolecule.SSMSuperpose(movChainSelectRef.current.value, refMolecule.molNo, refChainSelectRef.current.value)
         } else {
-            await movMolecule.lsqkbSuperpose(refMolecule.molNo, lsqkbResidueRanges, parseInt(lsqkbModeRef.current))
+            await movMolecule.lsqkbSuperpose(refMolecule.molNo, lsqkbResidueRanges, lsqkbModeRef.current)
         }
 
         if (makeCopyOfMovStructCheckRef.current.checked) {
@@ -298,7 +298,7 @@ export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: 
                 type="radio"
                 checked={lsqkbMode === 'all-atoms'}
                 onChange={() => { 
-                    lsqkbModeRef.current = "all-atoms"
+                    lsqkbModeRef.current = 0
                     setLsqkbMode("all-atoms")
                 }}
                 label="All Atoms"/>
@@ -307,7 +307,7 @@ export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: 
                 type="radio"
                 checked={lsqkbMode === 'mainchain'}
                 onChange={() => { 
-                    lsqkbModeRef.current = "mainchain"
+                    lsqkbModeRef.current = 1
                     setLsqkbMode("mainchain")
                 }}
                 label="Main Chain"/>
@@ -316,7 +316,7 @@ export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: 
                 type="radio"
                 checked={lsqkbMode === 'c-alphas'}
                 onChange={() => { 
-                    lsqkbModeRef.current = "c-alphas"
+                    lsqkbModeRef.current = 2
                     setLsqkbMode("c-alphas")
                 }}
                 label="C-Alphas"/>

--- a/baby-gru/src/components/modal/MoorhenSuperposeStructuresModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenSuperposeStructuresModal.tsx
@@ -6,7 +6,6 @@ import { convertViewtoPx } from '../../utils/MoorhenUtils';
 import { useDispatch, useSelector } from "react-redux";
 import { MoorhenMoleculeSelect } from "../select/MoorhenMoleculeSelect";
 import { MoorhenChainSelect } from "../select/MoorhenChainSelect";
-import { libcootApi } from "../../types/libcoot";
 import { Backdrop, IconButton, Tooltip } from "@mui/material";
 import { useSnackbar } from "notistack";
 import { addMolecule } from "../../moorhen";
@@ -195,7 +194,6 @@ export const MoorheSuperposeStructuresModal = (props: { show: boolean; setShow: 
         } else {
             setSelectedMovChain(evt.target.value)
         }
-        setLsqkbResidueRanges({ action: "empty" })
     }
 
     const handleAddLsqkbMatch = useCallback(() => {

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -305,17 +305,19 @@ export async function loadSessionData(
             return colourRule
         })
         molecule.defaultBondOptions = storedMoleculeData.defaultBondOptions
-        for (const item of storedMoleculeData.representations) {
-            const colourRules = !item.colourRules ? null : item.colourRules.map(item => {
-                const colourRule = MoorhenColourRule.initFromDataObject(item, commandCentre, molecule)
-                return colourRule
-            })
-            const representation = await molecule.addRepresentation(
-                item.style, item.cid, item.isCustom, colourRules, item.bondOptions
-            )
-            if (item.isCustom) {
-                dispatch( addCustomRepresentation(representation) )
-            }
+        if (storedMoleculeData.representations) {
+            for (const item of storedMoleculeData.representations) {
+                const colourRules = !item.colourRules ? null : item.colourRules.map(item => {
+                    const colourRule = MoorhenColourRule.initFromDataObject(item, commandCentre, molecule)
+                    return colourRule
+                })
+                const representation = await molecule.addRepresentation(
+                    item.style, item.cid, item.isCustom, colourRules, item.bondOptions
+                )
+                if (item.isCustom) {
+                    dispatch( addCustomRepresentation(representation) )
+                }
+            }    
         }
     }
     


### PR DESCRIPTION
This update includes:
- A fix for a bug preventing sessions where a molecule does not have any representation from being loaded correctly
- A fix for a bug where LSQKB match options were ignored
- Enable colouring of custom representations by mol. symm.
- Enable transparency in mol. symm. colour rules