### PR TITLE
Add build-and-pack-versioned for unique, traceable dev tarballs

### DIFF
--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -68,6 +68,7 @@
         "build-release-dev": "rm -rf dist/* && npm run prebuild && concurrently \"npm run build-webcomponent-dev\"  \"npm run build-react-dev\" \"npm run build-utils\" && npm run emit-declarations",
         "build-and-pack": "npm run build-release && cd dist && npm pack && cd ..",
         "build-and-pack-dev": "npm run build-release-dev && cd dist && npm pack && cd ..",
+        "build-and-pack-versioned": "node scripts/pack-versioned.mjs",
         "create-docs": "npm run create-version && npx jsdoc -c jsdoc.json ../README.md && mkdir -p docs/wasm_src_frontend && cp -a ../wasm_src_frontend/baby_gru.png docs/wasm_src_frontend",
         "test-api": "npm run create-version && npm run transpile-protobuf && npm run transpile-graphql-codegen && npx tsc && npm run transpile-ts-worker && env MOORHEN_TEST_PTHREAD_POOL_SIZE=${MOORHEN_TEST_PTHREAD_POOL_SIZE:-1} node --trace-warnings --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.config.js --selectProjects api-utils --runInBand --detectOpenHandles --forceExit",
         "test": "npm run test-api && npm run test-react",

--- a/baby-gru/scripts/pack-versioned.mjs
+++ b/baby-gru/scripts/pack-versioned.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+/*
+ * Build a uniquely-versioned dev/integration tarball.
+ *
+ * `npm pack` names the tarball from package.json's `version`, and consumers
+ * (e.g. ccp4i2 via `npm install ./moorhen-*.tgz`) key on that internal version
+ * — so reusing the same `1.0.0-alpha.3` for every build can be a silent no-op
+ * on reinstall and makes two tarballs indistinguishable.
+ *
+ * This stamps the version as `<base>-dev.g<short-sha>[.dirty]` for the duration
+ * of the build (so it is unique per commit and traceable back to it, and shows
+ * up in the in-app version readout via genversion), runs the production
+ * build-release + npm pack, then restores package.json / package-lock.json /
+ * src/version.js so the working tree is left exactly as it was.
+ */
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const babyGru = fileURLToPath(new URL("..", import.meta.url));
+const run = (cmd) => execSync(cmd, { stdio: "inherit", cwd: babyGru });
+const capture = (cmd) => execSync(cmd, { encoding: "utf8", cwd: babyGru }).trim();
+
+const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+const base = pkg.version.split("-dev.")[0]; // strip any prior dev suffix
+const sha = capture("git rev-parse --short HEAD");
+// "dirty" = uncommitted *tracked* changes (untracked files like dist/ don't count)
+const dirty = capture("git status --porcelain --untracked-files=no") ? ".dirty" : "";
+const devVersion = `${base}-dev.g${sha}${dirty}`;
+
+console.log(`\n[pack-versioned] building tarball as ${devVersion}\n`);
+run(`npm version ${devVersion} --no-git-tag-version --allow-same-version`);
+try {
+    run("npm run build-release");
+    run("cd dist && npm pack");
+} finally {
+    // Restore tracked files npm version touched, and regenerate the (gitignored)
+    // version.js from the restored package.json — leaves the tree pristine.
+    run("git checkout -- package.json package-lock.json");
+    run("npm run create-version");
+    console.log(`\n[pack-versioned] restored working tree; tarball: dist/moorhen-${devVersion}.tgz\n`);
+}


### PR DESCRIPTION
## Problem

`npm pack` names the tarball from `package.json`'s `version`, and consumers (e.g. ccp4i2 via `npm install ./moorhen-*.tgz`) key on that **internal** version. Reusing `1.0.0-alpha.3` for every dev build means:
- reinstalling a new tarball with the same version can be a **silent no-op** (the consumer keeps running the *old* build), and
- two tarballs are **indistinguishable** — you can't tell which commit a given ccp4i2 instance is running.

## Change

New script `build-and-pack-versioned` (`scripts/pack-versioned.mjs`) that:
1. stamps the version as `<base>-dev.g<short-sha>[.dirty]` (unique per commit, traceable; `.dirty` if there are uncommitted tracked changes),
2. runs the production `build-release` + `npm pack`,
3. restores `package.json` / `package-lock.json` / `src/version.js` so the working tree is left pristine.

The sha flows into the in-app version readout via `genversion`, so a running Moorhen shows exactly which build it is. The real `alpha.N` version — a release decision — is left untouched; existing `build-and-pack` is unchanged.

## Usage

```sh
cd baby-gru && npm run build-and-pack-versioned
# -> dist/moorhen-1.0.0-alpha.3-dev.g<sha>.tgz
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)