### PR TITLE
Improve edge detection shader and scale G-buffer to display

### DIFF
--- a/baby-gru/src/WebGLgComponents/mgWebGL.tsx
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.tsx
@@ -657,6 +657,35 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
 
     }
 
+    updateFramebufferSizes() {
+        const maxDim = Math.max(this.canvas.width, this.canvas.height);
+        const maxTex = this.gl.getParameter(this.gl.MAX_TEXTURE_SIZE);
+        const maxRB  = this.gl.getParameter(this.gl.MAX_RENDERBUFFER_SIZE);
+        const hwLimit = Math.min(maxTex, maxRB);
+
+        // G-buffer: half the canvas long edge, next power-of-two.
+        //   floor 512  – sane minimum for tiny windows / embedded panels
+        //   ceil  4096 – diminishing returns beyond this; protects slow GPUs
+        //                that report a large MAX_TEXTURE_SIZE but can't fill it
+        //   hwLimit    – hard cap from GL capabilities
+        const gSize = Math.max(512, Math.min(4096, hwLimit,
+                          Math.pow(2, Math.ceil(Math.log2(Math.max(1, maxDim / 2))))));
+        this.gBuffersFramebufferSize = gSize;
+
+        // Edge-detect buffer: same size as G-buffer (no point being higher)
+        this.edgeDetectFramebufferSize = gSize;
+
+        // Invalidate existing framebuffers so they get recreated at the new size
+        if (this.gFramebuffer) {
+            this.gl.deleteFramebuffer(this.gFramebuffer);
+            this.gFramebuffer = null;
+        }
+        if (this.edgeDetectFramebuffer) {
+            this.gl.deleteFramebuffer(this.edgeDetectFramebuffer);
+            this.edgeDetectFramebuffer = null;
+        }
+    }
+
     resize(width: number, height: number) : void {
 
         let theWidth = width;
@@ -678,11 +707,8 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
         if(this.useOffScreenBuffers&&this.WEBGL2){
             this.recreateOffScreeenBuffers(this.canvas.width,this.canvas.height);
         }
-        if(this.edgeDetectFramebuffer){
-            this.gl.deleteFramebuffer(this.edgeDetectFramebuffer);
-            this.edgeDetectFramebuffer = null;
 
-        }
+        this.updateFramebufferSizes();
 
         this.silhouetteBufferReady = false;
     }
@@ -1163,8 +1189,8 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
                Depth threshold:   1.4
                Normal threshoold: 0.5
         */
-        this.depthThreshold = 1.4;
-        this.normalThreshold = 0.5;
+        this.depthThreshold = 0.05;
+        this.normalThreshold = 0.8;
         this.scaleDepth = 2.0;
         this.scaleNormal = 1.0;
 
