### PR TITLE
No moorhen data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -582,6 +582,7 @@ tests/test.log
 .gitignore
 baby-gru/moorhen-0.1.0.tgz
 baby-gru/copyForDist.sh
+baby-gru/public/baby-gru/data.tar.gz
 baby-gru/public/baby-gru/CootWorker.js
 baby-gru/docs/
 baby-gru/src/version.js

--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -29,7 +29,6 @@
           "^/public$",
           "^/public/favicon.ico$",
           "^/public/index.html",
-          "^/public/logo192.png",
           "^/public/manifest.json",
           "^/Dockerfile",
           "^/README.md",

--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moorhen",
-  "version": "0.13.2-alpha.3",
+  "version": "0.13.2-alpha.4",
   "private": false,
   "main": "moorhen.js",
   "types": "./types/main.d.ts",

--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moorhen",
-  "version": "0.13.1",
+  "version": "0.13.2-alpha.0",
   "private": false,
   "main": "moorhen.js",
   "types": "./types/main.d.ts",

--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -81,7 +81,7 @@
     "make-linux": "npm run build && electron-forge make --platform linux",
     "make-win32": "npm run build && electron-forge make --platform win32",
     "create-docs": "npm run create-version && npx jsdoc -c jsdoc.json",
-    "test": "npm run create-version && npm run transpile-protobuf && npm run transpile-graphql-codegen && npx tsc && npm run transpile-ts-worker-jest && ln -sf ./public/moorhen.data ./moorhen.data && ln -sf ./public/ ./baby-gru && node --trace-warnings --experimental-wasm-eh --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
+    "test": "npm run create-version && npm run transpile-protobuf && npm run transpile-graphql-codegen && npx tsc && npm run transpile-ts-worker-jest && ln -sf ./public/ ./baby-gru && node --trace-warnings --experimental-wasm-eh --experimental-vm-modules node_modules/jest/bin/jest.js --forceExit",
     "test-react": "npm run create-version && npm run transpile-protobuf && npm run transpile-graphql-codegen && npx tsc && node --trace-warnings --experimental-vm-modules --experimental-wasm-threads node_modules/jest/bin/jest.js --forceExit --testPathIgnorePatterns=MoorhenContainer.test.jsx --testPathIgnorePatterns=MoorhenLigandMenu.test.jsx --testPathIgnorePatterns=MoorhenEditMenu.test.jsx --selectProjects react-components"
   },
   "eslintConfig": {
@@ -160,6 +160,7 @@
     "nested-worker": "git+https://github.com/johanholmerin/nested-worker.git#semver:^1.0.0",
     "nightingale-linegraph-track": "^3.8.10",
     "node-fetch": "^2.7.0",
+    "node-gzip": "^1.1.2",
     "nodemon": "^2.0.22",
     "notistack": "^3.0.1",
     "optionator": "^0.9.4",

--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moorhen",
-  "version": "0.13.2-alpha.0",
+  "version": "0.13.2-alpha.1",
   "private": false,
   "main": "moorhen.js",
   "types": "./types/main.d.ts",

--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moorhen",
-  "version": "0.13.2-alpha.1",
+  "version": "0.13.2-alpha.2",
   "private": false,
   "main": "moorhen.js",
   "types": "./types/main.d.ts",

--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moorhen",
-  "version": "0.13.2-alpha.2",
+  "version": "0.13.2-alpha.3",
   "private": false,
   "main": "moorhen.js",
   "types": "./types/main.d.ts",

--- a/baby-gru/public/CootWorker.ts
+++ b/baby-gru/public/CootWorker.ts
@@ -1298,17 +1298,14 @@ onmessage = function (e) {
             print: print,
             printErr: printErr,
         })
