### PR TITLE
Use MoorhenStack inputGrid in a few more menu entries.

### DIFF
--- a/baby-gru/src/components/menu-item/CopyFragmentUsingCid.tsx
+++ b/baby-gru/src/components/menu-item/CopyFragmentUsingCid.tsx
@@ -6,6 +6,7 @@ import { moorhen } from "../../types/moorhen";
 import { MoorhenButton } from "../inputs";
 import { MoorhenMoleculeSelect } from "../inputs";
 import { MoorhenCidInputForm } from "../inputs/MoorhenCidInputForm";
+import { MoorhenStack } from "../interface-base/Stack/Stack"
 
 const menuItemText = "Copy fragment...";
 
@@ -52,7 +53,7 @@ export const CopyFragmentUsingCid = () => {
     }, [residueSelection, molecules]);
 
     return (
-        <>
+        <MoorhenStack inputGrid>
             <MoorhenMoleculeSelect molecules={molecules} label="From molecule" allowAny={false} ref={moleculeSelectRef} />
             <MoorhenCidInputForm
                 margin={"0.5rem"}
@@ -66,6 +67,6 @@ export const CopyFragmentUsingCid = () => {
             <MoorhenButton variant="primary" onClick={createSelection}>
                 OK
             </MoorhenButton>
-        </>
+        </MoorhenStack>
     );
 };

--- a/baby-gru/src/components/menu-item/CreateSelection.tsx
+++ b/baby-gru/src/components/menu-item/CreateSelection.tsx
@@ -6,6 +6,7 @@ import { moorhen } from "../../types/moorhen";
 import { MoorhenButton } from "../inputs";
 import { MoorhenMoleculeSelect } from "../inputs";
 import { MoorhenCidInputForm } from "../inputs/MoorhenCidInputForm";
+import { MoorhenStack } from "../interface-base/Stack/Stack"
 
 export const CreateSelection = () => {
     const dispatch = useDispatch();
@@ -54,7 +55,7 @@ export const CreateSelection = () => {
     };
 
     return (
-        <>
+        <MoorhenStack inputGrid>
             <MoorhenMoleculeSelect ref={moleculeSelectRef} molecules={molecules} style={{ width: "20rem" }} />
             <MoorhenCidInputForm
                 margin={"0.5rem"}
@@ -66,6 +67,6 @@ export const CreateSelection = () => {
             <MoorhenButton variant="primary" onClick={createSelection}>
                 OK
             </MoorhenButton>
-        </>
+        </MoorhenStack>
     );
 };

--- a/baby-gru/src/components/menu-item/MultiplyBfactor.tsx
+++ b/baby-gru/src/components/menu-item/MultiplyBfactor.tsx
@@ -10,6 +10,7 @@ import { MoorhenMoleculeSelect } from "../inputs";
 import { MoorhenCidInputForm } from "../inputs/MoorhenCidInputForm";
 import { MoorhenChainSelect } from "../inputs/Selector/MoorhenChainSelect";
 import { MoorhenLigandSelect } from "../inputs/Selector/MoorhenLigandSelect";
+import { MoorhenStack } from "../interface-base/Stack/Stack"
 
 export const MultiplyBfactor = () => {
     const moleculeSelectRef = useRef<null | HTMLSelectElement>(null);
@@ -132,6 +133,7 @@ export const MultiplyBfactor = () => {
 
     return (
         <>
+            <MoorhenStack inputGrid>
             <MoorhenSelect
                 label="Selection type"
                 ref={ruleSelectRef}
@@ -173,6 +175,7 @@ export const MultiplyBfactor = () => {
                     allowUseCurrentSelection={true}
                 />
             )}
+        </MoorhenStack>
             <div style={{ paddingLeft: "2rem", paddingRight: "2rem", paddingTop: "0.1rem", paddingBottom: "0.1rem" }}>
                 <Slider
                     aria-label="Factor"

--- a/baby-gru/src/components/menu-item/OpenLhasa.tsx
+++ b/baby-gru/src/components/menu-item/OpenLhasa.tsx
@@ -118,7 +118,7 @@ export const OpenLhasa = () => {
     }, [molecules, fetchAndAddRdkitPickle]);
 
     return (
-        <MoorhenStack>
+        <MoorhenStack inputGrid>
             <MoorhenSelect
                 label="Load a ligand on start?"
                 ref={loadLigandSelectRef}


### PR DESCRIPTION
Use `inputGrid` to prettify the following menu entries:
* `CopyFragmentUsingCid`
* `CreateSelection`
* `MultiplyBfactor`
* `OpenLhasa`
