### PR TITLE
Map colours update instantly when transparent.

### DIFF
--- a/baby-gru/src/utils/MoorhenMap.ts
+++ b/baby-gru/src/utils/MoorhenMap.ts
@@ -797,17 +797,9 @@ export class MoorhenMap implements moorhen.Map {
 
         this.displayObjects['Coot'].forEach(buffer => {
             if (mapAlpha < 0.99) {
-                buffer.customColour = null;
                 buffer.transparent = true
-                buffer.triangleColours.forEach(colbuffer => {
-                    for (let idx = 0; idx < colbuffer.length; idx += 4) {
-                        colbuffer[idx] = mapColour.r
-                        colbuffer[idx + 1] = mapColour.g
-                        colbuffer[idx + 2] = mapColour.b
-                    }
-                })
-                buffer.isDirty = true;
                 buffer.alphaChanged = true;
+                buffer.setCustomColour([mapColour.r,mapColour.g,mapColour.b,mapAlpha])
             } else {
                 buffer.setCustomColour([mapColour.r,mapColour.g,mapColour.b,1.0])
                 buffer.transparent = false


### PR DESCRIPTION
I mosrtly removed the special case for transparent code (there is one line that is probably required in this:
```
                buffer.transparent = true
```
I am not sure if
```
                buffer.alphaChanged = true;
```
is required anymore, but I left it in anyway so as not to do too much damage. Seems to work for me, see what you think.