-            .then(async (returnedModule) => {
+            .then((returnedModule) => {
                 postMessage({ consoleMessage: 'Initialized molecules_container', message: e.data.message, messageId: e.data.messageId })
 
                 cootModule = returnedModule;
 
+                const fileData = e.data.data.cootData
                 cootModule.FS.mkdir("data_tmp")
-                const fileResponse = await fetch("baby-gru/data.tar.gz")
-
-                const fileData = await fileResponse.arrayBuffer()
-
-                cootModule.FS_createDataFile("data_tmp", "data.tar", new Uint8Array(fileData), true, true);
+                cootModule.FS_createDataFile("data_tmp", "data.tar", fileData, true, true);
                 const retVal = cootModule.unpackCootDataFile("data_tmp/data.tar","/")
                 cootModule.FS_unlink("data_tmp/data.tar")
 

--- a/baby-gru/public/CootWorker.ts
+++ b/baby-gru/public/CootWorker.ts
@@ -1304,10 +1304,22 @@ onmessage = function (e) {
                 cootModule = returnedModule;
 
                 const fileData = e.data.data.cootData
+                let doUnzip = false
+                let unzipName = ""
+
+
+                let tarFileName = "data.tar"
+                if(fileData[0]==0x1F && fileData[1]==0x8B){
+                    doUnzip = true
+                    tarFileName = "data.tar.gz"
+                    unzipName = "data_tmp/data.tar"
+                }
+
+                //FIXME - Need to consider the case of doUnzip is true.
                 cootModule.FS.mkdir("data_tmp")
-                cootModule.FS_createDataFile("data_tmp", "data.tar", fileData, true, true);
-                const retVal = cootModule.unpackCootDataFile("data_tmp/data.tar","/")
-                cootModule.FS_unlink("data_tmp/data.tar")
+                cootModule.FS_createDataFile("data_tmp", tarFileName, fileData, true, true);
+                const retVal = cootModule.unpackCootDataFile("data_tmp/"+tarFileName,doUnzip, unzipName,"")
+                cootModule.FS_unlink("data_tmp/"+tarFileName)
 
                 molecules_container = new cootModule.molecules_container_js(false)
                 molecules_container.set_use_gemmi(false)

--- a/baby-gru/public/CootWorker.ts
+++ b/baby-gru/public/CootWorker.ts
@@ -1298,9 +1298,20 @@ onmessage = function (e) {
             print: print,
             printErr: printErr,
         })
-            .then((returnedModule) => {
+            .then(async (returnedModule) => {
                 postMessage({ consoleMessage: 'Initialized molecules_container', message: e.data.message, messageId: e.data.messageId })
+
                 cootModule = returnedModule;
+
+                cootModule.FS.mkdir("data_tmp")
+                const fileResponse = await fetch("baby-gru/data.tar.gz")
+
+                const fileData = await fileResponse.arrayBuffer()
+
+                cootModule.FS_createDataFile("data_tmp", "data.tar", new Uint8Array(fileData), true, true);
+                const retVal = cootModule.unpackCootDataFile("data_tmp/data.tar","/")
+                cootModule.FS_unlink("data_tmp/data.tar")
+
                 molecules_container = new cootModule.molecules_container_js(false)
                 molecules_container.set_use_gemmi(false)
                 molecules_container.set_show_timings(false)

--- a/baby-gru/public/manifest.json
+++ b/baby-gru/public/manifest.json
@@ -6,16 +6,6 @@
       "src": "favicon.ico",
       "sizes": "64x64 32x32 24x24 16x16",
       "type": "image/x-icon"
-    },
-    {
-      "src": "logo192.png",
-      "type": "image/png",
-      "sizes": "192x192"
-    },
-    {
-      "src": "logo512.png",
-      "type": "image/png",
-      "sizes": "512x512"
     }
   ],
   "start_url": ".",

--- a/baby-gru/src/moorhen.ts
+++ b/baby-gru/src/moorhen.ts
@@ -7,6 +7,7 @@ import { MoorhenColourRule } from './utils/MoorhenColourRule';
 import { MoorhenMoleculeRepresentation } from './utils/MoorhenMoleculeRepresentation';
 import { MoorhenMolecule } from './utils/MoorhenMolecule';
 import { MoorhenMap } from './utils/MoorhenMap';
+import { getMultiColourRuleArgs } from './utils/utils';
 import { MoorhenCommandCentre } from './utils/MoorhenCommandCentre';
 import { MoorhenTimeCapsule } from './utils/MoorhenTimeCapsule';
 import { MoorhenPreferences } from "./utils/MoorhenPreferences";
@@ -90,5 +91,5 @@ export {
     resetGeneralStates, resetHoveringStates, resetLabelSettings, resetMapContourSettings, resetMoleculeMapUpdates,
     resetRefinementSettings, resetShortcutSettings, resetActiveModals, focusOnModal, setBFactorThreshold, 
     setClusteringType, setMoleculeBfactors, setMoleculeMaxBfactor, resetSliceNDiceSlice, setMoleculeMinBfactor, 
-    setNClusters, setPaeFileIsUploaded, setSlicingResults, setThresholdType, setPAEFileContents
+    setNClusters, setPaeFileIsUploaded, setSlicingResults, setThresholdType, setPAEFileContents, getMultiColourRuleArgs
 };

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -480,7 +480,7 @@ export namespace libcootApi {
         three_letter_code: string;
     }
     type CootModule = {
-        unpackCootDataFile(arg0: string, arg1: string): number;
+        unpackCootDataFile(arg0: string, arg1: boolean, arg2: string, arg3: string): number;
         SmilesToPDB(arg0: string, arg1: string, arg2: number, arg3: number): PairType<string, string>;
         FS: {
             readFile(tempFilename: string, arg1: { encoding: string; }): string | Uint8Array;

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -480,6 +480,7 @@ export namespace libcootApi {
         three_letter_code: string;
     }
     type CootModule = {
+        unpackCootDataFile(arg0: string, arg1: string): number;
         SmilesToPDB(arg0: string, arg1: string, arg2: number, arg3: number): PairType<string, string>;
         FS: {
             readFile(tempFilename: string, arg1: { encoding: string; }): string | Uint8Array;

--- a/baby-gru/src/types/main.d.ts
+++ b/baby-gru/src/types/main.d.ts
@@ -171,6 +171,9 @@ declare module 'moorhen' {
     }
     module.exports.MoorhenMap = MoorhenMap
 
+    function getMultiColourRuleArgs(molecule: _moorhen.Molecule, ruleType: string): Promise<string>;
+    module.exports = getMultiColourRuleArgs;
+
     function setPositiveMapColours(arg0: {molNo: number, rgb: {r: number; g: number; b: number}}): any;
     module.exports = setPositiveMapColours;
     

--- a/baby-gru/src/utils/MoorhenCommandCentre.ts
+++ b/baby-gru/src/utils/MoorhenCommandCentre.ts
@@ -67,7 +67,9 @@ export class MoorhenCommandCentre implements moorhen.CommandCentre {
         this.isClosed = false
         this.cootWorker = new Worker(`${this.urlPrefix}/../CootWorker.js`)
         this.cootWorker.onmessage = this.handleMessage.bind(this)
-        await this.postMessage({ message: 'CootInitialize', data: {} })
+        const fileResponse = await fetch("baby-gru/data.tar.gz")
+        const fileData = await fileResponse.arrayBuffer()
+        await this.postMessage({ message: 'CootInitialize', data: {cootData:new Uint8Array(fileData)} })
         if (this.onCootInitialized) {
             this.onCootInitialized()
         }

--- a/baby-gru/src/utils/MoorhenCommandCentre.ts
+++ b/baby-gru/src/utils/MoorhenCommandCentre.ts
@@ -67,7 +67,7 @@ export class MoorhenCommandCentre implements moorhen.CommandCentre {
         this.isClosed = false
         this.cootWorker = new Worker(`${this.urlPrefix}/../CootWorker.js`)
         this.cootWorker.onmessage = this.handleMessage.bind(this)
-        const fileResponse = await fetch("baby-gru/data.tar.gz")
+        const fileResponse = await fetch(`${this.urlPrefix}/../baby-gru/data.tar.gz`)
         const fileData = await fileResponse.arrayBuffer()
         await this.postMessage({ message: 'CootInitialize', data: {cootData:new Uint8Array(fileData)} })
         if (this.onCootInitialized) {

--- a/baby-gru/tests/__tests__/gemmi.test.js
+++ b/baby-gru/tests/__tests__/gemmi.test.js
@@ -4,6 +4,8 @@ jest.setTimeout(40000)
 const fs = require('fs')
 const path = require('path')
 const fetch = require('node-fetch')
+const {gzip, ungzip} = require('node-gzip');
+
 const createCootModule = require('../../public/moorhen')
 
 let cootModule;
@@ -15,8 +17,7 @@ beforeAll(() => {
         printErr(t) { () => console.log(["output", t]); }
     }).then(moduleCreated => {
         cootModule = moduleCreated
-        setupFunctions.copyTestDataToFauxFS()
-        return Promise.resolve()
+        return setupFunctions.copyTestDataToFauxFS()
     })
 })
 
@@ -321,5 +322,12 @@ const setupFunctions = {
             cootModule.FS_createDataFile(".", fileName, coordData, true, true);
         })
         cootModule.FS.mkdir("COOT_BACKUP");
+        const cootDataZipped = fs.readFileSync(path.join(__dirname, '..', '..', 'public', 'baby-gru', 'data.tar.gz' ), { encoding: null, flag: 'r' })
+        return ungzip(cootDataZipped).then((cootData) => {
+            cootModule.FS.mkdir("data_tmp")
+            cootModule.FS_createDataFile("data_tmp", "data.tar", cootData, true, true);
+            cootModule.unpackCootDataFile("data_tmp/data.tar","/")
+            cootModule.FS_unlink("data_tmp/data.tar")
+        })
     }
 }

--- a/baby-gru/tests/__tests__/gemmi.test.js
+++ b/baby-gru/tests/__tests__/gemmi.test.js
@@ -326,7 +326,7 @@ const setupFunctions = {
         return ungzip(cootDataZipped).then((cootData) => {
             cootModule.FS.mkdir("data_tmp")
             cootModule.FS_createDataFile("data_tmp", "data.tar", cootData, true, true);
-            cootModule.unpackCootDataFile("data_tmp/data.tar","/")
+            cootModule.unpackCootDataFile("data_tmp/data.tar",false,"","")
             cootModule.FS_unlink("data_tmp/data.tar")
         })
     }

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -2113,7 +2113,7 @@ const setupFunctions = {
         return ungzip(cootDataZipped).then((cootData) => {
             cootModule.FS.mkdir("data_tmp")
             cootModule.FS_createDataFile("data_tmp", "data.tar", cootData, true, true);
-            cootModule.unpackCootDataFile("data_tmp/data.tar","/")
+            cootModule.unpackCootDataFile("data_tmp/data.tar",false,"","")
             cootModule.FS_unlink("data_tmp/data.tar")
         })
     }

--- a/baby-gru/tests/__tests__/molecules_container.test.js
+++ b/baby-gru/tests/__tests__/molecules_container.test.js
@@ -4,6 +4,8 @@ jest.setTimeout(60000)
 
 const fs = require('fs')
 const path = require('path')
+const {gzip, ungzip} = require('node-gzip');
+
 const createCootModule = require('../../public/moorhen')
 
 let cootModule;
@@ -15,8 +17,7 @@ beforeAll(() => {
         printErr(t) { () => console.log(["output", t]); }
     }).then(moduleCreated => {
         cootModule = moduleCreated
-        setupFunctions.copyTestDataToFauxFS()
-        return Promise.resolve()
+        return setupFunctions.copyTestDataToFauxFS()
     })
 })
 
@@ -2108,5 +2109,12 @@ const setupFunctions = {
             cootModule.FS_createDataFile(".", fileName, coordData, true, true);
         })
         cootModule.FS.mkdir("COOT_BACKUP");
+        const cootDataZipped = fs.readFileSync(path.join(__dirname, '..', '..', 'public', 'baby-gru', 'data.tar.gz' ), { encoding: null, flag: 'r' })
+        return ungzip(cootDataZipped).then((cootData) => {
+            cootModule.FS.mkdir("data_tmp")
+            cootModule.FS_createDataFile("data_tmp", "data.tar", cootData, true, true);
+            cootModule.unpackCootDataFile("data_tmp/data.tar","/")
+            cootModule.FS_unlink("data_tmp/data.tar")
+        })
     }
 }

--- a/baby-gru/tests/__tests__/moorhenMap.test.js
+++ b/baby-gru/tests/__tests__/moorhenMap.test.js
@@ -285,7 +285,7 @@ const setupFunctions = {
         return ungzip(cootDataZipped).then((cootData) => {
             cootModule.FS.mkdir("data_tmp")
             cootModule.FS_createDataFile("data_tmp", "data.tar", cootData, true, true);
-            cootModule.unpackCootDataFile("data_tmp/data.tar","/")
+            cootModule.unpackCootDataFile("data_tmp/data.tar",false,"","")
             cootModule.FS_unlink("data_tmp/data.tar")
         })
     }

--- a/baby-gru/tests/__tests__/moorhenMap.test.js
+++ b/baby-gru/tests/__tests__/moorhenMap.test.js
@@ -8,6 +8,8 @@ jest.setTimeout(40000)
 
 const fs = require('fs')
 const path = require('path')
+const {gzip, ungzip} = require('node-gzip');
+
 const createCootModule = require('../../public/moorhen')
 let cootModule;
 
@@ -44,11 +46,10 @@ beforeAll(() => {
         printErr(t) { () => console.log(["output", t]); }
     }).then(moduleCreated => {
         cootModule = moduleCreated
-        setupFunctions.copyTestDataToFauxFS()
         global.window = {
             CCP4Module: cootModule,
         }
-        return Promise.resolve()
+        return setupFunctions.copyTestDataToFauxFS()
     })
 })
 
@@ -280,5 +281,12 @@ const setupFunctions = {
             cootModule.FS_createDataFile(".", fileName, coordData, true, true);
         })
         cootModule.FS.mkdir("COOT_BACKUP");
