### PR TITLE
Add symmetry and M2T parameters to session file

### DIFF
--- a/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
+++ b/baby-gru/src/components/card/MoorhenAddCustomRepresentationCard.tsx
@@ -166,6 +166,11 @@ export const MoorhenAddCustomRepresentationCard = (props: {
             }
         }
 
+        // TODO: Other parameters need to be set by user just like with bonds
+        let m2tParams = {
+            ...props.molecule.defaultM2tParams, nucleotideRibbonStyle: nucleotideStyleSelectRef.current?.value as ("DishyBases" | "StickBases")
+        }
+
         if (props.mode === 'add') {
             const representation = await props.molecule.addRepresentation(
                 styleSelectRef.current.value,
@@ -173,7 +178,7 @@ export const MoorhenAddCustomRepresentationCard = (props: {
                 true,
                 colourRule ? [ colourRule ] : null,
                 bondOptions,
-                nucleotideStyleSelectRef.current?.value as ("DishyBases" | "StickBases")
+                m2tParams
             )
             dispatch( addCustomRepresentation(representation) )
         } else if (props.mode === 'edit' && props.representationId) {

--- a/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeCard.tsx
@@ -102,7 +102,7 @@ export const MoorhenMoleculeCard = forwardRef<any, MoorhenMoleculeCardPropsInter
     const [surfaceRadius, setSurfaceRadius] = useState<number>(5.0)
     const [surfaceGridScale, setSurfaceGridScale] = useState<number>(0.7)
     const [surfaceBFactor, setSurfaceBFactor] = useState<number>(100)
-    const [symmetryRadius, setSymmetryRadius] = useState<number>(25.0)
+    const [symmetryRadius, setSymmetryRadius] = useState<number>(props.molecule.symmetryRadius)
 
     const customRepresentationList: moorhen.MoleculeRepresentation[] = useMemo(() => {
         return JSON.parse(customRepresentationsString).map(representationId => {

--- a/baby-gru/src/components/card/MoorhenMoleculeRepresentationSettingsCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeRepresentationSettingsCard.tsx
@@ -178,9 +178,9 @@ const SymmetrySettingsPanel = (props: {
     glRef: React.RefObject<webGL.MGWebGL>;
 }) => {
 
-    const [symmetryOn, setSymmetryOn] = useState<boolean>(false)
-    const [biomolOn, setBiomolOn] = useState<boolean>(false)
-    const [showUnitCell, setShowUnitCell] = useState<boolean>(false)
+    const [symmetryOn, setSymmetryOn] = useState<boolean>(props.molecule.symmetryOn)
+    const [biomolOn, setBiomolOn] = useState<boolean>(props.molecule.biomolOn)
+    const [showUnitCell, setShowUnitCell] = useState<boolean>(props.molecule.unitCellRepresentation?.visible)
 
     const {
         symmetryRadius, setSymmetryRadius

--- a/baby-gru/src/protobuf/MoorhenSession.proto
+++ b/baby-gru/src/protobuf/MoorhenSession.proto
@@ -7,6 +7,21 @@ message CootBondOptions {
   float atomRadiusBondRatio = 3;
 }
 
+message M2tParameters {
+  float ribbonStyleCoilThickness = 1;
+  float ribbonStyleHelixWidth = 2;
+  float ribbonStyleStrandWidth = 3;
+  float ribbonStyleArrowWidth = 4;
+  float ribbonStyleDNARNAWidth = 5;
+  int32 ribbonStyleAxialSampling = 6;
+  int32 cylindersStyleAngularSampling = 7;
+  float cylindersStyleCylinderRadius = 8;
+  float cylindersStyleBallRadius = 9;
+  float surfaceStyleProbeRadius = 10;
+  float ballsStyleRadiusMultiplier = 11;
+  string nucleotideRibbonStyle = 12;
+}
+
 message ColourRuleObject {
   string cid = 1;
   string color = 2;
@@ -37,6 +52,7 @@ message Representation {
     bool isCustom = 3;
     repeated ColourRuleObject colourRules = 4;
     CootBondOptions bondOptions = 5;
+    M2tParameters m2tParams = 6;
 }
 
 message MoleculeSessionData {
@@ -48,6 +64,10 @@ message MoleculeSessionData {
   repeated ColourRuleObject defaultColourRules = 6;
   repeated int32 connectedToMaps = 7;
   map<string, string> ligandDicts = 8;
+  M2tParameters defaultM2tParams = 9;
+  bool symmetryOn = 10;
+  bool biomolOn = 11;
+  float symmetryRadius = 12;
 }
 
 message MapDataSession {

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -102,6 +102,7 @@ export namespace moorhen {
         cylindersStyleBallRadius: number;
         surfaceStyleProbeRadius: number;
         ballsStyleRadiusMultiplier: number;
+        nucleotideRibbonStyle: "StickBases" | "DishyBases";
     }
     
     type ColourRuleObject = {
@@ -175,7 +176,7 @@ export namespace moorhen {
         fitLigand(mapMolNo: number, ligandMolNo: number, fitRightHere?: boolean, redraw?: boolean, useConformers?: boolean, conformerCount?: number): Promise<Molecule[]>;
         checkIsLigand(): boolean;
         removeRepresentation(representationId: string): void;
-        addRepresentation(style: string, cid: string, isCustom?: boolean, colour?: ColourRule[], bondOptions?: cootBondOptions, nucleotideStyle?: "DishyBases" | "StickBases"): Promise<MoleculeRepresentation>;
+        addRepresentation(style: string, cid: string, isCustom?: boolean, colour?: ColourRule[], bondOptions?: cootBondOptions, m2tParams?: moorhen.m2tParameters): Promise<MoleculeRepresentation>;
         getNeighborResiduesCids(selectionCid: string, maxDist: number): Promise<string[]>;
         drawWithStyleFromMesh(style: string, meshObjects: any[], cid?: string, fetchAtomBuffers?: boolean): Promise<void>;
         updateWithMovedAtoms(movedResidues: AtomInfo[][]): Promise<void>;
@@ -328,7 +329,6 @@ export namespace moorhen {
         ligandsCid: string;
         hoverColor: number[];
         residueSelectionColor: number[];
-        nucleotideStyle: 'DishyBases' | 'StickBases';
     }
 
     type ResidueSelection = {
@@ -548,11 +548,16 @@ export namespace moorhen {
             isCustom: boolean;
             colourRules: ColourRuleObject[];
             bondOptions: cootBondOptions;
+            m2tParams: moorhen.m2tParameters;
          }[];
         defaultBondOptions: cootBondOptions;
+        defaultM2tParams: m2tParameters;
         defaultColourRules: ColourRuleObject[];
         connectedToMaps: number[];
         ligandDicts: {[comp_id: string]: string};
+        symmetryOn: boolean;
+        biomolOn: boolean;
+        symmetryRadius: number;
     }
     
     type mapDataSession = {

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -150,7 +150,8 @@ export class MoorhenMolecule implements moorhen.Molecule {
             cylindersStyleCylinderRadius: 0.2,
             cylindersStyleBallRadius: 0.2,
             surfaceStyleProbeRadius: 1.4,
-            ballsStyleRadiusMultiplier: 1
+            ballsStyleRadiusMultiplier: 1,
+            nucleotideRibbonStyle: 'StickBases'
         }
         this.restraints = []
         this.adaptativeBondsEnabled = false
@@ -1113,9 +1114,9 @@ export class MoorhenMolecule implements moorhen.Molecule {
      * @param {boolean} [isCustom=false] - Indicates if the representation is considered "custom"
      * @param {moorhen.ColourRule[]} [colourRules=undefined] - A list of colour rules that will be applied to the new representation
      * @param {moorhen.cootBondOptions} [bondOptions=undefined] - An object that describes bond width, atom/bond ratio and other bond settings.
-     * @param {string} [nucleotideStyle=undefined] - Set the style for the nucleotides when using ribbon representations.
+     * @param {moorhen.m2tParameters} [m2tParams=undefined] - An object that describes ribbon width, nucleotide style and other ribbon settings.
      */
-    async addRepresentation(style: moorhen.RepresentationStyles, cid: string = '/*/*/*/*', isCustom: boolean = false, colourRules?: moorhen.ColourRule[], bondOptions?: moorhen.cootBondOptions, nucleotideStyle?: "DishyBases" | "StickBases") {
+    async addRepresentation(style: moorhen.RepresentationStyles, cid: string = '/*/*/*/*', isCustom: boolean = false, colourRules?: moorhen.ColourRule[], bondOptions?: moorhen.cootBondOptions, m2tParams?: moorhen.m2tParameters) {
         if (!this.defaultColourRules) {
             await this.fetchDefaultColourRules()
         }
@@ -1124,9 +1125,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         representation.setParentMolecule(this)
         representation.setColourRules(colourRules)
         representation.setBondOptions(bondOptions)
-        if (style === "CRs" && nucleotideStyle) {
-            representation.setNucleotideStyle(nucleotideStyle)
-        }
+        representation.setM2tParams(m2tParams)
         await representation.draw()
         this.representations.push(representation)
         await this.drawSymmetry(false)

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -214,11 +214,16 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
                     isCustom: item.isCustom,
                     colourRules: item.useDefaultColourRules ? null : item.colourRules.map(item => item.objectify()),
                     bondOptions: item.useDefaultBondOptions ? null : item.bondOptions,
+                    m2tParams: item.useDefaultM2tParams ? null : item.m2tParams,
                 }}),
                 defaultColourRules: molecule.defaultColourRules.map(item => item.objectify()),
                 defaultBondOptions: molecule.defaultBondOptions,
+                defaultM2tParams: molecule.defaultM2tParams,
                 connectedToMaps: molecule.connectedToMaps,
-                ligandDicts: molecule.ligandDicts
+                ligandDicts: molecule.ligandDicts,
+                symmetryOn: molecule.symmetryOn,
+                biomolOn: molecule.biomolOn,
+                symmetryRadius: molecule.symmetryRadius
             }
         })
 

--- a/baby-gru/src/utils/MoorhenUtils.ts
+++ b/baby-gru/src/utils/MoorhenUtils.ts
@@ -304,7 +304,12 @@ export async function loadSessionData(
             const colourRule = MoorhenColourRule.initFromDataObject(item, commandCentre, molecule)
             return colourRule
         })
-        molecule.defaultBondOptions = storedMoleculeData.defaultBondOptions
+        if (storedMoleculeData.defaultBondOptions){
+            molecule.defaultBondOptions = storedMoleculeData.defaultBondOptions
+        }
+        if (storedMoleculeData.defaultM2tParams) {
+            molecule.defaultM2tParams = storedMoleculeData.defaultM2tParams
+        }
         if (storedMoleculeData.representations) {
             for (const item of storedMoleculeData.representations) {
                 const colourRules = !item.colourRules ? null : item.colourRules.map(item => {
@@ -312,12 +317,18 @@ export async function loadSessionData(
                     return colourRule
                 })
                 const representation = await molecule.addRepresentation(
-                    item.style, item.cid, item.isCustom, colourRules, item.bondOptions
+                    item.style, item.cid, item.isCustom, colourRules, item.bondOptions, item.m2tParams
                 )
                 if (item.isCustom) {
                     dispatch( addCustomRepresentation(representation) )
                 }
             }    
+        }
+        if (storedMoleculeData.symmetryOn) {
+            molecule.setSymmetryRadius(storedMoleculeData.symmetryRadius)
+            await molecule.toggleSymmetry()
+        } else if (storedMoleculeData.biomolOn) {
+            molecule.toggleBiomolecule()
         }
     }
     


### PR DESCRIPTION
This will update session format so that symmetry on/off info is stored and M2T representation parameters are also stored. This should be a retro-compatible format.