### PR TITLE
Fix rotate/translate zone: pivot interactive render about fragment COM

### DIFF
--- a/baby-gru/src/WebGLgComponents/mgWebGL.tsx
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.tsx
@@ -7110,22 +7110,29 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
                 theMatrix[12] = this.activeMolecule.displayObjectsTransformation.origin[0];
                 theMatrix[13] = this.activeMolecule.displayObjectsTransformation.origin[1];
                 theMatrix[14] = this.activeMolecule.displayObjectsTransformation.origin[2];
-                //Just consider one origin.
-                const diff = [0, 0, 0];
+                // Pivot the interactive render about the fragment centre of mass
+                // (in world space: COM + view origin). This MUST be the same pivot used
+                // by the accept coordinate math (displayObjectsTransformation.centre in
+                // transformedCachedAtomsAsMovedAtoms), so the position shown during
+                // manipulation equals the accepted coordinates. Previously a shadowed
+                // `diff` left transformOriginInteractive at [0,0,0] (the view origin),
+                // so the fragment visibly pivoted about the screen and landed elsewhere
+                // on accept.
+                let centre: [number, number, number] = this.activeMolecule.displayObjectsTransformation.centre;
 
                 const dispObjs: moorhen.DisplayObject[][]  = this.activeMolecule.representations.filter(item => item.style !== 'transformation').map(item => item.buffers)
                 for (const value of dispObjs) {
                     if (value.length > 0) {
                         const com = centreOfMass(value[0].atoms);
-                        const diff : [number,number,number] = [com[0] + this.origin[0], com[1] + this.origin[1], com[2] + this.origin[2]];
-                        this.activeMolecule.displayObjectsTransformation.centre = diff;
+                        centre = [com[0] + this.origin[0], com[1] + this.origin[1], com[2] + this.origin[2]];
+                        this.activeMolecule.displayObjectsTransformation.centre = centre;
                         break;
                     }
                 }
                 for (const value of dispObjs) {
                     for (let ibuf = 0; ibuf < value.length; ibuf++) {
                         value[ibuf].transformMatrixInteractive = theMatrix;
-                        value[ibuf].transformOriginInteractive = diff;
+                        value[ibuf].transformOriginInteractive = centre;
                     }
                 }
                 // ###############

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -1862,6 +1862,7 @@ export class MoorhenMolecule {
         );
         this.displayObjectsTransformation.origin = [0, 0, 0];
         this.displayObjectsTransformation.quat = null;
+        this.displayObjectsTransformation.centre = [0, 0, 0];
         this.setAtomsDirty(true);
         await this.redraw();
     }


### PR DESCRIPTION
## Summary

During a rotate/translate-zone manipulation the fragment visibly swung about the screen centre and snapped to a different position on **Accept** — the interactive shader render pivoted about `[0,0,0]` (the view origin) while the accept coordinate math pivoted about the fragment **centre of mass**.

The cause was a shadowed `diff` in `mgWebGL.tsx`: the COM-based pivot (`com + view origin`) was computed in a block-scoped inner `diff` and stored on `displayObjectsTransformation.centre` (used by `transformedCachedAtomsAsMovedAtoms`), but the per-buffer `transformOriginInteractive` was assigned the **outer** `diff = [0,0,0]`. So render and accept used different pivots and diverged.

## Change

- Use a single `centre` (`com + view origin`) for **both** `displayObjectsTransformation.centre` and the per-buffer `transformOriginInteractive`, so the interactive render pivots about the same point the accept math uses — the shown position now equals the accepted coordinates.
- Reset `displayObjectsTransformation.centre = [0,0,0]` in `updateWithMovedAtoms` (alongside the existing `origin`/`quat` reset), so a stale centre can't carry into the next operation.

Two files, 13 lines.

## Verification (in the ccp4i2 embedding)

- Fragment now pivots about its own COM; on **Accept** atoms land exactly where shown (no swing/snap), single- and multi-residue zones.
- Move **persists** after accept; **Undo/Redo** scope is clean (only this edit). The previously-considered `delete(true)`/`pop_back` accept workaround was verified **unnecessary** — `shim_new_positions_for_residue_atoms` already updates all atoms reliably — so no change was made there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)