### PR TITLE
New edge detect settings fix and restrict number of primitives setting.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,10 +9,9 @@ A JavaScript molecular graphics program
 - [ ] Fix multiview with edge detect.
 - [ ] Ability to set origin/zoom/individual rotation in "Multiple views for different molecules".
 - [ ] Remove glRef from all component props and class constructor args.
+- [ ] Fix text labels being ugly when there is a transparent object.
 
 ### For 0.22.0
-- [ ] Fix video recordings being very stuttery.
-- [ ] Fix text labels being ugly when there is a transparent object.
 - [x] Fix multiview origins only sometimes correct.
 - [x] Fix multiview screenshots scaling.
 - [x] Fix multiview with transparency.

--- a/baby-gru/src/WebGLgComponents/mgWebGL.tsx
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.tsx
@@ -883,6 +883,14 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
         this.doSideBySideStereo = doSideBySideStereo;
     }
 
+    setDoRestrictDrawElements(elementsIndicesRestrict:boolean) {
+        if(this.WEBGL2&&!elementsIndicesRestrict){
+            this.max_elements_indices = this.gl.getParameter(this.gl.MAX_ELEMENTS_INDICES)
+        } else {
+            this.max_elements_indices = 65535;
+        }
+    }
+
     setDoMultiView(doMultiView) {
         this.doMultiView = doMultiView;
     }
@@ -1251,7 +1259,9 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
         store.dispatch(setGLCtx(this.gl))
         this.currentViewport = [0,0, this.gl.viewportWidth, this.gl.viewportWidth];
         this.currentAnaglyphColor = [1.0,0.0,0.0,1.0]
