### PR TITLE
Update moorhen.css to work with new MUI and parent app CSS

### DIFF
--- a/baby-gru/public/baby-gru/moorhen.css
+++ b/baby-gru/public/baby-gru/moorhen.css
@@ -132,6 +132,11 @@ div.darkly text.end-label {fill:#FFF !important;}
   height: 100%;
 }
 
+.rama-plot-div {
+  display: flex !important;
+  justify-content: center !important;
+}
+
 .big-validation-tool-container-row {
   width: 100%;
   margin: 0 !important;
@@ -220,6 +225,11 @@ div.darkly text.end-label {fill:#FFF !important;}
   border-radius: 2rem;
   align-items: center;
   align-content: center;
+  justify-content: center;
+}
+
+.moorhen-notification-div span {
+  display: flex;
   justify-content: center;
 }
 


### PR DESCRIPTION
When integrating Moorhen into an app that contains its own CSS and uses new versions of MUI some of Moorhen's text is not centered properly. This update should fixes the issue.