### PR TITLE
Add button to copy fitted ligand into new molecule

### DIFF
--- a/baby-gru/src/components/MoorhenContainer.tsx
+++ b/baby-gru/src/components/MoorhenContainer.tsx
@@ -228,14 +228,17 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
         allowScripting: true,
         backupStorageInstance: createLocalStorageInstance('Moorhen-TimeCapsule'),
         aceDRGInstance: null,
-        store: MoorhenReduxStore
+        store: MoorhenReduxStore,
+        allowAddNewFittedLigand: false,
+        allowMergeFittedLigand: true,
     }
 
     const {
         disableFileUploads, urlPrefix, extraNavBarMenus, viewOnly, extraDraggableModals, 
         monomerLibraryPath, extraFileMenuItems, allowScripting, backupStorageInstance,
         extraEditMenuItems, aceDRGInstance, extraCalculateMenuItems, setMoorhenDimensions,
-        onUserPreferencesChange, extraNavBarModals, includeNavBarMenuNames, store
+        onUserPreferencesChange, extraNavBarModals, includeNavBarMenuNames, store,
+        allowAddNewFittedLigand, allowMergeFittedLigand
     } = { ...defaultProps, ...props }
 
     const collectedProps: moorhen.CollectedProps = {
@@ -243,7 +246,7 @@ export const MoorhenContainer = (props: moorhen.ContainerProps) => {
         urlPrefix, viewOnly, mapsRef, allowScripting, extraCalculateMenuItems, extraEditMenuItems,
         extraNavBarMenus, monomerLibraryPath, moleculesRef, extraFileMenuItems, activeMapRef,
         videoRecorderRef, lastHoveredAtomRef, onUserPreferencesChange, extraNavBarModals, store,
-        includeNavBarMenuNames
+        includeNavBarMenuNames, allowAddNewFittedLigand, allowMergeFittedLigand
     }
     
     useLayoutEffect(() => {

--- a/baby-gru/src/components/card/MoorhenLigandCard.tsx
+++ b/baby-gru/src/components/card/MoorhenLigandCard.tsx
@@ -6,7 +6,6 @@ import { CenterFocusStrongOutlined, HelpOutlined, RadioButtonCheckedOutlined, Ra
 import parse from 'html-react-parser'
 import { convertViewtoPx, guid } from "../../utils/utils";
 import { LinearProgress, Popover, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from "@mui/material";
-import { libcootApi } from "../../types/libcoot";
 
 export const MoorhenLigandCard = (props: {
     ligand: moorhen.LigandInfo;

--- a/baby-gru/src/components/misc/MoorhenModalsContainer.tsx
+++ b/baby-gru/src/components/misc/MoorhenModalsContainer.tsx
@@ -68,7 +68,7 @@ export const MoorhenModalsContainer = (props: moorhen.CollectedProps) => {
         }
 
         {showFitLigandModal &&
-            <MoorheFindLigandModal />
+            <MoorheFindLigandModal {...props}/>
         }
 
         {showRamaPlotModal &&

--- a/baby-gru/src/components/modal/MoorhenFindLigandModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenFindLigandModal.tsx
@@ -21,8 +21,8 @@ const LigandHitCard = (props: {
     setLigandCardMolNoFocus: React.Dispatch<React.SetStateAction<number>>;
     ligandResults: moorhen.Molecule[];
     setLigandResults: React.Dispatch<React.SetStateAction<moorhen.Molecule[]>>;
-    allowMergeLigand?: boolean;
-    allowCreateLigand?: boolean;
+    allowAddNewFittedLigand?: boolean;
+    allowMergeFittedLigand?: boolean;
 }) => {
 
     const dispatch = useDispatch()
@@ -33,8 +33,8 @@ const LigandHitCard = (props: {
     const isDark = useSelector((state: moorhen.State) => state.sceneSettings.isDark)
 
     const {
-        allowMergeLigand, allowCreateLigand
-    } = { allowMergeLigand: true, allowCreateLigand: false, ...props }
+        allowMergeFittedLigand, allowAddNewFittedLigand
+    } = { allowMergeFittedLigand: true, allowAddNewFittedLigand: false, ...props }
 
     const handleShow = useCallback(async () => {
         if (props.ligandMolecule.representations.length > 0) {
@@ -97,14 +97,14 @@ const LigandHitCard = (props: {
                         <CrisisAlertOutlined/>
                     </IconButton>
                     </Tooltip>
-                    {allowCreateLigand &&
+                    {allowAddNewFittedLigand &&
                     <Tooltip title="Add to new molecule">
                     <IconButton style={{ marginRight:'0.5rem', color: isDark ? 'white' : 'grey' }} onClick={handleAdd}>
                         <DoneOutlined/>
                     </IconButton>
                     </Tooltip>                    
                     }
-                    {allowMergeLigand &&
+                    {allowMergeFittedLigand &&
                     <Tooltip title="Merge to molecule">
                     <IconButton style={{ marginRight:'0.5rem', color: isDark ? 'white' : 'grey' }} onClick={handleMerge}>
                         <MergeTypeOutlined/>
@@ -117,7 +117,10 @@ const LigandHitCard = (props: {
     </Card>
 }
 
-export const MoorheFindLigandModal = (props: { }) => {    
+export const MoorheFindLigandModal = (props: {
+    allowAddNewFittedLigand?: boolean;
+    allowMergeFittedLigand?: boolean;
+}) => {    
     const molecules = useSelector((state: moorhen.State) => state.molecules.moleculeList)
     const maps = useSelector((state: moorhen.State) => state.maps)
     const width = useSelector((state: moorhen.State) => state.sceneSettings.width)
@@ -252,7 +255,8 @@ export const MoorheFindLigandModal = (props: { }) => {
                             ligandCardMolNoFocus={ligandCardMolNoFocus}
                             setLigandCardMolNoFocus={setLigandCardMolNoFocus}
                             ligandResults={ligandResults}
-                            setLigandResults={setLigandResults}/>
+                            setLigandResults={setLigandResults}
+                            {...props}/>
             })
             }</div> : <span>No results...</span>}
         </Row>

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -925,6 +925,8 @@ export namespace moorhen {
         aceDRGInstance: AceDRGInstance | null; 
         includeNavBarMenuNames: string[];
         store: ToolkitStore;
+        allowAddNewFittedLigand: boolean;
+        allowMergeFittedLigand: boolean;
     }
     
     interface ContainerProps extends Partial<ContainerRefs>, Partial<ContainerOptionalProps> { }

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -2145,7 +2145,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
                 result.data.result.result.map(async (fitLigandResult: (number | libcootApi.fitLigandInfo), idx: number) => {
                     const newMolecule = new MoorhenMolecule(this.commandCentre, this.glRef, this.store, this.monomerLibraryPath)
                     newMolecule.molNo = fitRightHere ? fitLigandResult as number : (fitLigandResult as libcootApi.fitLigandInfo).imol 
-                    newMolecule.name = `Fit. lig. #${idx + 1}`
+                    newMolecule.name = `${ligandMolecule?.name ? ligandMolecule.name : "Lig."} fit. #${idx + 1}`
                     newMolecule.isDarkBackground = this.isDarkBackground
                     newMolecule.defaultBondOptions = this.defaultBondOptions
                     await ligandMolecule?.transferLigandDicts?.(newMolecule)


### PR DESCRIPTION
This update adds the option to have two separate buttons in the "Find ligand" menu:

- One button to merge the ligand into the main molecule. This is the button currently present.
- A new button to copy the ligand into a new separate molecule. This button is new.

Which buttons are rendered is now controlled from the `MoorhenContainer` by passing two new props: `allowAddNewFittedLigand` and `allowMergeFittedLigand`. By default, the app retains the previous behavior (only show a button to merge the ligand) but this can be changed easily in the future if we wish to do so.