+        const cootDataZipped = fs.readFileSync(path.join(__dirname, '..', '..', 'public', 'baby-gru', 'data.tar.gz' ), { encoding: null, flag: 'r' })
+        return ungzip(cootDataZipped).then((cootData) => {
+            cootModule.FS.mkdir("data_tmp")
+            cootModule.FS_createDataFile("data_tmp", "data.tar", cootData, true, true);
+            cootModule.unpackCootDataFile("data_tmp/data.tar","/")
+            cootModule.FS_unlink("data_tmp/data.tar")
+        })
     }
 }

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -1044,7 +1044,7 @@ const setupFunctions = {
         return ungzip(cootDataZipped).then((cootData) => {
             cootModule.FS.mkdir("data_tmp")
             cootModule.FS_createDataFile("data_tmp", "data.tar", cootData, true, true);
-            cootModule.unpackCootDataFile("data_tmp/data.tar","/")
+            cootModule.unpackCootDataFile("data_tmp/data.tar",false,"","")
             cootModule.FS_unlink("data_tmp/data.tar")
         })
     }

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -10,6 +10,8 @@ jest.setTimeout(60000)
 
 const fs = require('fs')
 const path = require('path')
+const {gzip, ungzip} = require('node-gzip');
+
 const createCootModule = require('../../public/moorhen')
 let cootModule;
 