-        if(this.WEBGL2){
+
+        const elementsIndicesRestrict = store.getState().glRef.elementsIndicesRestrict
+        if(this.WEBGL2&&!elementsIndicesRestrict){
             this.max_elements_indices = this.gl.getParameter(this.gl.MAX_ELEMENTS_INDICES)
         } else {
             this.max_elements_indices = 65535;

--- a/baby-gru/src/components/misc/MoorhenPreferencesContainer.tsx
+++ b/baby-gru/src/components/misc/MoorhenPreferencesContainer.tsx
@@ -17,6 +17,7 @@ import {
 import { setDefaultExpandDisplayCards, setTransparentModalsOnMouseOut } from "../../store/generalStatesSlice";
 import { setAnimateRefine, setEnableRefineAfterMod } from '../../store/refinementSettingsSlice';
 import { setDevMode, setUserPreferencesMounted, setUseGemmi } from "../../store/generalStatesSlice";
+import { setElementsIndicesRestrict } from "../../store/glRefSlice";
 import { moorhen } from "../../types/moorhen"
 
 export const MoorhenPreferencesContainer = (props: {
@@ -29,6 +30,9 @@ export const MoorhenPreferencesContainer = (props: {
     // Some important general app states
     const devMode = useSelector((state: moorhen.State) => state.generalStates.devMode)
     const useGemmi = useSelector((state: moorhen.State) => state.generalStates.useGemmi)
+
+    // Whether or not to restrict maximum element indices draw to 65535, or to use what driver thinks is best.
+    const elementsIndicesRestrict = useSelector((state: moorhen.State) => state.glRef.elementsIndicesRestrict)
 
     // Map settings
     const defaultMapLitLines = useSelector((state: moorhen.State) => state.mapContourSettings.defaultMapLitLines)
@@ -146,6 +150,7 @@ export const MoorhenPreferencesContainer = (props: {
         48: { label: "edgeDetectNormalScale", value: edgeDetectNormalScale, valueSetter: setEdgeDetectNormalScale},
         49: { label: "reContourMapOnlyOnMouseUp", value: reContourMapOnlyOnMouseUp, valueSetter: setReContourMapOnlyOnMouseUp},
         50: { label: "useGemmi", value: useGemmi, valueSetter: setUseGemmi},
+        51: { label: "elementsIndicesRestrict", value: elementsIndicesRestrict, valueSetter: setElementsIndicesRestrict},
     }
 
     const restoreDefaults = (preferences: moorhen.Preferences, defaultValues: moorhen.PreferencesValues)=> {
@@ -264,6 +269,16 @@ export const MoorhenPreferencesContainer = (props: {
         localForageInstanceRef.current?.localStorageInstance.setItem('useGemmi', useGemmi)
         .then(_ => props.onUserPreferencesChange('useGemmi', useGemmi));
     }, [useGemmi]);
+
+    useMemo(() => {
+
+        if (elementsIndicesRestrict === null) {
+            return
+        }
+
+        localForageInstanceRef.current?.localStorageInstance.setItem('elementsIndicesRestrict', elementsIndicesRestrict)
+        .then(_ => props.onUserPreferencesChange('elementsIndicesRestrict', elementsIndicesRestrict));
+    }, [elementsIndicesRestrict]);
 
     useMemo(() => {
 

--- a/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenFileMenu.tsx
@@ -114,6 +114,7 @@ export const MoorhenFileMenu = (props: MoorhenNavBarExtendedControlsInterface) =
             const arrayBuffer = await readDataFile(e.target.files[0])
             const bytes = new Uint8Array(arrayBuffer)
             const sessionMessage = moorhensession.Session.decode(bytes,undefined,undefined)
+            //console.log(JSON.stringify(sessionMessage, null, 4))
             await loadSession(sessionMessage)
         } catch (err) {
             console.log(err)
@@ -161,7 +162,7 @@ export const MoorhenFileMenu = (props: MoorhenNavBarExtendedControlsInterface) =
 
     const getSession = async () => {
         const sessionData = await props.timeCapsuleRef.current.fetchSession(true)
-        console.log(sessionData)
+        //console.log(JSON.stringify(sessionData, null, 4))
         const sessionMessage = moorhensession.Session.fromObject(sessionData)
         const sessionBytes = moorhensession.Session.encode(sessionMessage).finish()
         doDownload([sessionBytes], 'moorhen_session.pb')

--- a/baby-gru/src/components/navbar-menus/MoorhenPreferencesMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenPreferencesMenu.tsx
@@ -18,12 +18,14 @@ import { setAtomLabelDepthMode } from "../../store/labelSettingsSlice";
 import { setShortcutOnHoveredAtom, setShowShortcutToast } from "../../store/shortCutsSlice";
 import { setMakeBackups } from "../../store/backupSettingsSlice";
 import { setDevMode } from "../../store/generalStatesSlice";
+import { setElementsIndicesRestrict } from "../../store/glRefSlice";
 import { moorhen } from "../../types/moorhen";
 
 export const MoorhenPreferencesMenu = (props: MoorhenNavBarExtendedControlsInterface) => {
 
     const dispatch = useDispatch()
     const devMode = useSelector((state: moorhen.State) => state.generalStates.devMode)
+    const elementsIndicesRestrict = useSelector((state: moorhen.State) => state.glRef.elementsIndicesRestrict)
     const enableTimeCapsule = useSelector((state: moorhen.State) => state.backupSettings.enableTimeCapsule)
     const makeBackups = useSelector((state: moorhen.State) => state.backupSettings.makeBackups)
     const maxBackupCount = useSelector((state: moorhen.State) => state.backupSettings.maxBackupCount)
@@ -48,7 +50,7 @@ export const MoorhenPreferencesMenu = (props: MoorhenNavBarExtendedControlsInter
 
     return <div style={{maxHeight: convertViewtoPx(65, height), overflow: 'auto'}}>
                     <InputGroup className='moorhen-input-group-check'>
-                        <Form.Check 
+                        <Form.Check
                             type="switch"
                             label="Expand display cards after file upload"
                             checked={defaultExpandDisplayCards}
@@ -56,7 +58,7 @@ export const MoorhenPreferencesMenu = (props: MoorhenNavBarExtendedControlsInter
                         />
                     </InputGroup>
                     <InputGroup className='moorhen-input-group-check'>
-                        <Form.Check 
+                        <Form.Check
                             type="switch"
                             label="Make modals transparent on mouse out"
                             checked={transparentModalsOnMouseOut}
@@ -64,35 +66,42 @@ export const MoorhenPreferencesMenu = (props: MoorhenNavBarExtendedControlsInter
                         />
                     </InputGroup>
                     <InputGroup className='moorhen-input-group-check'>
-                        <Form.Check 
+                        <Form.Check
                             type="switch"
                             checked={atomLabelDepthMode}
                             onChange={() => {dispatch( setAtomLabelDepthMode(!atomLabelDepthMode) )}}
                             label="Depth cue atom labels"/>
                     </InputGroup>
                     <InputGroup className='moorhen-input-group-check'>
-                        <Form.Check 
+                        <Form.Check
                             type="switch"
                             checked={showShortcutToast}
                             onChange={() => {dispatch( setShowShortcutToast(!showShortcutToast) )}}
                             label="Show shortcut popup"/>
                     </InputGroup>
                     <InputGroup className='moorhen-input-group-check'>
-                        <Form.Check 
+                        <Form.Check
                             type="switch"
                             checked={makeBackups}
                             onChange={() => {dispatch( setMakeBackups(!makeBackups) )}}
                             label="Enable molecule undo/redo backups"/>
                     </InputGroup>
                     <InputGroup className='moorhen-input-group-check'>
-                        <Form.Check 
+                        <Form.Check
                             type="switch"
                             checked={shortcutOnHoveredAtom}
                             onChange={() => {dispatch( setShortcutOnHoveredAtom(!shortcutOnHoveredAtom) )}}
                             label="Hover on residue to use shortcuts"/>
                     </InputGroup>
                     <InputGroup className='moorhen-input-group-check'>
-                        <Form.Check 
+                        <Form.Check
+                            type="switch"
+                            checked={elementsIndicesRestrict}
+                            onChange={() => {dispatch( setElementsIndicesRestrict(!elementsIndicesRestrict) )}}
+                            label="Restrict number of primitives drawn at once"/>
+                    </InputGroup>
+                    <InputGroup className='moorhen-input-group-check'>
+                        <Form.Check
                             type="switch"
                             checked={devMode}
                             onChange={() => {dispatch( setDevMode(!devMode) )}}
@@ -102,7 +111,7 @@ export const MoorhenPreferencesMenu = (props: MoorhenNavBarExtendedControlsInter
                     <MoorhenMouseSensitivitySettingsMenuItem
                         setPopoverIsShown={setPopoverIsShown}
                     />
-                    <MoorhenBackupPreferencesMenuItem 
+                    <MoorhenBackupPreferencesMenuItem
                         setPopoverIsShown={setPopoverIsShown}
                     />
                     <MoorhenScoresToastPreferencesMenuItem

--- a/baby-gru/src/components/webMG/MoorhenWebMG.tsx
+++ b/baby-gru/src/components/webMG/MoorhenWebMG.tsx
@@ -126,6 +126,8 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
     const GLLabelsFontSize = useSelector((state: moorhen.State) => state.labelSettings.GLLabelsFontSize)
     const [drawQuat,setDrawQuat] = useState<quat4>([0, 0, 0, -1])
 
+    const elementsIndicesRestrict = useSelector((state: moorhen.State) => state.glRef.elementsIndicesRestrict)
+
     const setClipFogByZoom = (): void => {
         const fieldDepthFront: number = 8;
         const fieldDepthBack: number = 21;
@@ -222,6 +224,13 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
         }
     }, [zoom])
     */
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setDoRestrictDrawElements(elementsIndicesRestrict)
+            glRef.current.drawScene()
+        }
+    }, [elementsIndicesRestrict])
 
     useEffect(() => {
         if(glRef !== null && typeof glRef !== 'function') {

--- a/baby-gru/src/store/glRefSlice.ts
+++ b/baby-gru/src/store/glRefSlice.ts
@@ -33,12 +33,16 @@ const initialState = {
     shortCutHelp: [],
     canvasSize: [0,0],
     rttFramebufferSize: [0,0],
+    elementsIndicesRestrict: false
 }
 
 export const glRefSlice = createSlice({
   name: 'glRef',
   initialState: initialState,
   reducers: {
+    setElementsIndicesRestrict: (state, action: {payload: boolean, type: string}) => {
+        return { ...state, elementsIndicesRestrict: action.payload }
+    },
     setOrigin: (state, action: {payload: [number,number,number], type: string}) => {
         return { ...state, origin: action.payload }
     },
@@ -143,7 +147,7 @@ export const {
     setQuat, setFogClipOffset, setFogStart, setFogEnd, setClipStart, setClipEnd, setCursorPosition,
     setShortCutHelp, setDraggableMolecule, triggerRedrawEnv, triggerClearLabels, setGLCtx,
     setDisplayBuffers, setHoverSize, setLabelBuffers, setTexturedShapes,
-    setRttFramebufferSize, setCanvasSize
+    setRttFramebufferSize, setCanvasSize, setElementsIndicesRestrict
 } = glRefSlice.actions
 
 export default glRefSlice.reducer

--- a/baby-gru/src/types/moorhen.d.ts
+++ b/baby-gru/src/types/moorhen.d.ts
@@ -909,6 +909,7 @@ export namespace moorhen {
         shortCuts: string | {
             [label: string]: Shortcut;
         };
+        elementsIndicesRestrict: boolean;
     }
 
     interface Context extends ContextSetters, PreferencesValues { }
@@ -1171,6 +1172,7 @@ export namespace moorhen {
             texturedShapes: any[],
             canvasSize: [number,number],
             rttFramebufferSize: [number,number],
+            elementsIndicesRestrict: boolean
         };
         overlays: {
             imageOverlayList: any[]

--- a/baby-gru/src/utils/MoorhenPreferences.ts
+++ b/baby-gru/src/utils/MoorhenPreferences.ts
@@ -83,6 +83,7 @@ export class MoorhenPreferences implements moorhen.Preferences {
         animateRefine: true,
         devMode: false,
         useGemmi: false,
+        elementsIndicesRestrict: false,
         shortCuts: {
             "decrease_front_clip": {
                 modifiers: [],

--- a/baby-gru/src/utils/MoorhenTimeCapsule.ts
+++ b/baby-gru/src/utils/MoorhenTimeCapsule.ts
@@ -343,10 +343,10 @@ export class MoorhenTimeCapsule implements moorhen.TimeCapsule {
         const ssaoBias = this.store.getState().sceneSettings.ssaoBias
         const useOffScreenBuffers = this.store.getState().sceneSettings.useOffScreenBuffers
         const doEdgeDetect = this.store.getState().sceneSettings.doEdgeDetect
-        const depthScale = this.store.getState().sceneSettings.depthScale
-        const depthThreshold = this.store.getState().sceneSettings.depthThreshold
-        const normalScale = this.store.getState().sceneSettings.normalScale
-        const normalThreshold = this.store.getState().sceneSettings.normalThreshold
+        const depthScale = this.store.getState().sceneSettings.edgeDetectDepthScale
+        const depthThreshold = this.store.getState().sceneSettings.edgeDetectDepthThreshold
+        const normalScale = this.store.getState().sceneSettings.edgeDetectNormalScale
+        const normalThreshold = this.store.getState().sceneSettings.edgeDetectNormalThreshold
         const doPerspectiveProjection = this.store.getState().sceneSettings.doPerspectiveProjection
         const backgroundColor = this.store.getState().sceneSettings.backgroundColor
 


### PR DESCRIPTION
This fixes a problem whereby the new names of edge detect settings were not being used and thus the session file was corrupted. 

Also adds the setting to restrict number of GL elements drawn to 65535.