### PR TITLE
Simplify run-tests.yml for readability & improved cache

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,14 +20,14 @@ jobs:
       with:
         node-version: 18
 
-    - name: Cache node modules
-      id: cache-node-modules
+    - name: Cache npm cache
+      id: cache-npm
       uses: actions/cache@v4
       with:
-        path: baby-gru/node_modules
-        key: node-modules-${{ hashFiles('baby-gru/package-lock.json') }}
+        path: ~/.npm
+        key: npm-cache-${{ hashFiles('baby-gru/package-lock.json') }}
         restore-keys: |
-          node-modules-
+          npm-cache-
 
     - name: Install dependencies
       working-directory: baby-gru

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: baby-gru/node_modules
-        key: node-modules-${{ hashFiles('baby-gru/package.json') }}
+        key: node-modules-${{ hashFiles('baby-gru/package-lock.json') }}
         restore-keys: |
           node-modules-
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,40 +20,27 @@ jobs:
       with:
         node-version: 18
 
-    - name: Install dependencies 
-      working-directory: /home/runner/work/Moorhen/
-      run: | 
-        sudo apt-get update -y   
-        sudo apt-get install -y npm
-
-    - name: Restore cache node18 modules
-      id: cache-node16-modules-load
+    - name: Cache node modules
+      id: cache-node-modules
       uses: actions/cache@v4
       with:
-        path: /home/runner/work/Moorhen/Moorhen/baby-gru/node_modules
-        key: node16-modules-cache
+        path: baby-gru/node_modules
+        key: node-modules-${{ hashFiles('baby-gru/package.json') }}
+        restore-keys: |
+          node-modules-
 
-    - name: Install npm modules
-      working-directory: /home/runner/work/Moorhen/Moorhen/baby-gru
-      if: steps.cache-node16-modules-load.outputs.cache-hit != 'true'
+    - name: Install dependencies
+      working-directory: baby-gru
       run: npm install
 
-    - name: Save node modules cache
-      id: cache-node16-modules-save
-      if: steps.cache-node16-modules-load.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
-      with: 
-        path: /home/runner/work/Moorhen/Moorhen/baby-gru/node_modules
-        key: node16-modules-cache 
-
     - name: Test typescript transpilation
-      working-directory: /home/runner/work/Moorhen/Moorhen/baby-gru
-      run: |             
+      working-directory: baby-gru
+      run: |
         npm run create-version
-        npm run transpile-protobuf 
+        npm run transpile-protobuf
         npx graphql-codegen
         npx tsc
         
     - name: Run react tests
-      working-directory: /home/runner/work/Moorhen/Moorhen/baby-gru
+      working-directory: baby-gru
       run: npm run test-react

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,15 +19,8 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: 18
-
-    - name: Cache npm cache
-      id: cache-npm
-      uses: actions/cache@v4
-      with:
-        path: ~/.npm
-        key: npm-cache-${{ hashFiles('baby-gru/package-lock.json') }}
-        restore-keys: |
-          npm-cache-
+        cache: 'npm'
+        cache-dependency-path: baby-gru/package-lock.json
 
     - name: Install dependencies
       working-directory: baby-gru

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Install dependencies
       working-directory: baby-gru
-      run: npm install
+      run: npm ci
 
     - name: Test typescript transpilation
       working-directory: baby-gru


### PR DESCRIPTION
# Overview
Previously the same workflow was failing/passing differently between `push` and `pull_request` runs. E.g. https://github.com/moorhen-coot/Moorhen/pull/467/checks, where the code fails to transpile on the `push` run, despite this working fine for the `pull_request` run, potentially due to differences in the installed protobufjs version? The assumption here is that the cache/npm install is not consistent between runs. This PR aims to make the test CI consistent while maintaining the speed of the existing cache.

We now let the cache save automatically based on the contents of the package-lock.json, using the setup-node action. We now also install with `npm ci` which installs directly from `package-lock.json`, fixing the problems with inconsistencies between runs. The workflow file is also now shorter and easier to read.

# Tests
- [Cache miss, deps installed & saved](https://github.com/AlexB02/Moorhen/actions/runs/14641572280/job/41085034041)
- [Cache restored correctly](https://github.com/AlexB02/Moorhen/actions/runs/14641715320/job/41085505392)
- [ ] Check tests still pass on `pull_request` runs (requires workflow approval)