### PR TITLE
Add minor UI improvements as requested

### DIFF
--- a/baby-gru/src/components/card/MoorhenMapCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMapCard.tsx
@@ -339,12 +339,16 @@ export const MoorhenMapCard = forwardRef<any, MoorhenMapCardPropsInterface>((pro
 
     const handleWheelContourLevelCallback = useCallback((evt: moorhen.WheelContourLevelEvent) => {
         let newMapContourLevel: number
-        if (mapIsVisible && props.map.molNo === activeMap.molNo) {
-            if (evt.detail.factor > 1) {
+        if (props.map.molNo === activeMap.molNo) {
+            if (!mapIsVisible) {
+                enqueueSnackbar("Active map not displayed, cannot change contour lvl.", { variant: "warning"})
+            } else if (evt.detail.factor > 1) {
                 newMapContourLevel = mapContourLevel + contourWheelSensitivityFactor
             } else {
                 newMapContourLevel = mapContourLevel - contourWheelSensitivityFactor
             }
+        }
+        if (newMapContourLevel) {
             batch(() => {
                 dispatch( setContourLevel({ molNo: props.map.molNo, contourLevel: newMapContourLevel }) )
                 enqueueSnackbar(`map-${props.map.molNo}-contour-lvl-change`, {

--- a/baby-gru/src/components/modal/MoorhenControlsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenControlsModal.tsx
@@ -18,7 +18,8 @@ const shortCutMouseActions = {
     center_atom: ['middle-right-mouse-click', 'one-finger-tap'],
     set_map_contour: ['middle-right-mouse-click', 'mouse-scroll-arrows', 'two-finger-scroll'],
     pan_view: ['circle-left-mouse-click', 'mouse-move', 'one-finger-move'],
-    rotate_view: ['circle-left-mouse-click', 'mouse-move', 'one-finger-move']
+    rotate_view: ['circle-left-mouse-click', 'mouse-move', 'one-finger-move'],
+    contour_lvl: ['mouse-scroll-arrows', 'two-finger-scroll']
 }
 
 export const MoorhenControlsModal = (props: { urlPrefix: string }) => {
@@ -45,6 +46,7 @@ export const MoorhenControlsModal = (props: { urlPrefix: string }) => {
         shortCuts['pan_view'] = {modifiers: ['shiftKey', 'altKey'], keyPress: '', label: 'Pan view'}
         shortCuts['rotate_view'] = {modifiers: ['shiftKey'], keyPress: '', label: 'Rotate view'} 
         shortCuts['open_context_menu'] = {modifiers: [], keyPress: '', label: 'Open context menu'} 
+        shortCuts['contour_lvl'] = {modifiers: ['ctrlKey'], keyPress: '', label: 'Change active map contour'}
     }
 
     const handleMouseHover = (key: string, modifiers: string[], isMouseEnter: boolean = true) => {

--- a/baby-gru/src/components/modal/MoorhenControlsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenControlsModal.tsx
@@ -1,11 +1,12 @@
 import { Card, Col, Row } from "react-bootstrap";
 import { moorhen } from "../../types/moorhen";
 import { useSelector } from "react-redux";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { MoorhenDraggableModalBase } from "./MoorhenDraggableModalBase";
 import { convertViewtoPx } from "../../utils/utils";
 import parse from 'html-react-parser'
 import { modalKeys } from "../../utils/enums";
+import { Autocomplete, createFilterOptions, MenuItem, TextField } from "@mui/material";
 
 const shortCutMouseActions = {
     open_context_menu: ['circle-right-mouse-click', 'two-finger-tap'],
@@ -27,8 +28,24 @@ export const MoorhenControlsModal = (props: { urlPrefix: string }) => {
     const _shortCuts = useSelector((state: moorhen.State) => state.shortcutSettings.shortCuts)
     const height = useSelector((state: moorhen.State) => state.sceneSettings.height)
     const width = useSelector((state: moorhen.State) => state.sceneSettings.width)
+    const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
 
+    const [autocompleteOpen, setAutocompleteOpen] = useState<boolean>(false)
     const [svgString, setSvgString] = useState<string | null>(null)
+    const [autoCompleteValue, setAutoCompleteValue] = useState<string>("")
+
+    const previouslySearchedRef = useRef<string | null>(null)
+    const autoCompleteRef = useRef<string | null>(null)
+    const shortCuts = useMemo(() => {
+        const shortCuts: {[key: string]: {modifiers: string[]; keyPress: string; label: string}} = _shortCuts ? JSON.parse(_shortCuts as string) : null
+        if (shortCuts) {
+            shortCuts['pan_view'] = {modifiers: ['shiftKey', 'altKey'], keyPress: '', label: 'Pan view'}
+            shortCuts['rotate_view'] = {modifiers: ['shiftKey'], keyPress: '', label: 'Rotate view'} 
+            shortCuts['open_context_menu'] = {modifiers: [], keyPress: '', label: 'Open context menu'} 
+            shortCuts['contour_lvl'] = {modifiers: ['ctrlKey'], keyPress: '', label: 'Change active map contour'}
+        }
+        return shortCuts
+    }, [_shortCuts])
 
     useEffect(() => {
         const fetchSVG = async () => {
@@ -41,13 +58,10 @@ export const MoorhenControlsModal = (props: { urlPrefix: string }) => {
         fetchSVG()
     }, [])
 
-    const shortCuts: moorhen.Shortcut[] = _shortCuts ? JSON.parse(_shortCuts as string) : null
-    if (shortCuts) {
-        shortCuts['pan_view'] = {modifiers: ['shiftKey', 'altKey'], keyPress: '', label: 'Pan view'}
-        shortCuts['rotate_view'] = {modifiers: ['shiftKey'], keyPress: '', label: 'Rotate view'} 
-        shortCuts['open_context_menu'] = {modifiers: [], keyPress: '', label: 'Open context menu'} 
-        shortCuts['contour_lvl'] = {modifiers: ['ctrlKey'], keyPress: '', label: 'Change active map contour'}
-    }
+    const filterOptions = useMemo(() => createFilterOptions({
+        ignoreCase: true,
+        limit: 5
+    }), [])
 
     const handleMouseHover = (key: string, modifiers: string[], isMouseEnter: boolean = true) => {
         const cardElement = document.getElementById(`show-controls-card-${key}`)
@@ -80,16 +94,16 @@ export const MoorhenControlsModal = (props: { urlPrefix: string }) => {
                 modalId={modalKeys.SHOW_CONTROLS}
                 left={width / 5}
                 top={height / 5}
-                minHeight={convertViewtoPx(60, height)}
+                minHeight={convertViewtoPx(65, height)}
                 minWidth={convertViewtoPx(60, width)}
-                maxHeight={convertViewtoPx(60, height)}
+                maxHeight={convertViewtoPx(65, height)}
                 maxWidth={convertViewtoPx(60, width)}
                 headerTitle='Moorhen Controls'
                 enableResize={false}
                 footer={null}
                 body={
                     <Row style={{display: 'flex'}}>
-                    <Col className="col-4" style={{overflowY: 'scroll', height: convertViewtoPx(60, height)}}>
+                    <Col className="col-4" style={{overflowY: 'scroll', height: convertViewtoPx(65, height)}}>
                     {shortCuts && Object.keys(shortCuts).map(key => {
                             let modifiers = []
                             if (shortCuts[key].modifiers.includes('shiftKey')) modifiers.push("Shift")
@@ -98,7 +112,12 @@ export const MoorhenControlsModal = (props: { urlPrefix: string }) => {
                             if (shortCuts[key].modifiers.includes('altKey')) modifiers.push("Alt")
                             if (shortCuts[key].keyPress === " ") modifiers.push("Space")
                             return <Card id={`show-controls-card-${key}`} key={key} style={{margin:'0.5rem', borderColor: 'grey'}}
-                                         onMouseEnter={() => handleMouseHover(key, modifiers)}
+                                         onMouseEnter={() => {
+                                            if (previouslySearchedRef.current) {
+                                                handleMouseHover(previouslySearchedRef.current, shortCuts[previouslySearchedRef.current].modifiers, false)
+                                            }        
+                                            handleMouseHover(key, modifiers)
+                                        }}
                                          onMouseLeave={() => handleMouseHover(key, modifiers, false)}>
                                         <Card.Body style={{padding:'0.5rem'}}>
                                             <span style={{fontWeight:'bold'}}>
@@ -108,8 +127,63 @@ export const MoorhenControlsModal = (props: { urlPrefix: string }) => {
                                     </Card>
                             })}
                     </Col>
-                    <Col className="col-8" style={{ display: 'flex' }}>
-                        {svgString ? parse(svgString) : null}
+                    <Col className="col-8" style={{ display: 'flex', flexDirection: 'column' }}>
+                        <Autocomplete
+                            style={{ paddingTop: '0.5rem' }}
+                            disablePortal
+                            selectOnFocus
+                            clearOnBlur
+                            handleHomeEndKeys
+                            freeSolo
+                            includeInputInList
+                            filterSelectedOptions
+                            size='small'
+                            value={autoCompleteValue}
+                            open={autocompleteOpen}
+                            onClose={() => setAutocompleteOpen(false)}
+                            onOpen={() => setAutocompleteOpen(true)}
+                            renderInput={(params) => <TextField {...params} label="Search" InputProps={{
+                                ...params.InputProps
+                            }} />}
+                            renderOption={(props, key: string) => {
+                                return <MenuItem key={key} onClick={(_evt) => {
+                                    autoCompleteRef.current = key
+                                    setAutoCompleteValue(shortCuts[key].label)
+                                    setAutocompleteOpen(false)
+                                    if (previouslySearchedRef.current) {
+                                        handleMouseHover(previouslySearchedRef.current, shortCuts[previouslySearchedRef.current].modifiers, false)
+                                    }
+                                    previouslySearchedRef.current = key
+                                    handleMouseHover(key, shortCuts[key].modifiers)
+                                }}>{shortCuts[key].label}</MenuItem>
+                            }}
+                            options={Object.keys(shortCuts)}
+                            filterOptions={filterOptions}
+                            onChange={(evt, newSelection: string) => {
+                                autoCompleteRef.current = newSelection
+                                if (newSelection === null) {
+                                    setAutoCompleteValue(newSelection)
+                                }
+                                setAutocompleteOpen(false)
+                            }}
+                            sx={{
+                                '& .MuiInputBase-root': {
+                                    backgroundColor: isDark ? '#222' : 'white',
+                                    color: isDark ? 'white' : '#222',
+                                },
+                                '& .MuiOutlinedInput-notchedOutline': {
+                                    borderColor: isDark ? 'white' : 'grey',
+                                },
+                                '& .MuiButtonBase-root': {
+                                    color: isDark ? 'white' : 'grey',
+                                },
+                                '& .MuiFormLabel-root': {
+                                    color: isDark ? 'white' : '#222',
+                                },
+                            }}/>
+                            <div style={{display: 'flex'}}>
+                                {svgString ? parse(svgString) : null}
+                            </div>
                     </Col>
                     </Row>
                 }

--- a/baby-gru/src/utils/MoorhenKeyboardPress.ts
+++ b/baby-gru/src/utils/MoorhenKeyboardPress.ts
@@ -315,6 +315,7 @@ export const moorhenKeyPress = (
             glRef.current.showShortCutHelp.push(`<Shift><Alt> Translate View`)
             glRef.current.showShortCutHelp.push(`<Shift> Rotate View`)
             glRef.current.showShortCutHelp.push(`Double click go to blob`)
+            glRef.current.showShortCutHelp.push(`<Ctrl><Scroll> Change active map contour lvl.`)
             glRef.current.drawScene()
         } else  {
             glRef.current.showShortCutHelp = null


### PR DESCRIPTION
This resolves #421

- [x]    Trying to scroll the contour level with Ctrl + mouse wheel, if the active map is not displayed, nothing happens and there's no feedback for the user. It'd be helpful to display a message to say "active map not displayed, cannot change contour level" or similar
- [x]     The zoom controls don't seem to be documented anywhere. People will probably naturally discover the scroll wheel and pinch-to-zoom on a trackpad, but it'd be nice to have "Alt + click and drag vertically" documented in the "h" help text and the Moorhen Controls panel.
- [x]     It'd be great to have a search function in the Moorhen Controls panel
