### PR TITLE
Fix failure to load on recent versions of Chrome on Linux

### DIFF
--- a/baby-gru/index.html
+++ b/baby-gru/index.html
@@ -34,8 +34,9 @@
       }
 
       const memory64 = WebAssembly.validate(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 5, 3, 1, 4, 1]))
+      const isChromeLinux = (navigator.appVersion.indexOf("Linux") != -1) && (navigator.appVersion.indexOf("Chrome") != -1)
 
-      if (memory64) {
+      if (memory64&&!isChromeLinux) {
         loadScript('/moorhen64.js')
           .then(src => {
             console.log(src + ' loaded 64-bit successfully.')

--- a/baby-gru/public/CootWorker.ts
+++ b/baby-gru/public/CootWorker.ts
@@ -1312,11 +1312,13 @@ const doCootCommand = (messageData: {
 }
 
 onmessage = function (e) {
+
     if (e.data.message === 'CootInitialize') {
         let mod
         let scriptName
         let memory64 = WebAssembly.validate(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 5, 3, 1, 4, 1]))
-        if (memory64) {
+        const isLinux = (navigator.appVersion.indexOf("Linux") != -1)
+        if (memory64&&!isLinux) {
             try {
                 importScripts('./moorhen64.js')
                 mod = createCoot64Module
@@ -1327,8 +1329,7 @@ onmessage = function (e) {
                 console.log("Failed to load 64-bit libcoot in worker thread. Falling back to 32-bit.")
                 memory64 = false
             }
-        }
-        if (!memory64) {
+        } else {
             importScripts('./moorhen.js')
             mod = createCootModule
             scriptName = "moorhen.js"

--- a/baby-gru/public/CootWorker.ts
+++ b/baby-gru/public/CootWorker.ts
@@ -1317,8 +1317,8 @@ onmessage = function (e) {
         let mod
         let scriptName
         let memory64 = WebAssembly.validate(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 5, 3, 1, 4, 1]))
-        const isLinux = (navigator.appVersion.indexOf("Linux") != -1)
-        if (memory64&&!isLinux) {
+        const isChromeLinux = (navigator.appVersion.indexOf("Linux") != -1) && (navigator.appVersion.indexOf("Chrome") != -1)
+        if (memory64&&!isChromeLinux) {
             try {
                 importScripts('./moorhen64.js')
                 mod = createCoot64Module


### PR DESCRIPTION
The loading of the 64-bit wasm in Worker thread fails nearly all the time on Chrome/Linux since ca 134. This patch sniffs user agent for Chrome/Linux and disables 64-bit in such cases.