### PR TITLE
Restrict number of drawn primitives in a single draw call to deal with rendering problems with some browsers.

### DIFF
--- a/baby-gru/src/WebGLgComponents/mgWebGL.tsx
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.tsx
@@ -884,11 +884,8 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
     }
 
     setDoRestrictDrawElements(elementsIndicesRestrict:boolean) {
-        if(this.WEBGL2&&!elementsIndicesRestrict){
-            this.max_elements_indices = this.gl.getParameter(this.gl.MAX_ELEMENTS_INDICES)
-        } else {
-            this.max_elements_indices = 65535;
-        }
+        //This setting is now effectively always on. We hardwire max_elements_indices
+        this.max_elements_indices = 65535;
     }
 
     setDoMultiView(doMultiView) {
@@ -1260,12 +1257,7 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
         this.currentViewport = [0,0, this.gl.viewportWidth, this.gl.viewportWidth];
         this.currentAnaglyphColor = [1.0,0.0,0.0,1.0]
 
-        const elementsIndicesRestrict = store.getState().glRef.elementsIndicesRestrict
-        if(this.WEBGL2&&!elementsIndicesRestrict){
-            this.max_elements_indices = this.gl.getParameter(this.gl.MAX_ELEMENTS_INDICES)
-        } else {
-            this.max_elements_indices = 65535;
-        }
+        this.max_elements_indices = 65535;
 
         this.setupThreeWayTransformations()
         this.setupStereoTransformations()

--- a/baby-gru/src/components/navbar-menus/MoorhenPreferencesMenu.tsx
+++ b/baby-gru/src/components/navbar-menus/MoorhenPreferencesMenu.tsx
@@ -96,13 +96,6 @@ export const MoorhenPreferencesMenu = (props: MoorhenNavBarExtendedControlsInter
                     <InputGroup className='moorhen-input-group-check'>
                         <Form.Check
                             type="switch"
-                            checked={elementsIndicesRestrict}
-                            onChange={() => {dispatch( setElementsIndicesRestrict(!elementsIndicesRestrict) )}}
-                            label="Restrict number of primitives drawn at once"/>
-                    </InputGroup>
-                    <InputGroup className='moorhen-input-group-check'>
-                        <Form.Check
-                            type="switch"
                             checked={devMode}
                             onChange={() => {dispatch( setDevMode(!devMode) )}}
                             label="Developer mode"/>


### PR DESCRIPTION
Restrict number of drawn primitives in a single draw call to deal with rendering problems with some browsers. In particular this adresses a long standing problem with line meshes being badly messed up.