@@ -50,11 +52,10 @@ beforeAll(() => {
         printErr(t) { () => console.log(["output", t]); }
     }).then(moduleCreated => {
         cootModule = moduleCreated
-        setupFunctions.copyTestDataToFauxFS()
         global.window = {
             CCP4Module: cootModule,
         }
-        return Promise.resolve()
+        return setupFunctions.copyTestDataToFauxFS()
     })
 })
 
@@ -1039,5 +1040,12 @@ const setupFunctions = {
             cootModule.FS_createDataFile(".", fileName, coordData, true, true);
         })
         cootModule.FS.mkdir("COOT_BACKUP");
+        const cootDataZipped = fs.readFileSync(path.join(__dirname, '..', '..', 'public', 'baby-gru', 'data.tar.gz' ), { encoding: null, flag: 'r' })
+        return ungzip(cootDataZipped).then((cootData) => {
+            cootModule.FS.mkdir("data_tmp")
+            cootModule.FS_createDataFile("data_tmp", "data.tar", cootData, true, true);
+            cootModule.unpackCootDataFile("data_tmp/data.tar","/")
+            cootModule.FS_unlink("data_tmp/data.tar")
+        })
     }
 }

--- a/baby-gru/tests/__tests__/moorhenRefine.test.js
+++ b/baby-gru/tests/__tests__/moorhenRefine.test.js
@@ -145,7 +145,7 @@ const setupFunctions = {
         return ungzip(cootDataZipped).then((cootData) => {
             cootModule.FS.mkdir("data_tmp")
             cootModule.FS_createDataFile("data_tmp", "data.tar", cootData, true, true);
-            cootModule.unpackCootDataFile("data_tmp/data.tar","/")
+            cootModule.unpackCootDataFile("data_tmp/data.tar",false,"","")
             cootModule.FS_unlink("data_tmp/data.tar")
         })
         cootModule.FS.mkdir("COOT_BACKUP");

--- a/baby-gru/tests/__tests__/moorhenRefine.test.js
+++ b/baby-gru/tests/__tests__/moorhenRefine.test.js
@@ -11,6 +11,8 @@ jest.setTimeout(60000)
 
 const fs = require('fs')
 const path = require('path')
+const {gzip, ungzip} = require('node-gzip');
+
 const createCootModule = require('../../public/moorhen')
 let cootModule;
 
@@ -60,11 +62,10 @@ beforeAll(() => {
         printErr(t) { () => console.log(["output", t]); }
     }).then(moduleCreated => {
         cootModule = moduleCreated
-        setupFunctions.copyTestDataToFauxFS()
         global.window = {
             CCP4Module: cootModule,
         }
-        return Promise.resolve()
+        return setupFunctions.copyTestDataToFauxFS()
     })
 })
 
@@ -139,6 +140,13 @@ const setupFunctions = {
             }
             const coordData = fs.readFileSync(path.join(dirName, fileName), { encoding: fileName.includes('mtz') ? null : 'utf8', flag: 'r' })
             cootModule.FS_createDataFile(".", fileName, coordData, true, true);
+        })
+        const cootDataZipped = fs.readFileSync(path.join(__dirname, '..', '..', 'public', 'baby-gru', 'data.tar.gz' ), { encoding: null, flag: 'r' })
+        return ungzip(cootDataZipped).then((cootData) => {
+            cootModule.FS.mkdir("data_tmp")
+            cootModule.FS_createDataFile("data_tmp", "data.tar", cootData, true, true);
+            cootModule.unpackCootDataFile("data_tmp/data.tar","/")
+            cootModule.FS_unlink("data_tmp/data.tar")
         })
         cootModule.FS.mkdir("COOT_BACKUP");
     }

--- a/baby-gru/tests/__tests__/sliceNDice.test.js
+++ b/baby-gru/tests/__tests__/sliceNDice.test.js
@@ -4,6 +4,8 @@ jest.setTimeout(40000)
 
 const fs = require('fs')
 const path = require('path')
+const {gzip, ungzip} = require('node-gzip');
+
 const createCootModule = require('../../public/moorhen')
 
 let cootModule;
@@ -28,8 +30,7 @@ beforeAll(() => {
         printErr(t) { () => console.log(["output", t]); }
     }).then(moduleCreated => {
         cootModule = moduleCreated
-        setupFunctions.copyTestDataToFauxFS()
-        return Promise.resolve()
+        return setupFunctions.copyTestDataToFauxFS()
     })
 })
 
@@ -141,5 +142,12 @@ const setupFunctions = {
             cootModule.FS_createDataFile(".", fileName, coordData, true, true);
         })
         cootModule.FS.mkdir("COOT_BACKUP");
+        const cootDataZipped = fs.readFileSync(path.join(__dirname, '..', '..', 'public', 'baby-gru', 'data.tar.gz' ), { encoding: null, flag: 'r' })
+        return ungzip(cootDataZipped).then((cootData) => {
+            cootModule.FS.mkdir("data_tmp")
+            cootModule.FS_createDataFile("data_tmp", "data.tar", cootData, true, true);
+            cootModule.unpackCootDataFile("data_tmp/data.tar","/")
+            cootModule.FS_unlink("data_tmp/data.tar")
+        })
     }
 }

