### PR TITLE
Update coot to 657e13a05d + export MoorhenMenuSystem (ccp4i2 integration baseline)

### DIFF
--- a/VERSIONS
+++ b/VERSIONS
@@ -21,6 +21,6 @@ png_release="1.6.55"
 freetype_release="2.14.3"
 jsoncpp_release="1.9.6"
 lhasa_commit="896185ae1a"
-coot_commit="0636b79bda"
+coot_commit="657e13a05d"
 # This is the GitHub repo username of the person who owns the repository of Coot that we use.
 coot_fork="pemsley"

--- a/baby-gru/src/moorhen.ts
+++ b/baby-gru/src/moorhen.ts
@@ -37,6 +37,7 @@ export { MoorhenValidation } from "./components/validation-tools/MoorhenValidati
 export { MoorhenWaterValidation } from "./components/validation-tools/MoorhenWaterValidation";
 export { autoOpenFiles } from "./utils/MoorhenFileLoading";
 export { MoorhenInstance, MoorhenInstanceProvider } from "./InstanceManager";
+export { MoorhenMenuSystem } from "./components/menu-system/MenuSystem";
 export { reducers as MoorhenStoreReducers } from "./store/MoorhenReduxStore";
 export type { RootState  } from "./store/MoorhenReduxStore";
 export { useCommandCentre, useCommandAndCapsule, useMoorhenInstance } from '@/InstanceManager';


### PR DESCRIPTION
## Summary

Low-risk integration baseline, validated to mount cleanly in ccp4i2:

1. **Bump coot** — `coot_commit` in `VERSIONS`: `0636b79bda` → `657e13a05d` (latest `pemsley/coot` main).
2. **Export `MoorhenMenuSystem`** from the react-lib barrel (`src/moorhen.ts`) — it was defined in `components/menu-system/MenuSystem.ts` but not re-exported, so ccp4i2 could not import it.

## Note on scope

The gemmi atom-name trim that was originally bundled here has been **split into #601** so it can be reviewed on its own merits (per review feedback). The coot bump does not depend on it.

## Build notes (for reviewers rebuilding)

Current coot main `#include`s `<rdkit/GraphMol/chemdraw.h>` unconditionally in `lhasa/lhasa.cpp`, so rdkit must be built with `RDK_BUILD_CHEMDRAW_SUPPORT=ON` (already set in `moorhen_build.sh`). A stale rdkit install predating ChemDraw will fail to compile coot — force an rdkit rebuild (`./moorhen_build.sh rdkit moorhen`). Verified `chemdraw.h` installs to `install/include/rdkit/GraphMol/chemdraw.h`; 32- and 64-bit builds both compile `coot`/`moorhen`/`gemmi-wasm`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)