### PR TITLE
Workaround change to igraph in 1.0.0 which breaks SliceNDice.

### DIFF
--- a/get_sources_funs
+++ b/get_sources_funs
@@ -143,6 +143,8 @@ getslicendice() {
     else
         echo "Checking out SliceNDice"
         git clone https://github.com/hlasimpk/slicendice_cpp.git
+        cd slicendice_cpp
+        patch -p0 < ../../patches/slicendice-igraph-100.patch
     fi
     echo
 }

--- a/patches/slicendice-igraph-100.patch
+++ b/patches/slicendice-igraph-100.patch
@@ -1,0 +1,19 @@
+diff --git prog/pae_igraph.cpp prog/pae_igraph.cpp
+index 05de7c6..58e3ba1 100644
+--- prog/pae_igraph.cpp
++++ prog/pae_igraph.cpp
+@@ -158,6 +158,7 @@ void PAE::fit(MatrixXd& X) {
+         &g, 
+         &igraph_weights, 
+         NULL, 
++        NULL, 
+         resolution, 
+         beta,
+         start,
+@@ -211,4 +212,4 @@ void PAE::fit(MatrixXd& X) {
+     }
+ 
+     return;
+-}
+\ No newline at end of file
++}


### PR DESCRIPTION
Adds a new NULL argument to call of `igraph_community_leiden` as described at https://github.com/igraph/igraph/releases/tag/1.0.0