### PR TITLE
Assemblies can be generated properly

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,8 +8,7 @@ A JavaScript molecular graphics program
 - [ ] Undo button on a molecule loaded from SMILES/PubChem with name > 3 letters breaks the structure.
 - [x] Small molecule CIF loading via UI
 - [ ] "Somehow" determine PLDDT vs B-factor in SliceNDice
-- [ ] 1dp4 biomolecule may not be correct.
-- [ ] Should biomolecules be automatic?
+- [x] 1dp4 biomolecule may not be correct.
 - [ ] Add Zoom to "Show controls"
 
 ### Todo

--- a/baby-gru/public/CootWorker.ts
+++ b/baby-gru/public/CootWorker.ts
@@ -1,6 +1,7 @@
 import { libcootApi } from "../src/types/libcoot"
 import { emscriptem } from "../src/types/emscriptem"
 import { privateer } from "../src/types/privateer";
+import { gemmi } from "../src/types/gemmi";
 
 let cootModule: libcootApi.CootModule;
 let molecules_container: libcootApi.MoleculesContainerJS;
@@ -957,6 +958,13 @@ const replace_map_by_mtz_from_file = (imol: number, mtzData: ArrayBufferLike, se
     return result
 }
 
+const generate_assembly = (coordString: string, assemblyNumber: string, mol_name: string) => {
+    const gemmiStructure = cootModule.read_structure_from_string(coordString,mol_name)
+    const assembly = cootModule.copy_to_assembly_to_new_structure(gemmiStructure,assemblyNumber)
+    const assembly_cif_string = cootModule.get_mmcif_string_from_gemmi_struct(assembly)
+    return molecules_container["read_coords_string"](assembly_cif_string,mol_name)
+}
+
 const new_positions_for_residue_atoms = (molToUpDate: number, residues: libcootApi.AtomInfo[][]) => {
     let success = 0
     const movedResidueVector = new cootModule.Vectormoved_residue_t()
@@ -1120,6 +1128,9 @@ const doCootCommand = (messageData: {
 
         let cootResult
         switch (command) {
+            case 'shim_generate_assembly':
+                cootResult = generate_assembly(...commandArgs as [string, string, string])
+                break
             case 'shim_new_positions_for_residue_atoms':
                 cootResult = new_positions_for_residue_atoms(...commandArgs as [number, libcootApi.AtomInfo[][]])
                 break

--- a/baby-gru/src/components/button-bar/MoorhenMoleculeCardButtonBar.tsx
+++ b/baby-gru/src/components/button-bar/MoorhenMoleculeCardButtonBar.tsx
@@ -163,7 +163,7 @@ export const MoorhenMoleculeCardButtonBar = (props: MoorhenMoleculeCardButtonBar
         assembly.delete()
         generators.delete()
 
-        if(n_tot_op!==60){
+        if(n_tot_op!==60&&n_tot_op!==1){
             showAssemblies = true
             break
         }

--- a/baby-gru/src/components/button-bar/MoorhenMoleculeCardButtonBar.tsx
+++ b/baby-gru/src/components/button-bar/MoorhenMoleculeCardButtonBar.tsx
@@ -5,7 +5,7 @@ import { MenuItem } from "@mui/material";
 import { UndoOutlined, RedoOutlined, CenterFocusWeakOutlined, ExpandMoreOutlined, ExpandLessOutlined, VisibilityOffOutlined, VisibilityOutlined, DownloadOutlined, Settings, InfoOutlined } from '@mui/icons-material';
 import { MoorhenDeleteDisplayObjectMenuItem } from "../menu-item/MoorhenDeleteDisplayObjectMenuItem"
 import { MoorhenRenameDisplayObjectMenuItem } from "../menu-item/MoorhenRenameDisplayObjectMenuItem"
-import { MoorhenGenerateBiomoleculeMenuItem } from "../menu-item/MoorhenGenerateBiomoleculeMenuItem"
+import { MoorhenGenerateAssemblyMenuItem } from "../menu-item/MoorhenGenerateAssemblyMenuItem"
 import { clickedResidueType } from "../card/MoorhenMoleculeCard";
 import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
@@ -122,7 +122,7 @@ export const MoorhenMoleculeCardButtonBar = (props: MoorhenMoleculeCardButtonBar
     const bioMolButtons: { [key: number]: { label: string; compressed: () => JSX.Element; expanded: null | (() => JSX.Element); } } = {
         8: {
             label: 'Generate assembly',
-            compressed: () => { return (<MoorhenGenerateBiomoleculeMenuItem key={8} setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.molecule} />) },
+            compressed: () => { return (<MoorhenGenerateAssemblyMenuItem key={8} setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.molecule} />) },
             expanded: null
         },
     }

--- a/baby-gru/src/components/button-bar/MoorhenMoleculeCardButtonBar.tsx
+++ b/baby-gru/src/components/button-bar/MoorhenMoleculeCardButtonBar.tsx
@@ -121,7 +121,7 @@ export const MoorhenMoleculeCardButtonBar = (props: MoorhenMoleculeCardButtonBar
 
     const bioMolButtons: { [key: number]: { label: string; compressed: () => JSX.Element; expanded: null | (() => JSX.Element); } } = {
         8: {
-            label: 'Generate biomolecule',
+            label: 'Generate assembly',
             compressed: () => { return (<MoorhenGenerateBiomoleculeMenuItem key={8} setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.molecule} />) },
             expanded: null
         },
@@ -145,7 +145,20 @@ export const MoorhenMoleculeCardButtonBar = (props: MoorhenMoleculeCardButtonBar
         }
     })
 
-    if(props.molecule.gemmiStructure.assemblies.size()>0){
+    const assemblies = props.molecule.gemmiStructure.assemblies
+    let showAssemblies = false
+    for(let i=0; i<assemblies.size(); i++){
+        const assembly = assemblies.get(i)
+        const is_icoso_kind = assembly.is_complete_icosohedral_special_kind()
+        assembly.delete()
+        if(!is_icoso_kind){
+            showAssemblies = true
+            break
+        }
+    }
+    assemblies.delete()
+
+    if(showAssemblies){
         Object.keys(bioMolButtons).forEach(key => {
             if (bioMolButtons[key].expanded === null) {
                 compressedButtons.push(bioMolButtons[key].compressed())

--- a/baby-gru/src/components/button-bar/MoorhenMoleculeCardButtonBar.tsx
+++ b/baby-gru/src/components/button-bar/MoorhenMoleculeCardButtonBar.tsx
@@ -5,6 +5,7 @@ import { MenuItem } from "@mui/material";
 import { UndoOutlined, RedoOutlined, CenterFocusWeakOutlined, ExpandMoreOutlined, ExpandLessOutlined, VisibilityOffOutlined, VisibilityOutlined, DownloadOutlined, Settings, InfoOutlined } from '@mui/icons-material';
 import { MoorhenDeleteDisplayObjectMenuItem } from "../menu-item/MoorhenDeleteDisplayObjectMenuItem"
 import { MoorhenRenameDisplayObjectMenuItem } from "../menu-item/MoorhenRenameDisplayObjectMenuItem"
+import { MoorhenGenerateBiomoleculeMenuItem } from "../menu-item/MoorhenGenerateBiomoleculeMenuItem"
 import { clickedResidueType } from "../card/MoorhenMoleculeCard";
 import { moorhen } from "../../types/moorhen";
 import { webGL } from "../../types/mgWebGL";
@@ -118,6 +119,14 @@ export const MoorhenMoleculeCardButtonBar = (props: MoorhenMoleculeCardButtonBar
         },
     }
 
+    const bioMolButtons: { [key: number]: { label: string; compressed: () => JSX.Element; expanded: null | (() => JSX.Element); } } = {
+        8: {
+            label: 'Generate biomolecule',
+            compressed: () => { return (<MoorhenGenerateBiomoleculeMenuItem key={8} setPopoverIsShown={setPopoverIsShown} setCurrentName={setCurrentName} item={props.molecule} />) },
+            expanded: null
+        },
+    }
+
     const maximumAllowedWidth = props.sideBarWidth * 0.65
     let currentlyUsedWidth = 0
     let expandedButtons: JSX.Element[] = []
@@ -135,6 +144,21 @@ export const MoorhenMoleculeCardButtonBar = (props: MoorhenMoleculeCardButtonBar
             }
         }
     })
+
+    if(props.molecule.gemmiStructure.assemblies.size()>0){
+        Object.keys(bioMolButtons).forEach(key => {
+            if (bioMolButtons[key].expanded === null) {
+                compressedButtons.push(bioMolButtons[key].compressed())
+            } else {
+                currentlyUsedWidth += 60
+                if (currentlyUsedWidth < maximumAllowedWidth) {
+                    expandedButtons.push(bioMolButtons[key].expanded())
+                } else {
+                    compressedButtons.push(bioMolButtons[key].compressed())
+                }
+            }
+        })
+    }
 
     compressedButtons.push(
         <MoorhenDeleteDisplayObjectMenuItem 

--- a/baby-gru/src/components/button-bar/MoorhenMoleculeCardButtonBar.tsx
+++ b/baby-gru/src/components/button-bar/MoorhenMoleculeCardButtonBar.tsx
@@ -149,9 +149,21 @@ export const MoorhenMoleculeCardButtonBar = (props: MoorhenMoleculeCardButtonBar
     let showAssemblies = false
     for(let i=0; i<assemblies.size(); i++){
         const assembly = assemblies.get(i)
-        const is_icoso_kind = assembly.is_complete_icosohedral_special_kind()
+        const generators = assembly.generators
+        const n_gen = generators.size()
+        let n_tot_op = 0
+        for (let i_gen=0; i_gen < n_gen; i_gen++) { 
+            const gen = generators.get(i_gen)
+            const operators = gen.operators
+            const n_op = operators.size()
+            n_tot_op += n_op
+            gen.delete()
+            operators.delete()
+        }
         assembly.delete()
-        if(!is_icoso_kind){
+        generators.delete()
+
+        if(n_tot_op!==60){
             showAssemblies = true
             break
         }

--- a/baby-gru/src/components/card/MoorhenMoleculeRepresentationSettingsCard.tsx
+++ b/baby-gru/src/components/card/MoorhenMoleculeRepresentationSettingsCard.tsx
@@ -229,6 +229,32 @@ const SymmetrySettingsPanel = (props: {
         }
     }, [showUnitCell])
 
+    const assemblies = props.molecule.gemmiStructure.assemblies
+    let showAssemblies = false
+    for(let i=0; i<assemblies.size(); i++){
+        const assembly = assemblies.get(i)
+        const generators = assembly.generators
+        const n_gen = generators.size()
+        let n_tot_op = 0
+        for (let i_gen=0; i_gen < n_gen; i_gen++) { 
+            const gen = generators.get(i_gen)
+            const operators = gen.operators
+            const n_op = operators.size()
+            n_tot_op += n_op
+            gen.delete()
+            operators.delete()
+        }
+        assembly.delete()
+        generators.delete()
+
+        if(n_tot_op===60){
+            showAssemblies = true
+            break
+        }
+
+    }
+    assemblies.delete()
+
     return <div style={{paddingLeft: '2rem', paddingRight: '2rem', paddingTop: '0.5rem', paddingBottom: '0.5rem', borderStyle: 'solid', borderWidth: '1px', borderColor: 'grey', borderRadius: '1.5rem'}}>
         <Form.Check
             type="switch"
@@ -243,14 +269,14 @@ const SymmetrySettingsPanel = (props: {
                 setSymmetryOn(!symmetryOn)
             }}
             label="Show symmetry mates" />
-        <Form.Check
+        {showAssemblies && <Form.Check
             type="switch"
             checked={biomolOn}
             onChange={() => { 
                 if(symmetryOn && !biomolOn) setSymmetryOn(false)
                 setBiomolOn(!biomolOn)
             }}
-            label="Show biomolecule" />
+            label="Show biomolecule" />}
         <MoorhenSlider
             isDisabled={!symmetryOn}
             sliderTitle="Symmetry Radius"

--- a/baby-gru/src/components/menu-item/MoorhenGenerateAssemblyMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenGenerateAssemblyMenuItem.tsx
@@ -21,9 +21,8 @@ export const MoorhenGenerateAssemblyMenuItem = (props: {
         const assembly = assemblies.get(i)
         const assembly_name = assembly.name
         const oligomeric_details = assembly.oligomeric_details
-        const is_icoso_kind = assembly.is_complete_icosohedral_special_kind()
-        if(!is_icoso_kind) rows.push(<option value={assembly_name} key={assembly_name}>({assembly_name}) {oligomeric_details}</option>)
         assembly.delete()
+        rows.push(<option value={assembly_name} key={assembly_name}>({assembly_name}) {oligomeric_details}</option>)
     }
     assemblies.delete()
     const panelContent = <>

--- a/baby-gru/src/components/menu-item/MoorhenGenerateAssemblyMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenGenerateAssemblyMenuItem.tsx
@@ -5,7 +5,7 @@ import { moorhen } from "../../types/moorhen";
 import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem";
 import { addMolecule, hideMolecule, showMolecule } from "../../store/moleculesSlice"
 
-export const MoorhenGenerateBiomoleculeMenuItem = (props: {
+export const MoorhenGenerateAssemblyMenuItem = (props: {
     item: moorhen.Molecule;
     setCurrentName: React.Dispatch<React.SetStateAction<string>>;
     setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>;
@@ -27,7 +27,7 @@ export const MoorhenGenerateBiomoleculeMenuItem = (props: {
     }
     assemblies.delete()
     const panelContent = <>
-        <Form.Group style={{ width: '10rem', margin: '0' }} controlId="MoorhenGenerateBiomoleculeMenuItem" className="mb-3">
+        <Form.Group style={{ width: '10rem', margin: '0' }} controlId="MoorhenGenerateAssemblyMenuItem" className="mb-3">
             <Form.Label>Assembly</Form.Label>
             <FormSelect size="sm" ref={ruleSelectRef} onChange={(val) => setSelectionType(val.target.value)}>
             {rows}

--- a/baby-gru/src/components/menu-item/MoorhenGenerateBiomoleculeMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenGenerateBiomoleculeMenuItem.tsx
@@ -20,7 +20,9 @@ export const MoorhenGenerateBiomoleculeMenuItem = (props: {
     for(let i=0; i<assemblies.size(); i++){
         const assembly = assemblies.get(i)
         const assembly_name = assembly.name
-        rows.push(<option value={assembly_name} key={assembly_name}>{assembly_name}</option>)
+        const oligomeric_details = assembly.oligomeric_details
+        const is_icoso_kind = assembly.is_complete_icosohedral_special_kind()
+        if(!is_icoso_kind) rows.push(<option value={assembly_name} key={assembly_name}>({assembly_name}) {oligomeric_details}</option>)
         assembly.delete()
     }
     assemblies.delete()
@@ -42,7 +44,7 @@ export const MoorhenGenerateBiomoleculeMenuItem = (props: {
     return <MoorhenBaseMenuItem
         popoverPlacement='left'
         popoverContent={panelContent}
-        menuItemText={"Generate biomolecule"}
+        menuItemText={"Generate assembly"}
         onCompleted={onCompleted}
         setPopoverIsShown={props.setPopoverIsShown}
     />

--- a/baby-gru/src/components/menu-item/MoorhenGenerateBiomoleculeMenuItem.tsx
+++ b/baby-gru/src/components/menu-item/MoorhenGenerateBiomoleculeMenuItem.tsx
@@ -1,0 +1,49 @@
+import { useCallback,useRef, useState } from "react"
+import { useDispatch } from "react-redux"
+import { Button, Form, FormSelect } from "react-bootstrap";
+import { moorhen } from "../../types/moorhen";
+import { MoorhenBaseMenuItem } from "./MoorhenBaseMenuItem";
+import { addMolecule, hideMolecule, showMolecule } from "../../store/moleculesSlice"
+
+export const MoorhenGenerateBiomoleculeMenuItem = (props: {
+    item: moorhen.Molecule;
+    setCurrentName: React.Dispatch<React.SetStateAction<string>>;
+    setPopoverIsShown: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
+
+    const ruleSelectRef = useRef<null | HTMLSelectElement>(null)
+    const [selectionType, setSelectionType] = useState<string>("1")
+    const dispatch = useDispatch()
+
+    const rows = []
+    const assemblies = props.item.gemmiStructure.assemblies
+    for(let i=0; i<assemblies.size(); i++){
+        const assembly = assemblies.get(i)
+        const assembly_name = assembly.name
+        rows.push(<option value={assembly_name} key={assembly_name}>{assembly_name}</option>)
+        assembly.delete()
+    }
+    assemblies.delete()
+    const panelContent = <>
+        <Form.Group style={{ width: '10rem', margin: '0' }} controlId="MoorhenGenerateBiomoleculeMenuItem" className="mb-3">
+            <Form.Label>Assembly</Form.Label>
+            <FormSelect size="sm" ref={ruleSelectRef} onChange={(val) => setSelectionType(val.target.value)}>
+            {rows}
+            </FormSelect>
+        </Form.Group>
+    </>
+
+    const onCompleted = useCallback(async() => {
+        props.setPopoverIsShown(false)
+        const newMolecule = await props.item.generateAssembly(ruleSelectRef.current.value)
+        dispatch(addMolecule(newMolecule))
+    },[])
+
+    return <MoorhenBaseMenuItem
+        popoverPlacement='left'
+        popoverContent={panelContent}
+        menuItemText={"Generate biomolecule"}
+        onCompleted={onCompleted}
+        setPopoverIsShown={props.setPopoverIsShown}
+    />
+}

--- a/baby-gru/src/types/gemmi.d.ts
+++ b/baby-gru/src/types/gemmi.d.ts
@@ -138,5 +138,6 @@ export namespace gemmi {
         first_model: () => Model;
         remove_empty_chains: () => void;
         get_info: (tag: string) => string;
+        as_string: () => string;
     }
 }

--- a/baby-gru/src/types/gemmi.d.ts
+++ b/baby-gru/src/types/gemmi.d.ts
@@ -129,6 +129,8 @@ export namespace gemmi {
     }
     interface Assembly extends emscriptem.instance<Assembly> {
         name: string;
+        special_kind: string;
+        is_complete_icosohedral_special_kind: () => boolean;
         generators: emscriptem.vector<Gen>;
     }
     interface Structure extends emscriptem.instance<Structure> {

--- a/baby-gru/src/types/gemmi.d.ts
+++ b/baby-gru/src/types/gemmi.d.ts
@@ -129,6 +129,7 @@ export namespace gemmi {
     }
     interface Assembly extends emscriptem.instance<Assembly> {
         name: string;
+        oligomeric_details: string;
         special_kind: string;
         is_complete_icosohedral_special_kind: () => boolean;
         generators: emscriptem.vector<Gen>;

--- a/baby-gru/src/types/gemmi.d.ts
+++ b/baby-gru/src/types/gemmi.d.ts
@@ -130,8 +130,6 @@ export namespace gemmi {
     interface Assembly extends emscriptem.instance<Assembly> {
         name: string;
         oligomeric_details: string;
-        special_kind: string;
-        is_complete_icosohedral_special_kind: () => boolean;
         generators: emscriptem.vector<Gen>;
     }
     interface Structure extends emscriptem.instance<Structure> {

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -38,12 +38,14 @@ export namespace libcootApi {
         remove_hydrogens_structure(gemmiStructure: gemmi.Structure): void;
         read_structure_from_string(coordData: string | ArrayBuffer, molName: string): gemmi.Structure;
         is_small_structure(coordData: string): boolean;
+        copy_to_assembly_to_new_structure(gemmiStructure: gemmi.Structure, assembly_name: string): gemmi.Structure;
         get_mtz_columns(fileName: string): emscriptem.vector<string>;
         FS_createDataFile(arg0: string, fileName: string, byteArray: Uint8Array, arg3: boolean, arg4: boolean): void;
         getElementNameAsString: (arg0: emscriptem.instance<string>) => string;
         FS_unlink: (arg0: string) => void;
         cif_parse_string: (arg0: gemmi.cifDocument, arg1: string) => void;
         get_pdb_string_from_gemmi_struct: (arg0:gemmi.Structure) => string;
+        get_mmcif_string_from_gemmi_struct: (arg0:gemmi.Structure) => string;
         validate: (file: string, name: string) => emscriptem.vector<privateer.ResultsEntry>;
         Selection: { new(cid: string): gemmi.Selection };
         NeighborSearch: { new(model: gemmi.Model, unitCell: gemmi.UnitCell, radius: number): gemmi.NeighborSearch };
@@ -483,6 +485,8 @@ export namespace libcootApi {
     type CootModule = {
         unpackCootDataFile(arg0: string, arg1: boolean, arg2: string, arg3: string): number;
         SmilesToPDB(arg0: string, arg1: string, arg2: number, arg3: number): PairType<string, string>;
+        get_mmcif_string_from_gemmi_struct(arg0:gemmi.Structure): string;
+        read_structure_from_string(coordData: string | ArrayBuffer, molName: string): gemmi.Structure;
         MolTextToPDB(mol_text_cpp:string, TLC: string, nconf: number, maxIters: number, keep_orig_coords: boolean, minimize: boolean): PairType<string, string>;
 
         FS: {
@@ -492,6 +496,7 @@ export namespace libcootApi {
         FS_unlink(tempFilename: string): void;
         FS_createDataFile(arg0: string, arg1: string, arg2: Uint8Array | string, arg3: boolean, arg4: boolean, arg5?: boolean): void;
         testFloat32Array( arg0: any ): Float32Array;
+        copy_to_assembly_to_new_structure(gemmiStructure: gemmi.Structure, assembly_name: string): gemmi.Structure;
         getPositionsFromSimpleMesh( arg0: any ): Float32Array;
         getNormalsFromSimpleMesh( arg0: any ): Float32Array;
         getReversedNormalsFromSimpleMesh( arg0: any ): Float32Array;

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -165,6 +165,7 @@ export namespace moorhen {
         minimizeEnergyUsingCidAnimated(cid: string, ncyc: number, nIterations: number, useRamaRestraints: boolean, ramaWeight: number, useTorsionRestraints: boolean, torsionWeight: number): Promise<void>;
         addColourRule(ruleType: string, cid: string, color: string, args: (string | number)[], isMultiColourRule?: boolean, applyColourToNonCarbonAtoms?: boolean, label?: string): void;
         splitMultiModels(draw?: boolean): Promise<Molecule[]>;
+        generateAssembly(assemblyNumber: string, draw?: boolean): Promise<Molecule>;
         getActiveAtom(): Promise<string>;
         setDrawAdaptativeBonds(newValue: boolean): Promise<void>;
         redrawAdaptativeBonds(selectionString?: string): Promise<void>;

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -296,8 +296,8 @@ export class MoorhenMolecule implements moorhen.Molecule {
                 const generators = assembly.generators
                 const n_gen = generators.size()
                 console.log("n_gen",n_gen)
-                if (n_gen > 0) {
-                    const gen = generators.get(0)
+                for (let i_gen=0; i_gen < n_gen; i_gen++) { 
+                    const gen = generators.get(i_gen)
                     const operators = gen.operators
                     const n_op = operators.size()
                     const chains = gen.chains
@@ -363,6 +363,7 @@ export class MoorhenMolecule implements moorhen.Molecule {
             }
             assemblies.delete()
         }
+        console.log("Number of matrices",this.symmetryMatrices.length)
     }
 
     /**

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -2477,7 +2477,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
             command: 'shim_generate_assembly',
             commandArgs: [ coordString, assemblyNumber, newMolecule.name ],
         }, true) as moorhen.WorkerResponse<libcootApi.PairType<number, moorhen.coorFormats>>
-        console.log(response)
 
         newMolecule.molNo = response.data.result.result.first
 

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -304,14 +304,6 @@ export class MoorhenMolecule implements moorhen.Molecule {
                     const subchains = gen.subchains
                     const n_chains = chains.size()
                     const n_subchains = subchains.size()
-                    console.log(n_chains)
-                    console.log(n_subchains)
-                    for (let i_ch=0; i_ch < n_chains; i_ch++) {
-                        console.log("ch:",chains.get(i_ch))
-                    }
-                    for (let i_subch=0; i_subch < n_subchains; i_subch++) {
-                        console.log("subch:",subchains.get(i_subch))
-                    }
 
                     for (let i_op=0; i_op < n_op; i_op++) {
                         let mat16 = []

--- a/wasm_src/gemmi-wrappers.cc
+++ b/wasm_src/gemmi-wrappers.cc
@@ -47,10 +47,6 @@ using namespace emscripten;
 using GemmiSMat33double = gemmi::SMat33<double>;
 using GemmiSMat33float = gemmi::SMat33<float>;
 
-bool isCompleteIcosohedralSpecialKind(const gemmi::Assembly &assembly){
-    return assembly.special_kind == gemmi::Assembly::SpecialKind::CompleteIcosahedral;
-}
-
 bool structure_is_ligand(const gemmi::Structure &Structure) {
     bool isLigand = true;
     auto structure_copy = Structure;
@@ -1702,7 +1698,6 @@ EMSCRIPTEN_BINDINGS(gemmi_module) {
     .property("ssa",&gemmi::Assembly::ssa)
     .property("more",&gemmi::Assembly::more)
     .property("generators",&gemmi::Assembly::generators)
-    .function("is_complete_icosohedral_special_kind",&isCompleteIcosohedralSpecialKind)
     ;
 
     class_<gemmi::NcsOp>("NcsOp")

--- a/wasm_src/gemmi-wrappers.cc
+++ b/wasm_src/gemmi-wrappers.cc
@@ -17,6 +17,7 @@
 #include <emscripten/bind.h>
 
 #include <gemmi/to_cif.hpp>
+#include <gemmi/to_mmcif.hpp> 
 #include <gemmi/to_pdb.hpp>
 #include <gemmi/span.hpp>
 #include <gemmi/neighbor.hpp>
@@ -60,6 +61,14 @@ bool structure_is_ligand(const gemmi::Structure &Structure) {
     return isLigand;
 }
 
+std::string get_mmcif_string_from_gemmi_struct(const gemmi::Structure &Structure){
+    gemmi::cif::Document doc = gemmi::make_mmcif_document(Structure);
+    std::ostringstream oss;
+    gemmi::cif::write_cif_to_stream(oss, doc);
+    std::string s = oss.str();
+    return s;
+}
+
 std::string get_pdb_string_from_gemmi_struct(const gemmi::Structure &Structure){
     std::ostringstream oss;
     gemmi::write_pdb(Structure, oss);
@@ -77,6 +86,13 @@ bool is_small_structure(const std::string &data){
       return false;
   }
   return false;
+}
+
+gemmi::Structure copy_to_assembly_to_new_structure(const gemmi::Structure &s, const std::string &name){
+    gemmi::Structure assembly = s;
+    gemmi::HowToNameCopiedChain how = gemmi::HowToNameCopiedChain::AddNumber;
+    gemmi::transform_to_assembly(assembly,name,how,nullptr);
+    return assembly;
 }
 
 gemmi::Structure read_structure_from_string(const std::string &data, const std::string& path){
@@ -1844,6 +1860,7 @@ EMSCRIPTEN_BINDINGS(gemmi_module) {
     .function("empty_copy",&gemmi::Structure::empty_copy)
     .function("setup_cell_images",&gemmi::Structure::setup_cell_images)
     .function("first_model",select_overload<const gemmi::Model&(void)const>(&gemmi::Structure::first_model))
+    .function("as_string",&get_mmcif_string_from_gemmi_struct)
     ;
 
     class_<gemmi::NearestImage>("NearestImage")
@@ -2804,9 +2821,11 @@ GlobWalk
     function("remove_selected_residues",&remove_selected_residues);
     function("count_residues_in_selection",&count_residues_in_selection);
     function("get_pdb_string_from_gemmi_struct",&get_pdb_string_from_gemmi_struct);
+    function("get_mmcif_string_from_gemmi_struct",&get_mmcif_string_from_gemmi_struct);
     function("structure_is_ligand",&structure_is_ligand);
     function("read_structure_from_string",&read_structure_from_string);
     function("is_small_structure",&is_small_structure);
+    function("copy_to_assembly_to_new_structure",&copy_to_assembly_to_new_structure);
     function("parse_ligand_dict_info", &parse_ligand_dict_info);
     function("read_structure_file",&gemmi::read_structure_file);
 #if (__EMSCRIPTEN_major__ == 3 && __EMSCRIPTEN_minor__ == 1 && __EMSCRIPTEN_tiny__ >= 60) || __EMSCRIPTEN_major__ > 3

--- a/wasm_src/gemmi-wrappers.cc
+++ b/wasm_src/gemmi-wrappers.cc
@@ -47,6 +47,10 @@ using namespace emscripten;
 using GemmiSMat33double = gemmi::SMat33<double>;
 using GemmiSMat33float = gemmi::SMat33<float>;
 
+bool isCompleteIcosohedralSpecialKind(const gemmi::Assembly &assembly){
+    return assembly.special_kind == gemmi::Assembly::SpecialKind::CompleteIcosahedral;
+}
+
 bool structure_is_ligand(const gemmi::Structure &Structure) {
     bool isLigand = true;
     auto structure_copy = Structure;
@@ -1698,6 +1702,7 @@ EMSCRIPTEN_BINDINGS(gemmi_module) {
     .property("ssa",&gemmi::Assembly::ssa)
     .property("more",&gemmi::Assembly::more)
     .property("generators",&gemmi::Assembly::generators)
+    .function("is_complete_icosohedral_special_kind",&isCompleteIcosohedralSpecialKind)
     ;
 
     class_<gemmi::NcsOp>("NcsOp")


### PR DESCRIPTION
General assembly information in coordinate files can be used to generate a new molecule with the correct symmetry operators applied. 

60-mer symmetry of viruses is still applied to current molecule just as matrix transformation of meshes. This is probably a reasonable compromise as generating whole new molecule in these cases will be slow.