@@ -3705,11 +3731,7 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
 
         if ((this.doEdgeDetect||this.doSSAO)&&this.WEBGL2) {
             if(this.renderToTexture) {
-                this.gBuffersFramebufferSize = 4096;
-                if(this.gFramebuffer){
-                    this.gl.deleteFramebuffer(this.gFramebuffer);
-                    this.gFramebuffer = null;
-                }
+                this.updateFramebufferSizes();
                 this.createGBuffers(this.gBuffersFramebufferSize,this.gBuffersFramebufferSize);
             }
             if(!this.gFramebuffer) this.createGBuffers(this.gBuffersFramebufferSize,this.gBuffersFramebufferSize);
@@ -3748,13 +3770,9 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
             const ratio = 1.0 * this.gl.viewportWidth / this.gl.viewportHeight;
 
             if(this.renderToTexture) {
-                this.edgeDetectFramebufferSize = 4096;
-                if(this.edgeDetectFramebuffer){
-                    this.gl.deleteFramebuffer(this.edgeDetectFramebuffer);
-                    this.edgeDetectFramebuffer = null;
-                }
+                this.updateFramebufferSizes();
                 this.createGBuffers(this.gBuffersFramebufferSize,this.gBuffersFramebufferSize);
-                if(!this.edgeDetectFramebuffer) this.createEdgeDetectFramebufferBuffer(4096,4096);
+                if(!this.edgeDetectFramebuffer) this.createEdgeDetectFramebufferBuffer(this.edgeDetectFramebufferSize,this.edgeDetectFramebufferSize);
             } else {
                 if(!this.edgeDetectFramebuffer){
                     if(ratio>1.0)
@@ -4196,16 +4214,7 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
         }
 
         if(this.renderToTexture) {
-            this.edgeDetectFramebufferSize = 2048;
-            this.gBuffersFramebufferSize = 1024;
-            if(this.edgeDetectFramebuffer){
-                this.gl.deleteFramebuffer(this.edgeDetectFramebuffer);
-                this.edgeDetectFramebuffer = null;
-            }
-            if(this.gFramebuffer){
-                this.gl.deleteFramebuffer(this.gFramebuffer);
-                this.gFramebuffer = null;
-            }
+            this.updateFramebufferSizes();
         }
     }
 

--- a/baby-gru/src/WebGLgComponents/webgl-2/edge-detect-fragment-shader.js
+++ b/baby-gru/src/WebGLgComponents/webgl-2/edge-detect-fragment-shader.js
@@ -3,68 +3,85 @@ precision mediump float;
 
 out vec4 fragColor;
 
-uniform sampler2D gPosition;
-uniform sampler2D gNormal;
+uniform sampler2D gPosition;   // eye-space position (G-buffer)
+uniform sampler2D gNormal;     // eye-space normal   (G-buffer)
 
+uniform float depthThreshold;  // relative depth sensitivity  (try 0.05)
+uniform float normalThreshold; // normal-change sensitivity   (try 0.8)
+
+// Kept for backward-compat with uniform-location lookups; unused.
 uniform float zoom;
 uniform float depthBufferSize;
-
-uniform float depthThreshold;
-uniform float normalThreshold;
 uniform float scaleDepth;
 uniform float scaleNormal;
 uniform float xPixelOffset;
 uniform float yPixelOffset;
 uniform float depthFactor;
 
-in mediump mat4 pMatrix;
 in vec2 out_TexCoord0;
 
 void main() {
 
-    float halfScaleFloorDepth = scaleDepth - 0.0625;
-    float halfScaleCeilDepth = scaleDepth + 0.0625;
-    float halfScaleFloorNormal = scaleNormal*.5 - 0.0625;
-    float halfScaleCeilNormal = scaleNormal*.5 + 0.0625;
-    /*
-    float halfScaleFloorDepth = floor(scaleDepth * 0.5);
-    float halfScaleCeilDepth = ceil(scaleDepth * 0.5);
-    float halfScaleFloorNormal = floor(scaleNormal * 0.5);
-    float halfScaleCeilNormal = ceil(scaleNormal * 0.5);
-    */
-    
+    // One-texel step in the G-buffer, independent of zoom
+    vec2 ts = 1.0 / vec2(textureSize(gPosition, 0));
 
-    float depth0 = depthFactor*texture(gPosition, out_TexCoord0 - vec2(xPixelOffset,yPixelOffset)*halfScaleFloorDepth).z;
-    float depth1 = depthFactor*texture(gPosition, out_TexCoord0 + vec2(xPixelOffset,yPixelOffset)*halfScaleCeilDepth).z;
-    float depth2 = depthFactor*texture(gPosition, out_TexCoord0 + vec2( xPixelOffset * halfScaleCeilDepth, -yPixelOffset * halfScaleFloorDepth)).z;
-    float depth3 = depthFactor*texture(gPosition, out_TexCoord0 + vec2(-xPixelOffset * halfScaleFloorDepth, yPixelOffset * halfScaleCeilDepth)).z;
-    float depth4 = depthFactor*texture(gPosition, out_TexCoord0).z;
+    // ---- centre samples ----
+    float mc = texture(gPosition, out_TexCoord0).z;
+    vec3  nc = normalize(texture(gNormal,   out_TexCoord0).xyz);
 
-    vec3 normal0 = normalize(texture(gNormal, out_TexCoord0 - vec2(xPixelOffset,yPixelOffset)*halfScaleFloorNormal)).xyz;
-    vec3 normal1 = normalize(texture(gNormal, out_TexCoord0 + vec2(xPixelOffset,yPixelOffset)*halfScaleCeilNormal)).xyz;
-    vec3 normal2 = normalize(texture(gNormal, out_TexCoord0 + vec2( xPixelOffset * halfScaleCeilNormal, -yPixelOffset * halfScaleFloorNormal))).xyz;
-    vec3 normal3 = normalize(texture(gNormal, out_TexCoord0 + vec2(-xPixelOffset * halfScaleFloorNormal, yPixelOffset * halfScaleCeilNormal))).xyz;
+    // ---- 4 cardinal neighbours ----
+    float d_u = texture(gPosition, out_TexCoord0 + vec2(  0.0, -ts.y)).z;
+    float d_d = texture(gPosition, out_TexCoord0 + vec2(  0.0,  ts.y)).z;
+    float d_l = texture(gPosition, out_TexCoord0 + vec2(-ts.x,   0.0)).z;
+    float d_r = texture(gPosition, out_TexCoord0 + vec2( ts.x,   0.0)).z;
 
-    float depthFiniteDifference0 = depth1 - depth0;
-    float depthFiniteDifference1 = depth3 - depth2;
+    vec3 n_u = normalize(texture(gNormal, out_TexCoord0 + vec2(  0.0, -ts.y)).xyz);
+    vec3 n_d = normalize(texture(gNormal, out_TexCoord0 + vec2(  0.0,  ts.y)).xyz);
+    vec3 n_l = normalize(texture(gNormal, out_TexCoord0 + vec2(-ts.x,   0.0)).xyz);
+    vec3 n_r = normalize(texture(gNormal, out_TexCoord0 + vec2( ts.x,   0.0)).xyz);
 
-    float diff = sqrt(pow(depthFiniteDifference0, 2.0) + pow(depthFiniteDifference1, 2.0)) * 10.0 * depthBufferSize/60.;
+    // ================================================================
+    //  Depth edge  –  max neighbour depth difference
+    //
+    //  Each pixel asks: "does ANY of my 4 neighbours have a very
+    //  different depth?"  This gives exactly 1-pixel-wide edges
+    //  with no bleeding into adjacent pixels (unlike Sobel's 3x3).
+    //  Dividing by |centre Z| keeps the threshold zoom-invariant.
+    // ================================================================
 
-    fragColor = vec4(depth0,depth0,depth0,1.0);
+    float maxDD = max(max(abs(d_u - mc), abs(d_d - mc)),
+                      max(abs(d_l - mc), abs(d_r - mc)));
 
-    diff = diff > depthThreshold ? 1.0 : 0.0;
+    float absZ = abs(mc);
+    float relDepth = (absZ > 0.001) ? maxDD / absZ : 0.0;
 
-    diff = 1.0 - diff;
+    float depthEdge = smoothstep(depthThreshold * 0.7,
+                                 depthThreshold * 1.3,
+                                 relDepth);
 
-    vec3 normalFiniteDifference0 = normal1 - normal0;
-    vec3 normalFiniteDifference1 = normal3 - normal2;
+    // ================================================================
+    //  Normal edge  –  max neighbour normal difference
+    //
+    //  Catches crease/fold edges.  Threshold of ~0.8 ignores the
+    //  22.5-degree facet seams on 16-segment cylinders (response
+    //  ~0.39) while still catching creases >= ~50 degrees.
+    // ================================================================
 
-    float edgeNormal = sqrt(dot(normalFiniteDifference0, normalFiniteDifference0) + dot(normalFiniteDifference1, normalFiniteDifference1));
-    edgeNormal = edgeNormal > normalThreshold ? 1.0 : 0.0;
-    edgeNormal = 1.0 - edgeNormal;
+    float maxND = max(max(length(n_u - nc), length(n_d - nc)),
+                      max(length(n_l - nc), length(n_r - nc)));
 
-    float edgeVal = min(edgeNormal,diff);
-    fragColor = vec4(edgeVal,edgeVal,edgeVal,1.0);
+    float normalEdge = smoothstep(normalThreshold * 0.7,
+                                  normalThreshold * 1.3,
+                                  maxND);
+
+    // ================================================================
+    //  Combine – either edge source triggers an outline
+    // ================================================================
+
+    float edge = max(depthEdge, normalEdge);
+
+    // 1.0 = no edge,  0.0 = full edge  (for multiplicative compositing)
+    fragColor = vec4(vec3(1.0 - edge), 1.0);
 }
 `;
 


### PR DESCRIPTION
## Summary
- **Rewritten edge detection shader** — replaces the zoom-sensitive Roberts Cross + magic-number scaling chain with a max-neighbour-difference approach that uses fixed texel spacing and depth-relative thresholding. Edges are 1-pixel wide, anti-aliased via smoothstep, and invariant to zoom level and projection type.
- **Display-adaptive G-buffer sizing** — new `updateFramebufferSizes()` derives the G-buffer and edge-detect framebuffer resolution from the actual canvas size (including devicePixelRatio), rounded to next power-of-two, with a floor of 512, a ceiling of 4096, and a hard clamp at GL hardware limits. Replaces the hardcoded 1024/2048/4096 values.
- **Tuned thresholds** — `depthThreshold` recalibrated from 1.4 to 0.05 (now means "relative depth change"), `normalThreshold` raised from 0.5 to 0.8 to ignore 16-segment cylinder facet seams while still catching structural creases.

## Test plan
- [ ] Verify outlines appear on ribbon silhouettes and domain boundaries at default zoom
- [ ] Zoom in/out and confirm outlines remain consistent (no pop-in/out or blobbiness)
- [ ] Check that bond cylinders (sticks) are not overwhelmed by outlines
- [ ] Test on a retina display — G-buffer should auto-size to ~2048
- [ ] Test on a non-retina / lower-res display — G-buffer should fall back to ~1024
- [ ] Confirm acceptable FPS on M1 Mac baseline hardware
- [ ] Toggle edge detection on/off and verify no rendering artefacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)