--- a/baby-gru/tests/__tests__/sliceNDice.test.js
+++ b/baby-gru/tests/__tests__/sliceNDice.test.js
@@ -146,7 +146,7 @@ const setupFunctions = {
         return ungzip(cootDataZipped).then((cootData) => {
             cootModule.FS.mkdir("data_tmp")
             cootModule.FS_createDataFile("data_tmp", "data.tar", cootData, true, true);
-            cootModule.unpackCootDataFile("data_tmp/data.tar","/")
+            cootModule.unpackCootDataFile("data_tmp/data.tar",false,"","")
             cootModule.FS_unlink("data_tmp/data.tar")
         })
     }

--- a/wasm_src/CMakeLists.txt
+++ b/wasm_src/CMakeLists.txt
@@ -554,15 +554,15 @@ FILE(COPY ${coot_src}/data/metal/metal-O-distance.table DESTINATION data/coot/da
 FILE(COPY ${coot_src}/data/metal/metal-S-distance.table DESTINATION data/coot/data/metal )
 FILE(COPY ${CMAKE_INSTALL_PREFIX}/share/RDKit/Data/BaseFeatures.fdef DESTINATION data/RDKit/Data )
 
-add_executable(moorhen moorhen-wrappers.cc ../wasm_src_frontend/headers.cc gemmi-wrappers.cc smilestopdb.cc ${coot_src}/lhasa/embind.cpp)
+add_executable(moorhen untar.c moorhen-wrappers.cc ../wasm_src_frontend/headers.cc gemmi-wrappers.cc smilestopdb.cc ${coot_src}/lhasa/embind.cpp)
 if(${MEMORY64} MATCHES "1")
-target_link_options(moorhen PRIVATE -sASSERTIONS=2 -pthread -sPTHREAD_POOL_SIZE=32 -sPTHREAD_POOL_SIZE_STRICT=32 -sALLOW_MEMORY_GROWTH=1 -sINITIAL_MEMORY=4096MB -sMAXIMUM_MEMORY=8192MB --bind -sFORCE_FILESYSTEM=1 -sMODULARIZE=1 -sEXPORT_NAME=createCoot64Module -sEXPORTED_RUNTIME_METHODS=['FS'] --preload-file data  --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/coot_env_web.js)
+target_link_options(moorhen PRIVATE -sASSERTIONS=2 -pthread -sPTHREAD_POOL_SIZE=32 -sPTHREAD_POOL_SIZE_STRICT=32 -sALLOW_MEMORY_GROWTH=1 -sINITIAL_MEMORY=4096MB -sMAXIMUM_MEMORY=8192MB --bind -sFORCE_FILESYSTEM=1 -sMODULARIZE=1 -sEXPORT_NAME=createCoot64Module -sEXPORTED_RUNTIME_METHODS=['FS'] --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/coot_env_web.js)
 set_target_properties(moorhen PROPERTIES OUTPUT_NAME moorhen64)
 target_link_directories(moorhen PUBLIC 
     ${CMAKE_INSTALL_PREFIX}/install64/lib
 )
 else()
-target_link_options(moorhen PRIVATE -sASSERTIONS=2 -pthread -sPTHREAD_POOL_SIZE=32 -sPTHREAD_POOL_SIZE_STRICT=32 -sALLOW_MEMORY_GROWTH=1 --bind -sFORCE_FILESYSTEM=1 -sMODULARIZE=1 -sEXPORT_NAME=createCootModule -sEXPORTED_RUNTIME_METHODS=['FS'] --preload-file data  --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/coot_env_web.js)
+target_link_options(moorhen PRIVATE -sASSERTIONS=2 -pthread -sPTHREAD_POOL_SIZE=32 -sPTHREAD_POOL_SIZE_STRICT=32 -sALLOW_MEMORY_GROWTH=1 --bind -sFORCE_FILESYSTEM=1 -sMODULARIZE=1 -sEXPORT_NAME=createCootModule -sEXPORTED_RUNTIME_METHODS=['FS'] --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/coot_env_web.js)
 target_link_directories(moorhen PUBLIC 
     ${CMAKE_INSTALL_PREFIX}/install/lib
 )
@@ -646,14 +646,18 @@ else()
     set(MOORHEN_MODULE_SUFFIX "")
 endif()
 
+add_custom_target(create_tar ALL COMMAND
+    ${CMAKE_COMMAND} -E tar "cfvz" "data.tar.gz" ${CMAKE_CURRENT_BINARY_DIR}/data)
+add_dependencies(create_tar moorhen)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/data.tgz DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/../baby-gru/public/baby-gru)
+
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moorhen${MOORHEN_MODULE_SUFFIX}.wasm
 ${CMAKE_CURRENT_BINARY_DIR}/moorhen${MOORHEN_MODULE_SUFFIX}.js
-${CMAKE_CURRENT_BINARY_DIR}/moorhen${MOORHEN_MODULE_SUFFIX}.data
 ${CMAKE_CURRENT_SOURCE_DIR}/coot_env_web.js
 DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/../baby-gru/public)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moorhen${MOORHEN_MODULE_SUFFIX}.wasm
 ${CMAKE_CURRENT_BINARY_DIR}/moorhen${MOORHEN_MODULE_SUFFIX}.js
-${CMAKE_CURRENT_BINARY_DIR}/moorhen${MOORHEN_MODULE_SUFFIX}.data
 ${CMAKE_CURRENT_SOURCE_DIR}/coot_env_web.js
 DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/../moorhen_tests)

--- a/wasm_src/CMakeLists.txt
+++ b/wasm_src/CMakeLists.txt
@@ -88,8 +88,6 @@ ${coot_src}/pli/pi-stacking.cc
 ${coot_src}/coot-utils/cmtz-interface.cc
 ${coot_src}/coot-utils/lidia-core-functions.cc
 ${coot_src}/coot-utils/atom-selection-container.cc
