### PR TITLE
Fix bugs in "Find ligand" menu

### DIFF
--- a/baby-gru/src/components/modal/MoorhenFindLigandModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenFindLigandModal.tsx
@@ -260,6 +260,7 @@ export const MoorheFindLigandModal = (props: { }) => {
                 maxWidth={convertViewtoPx(50, width)}
                 additionalChildren={spinnerContent}
                 headerTitle='Find ligand'
+                onClose={handleClose}
                 footer={footerContent}
                 body={bodyContent}
             />

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -2156,6 +2156,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
         }, true) as moorhen.WorkerResponse<(number[] | libcootApi.fitLigandInfo[])>
         
         if (result.data.result.status === "Completed") {
+            const ligandMolecule: moorhen.Molecule = this.store.getState().molecules.moleculeList.find((molecule: moorhen.Molecule) => molecule.molNo === ligandMolNo)
             newMolecules = await Promise.all(
                 result.data.result.result.map(async (fitLigandResult: (number | libcootApi.fitLigandInfo), idx: number) => {
                     const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.store, this.monomerLibraryPath)
@@ -2163,6 +2164,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
                     newMolecule.name = `Fit. lig. #${idx + 1}`
                     newMolecule.isDarkBackground = this.isDarkBackground
                     newMolecule.defaultBondOptions = this.defaultBondOptions
+                    await ligandMolecule?.transferLigandDicts?.(newMolecule)
                     if (redraw) {
                         await newMolecule.fetchIfDirtyAndDraw('CBs')
                     }


### PR DESCRIPTION
This update fixes the two following bugs:
- New ligands created with the "Find ligand" menu do not have the dictionaries associated to the original ligand molecule.
- Cleanup temporary ligand molecules when the user closes the "Find ligand" modal using the top right cross rather than the "Close" button.