### PR TITLE
Automatically colour model by B-factor / PLDDT when opening slice-n-dice modal

### DIFF
--- a/baby-gru/src/components/context-menu/MoorhenContextButtonBase.tsx
+++ b/baby-gru/src/components/context-menu/MoorhenContextButtonBase.tsx
@@ -104,12 +104,11 @@ export const MoorhenContextButtonBase = (props: {
 }) => {
 
     const defaultProps = {
-        needsMapData: false, needsAtomData: true, 
-        refineAfterMod: true, onExit: null, onCompleted: null
+        needsMapData: false, needsAtomData: true, refineAfterMod: true
     }
     
     const {
-        refineAfterMod, onCompleted, needsAtomData, needsMapData, onExit
+        refineAfterMod, needsAtomData, needsMapData,
     } = {...defaultProps, ...props}
     
     const molecules = useSelector((state: moorhen.State) => state.molecules.moleculeList)
@@ -126,9 +125,7 @@ export const MoorhenContextButtonBase = (props: {
         
         const cootResult = await props.commandCentre.current.cootCommand(cootCommandInput, true)
         
-        if (onCompleted) {
-            onCompleted(props.selectedMolecule, props.chosenAtom)
-        }
+        props.onCompleted?.(props.selectedMolecule, props.chosenAtom)
         
         if (refineAfterMod && enableRefineAfterMod && activeMap) {
             try {
@@ -149,9 +146,7 @@ export const MoorhenContextButtonBase = (props: {
         dispatch( triggerUpdate(props.selectedMolecule.molNo) )
         props.selectedMolecule.clearBuffersOfStyle('hover')
       
-        if(onExit) {
-            onExit(props.selectedMolecule, props.chosenAtom, cootResult)
-        }        
+        props.onExit?.(props.selectedMolecule, props.chosenAtom, cootResult)
     }
   
     const handleClick = useCallback(async () => {

--- a/baby-gru/src/components/context-menu/MoorhenContextMenu.tsx
+++ b/baby-gru/src/components/context-menu/MoorhenContextMenu.tsx
@@ -2,8 +2,8 @@ import styled, { css } from "styled-components";
 import { ClickAwayListener, FormGroup, List, Tooltip } from '@mui/material';
 import { MoorhenBackgroundColorMenuItem } from "../menu-item/MoorhenBackgroundColorMenuItem"
 import { atomInfoToResSpec, convertRemToPx } from "../../utils/utils";
-import { useEffect, useRef, useState, useCallback, MutableRefObject, RefObject } from "react";
-import { Popover, Overlay, FormLabel, FormSelect, Button, Stack } from "react-bootstrap";
+import { useEffect, useRef, useState, useCallback, RefObject } from "react";
+import { Popover, Overlay } from "react-bootstrap";
 import { MoorhenAddAltConfButton } from "./MoorhenAddAltConfButton"
 import { MoorhenAddTerminalResidueButton } from "./MoorhenAddTerminalResidueButton"
 import { MoorhenAutofitRotamerButton } from "./MoorhenAutofitRotamerButton"


### PR DESCRIPTION
After this update, models are automatically coloured by the selected threshold when the slice-n-dice modal mounts.