### PR TITLE
Merge main to 0.23 dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ The following libraries/programs are compiled to Web Assembly:
 * ssm (1.4.0)
 * mmdb2 (2.0.22)
 * gemmi 0.7.0
-* Coot 1.1.19
+* libcoot main branch (last release tag 1.1.20)
 * fftw 2.1.5
 * fftw3 3.3.5
 * gsl 2.7.1
 * Boost 1.89.0
 * glm 0.9.9.8
 * Eigen 3.4.0
-* RDKit 2025\_09\_1
+* RDKit 2025\_09\_2
 * graphene 1.10.8
 * libsigc++ 3.6.0
 * Freetype 2.14.1
@@ -59,7 +59,7 @@ Binaries are available on the releases page. Please read the instructions there 
 * emsdk/emscripten (Steps 1 and 2 below)
 \
 \
-Most of these (except emscripten) can be installed by somelike like `sudo apt install git cmake curl patch meson ninja-build autoconf automake libtool flex bison g++` on a Debian like system. All of these should be available through Homebrew or Ports on macOS.
+Most of these (except emscripten) can be installed by somelike like `sudo apt install git cmake curl patch meson ninja-build autoconf automake libtool flex bison g++ pkg-config` on a Debian like system. All of these should be available through Homebrew or Ports on macOS.
 \
 \
 Moorhen should build on any reasonably recent version of macOS (Intel or Arm64) and any reasonly recent Linux distribution (x86\_64 or aarch64). Tested on Ubuntu 22.04 x86\_64, Raspberry Pi OS Bookworm/Debian 12 on Pi5, macOS Monteray and Sonama and others.
@@ -70,7 +70,7 @@ Moorhen should build on any reasonably recent version of macOS (Intel or Arm64) 
 `git pull`  
 `./emsdk install latest`  
 `./emsdk activate latest`  
-(Moorhen is known to build successfully with emscripten version 4.0.15, the 17th September 2025 release.)
+(Moorhen is known to build successfully with emscripten version 5.0.0 - the 24th January 2026 release, and several earlier versions.)
 
 2. Each time you want to use emscripten:  
 `source ./emsdk_env.sh`

--- a/TODO.md
+++ b/TODO.md
@@ -23,6 +23,9 @@ Planned features
 - [x] Fix multiview with SSAO.
 - [x] Sensible blur radius (3) for SSAO.
 
+### For 0.22.2
+- [ ] Make ligand environment text labels much bigger.
+
 ### For 0.22.0
 - [x] Fix multiview origins only sometimes correct.
 - [x] Fix multiview screenshots scaling.

--- a/VERSIONS
+++ b/VERSIONS
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-rdkit_release="Release_2025_09_1"
+rdkit_release="Release_2025_09_2"
 libccp4_release="8.0.0"
 clipper_release="20240123"
 ssm_release="1.4.0"

--- a/baby-gru/src/components/validation-tools/MoorhenJsonValidation.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenJsonValidation.tsx
@@ -334,6 +334,9 @@ export const MoorhenJsonValidation = () => {
                             if (sectionSortable.keys[section_index]) {
                                 additionalLabel += " (" + issue.badness + ")";
                             }
+                            if(issue["display-metrics"]){
+                                additionalLabel += " " + issue["display-metrics"]
+                            }
                             return (
                                 <Table key={index} style={{ margin: "0", padding: "0" }}>
                                     <tbody>

--- a/wasm_src/CMakeLists.txt
+++ b/wasm_src/CMakeLists.txt
@@ -634,6 +634,7 @@ target_link_libraries(moorhen
     RDKit::RDGeneral
     RDKit::DataStructs
     RDKit::GenericGroups
+    RDKit::RDInchiLib
     Boost::thread
     Boost::serialization
     freetype


### PR DESCRIPTION
This is a merge of `main` into `0.23-dev` on 24th Feb 2026. This is to facilitate the reverse process which will have to happen before next release.