### PR TITLE
Enable embedding Moorhen in external React apps

### DIFF
--- a/baby-gru/src/components/container/MainContainer.tsx
+++ b/baby-gru/src/components/container/MainContainer.tsx
@@ -151,6 +151,7 @@ interface ContainerOptionalProps {
     urlPrefix?: string;
     viewOnly: boolean;
     extraDraggableModals?: React.JSX.Element[];
+    extraSidePanels?: Record<string, import("../panels").MoorhenPanel>;
     monomerLibraryPath?: string;
     setMoorhenDimensions?: null | (() => [number, number]);
     allowScripting?: boolean;
@@ -518,7 +519,7 @@ export const MoorhenContainer = (props: ContainerProps) => {
                         </MoorhenDroppable>
                     </div>
                     <BottomPanelContainer />
-                    <MoorhenSidePanel />
+                    <MoorhenSidePanel extraSidePanels={props.extraSidePanels} />
                 </SnackbarProvider>
             </div>
         </>

--- a/baby-gru/src/components/panels/SidePanels/SidePanel.tsx
+++ b/baby-gru/src/components/panels/SidePanels/SidePanel.tsx
@@ -1,13 +1,26 @@
 import { useDispatch, useSelector } from "react-redux";
-import React, { Activity, useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+const ActivityCompat = (React as any).Activity ??
+    (({ mode, children }: { mode: string; children: React.ReactNode }) => (
+        <div style={{ display: mode === "visible" ? "flex" : "none", flex: 1, minWidth: 0, overflow: "hidden" }}>{children}</div>
+    ));
 import useStateWithRef from "@/hooks/useStateWithRef";
 import { RootState, setEnableAtomHovering, setShownSidePanel } from "@/store";
 import { setSidePanelWidth } from "@/store/globalUISlice";
-import { PanelIDs, PanelsList } from "./SidePanelList";
+import { MoorhenPanel, PanelIDs, PanelsList } from "./SidePanelList";
 import { TabsToggle } from "./TabsToggle";
 import "./side-panels.css";
 
-export const MoorhenSidePanel = () => {
+interface MoorhenSidePanelProps {
+    extraSidePanels?: Record<string, MoorhenPanel>;
+}
+
+export const MoorhenSidePanel = ({ extraSidePanels }: MoorhenSidePanelProps) => {
+    const allPanels: Record<string, MoorhenPanel> = useMemo(
+        () => extraSidePanels ? { ...PanelsList, ...extraSidePanels } : PanelsList,
+        [extraSidePanels]
+    );
     const height = useSelector((state: RootState) => state.sceneSettings.height);
     const [showHintLabel, setShowHintLabel] = useState<boolean>(null);
     const shownPanel = useSelector((state: RootState) => state.globalUI.shownSidePanel);
@@ -115,8 +128,8 @@ export const MoorhenSidePanel = () => {
     const toggles: React.JSX.Element[] = activePanels.map(id => {
         return (
             <TabsToggle
-                icon={PanelsList[id].icon}
-                label={PanelsList[id].label}
+                icon={allPanels[id].icon}
+                label={allPanels[id].label}
                 id={id}
                 key={`${id}-tab-toggle`}
                 showHintLabel={showHintLabel}
@@ -127,9 +140,9 @@ export const MoorhenSidePanel = () => {
 
     const panels: React.JSX.Element[] = activePanels.map(id => {
         return (
-            <Activity mode={shownPanel === id ? "visible" : "hidden"} key={`${id}-activity-panel`}>
-                {PanelsList[id].panelContent}
-            </Activity>
+            <ActivityCompat mode={shownPanel === id ? "visible" : "hidden"} key={`${id}-activity-panel`}>
+                {allPanels[id].panelContent}
+            </ActivityCompat>
         );
     });
 

--- a/baby-gru/src/components/panels/SidePanels/SidePanelList.tsx
+++ b/baby-gru/src/components/panels/SidePanels/SidePanelList.tsx
@@ -5,11 +5,12 @@ import { MapsPanel } from "./MapsPanel";
 import { ModelsPanel } from "./ModelsPanel";
 import { SidePanelContainer } from "./utils/SidePanelContainer";
 
-export type PanelIDs = "models" | "maps" | "sceneSettings";
+export type BuiltinPanelIDs = "models" | "maps" | "sceneSettings";
+export type PanelIDs = BuiltinPanelIDs | (string & {});
 
 export type MoorhenPanel = { icon: MoorhenSVG; label: string; panelContent: React.JSX.Element };
 
-export const PanelsList: Partial<Record<PanelIDs, MoorhenPanel>> = {
+export const PanelsList: Record<string, MoorhenPanel> = {
     maps: { icon: "menuMaps", label: "Maps", panelContent: <MapsPanel /> },
     models: { icon: "menuModels", label: "Models", panelContent: <ModelsPanel /> },
     sceneSettings: {

--- a/baby-gru/src/components/panels/index.ts
+++ b/baby-gru/src/components/panels/index.ts
@@ -1,1 +1,1 @@
-export type { PanelIDs } from "./SidePanels/SidePanelList";
+export type { PanelIDs, MoorhenPanel } from "./SidePanels/SidePanelList";

--- a/baby-gru/src/moorhen.ts
+++ b/baby-gru/src/moorhen.ts
@@ -8,6 +8,8 @@ export { MoorhenApp } from "./components/MoorhenApp";
 export { MoorhenReduxStoreType } from "@/store/index";
 export { MoorhenProvider } from "./components/MoorhenProvider";
 export { MoorhenContainer } from "./components/container/MainContainer";
+export type { ContainerProps } from "./components/container/MainContainer";
+export type { MoorhenPanel, PanelIDs } from "./components/panels";
 export { MoorhenDraggableModalBase } from "./components/interface-base/ModalBase/DraggableModalBase";
 export { MoorhenQuerySequenceModal } from "./components/modal/MoorhenQuerySequenceModal";
 export { ColourRule } from "./utils/MoorhenColourRule";

--- a/baby-gru/webpack.config.js
+++ b/baby-gru/webpack.config.js
@@ -62,13 +62,13 @@ module.exports = (env, argv) => {
                 chunkFilename: "public/MoorhenAssets/[id].css",
                 ignoreOrder: false,
             }),
-            new TerserPlugin({
+            ...(argv.mode === "production" ? [new TerserPlugin({
                 terserOptions: {
                     compress: {
-                        pure_funcs: argv.mode === "production" ? ["console.log"] : [],
+                        pure_funcs: ["console.log"],
                     },
                 },
-            }),
+            })] : []),
             new CopyWebpackPlugin({
                 patterns: [
                     {
@@ -124,13 +124,14 @@ module.exports = (env, argv) => {
                         {
                             loader: "ts-loader",
                             options: {
-                                transpileOnly: true, // Skip type checking for faster builds with React Compiler
+                                transpileOnly: true,
                             },
                         },
-                        {
-                            loader: reactCompilerLoader,
-                            options: defineReactCompilerLoaderOption(),
-                        },
+                        // React Compiler disabled for CCP4i2 compatibility diagnostic
+                        // {
+                        //     loader: reactCompilerLoader,
+                        //     options: defineReactCompilerLoaderOption(),
+                        // },
                     ],
                 },
                 {
@@ -148,10 +149,11 @@ module.exports = (env, argv) => {
                     exclude: /node_modules/,
                     use: [
                         "babel-loader",
-                        {
-                            loader: reactCompilerLoader,
-                            options: defineReactCompilerLoaderOption({}),
-                        },
+                        // React Compiler disabled for CCP4i2 compatibility diagnostic
+                        // {
+                        //     loader: reactCompilerLoader,
+                        //     options: defineReactCompilerLoaderOption({}),
+                        // },
                     ],
                 },
                 {
@@ -216,11 +218,13 @@ module.exports = (env, argv) => {
                 "@": path.resolve(__dirname, "src"),
             },
         },
-        externals: {
-            react: "react",
-            "react-dom": "react-dom",
-            // "react-redux": "react-redux", adding those as external seem to not work
-            // "@reduxjs/toolkit": "@reduxjs/toolkit",
-        },
+        externals: [
+            function({ request }, callback) {
+                if (/^react(-dom|-redux)?(\/.*)?$/.test(request) || /^@reduxjs\/toolkit(\/.*)?$/.test(request)) {
+                    return callback(null, 'commonjs ' + request);
+                }
+                callback();
+            }
+        ],
     };
 };


### PR DESCRIPTION
## Summary
- **Webpack externals**: function-based pattern to properly externalize react, react-dom, react-redux, and @reduxjs/toolkit (including sub-path imports like `react-dom/client`)
- **Conditional TerserPlugin**: only minifies in production mode, so `build-release-dev` produces debuggable output
- **React Compiler disabled**: avoids `useMemoCache` incompatibility with vendored React 19 builds (e.g. Next.js canary)
- **`extraSidePanels` prop**: embedding apps can inject custom side panels into `MoorhenContainer` via a `Record<string, MoorhenPanel>` prop
- **`ActivityCompat` fallback**: gracefully handles React 19.2 builds that don't export `Activity`
- **New type exports**: `ContainerProps`, `MoorhenPanel`, `PanelIDs` exported from the library entry point

## Test plan
- [ ] `npm run build` produces a working bundle with react/redux externalized
- [ ] `npm run build-release-dev` produces unminified output
- [ ] Moorhen loads standalone with built-in side panels (models, maps, scene settings)
- [ ] Embedding app can pass `extraSidePanels` and see custom panels in the sidebar
- [ ] Works with both standard React 19.2 (Activity available) and vendored builds (Activity fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)