### PR TITLE
Fix XH-Pi when atom names are padded

### DIFF
--- a/baby-gru/src/components/card/MoleculeCard/list/MoorhenXPIDList.tsx
+++ b/baby-gru/src/components/card/MoleculeCard/list/MoorhenXPIDList.tsx
@@ -52,7 +52,9 @@ export const MoorhenXPIDList = (props: {
 
     const validate = async () => {
         props.setBusy?.(true);
-        const result = window.CCP4Module.detect_xhpi_interactions_json(props.molecule.gemmiStructure)
+        const structure = window.CCP4Module.cloneGemmiStructureWithTrimmedAtomNames(props.molecule.gemmiStructure)
+        const result = window.CCP4Module.detect_xhpi_interactions_json(structure)
+        structure.delete()
         const interactions = JSON.parse(result)
         const theVectors = []
         const visibleList:boolean[]  = []

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -78,6 +78,7 @@ export namespace libcootApi {
         // Gemmi vector constructors
         VectorString: { new (): emscriptem.vector<string> };
         detect_xhpi_interactions_json(arg0: gemmi.Structure): string;
+        cloneGemmiStructureWithTrimmedAtomNames(arg0: gemmi.Structure): gemmi.Structure;
     };
     type headerInfoGemmi = {
         title: string;
@@ -657,6 +658,7 @@ export namespace libcootApi {
         Fractional: { new (x: number, y: number, z: number): gemmi.Fractional };
         cifDocument: { new (): gemmi.cifDocument };
         detect_xhpi_interactions_json(arg0: gemmi.Structure): string;
+        cloneGemmiStructureWithTrimmedAtomNames(arg0: gemmi.Structure): gemmi.Structure;
     };
     interface DoublePairDoubleJS {
         first: number;

--- a/wasm_src/moorhen-types-wrappers.cc
+++ b/wasm_src/moorhen-types-wrappers.cc
@@ -1,5 +1,23 @@
 #include "moorhen-wrappers-helpers.h"
 
+gemmi::Structure cloneGemmiStructureWithTrimmedAtomNames(const gemmi::Structure &st){
+
+    gemmi::Structure newStructure = st;
+
+    for(auto &model : newStructure.models) {
+        for (auto &chain : model.chains) {
+            for (auto &residue : chain.residues) {
+                for (auto &atom : residue.atoms) {
+                    atom.name = moorhen::rtrim(moorhen::ltrim(atom.name));
+                }
+            }
+        }
+    }
+
+    return newStructure;
+}
+
+
 EMSCRIPTEN_BINDINGS(moorhen_types) {
         // PRIVATEER
     value_object<TorsionEntry>("TorsionEntry")
@@ -37,6 +55,8 @@ EMSCRIPTEN_BINDINGS(moorhen_types) {
 
     //Sean Wang's XPID
     function("detect_xhpi_interactions_json", &xhpi::detect_xhpi_interactions_json);
+
+    function("cloneGemmiStructureWithTrimmedAtomNames", &cloneGemmiStructureWithTrimmedAtomNames);
 
     function("unpackCootDataFile",&unpackCootDataFile);
     function("testFloat32Array", &testFloat32Array);


### PR DESCRIPTION
Create a clone gemmiStructure which unpads atom names before sending to XH-Pi.