### PR TITLE
Fix representation opacity lost on redraw

### DIFF
--- a/baby-gru/src/utils/MoorhenMoleculeRepresentation.ts
+++ b/baby-gru/src/utils/MoorhenMoleculeRepresentation.ts
@@ -496,6 +496,9 @@ export class MoleculeRepresentation {
                 }
             });
         }
+        if (this.nonCustomOpacity < 0.99) {
+            this.setNonCustomOpacity(this.nonCustomOpacity);
+        }
     }
 
     /**
@@ -517,6 +520,9 @@ export class MoleculeRepresentation {
                 buf.origin = selectionCentre;
             }
         });
+        if (this.nonCustomOpacity < 0.99) {
+            this.setNonCustomOpacity(this.nonCustomOpacity);
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

A custom representation set semi-transparent (e.g. a MolecularSurface with opacity < 1 via the Add Custom Representation / Picture Wizard cards, or programmatically) renders correctly transparent at first, then flips fully opaque the next time it is rebuilt — after a colour-rule change, a recompute, a visibility toggle, or simply when an async surface mesh finishes building. The tell-tale timing: transparent while loading, opaque once drawn.

## Root cause

Opacity is stored on the representation as `this.nonCustomOpacity` (default `1.0`) but is only written into the buffers by `setNonCustomOpacity()`, which mutates the buffers that exist *at call time*.

`draw()` and `redraw()` both rebuild buffers from scratch via `getBufferObjects()` + `buildBuffers(objects)` and never re-applied `this.nonCustomOpacity` to the new buffers. So any rebuild resets the freshly-built buffers to opaque (default colour alpha = 1), discarding the stored opacity.

## Fix

Re-apply the stored opacity at the end of both `draw()` and `redraw()` when it is transparent:

```ts
if (this.nonCustomOpacity < 0.99) {
    this.setNonCustomOpacity(this.nonCustomOpacity);
}
```

This reuses the existing buffer-mutation logic, is a no-op for opaque representations (default `1.0`, guarded by `< 0.99`), and makes opacity survive every redraw for all representation types. `this.buffers` is populated at that point (post-`buildBuffers`), so `setNonCustomOpacity`'s `if (this.buffers)` guard passes. No re-entrancy: `setNonCustomOpacity` calls the imported `buildBuffers` helper, not `draw()`/`redraw()`.

## Testing

- TypeScript clean.
- Manually verified with `npm run start`: a semi-transparent MolecularSurface now stays transparent across a rebuild instead of flipping opaque; a representation left at default opacity (1.0) is visually unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)