### PR TITLE
Trim gemmi atom names in copy_atom_from_mmdb (root-cause fix for padded atom names)

### DIFF
--- a/get_sources_funs
+++ b/get_sources_funs
@@ -158,7 +158,8 @@ getgemmi() {
         git clone https://github.com/project-gemmi/gemmi.git gemmi &&\
         cd gemmi &&\
         git checkout $gemmi_release &&\
-        patch -p1 < ../../patches/gemmi-emscripten-64.patch || fail "Failed to clone and patch gemmi"
+        patch -p1 < ../../patches/gemmi-emscripten-64.patch &&\
+        patch -p1 < ../../patches/gemmi-atom-name-trim.patch || fail "Failed to clone and patch gemmi"
     fi
     echo
 }

--- a/patches/gemmi-atom-name-trim.patch
+++ b/patches/gemmi-atom-name-trim.patch
@@ -1,0 +1,11 @@
+diff --git a/include/gemmi/mmdb.hpp b/include/gemmi/mmdb.hpp
+--- a/include/gemmi/mmdb.hpp
++++ b/include/gemmi/mmdb.hpp
+@@ -237,7 +237,7 @@ inline Atom copy_atom_from_mmdb(mmdb::Atom& m_atom) {
+ inline Atom copy_atom_from_mmdb(mmdb::Atom& m_atom) {
+   Atom atom;
+-  atom.name = m_atom.label_atom_id;
++  atom.name = trim_str(m_atom.label_atom_id);
+   atom.altloc = m_atom.altLoc[0];
+   atom.charge = (signed char) m_atom.charge;
+   atom.element = Element(m_atom.element);


### PR DESCRIPTION
## What

One-line patch to vendored gemmi (`patches/gemmi-atom-name-trim.patch`, applied in `getgemmi`) so `copy_atom_from_mmdb` stores **trimmed** atom names:

```cpp
- atom.name = m_atom.label_atom_id;          // mmdb PDB-padded, e.g. ' CA '
+ atom.name = trim_str(m_atom.label_atom_id); // gemmi convention, 'CA'
```

Split out of #600 so it can be reviewed on its own merits (per review feedback that it "needs checking").

## Why this is correct (evidence)

- **gemmi's invariant is unpadded names.** Its cid `Selection` matches atom names by exact compare — `atom_names.has(atom.name)` in `select.hpp`. Padded names therefore *break* gemmi cid selection; trimming makes it correct.
- **The codebase already asked for this fix.** Our own export wrapper has a stopgap trim with an explicit TODO — `wasm_src/moorhen-wrappers-helpers.h`:
  ```cpp
  //* this remove mmdb atom padding, this shouldn't be usefull copy_from_mmdb should be fixed.
  for (gemmi::Atom& atom : residue.atoms) atom.name = moorhen::ltrim(moorhen::rtrim(atom.name));
  ```
  This patch fixes exactly the `copy_from_mmdb` that comment points at.
- **Consumers already expect trimmed names**, and some are silently broken without it — e.g. `MoorhenMolecule.ts` orientation helper does `atom.name === "CA"` on gemmi-sourced atoms, and the accept re-padding `(" " + atom.name).padEnd(4)` only yields valid PDB padding from a trimmed input.
- **Updating gemmi instead won't help:** `copy_atom_from_mmdb` is un-trimmed in **both v0.7.0 and v0.7.5**; only gemmi `master` has the trim. A pinned-release build must carry the patch.

## Risk / "does this break atom-by-cid references (Vectors)?"

Checked — safe, and largely an improvement:
- **Vectors** already has a padded↔unpadded fallback (`vectorsDraw.ts`, commits `d818c72a`/`318454e7`) added *because* gemmi returned padded names. With the trim the primary unpadded path succeeds; the fallback still covers old saved states.
- Other consumers already `.trim()` before comparing (representation O/C/N/S checks, superpose CA filter) → unaffected.
- **No** code path was found that *requires* padded gemmi names.

Net effect: the scattered stopgaps (this export-side trim, the vectors fallback, ccp4i2's defensive trim) can eventually retire.

## Suggested verification before merge

- Vectors regression (the fallback covers padded↔unpadded either way).
- Confirm mmCIF export still validates (independently guaranteed by the existing export-side trim).
- Downstream: exported coordinates load into servalcat without the padded-atom-name monomer-coverage failure.

Build-verified: applies cleanly to gemmi v0.7.0; full 32- and 64-bit builds compile (`coot`/`moorhen`/`gemmi-wasm`) with the trim present in the installed header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)