-${coot_src}/coot-utils/dictionary-atom-types.cc
-${coot_src}/coot-utils/cod-db-access.cc
 ${coot_src}/coot-utils/diff-diff-map-peaks.cc
 ${coot_src}/coot-utils/gltf-export.cc
 ${coot_src}/coot-utils/texture-as-floats.cc
@@ -216,7 +214,6 @@ ${coot_src}/skeleton/graphical_skel.cc
 ${coot_src}/ideal/pepflip.cc
 ${coot_src}/ideal/parallel-planes.cc
 ${coot_src}/ideal/simple-restraint.cc
-#${coot_src}/ideal/mini-rsr.cc
 ${coot_src}/ideal/ng.cc
 ${coot_src}/ideal/torsion-bonds.cc
 ${coot_src}/ideal/chi-squareds.cc
@@ -258,7 +255,6 @@ ${coot_src}/utils/logging.cc
 ${coot_src}/utils/pir-alignment.cc
 ${coot_src}/utils/setup-syminfo.cc
 ${coot_src}/db-main/db-strands.cc
-#${coot_src}/db-main/testdbmain.cc
 ${coot_src}/high-res/residue-distortions.cc
 ${coot_src}/high-res/coot-atom-graph.cc
 ${coot_src}/high-res/sequence-assignment.cc
@@ -270,7 +266,6 @@ ${coot_src}/pli/flev-annotations.cc
 ${coot_src}/pli/protein-ligand-interactions.cc
 ${coot_src}/pli/pi-stacking.cc
 ${coot_src}/pli/sdf-interface.cc
-#${coot_src}/pli/specs.cc
 ${coot_src}/utils/base64-encode-decode.cc
 ${coot_src}/coot-utils/merge-atom-selections.cc
 ${coot_src}/coot-utils/coot-least-squares.cc
@@ -374,7 +369,6 @@ ${coot_src}/geometry/mol-utils-2.cc
 ${coot_src}/geometry/protein-donor-acceptors.cc
 ${coot_src}/geometry/intercept-3GP.cc
 ${coot_src}/build/CalphaBuild.cc
-#${coot_src}/build/testcabuild.cc
 ${coot_src}/mini-mol/mini-mol-utils.cc
 ${coot_src}/mini-mol/mini-mol.cc
 ${coot_src}/mini-mol/atom-quads.cc

--- a/wasm_src/CMakeLists.txt
+++ b/wasm_src/CMakeLists.txt
@@ -650,7 +650,7 @@ add_custom_target(create_tar ALL COMMAND
     ${CMAKE_COMMAND} -E tar "cfvz" "data.tar.gz" ${CMAKE_CURRENT_BINARY_DIR}/data)
 add_dependencies(create_tar moorhen)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/data.tgz DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/../baby-gru/public/baby-gru)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/data.tar.gz DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/../baby-gru/public/baby-gru)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moorhen${MOORHEN_MODULE_SUFFIX}.wasm
 ${CMAKE_CURRENT_BINARY_DIR}/moorhen${MOORHEN_MODULE_SUFFIX}.js

--- a/wasm_src/moorhen-wrappers.cc
+++ b/wasm_src/moorhen-wrappers.cc
@@ -65,6 +65,10 @@ using namespace emscripten;
 
 #include "headers.h"
 
+extern "C" {
+void untar(FILE *a, const char *path);
+}
+
 struct RamachandranInfo {
     std::string chainId;
     int seqNum;
@@ -203,7 +207,6 @@ bool isSugar(const std::string &resName);
 class molecules_container_js : public molecules_container_t {
     public:
         explicit molecules_container_js(bool verbose=true) : molecules_container_t(verbose) {
-            
         }
 
         std::vector<std::pair<std::string,int>> slicendice_slice(int imol, int nclusters, const std::string &clustering_method, const std::string &pae_contents_string){
@@ -332,7 +335,7 @@ class molecules_container_js : public molecules_container_t {
                 for (int ichain=0; ichain < nchains; ichain++) {
                     mmdb::Chain *chain = model->GetChain(ichain);
                     int nres = chain->GetNumberOfResidues();
-                    for (int ires=0; ires<nres; ires++) { 
+                    for (int ires=0; ires<nres; ires++) {
                         mmdb::Residue *residue = chain->GetResidue(ires);
                         if (isSugar(residue->name)) {
                             return true;
@@ -347,16 +350,16 @@ class molecules_container_js : public molecules_container_t {
             const std::string charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
             std::string rand_str;
             rand_str.reserve(len);
-            
+
             std::random_device rand_dev;
             std::mt19937 gen(rand_dev());
             std::uniform_int_distribution<> distrib(0, charset.length() - 1);
-    
+
             for (int i = 0; i < len; ++i) {
                 int randomIndex = distrib(gen);
                 rand_str += charset[randomIndex];
             }
-            
+
             return rand_str;
         }
 
@@ -364,7 +367,7 @@ class molecules_container_js : public molecules_container_t {
             std::string line;
             std::string file_contents;
             std::ifstream file_stream (file_name.c_str());
-            
+
             if (file_stream.is_open()) {
                 while(!file_stream.eof()) {
                     std::getline(file_stream, line);
@@ -372,9 +375,9 @@ class molecules_container_js : public molecules_container_t {
                 }
                 file_stream.close();
             } else {
-                std::cout << "Unable to open file"; 
+                std::cout << "Unable to open file";
             }
-            
+
             return file_contents;
         }
 
@@ -398,7 +401,7 @@ class molecules_container_js : public molecules_container_t {
 
         std::string get_molecule_atoms(int imol, const std::string &format) {
             std::string file_name = generate_rand_str(32);
-            std::string pdb_data;  
+            std::string pdb_data;
             try {
                 if (format == "pdb") {
                     file_name += ".pdb";
@@ -424,7 +427,7 @@ class molecules_container_js : public molecules_container_t {
             char *c_data = (char *)file_contents.c_str();
             size_t size = file_contents.length();
             const char* end = c_data + size;
-            
+
             int coor_format = int(gemmi::coor_format_from_content(c_data, end));
 
             std::string result;
@@ -473,7 +476,7 @@ class molecules_container_js : public molecules_container_t {
                 file_name += ".pdb";
             }
             write_text_file(file_name, pdb_string);
-            molecules_container_t::replace_molecule_by_model_from_file(imol, file_name); 
+            molecules_container_t::replace_molecule_by_model_from_file(imol, file_name);
             remove_file(file_name);
         }
 
@@ -485,7 +488,7 @@ class molecules_container_js : public molecules_container_t {
         std::vector<std::pair<int, int>> get_consecutive_ranges(const std::vector<int> &numbers) {
             std::vector<int> numbers_vec = numbers;
             std::sort(numbers_vec.begin(), numbers_vec.end());
-            
+
             std::vector<std::pair<int, int>> ranges;
             if (!numbers_vec.empty()) {
                 int start = numbers_vec[0];
@@ -504,7 +507,7 @@ class molecules_container_js : public molecules_container_t {
                 std::pair<int, int> i_pair(start, end);
                 ranges.push_back(i_pair);
             }
-            
+
             return ranges;
         }
 
@@ -543,7 +546,7 @@ class molecules_container_js : public molecules_container_t {
             return neighb_cid;
         }
 
-        std::pair<coot::symmetry_info_t,std::vector<std::array<float, 16>>> get_symmetry_with_matrices(int imol, float symmetry_search_radius, float x, float y, float z) { 
+        std::pair<coot::symmetry_info_t,std::vector<std::array<float, 16>>> get_symmetry_with_matrices(int imol, float symmetry_search_radius, float x, float y, float z) {
             coot::symmetry_info_t si = get_symmetry(imol, symmetry_search_radius, x, y, z);
             mmdb::Manager *mol = get_mol(imol);
             mmdb::Cryst *cryst = mol->GetCrystData();
@@ -598,21 +601,21 @@ class molecules_container_js : public molecules_container_t {
             return thePair;
         }
 
-        std::vector<float> getFloats(unsigned nFloats) { 
+        std::vector<float> getFloats(unsigned nFloats) {
             std::vector<float> fs;
             for(unsigned i=0;i<nFloats;i++){
                 fs.push_back(i*1.0);
             }
             return fs;
         }
-        int add(int ic) { 
+        int add(int ic) {
             return ic + 1;
         }
-        int writePDBASCII(int imol, const std::string &file_name) { 
+        int writePDBASCII(int imol, const std::string &file_name) {
             const char *fname_cp = file_name.c_str();
             return get_mol(imol)->WritePDBASCII(fname_cp);
         }
-        int writeCIFASCII(int imol, const std::string &file_name) { 
+        int writeCIFASCII(int imol, const std::string &file_name) {
             const auto mol = get_mol(imol);
             mmdb::Manager *mol_copy  = new mmdb::Manager;
             mol_copy->Copy(mol, mmdb::MMDBFCM_All);
@@ -625,7 +628,7 @@ class molecules_container_js : public molecules_container_t {
             clipperMap.open_write(file_name);
             clipperMap.export_xmap(xMap);
             return 0;
-        }        
+        }
         int count_simple_mesh_vertices(const coot::simple_mesh_t &m) { return m.vertices.size(); }
         std::vector<float> go_to_blob_array(float x1, float y1, float z1, float x2, float y2, float z2, float contour_level){
             std::vector<float> o;
@@ -674,7 +677,7 @@ std::string GetLabelAsymIDFromResidue(mmdb::Residue *res){
 std::string GetLabelCompIDFromResidue(mmdb::Residue *res){
     return std::string(res->GetLabelCompID());
 }
- 
+
 std::string GetInsCodeFromResidue(mmdb::Residue *res){
     return std::string(res->GetInsCode());
 }
@@ -1003,6 +1006,20 @@ emscripten::val testFloat32Array(const emscripten::val &floatArrayObject){
     return result;
 }
 
+
+void unpackCootDataFile(const std::string &fileName, const std::string &targetDir){
+
+    //FIXME - targetDir is ignored
+    std::cout << fileName << std::endl;
+
+    const char *fn_cp = fileName.c_str();
+    FILE *a = fopen(fn_cp, "rb");
+    untar(a, fn_cp);
+    fclose(a);
+
+    return;
+}
+
 EMSCRIPTEN_BINDINGS(my_module) {
         // PRIVATEER
     value_object<TorsionEntry>("TorsionEntry")
@@ -1035,6 +1052,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     register_vector<TableEntry>("Table");
     // END PRIVATEER
 
+    function("unpackCootDataFile",&unpackCootDataFile);
     function("testFloat32Array", &testFloat32Array);
     function("getPositionsFromSimpleMesh2", &getPositionsFromSimpleMesh2);
     function("getReversedNormalsFromSimpleMesh2", &getReversedNormalsFromSimpleMesh2);

--- a/wasm_src/untar.c
+++ b/wasm_src/untar.c
@@ -1,0 +1,247 @@
+/*
+ * This file is in the public domain.  Use it as you see fit.
+ */
+
+/*
+ * "untar" is an extremely simple tar extractor:
+ *  * A single C source file, so it should be easy to compile
+ *    and run on any system with a C compiler.
+ *  * Extremely portable standard C.  The only non-ANSI function
+ *    used is mkdir().
+ *  * Reads basic ustar tar archives.
+ *  * Does not require libarchive or any other special library.
+ *
+ * To compile: cc -o untar untar.c
+ *
+ * Usage:  untar <archive>
+ *
+ * In particular, this program should be sufficient to extract the
+ * distribution for libarchive, allowing people to bootstrap
+ * libarchive on systems that do not already have a tar program.
+ *
+ * To unpack libarchive-x.y.z.tar.gz:
+ *    * gunzip libarchive-x.y.z.tar.gz
+ *    * untar libarchive-x.y.z.tar
+ *
+ * Written by Tim Kientzle, March 2009.
+ *
+ * Released into the public domain.
+ */
+
+/* These are all highly standard and portable headers. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* This is for mkdir(); this may need to be changed for some platforms. */
+#include <sys/stat.h>  /* For mkdir() */
+
+#if defined(_WIN32) && !defined(__CYGWIN__)
+#include <windows.h>
+#endif
+
+#define BLOCKSIZE 512
+
+/* System call to create a directory. */
+int
+system_mkdir(char *pathname, int mode)
+{
+#if defined(_WIN32) && !defined(__CYGWIN__)
+	(void)mode; /* UNUSED */
+	return _mkdir(pathname);
+#else
+	return mkdir(pathname, mode);
+#endif
+}
+
+/* Parse an octal number, ignoring leading and trailing nonsense. */
+unsigned long
+parseoct(const char *p, size_t n)
+{
+	unsigned long i = 0;
+
+	while ((*p < '0' || *p > '7') && n > 0) {
+		++p;
+		--n;
+	}
+	while (*p >= '0' && *p <= '7' && n > 0) {
+		i *= 8;
+		i += *p - '0';
+		++p;
+		--n;
+	}
+	return (i);
+}
+
+/* Returns true if this is 512 zero bytes. */
+int
+is_end_of_archive(const char *p)
+{
+	int n;
+	for (n = 0; n < BLOCKSIZE; ++n)
+		if (p[n] != '\0')
+			return (0);
+	return (1);
+}
+
+/* Create a directory, including parent directories as necessary. */
+void
+create_dir(char *pathname, int mode)
+{
+	char *p;
+	int r;
+
+	/* Strip trailing '/' */
+	if (pathname[strlen(pathname) - 1] == '/')
+		pathname[strlen(pathname) - 1] = '\0';
+
+	/* Try creating the directory. */
+	r = system_mkdir(pathname, mode);
+	if (r != 0) {
+		/* On failure, try creating parent directory. */
+		p = strrchr(pathname, '/');
+		if (p != NULL) {
+			*p = '\0';
+			create_dir(pathname, 0755);
+			*p = '/';
+			r = system_mkdir(pathname, mode);
+		}
+	}
+	if (r != 0)
+		fprintf(stderr, "Could not create directory %s\n", pathname);
+}
+
+/* Create a file, including parent directory as necessary. */
+FILE *
+create_file(char *pathname, int mode)
+{
+	FILE *f;
+	f = fopen(pathname, "wb+");
+	if (f == NULL) {
+		/* Try creating parent dir and then creating file. */
+		char *p = strrchr(pathname, '/');
+		if (p != NULL) {
+			*p = '\0';
+			create_dir(pathname, 0755);
+			*p = '/';
+			f = fopen(pathname, "wb+");
+		}
+	}
+	return (f);
+}
+
+/* Verify the tar checksum. */
+int
+verify_checksum(const char *p)
+{
+	int n, u = 0;
+	for (n = 0; n < BLOCKSIZE; ++n) {
+		if (n < 148 || n > 155)
+			/* Standard tar checksum adds unsigned bytes. */
+			u += ((unsigned char *)p)[n];
+		else
+			u += 0x20;
+
+	}
+	return (u == (int)parseoct(p + 148, 8));
+}
+
+/* Extract a tar archive. */
+void
+untar(FILE *a, const char *path)
+{
+	char buff[BLOCKSIZE];
+	FILE *f = NULL;
+	size_t bytes_read;
+	unsigned long filesize;
+
+	printf("Extracting from %s\n", path);
+	for (;;) {
+		bytes_read = fread(buff, 1, BLOCKSIZE, a);
+		if (bytes_read < BLOCKSIZE) {
+			fprintf(stderr,
+			    "Short read on %s: expected %d, got %d\n",
+			    path, BLOCKSIZE, (int)bytes_read);
+			return;
+		}
+		if (is_end_of_archive(buff)) {
+			printf("End of %s\n", path);
+			return;
+		}
+		if (!verify_checksum(buff)) {
+			fprintf(stderr, "Checksum failure\n");
+			return;
+		}
+		filesize = parseoct(buff + 124, 12);
+		switch (buff[156]) {
+		case '1':
+			printf(" Ignoring hardlink %s\n", buff);
+			break;
+		case '2':
+			printf(" Ignoring symlink %s\n", buff);
+			break;
+		case '3':
+			printf(" Ignoring character device %s\n", buff);
+				break;
+		case '4':
+			printf(" Ignoring block device %s\n", buff);
+			break;
+		case '5':
+			printf(" Extracting dir %s\n", buff);
+			create_dir(buff, (int)parseoct(buff + 100, 8));
+			filesize = 0;
+			break;
+		case '6':
+			printf(" Ignoring FIFO %s\n", buff);
+			break;
+		default:
+			printf(" Extracting file %s\n", buff);
+			f = create_file(buff, (int)parseoct(buff + 100, 8));
+			break;
+		}
+		while (filesize > 0) {
+			bytes_read = fread(buff, 1, BLOCKSIZE, a);
+			if (bytes_read < BLOCKSIZE) {
+				fprintf(stderr,
+				    "Short read on %s: Expected %d, got %d\n",
+				    path, BLOCKSIZE, (int)bytes_read);
+				return;
+			}
+			if (filesize < BLOCKSIZE)
+				bytes_read = (size_t)filesize;
+			if (f != NULL) {
+				if (fwrite(buff, 1, bytes_read, f)
+				    != bytes_read)
+				{
+					fprintf(stderr, "Failed write\n");
+					fclose(f);
+					f = NULL;
+				}
+			}
+			filesize -= bytes_read;
+		}
+		if (f != NULL) {
+			fclose(f);
+			f = NULL;
+		}
+	}
+}
+
+#ifdef _UNTAR_MAIN_
+int main(int argc, char **argv)
+{
+	FILE *a;
+
+	++argv; /* Skip program name */
+	for ( ;*argv != NULL; ++argv) {
+		a = fopen(*argv, "rb");
+		if (a == NULL)
+			fprintf(stderr, "Unable to open %s\n", *argv);
+		else {
+			untar(a, *argv);
+			fclose(a);
+		}
+	}
+	return (0);
+}
+#endif


### PR DESCRIPTION
This changes the way that data files (especially rotamer tables) are bundled. The data is no longer the moorhen.data file bundled with the JS/WASM, but is insterad pulled from server as tar.gz.