### PR TITLE
Use gemmi module

### DIFF
--- a/baby-gru/src/WebGLgComponents/vectorsDraw.ts
+++ b/baby-gru/src/WebGLgComponents/vectorsDraw.ts
@@ -86,17 +86,17 @@ export const getVectorsBuffers = async (store: Store<RootState>): Promise<any>  
                     let fromAtoms
                     let nFromAtoms = 0
                     try {
-                        fromAtoms = window.CCP4Module.get_atom_info_for_selection(fromMol.gemmiStructure, vec.cidFrom, "" )
+                        fromAtoms = window.gemmiModule.get_atom_info_for_selection(fromMol.gemmiStructure, vec.cidFrom, "" )
                         nFromAtoms = fromAtoms.size()
                         if(nFromAtoms===0 && vec.cidFrom.length!==4){
                             //Try 4-char padding/unpadding
                             fromAtoms.delete()
                             const newCid = get1LetterElementPaddedCid(vec.cidFrom)
-                            fromAtoms = window.CCP4Module.get_atom_info_for_selection(fromMol.gemmiStructure, newCid, "" )
+                            fromAtoms = window.gemmiModule.get_atom_info_for_selection(fromMol.gemmiStructure, newCid, "" )
                             nFromAtoms = fromAtoms.size()
                             if(nFromAtoms===0){
                                 const newCid2 = get2LetterElementPaddedCid(vec.cidFrom)
-                                fromAtoms = window.CCP4Module.get_atom_info_for_selection(fromMol.gemmiStructure, newCid2, "" )
+                                fromAtoms = window.gemmiModule.get_atom_info_for_selection(fromMol.gemmiStructure, newCid2, "" )
                                 nFromAtoms = fromAtoms.size()
                             }
                         }
@@ -131,17 +131,17 @@ export const getVectorsBuffers = async (store: Store<RootState>): Promise<any>  
                     let toAtoms
                     let nToAtoms = 0
                     try {
-                        toAtoms = window.CCP4Module.get_atom_info_for_selection(toMol.gemmiStructure, vec.cidTo, "" )
+                        toAtoms = window.gemmiModule.get_atom_info_for_selection(toMol.gemmiStructure, vec.cidTo, "" )
                         nToAtoms = toAtoms.size()
                         if(nToAtoms===0 && vec.cidTo.length!==4){
                             //Try 4-char padding/unpadding
                             toAtoms.delete()
                             const newCid = get1LetterElementPaddedCid(vec.cidTo)
-                            toAtoms = window.CCP4Module.get_atom_info_for_selection(toMol.gemmiStructure, newCid, "" )
+                            toAtoms = window.gemmiModule.get_atom_info_for_selection(toMol.gemmiStructure, newCid, "" )
                             nToAtoms = toAtoms.size()
                             if(nToAtoms===0){
                                 const newCid2 = get2LetterElementPaddedCid(vec.cidTo)
-                                toAtoms = window.CCP4Module.get_atom_info_for_selection(toMol.gemmiStructure, newCid2, "" )
+                                toAtoms = window.gemmiModule.get_atom_info_for_selection(toMol.gemmiStructure, newCid2, "" )
                                 nToAtoms = toAtoms.size()
                             }
                         }

--- a/baby-gru/src/components/card/MoleculeCard/AddCustomRepresentationCard.tsx
+++ b/baby-gru/src/components/card/MoleculeCard/AddCustomRepresentationCard.tsx
@@ -183,7 +183,7 @@ export const AddCustomRepresentationCard = memo(
                         (representationStyle === "MetaBalls" || representationStyle === "VdwSpheres" || representationStyle === "CBs") &&
                         restrictToNeighbours
                     ) {
-                        const restrictedCid = window.cootModule.cidToNeighboursCid(
+                        const restrictedCid = window.gemmiModule.cidToNeighboursCid(
                             theMolecule.gemmiStructure,
                             unRestrictedCidSelection,
                             neighboursCid,
@@ -201,7 +201,7 @@ export const AddCustomRepresentationCard = memo(
                             .map(r => r + extraRestrict)
                             .join("||");
                     } else if (representationStyle === "CAs" && restrictToNeighbours) {
-                        const restrictedCid = window.cootModule.cidToNeighboursCid(
+                        const restrictedCid = window.gemmiModule.cidToNeighboursCid(
                             theMolecule.gemmiStructure,
                             unRestrictedCidSelection,
                             neighboursCid,
@@ -224,7 +224,7 @@ export const AddCustomRepresentationCard = memo(
                             restrictToNeighbours
                         ) {
                             const waterSelection = "/*/*/(HOH)";
-                            const restrictedWaterCid = window.cootModule.cidToNeighboursCid(
+                            const restrictedWaterCid = window.gemmiModule.cidToNeighboursCid(
                                 theMolecule.gemmiStructure,
                                 waterSelection,
                                 neighboursCid,

--- a/baby-gru/src/components/card/MoleculeCard/PictureWizardCard.tsx
+++ b/baby-gru/src/components/card/MoleculeCard/PictureWizardCard.tsx
@@ -191,7 +191,7 @@ export const PictureWizardCard = memo(
                     }
 
                     if (representationStyle === "CBs" && restrictToNeighbours) {
-                        const restrictedCid = window.cootModule.cidToNeighboursCid(theMolecule.gemmiStructure,unRestrictedCidSelection,neighboursCid,neighboursDistance,excludeNeighbours)
+                        const restrictedCid = window.gemmiModule.cidToNeighboursCid(theMolecule.gemmiStructure,unRestrictedCidSelection,neighboursCid,neighboursDistance,excludeNeighbours)
                         let extraRestrict = ""
                         if(sideChainOnly) extraRestrict += "/!O,C,N,H"
                         if(notH&&!sideChainOnly) extraRestrict += "/*[!H]"
@@ -200,7 +200,7 @@ export const PictureWizardCard = memo(
                         extraRestrict += ":*"
                         cidSelection = restrictedCid.split("||").map(r => r+extraRestrict).join("||")
                     } else if (representationStyle === "CAs" && restrictToNeighbours) {
-                        const restrictedCid = window.cootModule.cidToNeighboursCid(theMolecule.gemmiStructure,unRestrictedCidSelection,neighboursCid,neighboursDistance,excludeNeighbours)
+                        const restrictedCid = window.gemmiModule.cidToNeighboursCid(theMolecule.gemmiStructure,unRestrictedCidSelection,neighboursCid,neighboursDistance,excludeNeighbours)
                         cidSelection = restrictedCid
                     } else {
                         cidSelection += ":*";
@@ -208,7 +208,7 @@ export const PictureWizardCard = memo(
                     if (representationStyle === "CBs" && !notHOH && sideChainOnly) {
                         if (representationStyle === "CBs" && restrictToNeighbours) {
                             const waterSelection = "/*/*/(HOH)";
-                            const restrictedWaterCid = window.cootModule.cidToNeighboursCid(theMolecule.gemmiStructure,waterSelection,neighboursCid,neighboursDistance,excludeNeighbours)
+                            const restrictedWaterCid = window.gemmiModule.cidToNeighboursCid(theMolecule.gemmiStructure,waterSelection,neighboursCid,neighboursDistance,excludeNeighbours)
                             if(restrictedWaterCid.length>2)
                                 cidSelection += "||"+restrictedWaterCid
                         } else {
@@ -231,7 +231,7 @@ export const PictureWizardCard = memo(
                         cidSelection += "[!H]";
                     }
                     if (representationStyle === "CBs" && restrictToNeighbours) {
-                        const restrictedCid = window.cootModule.cidToNeighboursCid(theMolecule.gemmiStructure,unRestrictedCidSelection,neighboursCid,neighboursDistance,excludeNeighbours)
+                        const restrictedCid = window.gemmiModule.cidToNeighboursCid(theMolecule.gemmiStructure,unRestrictedCidSelection,neighboursCid,neighboursDistance,excludeNeighbours)
                         let extraRestrict = ""
                         if(sideChainOnly) extraRestrict += "/!O,C,N,H"
                         if(notH&&!sideChainOnly) extraRestrict += "/*[!H]"

--- a/baby-gru/src/components/container/MainContainer.tsx
+++ b/baby-gru/src/components/container/MainContainer.tsx
@@ -244,7 +244,6 @@ export const MoorhenContainer = (props: ContainerProps) => {
 
     useEffect(() => {
         const startupEffect = async () => {
-            if (!window.cootModule) windowCootCCP4Loader(`${urlPrefix}/wasm/`);
             if (!window.gemmiModule) windowGemmiLoader(`${urlPrefix}/wasm/`);
             if (!window.MathJax) loadMathjax(`${urlPrefix}`);
             setWindowDimensions();

--- a/baby-gru/src/components/container/MainContainer.tsx
+++ b/baby-gru/src/components/container/MainContainer.tsx
@@ -34,7 +34,7 @@ import { moorhen } from "../../types/moorhen";
 import { allFontsSet } from "../../utils/enums";
 import { loadMathjax } from "../../utils/mathJaxLoader";
 import { getTooltipShortcutLabel, parseAtomInfoLabel } from "../../utils/utils";
-import { windowCootCCP4Loader } from "../../utils/windowCootCCP4Loader";
+import { windowCootCCP4Loader, windowGemmiLoader } from "../../utils/windowCootCCP4Loader";
 import { MoorhenSpinner } from "../icons";
 import { MoorhenStack } from "../interface-base";
 import { MoorhenModalsContainer } from "../interface-base/ModalBase/ModalsContainer";
@@ -245,6 +245,7 @@ export const MoorhenContainer = (props: ContainerProps) => {
     useEffect(() => {
         const startupEffect = async () => {
             if (!window.cootModule) windowCootCCP4Loader(`${urlPrefix}/wasm/`);
+            if (!window.gemmiModule) windowGemmiLoader(`${urlPrefix}/wasm/`);
             if (!window.MathJax) loadMathjax(`${urlPrefix}`);
             setWindowDimensions();
             dispatch(setViewOnly(viewOnly));

--- a/baby-gru/src/components/menu-item/OpenLhasa.tsx
+++ b/baby-gru/src/components/menu-item/OpenLhasa.tsx
@@ -1,5 +1,5 @@
 import { useDispatch, useSelector } from "react-redux";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState, useEffect } from "react";
 import { enqueueSnackbar } from "@/store";
 import { useCommandCentre, usePaths } from "../../InstanceManager";
 import { addRdkitMoleculePickle } from "../../store/lhasaSlice";
@@ -10,6 +10,7 @@ import { MoorhenButton, MoorhenSelect, MoorhenTextInput } from "../inputs";
 import { MoorhenMoleculeSelect } from "../inputs";
 import { MoorhenLigandSelect } from "../inputs/Selector/MoorhenLigandSelect";
 import { MoorhenStack } from "../interface-base";
+import { windowCootCCP4Loader } from "../../utils/windowCootCCP4Loader";
 
 export const OpenLhasa = () => {
     const molecules = useSelector((state: moorhen.State) => state.molecules.moleculeList);
@@ -25,7 +26,19 @@ export const OpenLhasa = () => {
 
     const dispatch = useDispatch();
 
+    const urlPrefix = usePaths().urlPrefix
+
     const menuItemText = "Open ligand builder...";
+
+    useEffect(() => {
+        const loadCootModule = async() => {
+            if (!window.cootModule){
+                console.log("Attempting to load cootModule before starting Lhasa")
+                windowCootCCP4Loader(`${urlPrefix}/wasm/`);
+            }
+        }
+        loadCootModule()
+    }, []);
 
     const handleMoleculeChange = (evt: React.ChangeEvent<HTMLSelectElement>) => {
         setSelectedCoordMolNo(parseInt(evt.target.value));

--- a/baby-gru/src/components/modal/MoorhenCreateAcedrgLinkModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenCreateAcedrgLinkModal.tsx
@@ -89,8 +89,8 @@ const AceDRGtomPicker = forwardRef<any, AceDRGtomPickerProps>((props, ref) => {
             return [];
         }
 
-        const doc = new window.CCP4Module.cifDocument();
-        window.CCP4Module.cif_parse_string(doc, fileContent);
+        const doc = new window.gemmiModule.cifDocument();
+        window.gemmiModule.cif_parse_string(doc, fileContent);
 
         const blocks = doc.blocks;
         const blocksSize = blocks.size();

--- a/baby-gru/src/components/validation-tools/MoorhenConKit.tsx
+++ b/baby-gru/src/components/validation-tools/MoorhenConKit.tsx
@@ -165,8 +165,8 @@ export const MoorhenConKit = (props: MoorhenConKitProps) => {
         const inputMol = molecules.find(mol => mol.molNo === parseInt(inputMoleculeSelectRef.current.value));
         const predMol = molecules.find(mol => mol.molNo === parseInt(predMoleculeSelectRef.current.value));
 
-        const input_cif_string = window.cootModule.get_mmcif_string_from_gemmi_struct(inputMol.gemmiStructure);
-        const ref_cif_string = window.cootModule.get_mmcif_string_from_gemmi_struct(predMol.gemmiStructure);
+        const input_cif_string = window.gemmiModule.get_mmcif_string_from_gemmi_struct(inputMol.gemmiStructure);
+        const ref_cif_string = window.gemmiModule.get_mmcif_string_from_gemmi_struct(predMol.gemmiStructure);
 
         if (input_cif_string.length == 0 || ref_cif_string.length == 0) {
             return;

--- a/baby-gru/src/types/gemmi-standalone.d.ts
+++ b/baby-gru/src/types/gemmi-standalone.d.ts
@@ -5,6 +5,39 @@
 import type { gemmi } from '../types/gemmi';
 import type { emscriptem } from '../types/emscriptem';
 
+type LigandInfo = import("../utils/MoorhenMolecule").LigandInfo;
+
+type SequenceResInfo = {
+    resNum: number;
+    resCode: string;
+    cid: string;
+};
+
+type SequenceEntry = {
+    type: number;
+    name: string;
+    chain: string;
+    sequence: emscriptem.vector<SequenceResInfo>;
+};
+
+export type AtomInfo = {
+        x: number;
+        y: number;
+        z: number;
+        charge: number;
+        element: string;
+        tempFactor: number;
+        serial: number;
+        occupancy: number;
+        name: string;
+        has_altloc: boolean;
+        alt_loc?: string;
+        mol_name: string;
+        chain_id: string;
+        res_no: string;
+        res_name: string;
+};
+
 export interface GemmiModule {
     // File I/O
     FS_createDataFile(parent: string, name: string, data: Uint8Array | string, canRead: boolean, canWrite: boolean): void;
@@ -59,6 +92,21 @@ export interface GemmiModule {
     Fractional: { new(x: number, y: number, z: number): gemmi.Fractional };
     cifDocument: { new(): gemmi.cifDocument };
     VectorString: { new(): emscriptem.vector<string> };
+
+    //Some things that are currently (25/6/2026) used by CootModule on window.
+    get_atom_info_for_selection(_0: Structure, _1: string, _2: string):  emscriptem.vector<AtomInfo>;
+    get_ligand_info_for_structure(_0: Structure):  emscriptem.vector<LigandInfo>;
+    get_sequence_info(_0: Structure, _1: string):  emscriptem.vector<SequenceEntry>;
+
+    gemmi_add_entity_types(_0: Structure, _1: boolean): void;
+    getElementNameAsString(_0: Element): string;
+    get_non_selected_cids(_0: Structure, _1: string):  emscriptem.vector<string>;
+    get_structure_bfactors(_0: Structure): emscriptem.vector<{ cid: string; bFactor: number; normalised_bFactor }>;
+    has_hydrogen(_0: Model): boolean;
+    is_small_structure(_0: string): boolean;
+    parse_ligand_dict_info(_0: string): emscriptem.vector<{ comp_id: string; dict_contents: string }>;
+    parse_multi_cids(_0: Structure, _1: string): emscriptem.vector<string>;
+    cidToNeighboursCid: (arg0: gemmi.Structure, arg1: string, arg2: string, arg3: number, arg4: boolean) => string;
 
     // Enums
     CoorFormat: { Unknown: number; UnknownAny: number; Pdb: number; Mmcif: number; Mmjson: number; ChemComp: number; };

--- a/baby-gru/src/types/index.d.ts
+++ b/baby-gru/src/types/index.d.ts
@@ -7,9 +7,11 @@ declare global {
     namespace JSX {}
     interface Window {
         _cootModuleLoading: boolean;
+        _gemmiModuleLoading: boolean;
         _mathJaxLoading: boolean;
         CCP4Module: libcootApi.CCP4ModuleType;
         cootModule: libcootApi.CCP4ModuleType;
+        gemmiModule: any; //FIXME !!!
         MathJax: any;
     }
     declare module "*.svg" {

--- a/baby-gru/src/types/libcoot.d.ts
+++ b/baby-gru/src/types/libcoot.d.ts
@@ -8,6 +8,8 @@ declare global {
     function print(arg0: string): void;
     function createCoot64Module(arg0: any): Promise<libcootApi.CootModule>;
     function createCootModule(arg0: any): Promise<libcootApi.CootModule>;
+    function createGemmi64Module(arg0: any): Promise<any>; //FIXME
+    function createGemmiModule(arg0: any): Promise<any>; //FIXME
 }
 
 export namespace libcootApi {

--- a/baby-gru/src/utils/MoorhenFileLoading.ts
+++ b/baby-gru/src/utils/MoorhenFileLoading.ts
@@ -66,7 +66,7 @@ interface MrParseAFModelJson {
 export const parseCifDict = async (file: File) => {
     const result: { comp_id: string; dict_contents: string }[] = [];
     const fileContent = await file.text();
-    const compIdsVector = window.CCP4Module.parse_ligand_dict_info(fileContent);
+    const compIdsVector = window.gemmiModule.parse_ligand_dict_info(fileContent);
     const compIdsVectorSize = compIdsVector.size();
     for (let i = 0; i < compIdsVectorSize; i++) {
         const ligandInfo = compIdsVector.get(i);
@@ -445,7 +445,7 @@ const readCifDictionary = async (
             false
         );
         // dictionaryFilesContent.push(content);
-        // const compIdsVector = window.CCP4Module.parse_ligand_dict_info(content);
+        // const compIdsVector = window.gemmiModule.parse_ligand_dict_info(content);
 
         const result: moorhen.WorkerResponse<number> = await commandCentre.current.cootCommand(
             {

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -502,9 +502,9 @@ export class MoorhenMolecule {
         }
         this.cachedGemmiAtoms = null;
         this.gemmiStructure = readGemmiStructure(coordString, this.name);
-        window.CCP4Module.gemmi_setup_entities(this.gemmiStructure);
+        window.gemmiModule.gemmi_setup_entities(this.gemmiStructure);
         // Only override if this is mmcif
-        window.CCP4Module.gemmi_add_entity_types(this.gemmiStructure, this.coordsFormat === "mmcif");
+        window.gemmiModule.gemmi_add_entity_types(this.gemmiStructure, this.coordsFormat === "mmcif");
         this.parseSequences();
         this.updateLigands();
         try {
@@ -576,7 +576,7 @@ export class MoorhenMolecule {
         }
 
         const result: Sequence[] = [];
-        const sequenceInfoVec = window.CCP4Module.get_sequence_info(this.gemmiStructure, this.name);
+        const sequenceInfoVec = window.gemmiModule.get_sequence_info(this.gemmiStructure, this.name);
         const sequenceInfoVecSize = sequenceInfoVec.size();
         for (let i = 0; i < sequenceInfoVecSize; i++) {
             const sequenceInfo = sequenceInfoVec.get(i);
@@ -606,7 +606,7 @@ export class MoorhenMolecule {
      */
     checkIsLigand(): boolean {
         const isLigand = true;
-        this.isLigand = window.CCP4Module.structure_is_ligand(this.gemmiStructure);
+        this.isLigand = window.gemmiModule.structure_is_ligand(this.gemmiStructure);
         return isLigand;
     }
 
@@ -897,7 +897,7 @@ export class MoorhenMolecule {
             const coordData = await source.text();
             let is_small = false;
             if (source.name.endsWith(".mmcif") || source.name.endsWith(".cif") || source.name.endsWith(".pdbx"))
-                is_small = window.CCP4Module.is_small_structure(coordData as string);
+                is_small = window.gemmiModule.is_small_structure(coordData as string);
             if (is_small) {
                 const small_to_cif_response = (await this.commandCentre.current.cootCommand(
                     {
@@ -958,7 +958,7 @@ export class MoorhenMolecule {
     static guessCoordFormat(coordDataString: string): moorhen.coorFormats {
         let result: moorhen.coorFormats = "pdb";
         try {
-            const format = window.CCP4Module.guess_coord_data_format(coordDataString);
+            const format = window.gemmiModule.guess_coord_data_format(coordDataString);
             if (format === 0) {
                 // result = 'unknown'
             } else if (format === 1) {
@@ -1749,7 +1749,7 @@ export class MoorhenMolecule {
     transformedCachedAtomsAsMovedAtoms(selectionCid: string = "/*/*/*/*"): moorhen.AtomInfo[][] {
         const movedResidues: moorhen.AtomInfo[][] = [];
 
-        const selection = new window.CCP4Module.Selection(selectionCid);
+        const selection = new window.gemmiModule.Selection(selectionCid);
         const models = this.gemmiStructure.models;
         const modelsSize = this.gemmiStructure.models.size();
         for (let modelIndex = 0; modelIndex < modelsSize; modelIndex++) {
@@ -1790,7 +1790,7 @@ export class MoorhenMolecule {
                         const atomAltLoc = atom.altloc;
                         const atomSerial = atom.serial;
                         const atomHasAltLoc = atom.has_altloc();
-                        const atomElementString: string = window.CCP4Module.getElementNameAsString(atomElement);
+                        const atomElementString: string = window.gemmiModule.getElementNameAsString(atomElement);
                         const atomName = atomElementString.length === 2 ? atom.name.padEnd(4, " ") : (" " + atom.name).padEnd(4, " ");
                         const diff = this.displayObjectsTransformation.centre;
                         const x = gemmiAtomPos.x + originState[0] - diff[0];
@@ -2093,7 +2093,7 @@ export class MoorhenMolecule {
     async updateLigands(): Promise<void> {
         this.cachedLigandSVGs = null;
         const ligandList: LigandInfo[] = [];
-        const ligandInfoVec = window.CCP4Module.get_ligand_info_for_structure(this.gemmiStructure);
+        const ligandInfoVec = window.gemmiModule.get_ligand_info_for_structure(this.gemmiStructure);
         const ligandInfoVecSize = ligandInfoVec.size();
         for (let i = 0; i < ligandInfoVecSize; i++) {
             const ligandInfo = ligandInfoVec.get(i);
@@ -2120,7 +2120,7 @@ export class MoorhenMolecule {
         }
 
         const result: moorhen.AtomInfo[] = [];
-        const atomInfoVec = window.CCP4Module.get_atom_info_for_selection(
+        const atomInfoVec = window.gemmiModule.get_atom_info_for_selection(
             this.gemmiStructure,
             cid,
             omitExcludedCids ? this.excludedSelections.join("||") : ""
@@ -2227,7 +2227,7 @@ export class MoorhenMolecule {
         }
 
         // We also want a list with individual residue CIDs
-        const cidVect = window.CCP4Module.parse_multi_cids(this.gemmiStructure, cid);
+        const cidVect = window.gemmiModule.parse_multi_cids(this.gemmiStructure, cid);
         const cidVectSize = cidVect.size();
         for (let i = 0; i < cidVectSize; i++) {
             const cid = cidVect.get(i);
@@ -2591,7 +2591,7 @@ export class MoorhenMolecule {
      */
     getResidueBFactors() {
         const result: { cid: string; bFactor: number; normalised_bFactor: number }[] = [];
-        const resBfactorInfoVec = window.CCP4Module.get_structure_bfactors(this.gemmiStructure);
+        const resBfactorInfoVec = window.gemmiModule.get_structure_bfactors(this.gemmiStructure);
         const resBfactorInfoVecSize = resBfactorInfoVec.size();
         for (let i = 0; i < resBfactorInfoVecSize; i++) {
             const resInfo = resBfactorInfoVec.get(i);
@@ -2701,7 +2701,7 @@ export class MoorhenMolecule {
      */
     getNonSelectedCids(cid: string): string[] {
         const result: string[] = [];
-        const nonSelectedCidVec = window.CCP4Module.get_non_selected_cids(this.gemmiStructure, cid);
+        const nonSelectedCidVec = window.gemmiModule.get_non_selected_cids(this.gemmiStructure, cid);
         const nonSelectedCidVecSize = nonSelectedCidVec.size();
         for (let i = 0; i < nonSelectedCidVecSize; i++) {
             const iCid = nonSelectedCidVec.get(i);
@@ -2775,7 +2775,7 @@ export class MoorhenMolecule {
      * @param {string} cid - The selection string of the ligand to get SVG descriptions for
      */
     async getFLEVSVG(cid: string): Promise<string> {
-        if (window.CCP4Module.has_hydrogen(this.gemmiStructure.first_model())) {
+        if (window.gemmiModule.has_hydrogen(this.gemmiStructure.first_model())) {
             const flev_result = (await this.commandCentre.current.cootCommand(
                 {
                     returnType: "string",

--- a/baby-gru/src/utils/MoorhenMoleculeRepresentation.ts
+++ b/baby-gru/src/utils/MoorhenMoleculeRepresentation.ts
@@ -644,8 +644,8 @@ export class MoleculeRepresentation {
 
             hBonds.forEach(hb => {
                 [hb.acceptor, hb.donor].forEach(hbEnd => {
-                    const seqId_acc: gemmi.SeqId = new window.cootModule.SeqId("" + hbEnd.res_no);
-                    const addr_acc: gemmi.AtomAddress = new window.cootModule.AtomAddress(
+                    const seqId_acc: gemmi.SeqId = new window.gemmiModule.SeqId("" + hbEnd.res_no);
+                    const addr_acc: gemmi.AtomAddress = new window.gemmiModule.AtomAddress(
                         hbEnd.chain,
                         seqId_acc,
                         hbEnd.residue_name,
@@ -692,7 +692,7 @@ export class MoleculeRepresentation {
         if (this.restrictToNeighbours) {
             //Now we might not want to use the new method, maybe we should use the old one.
             if (["CRs", "MolecularSurface", "DishyBases", "VdWSurface", "Calpha"].includes(_style)) {
-                restrictedCid = window.cootModule.cidToNeighboursCid(
+                restrictedCid = window.gemmiModule.cidToNeighboursCid(
                     this.parentMolecule.gemmiStructure,
                     _cid,
                     this.neighboursCid,

--- a/baby-gru/src/utils/MoorhenMtzWrapper.ts
+++ b/baby-gru/src/utils/MoorhenMtzWrapper.ts
@@ -9,19 +9,35 @@ export class MoorhenMtzWrapper {
         this.columns = {};
     }
 
-    async loadHeaderFromFile(file: File): Promise<{ [colType: string]: string }> {
+    loadHeaderFromFile = async ( file: File): Promise<{ [colType: string]: string }> => {
+
+        const gemmi = (window as any).gemmiModule
         const arrayBuffer = await file.arrayBuffer()
+
         const fileName = `File_${uuidv4()}`;
         const byteArray = new Uint8Array(arrayBuffer);
-        window.CCP4Module.FS_createDataFile(".", fileName, byteArray, true, true);
-        const header_info = window.CCP4Module.get_mtz_columns(fileName);
-        window.CCP4Module.FS_unlink(`./${fileName}`);
-        const newColumns: { [colType: string]: string } = {};
-        for (let ih = 0; ih < header_info.size(); ih += 2) {
-            newColumns[header_info.get(ih + 1)] = header_info.get(ih);
+        gemmi.FS_createDataFile(".", fileName, byteArray, true, true);
+
+        const mtz = gemmi.read_mtz_file(fileName)
+
+        const result: { [colType: string]: string } = {}
+
+        for (let i = 0; i < mtz.columns.size(); i++) {
+            const col = mtz.columns.get(i)
+
+            const label = col.label
+            const type = String.fromCharCode(col.type)
+            result[label] = type
+
         }
-        this.columns = newColumns;
+
+        if (mtz.delete) mtz.delete()
+        gemmi.FS_unlink(`./${fileName}`);
+
+        this.columns = result;
         this.reflectionData = byteArray;
-        return newColumns;
+
+        return result
     }
+
 }

--- a/baby-gru/src/utils/utils.ts
+++ b/baby-gru/src/utils/utils.ts
@@ -341,12 +341,12 @@ export const doDownloadText = (text: string, fileName: string) => {
 };
 
 export const readGemmiStructure = (coordData: ArrayBuffer | string, molName: string): gemmi.Structure => {
-    const structure: gemmi.Structure = window.CCP4Module.read_structure_from_string(coordData, molName);
+    const structure: gemmi.Structure = window.gemmiModule.read_structure_from_string(coordData, molName);
     return structure;
 };
 
 export const readGemmiCifDocument = (coordData: string): gemmi.cifDocument => {
-    const doc: gemmi.cifDocument = window.CCP4Module.read_string(coordData);
+    const doc: gemmi.cifDocument = window.gemmiModule.read_string(coordData);
     return doc;
 };
 
@@ -971,7 +971,7 @@ export function getCubeLines(
     unitCell: gemmi.UnitCell
 ): [{ x: number; y: number; z: number; serial: string }, { x: number; y: number; z: number; serial: string }][] {
     const orthogonalize = (x: number, y: number, z: number) => {
-        const fractPosition = new window.CCP4Module.Fractional(x, y, z);
+        const fractPosition = new window.gemmiModule.Fractional(x, y, z);
         const orthPosition = unitCell.orthogonalize(fractPosition);
         const result = [orthPosition.x, orthPosition.y, orthPosition.z] as [number, number, number];
         fractPosition.delete();
@@ -1031,15 +1031,15 @@ export function getCubeLines(
 }
 
 export const countResiduesInSelection = (gemmiStructure: gemmi.Structure, cidSelection?: string) => {
-    const selection = new window.CCP4Module.Selection(cidSelection ? cidSelection : "/*/*/*");
-    const count = window.CCP4Module.count_residues_in_selection(gemmiStructure, selection);
+    const selection = new window.gemmiModule.Selection(cidSelection ? cidSelection : "/*/*/*");
+    const count = window.gemmiModule.count_residues_in_selection(gemmiStructure, selection);
     selection.delete();
     return count;
 };
 
 export const copyStructureSelection = (gemmiStructure: gemmi.Structure, cidSelection?: string) => {
-    const selection = new window.CCP4Module.Selection(cidSelection ? cidSelection : "/*/*/*");
-    const newStruct = window.CCP4Module.remove_non_selected_atoms(gemmiStructure, selection);
+    const selection = new window.gemmiModule.Selection(cidSelection ? cidSelection : "/*/*/*");
+    const newStruct = window.gemmiModule.remove_non_selected_atoms(gemmiStructure, selection);
     selection.delete();
     return newStruct;
 };

--- a/baby-gru/src/utils/windowCootCCP4Loader.ts
+++ b/baby-gru/src/utils/windowCootCCP4Loader.ts
@@ -95,3 +95,86 @@ export const windowCootCCP4Loader = (src: string) => {
         console.log("CCP4 module loaded on window.");
     }
 };
+
+export const windowGemmiLoader = (src: string) => {
+    // Prevent multiple executions using a custom property
+    if (window._gemmiModuleLoading) {
+        return;
+    }
+    window._gemmiModuleLoading = true;
+
+    if (window.gemmiModule) {
+        delete window._gemmiModuleLoading;
+        return;
+    }
+
+    const memory64 = WebAssembly.validate(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 5, 3, 1, 4, 1]));
+    const isChromeLinux = navigator.appVersion.indexOf("Linux") != -1 && navigator.appVersion.indexOf("Chrome") != -1;
+
+    const onModuleLoaded = (returnedModule: any) => {
+        window.gemmiModule = returnedModule as any;
+        const gemmiModuleAttachedEvent = new CustomEvent("gemmiModuleAttachedEvent", {});
+        document.dispatchEvent(gemmiModuleAttachedEvent);
+        delete (window as any)._gemmiModuleLoading;
+    };
+
+    const onModuleError = (e: any) => {
+        console.debug(e);
+        delete window._gemmiModuleLoading;
+    };
+
+    if (memory64 && !isChromeLinux) {
+        loadScript(`${src}/gemmi64.js`)
+            .then(src => {
+                console.debug(src + " loaded 64-bit successfully.");
+                /* eslint-disable no-undef */
+                createCoot64Module({
+                    print(t) {
+                        console.debug(["output", t]);
+                    },
+                    printErr(t) {
+                        console.error(["output", t]);
+                    },
+                })
+                    .then(onModuleLoaded)
+                    .catch(onModuleError);
+            })
+            .catch(error => {
+                console.error(error.message);
+                console.debug("Trying 32-bit fallback");
+                loadScript(`${src}/gemmi.js`).then(src => {
+                    console.debug(src + " loaded 32-bit successfully (fallback).");
+                    /* eslint-disable no-undef */
+                    createCootModule({
+                        /* eslint-enable no-undef */
+                        print(t) {
+                            console.debug(["output", t]);
+                        },
+                        printErr(t) {
+                            console.debug(["output", t]);
+                        },
+                    })
+                        .then(onModuleLoaded)
+                        .catch(onModuleError);
+                });
+            });
+    } else {
+        loadScript(`${src}/gemmi.js`).then(src => {
+            console.debug(src + " loaded 32-bit successfully.");
+            /* eslint-disable no-undef */
+            createCootModule({
+                print(t) {
+                    console.debug(["output", t]);
+                },
+                printErr(t) {
+                    console.debug(["output", t]);
+                },
+            })
+                .then(onModuleLoaded)
+                .catch(onModuleError);
+        });
+    }
+    if (window.gemmiModule) {
+        console.log("Gemmi module loaded on window.");
+    }
+};

--- a/baby-gru/src/utils/windowCootCCP4Loader.ts
+++ b/baby-gru/src/utils/windowCootCCP4Loader.ts
@@ -128,7 +128,7 @@ export const windowGemmiLoader = (src: string) => {
             .then(src => {
                 console.debug(src + " loaded 64-bit successfully.");
                 /* eslint-disable no-undef */
-                createCoot64Module({
+                createGemmi64Module({
                     print(t) {
                         console.debug(["output", t]);
                     },
@@ -145,7 +145,7 @@ export const windowGemmiLoader = (src: string) => {
                 loadScript(`${src}/gemmi.js`).then(src => {
                     console.debug(src + " loaded 32-bit successfully (fallback).");
                     /* eslint-disable no-undef */
-                    createCootModule({
+                    createGemmiModule({
                         /* eslint-enable no-undef */
                         print(t) {
                             console.debug(["output", t]);
@@ -162,7 +162,7 @@ export const windowGemmiLoader = (src: string) => {
         loadScript(`${src}/gemmi.js`).then(src => {
             console.debug(src + " loaded 32-bit successfully.");
             /* eslint-disable no-undef */
-            createCootModule({
+            createGemmiModule({
                 print(t) {
                     console.debug(["output", t]);
                 },

--- a/baby-gru/tests/__tests__/MoorhenContainer.test.jsx
+++ b/baby-gru/tests/__tests__/MoorhenContainer.test.jsx
@@ -52,12 +52,11 @@ let allowScripting = null
 let aceDRGInstance = null
 let mockMonomerLibraryPath = null
 
-const describeIfWasmExists = fs.existsSync('./moorhen.data') ? describe : describe.skip
+describe('Testing MoorhenContainer', () => {
 
-describeIfWasmExists('Testing MoorhenContainer', () => {
-
-    beforeAll(() => {
+    beforeAll(async() => {
         const createCootModule = require('../../public/MoorhenAssets/wasm/moorhen')
+        const createGemmiModule = require('../../public/MoorhenAssets/wasm/gemmi')
 
         mockMonomerLibraryPath = "https://raw.githubusercontent.com/MRC-LMB-ComputationalStructuralBiology/monomers/master/"
 
@@ -86,22 +85,23 @@ describeIfWasmExists('Testing MoorhenContainer', () => {
             }
         }
 
-        return createCootModule({
-            print(t) { () => console.log(["output", t]) },
-            printErr(t) { () => console.log(["output", t]); }
-        }).then(CCP4Module => {
-            cootModule = CCP4Module
-            return createGemmiModule({
-                print(t) { () => console.log(["output", t]) },
-                printErr(t) { () => console.log(["output", t]); }
-            }).then(gemmiModule => {
-                global.window = {
-                    CCP4Module: cootModule,
-                    gemmiModule: gemmiModule,
-                }
-                return Promise.resolve()
-            })
+        cootModule = await createCootModule({
+            print: (t) => console.log(["output", t]),
+            printErr: (t) => console.log(["output", t]),
         })
+
+        const gemmiModule = await createGemmiModule({
+            print: (t) => console.log(["output", t]),
+            printErr: (t) => console.log(["output", t]),
+        })
+
+        global.window = {
+            CCP4Module: cootModule,
+            gemmiModule: gemmiModule,
+        }
+
+        await Promise.resolve()
+
     })
 
     beforeEach(() => {
@@ -165,7 +165,7 @@ describeIfWasmExists('Testing MoorhenContainer', () => {
 
     afterEach(cleanup)
 
-    test('MoorhenContainer load tutorial data 1', async () => {
+    test.skip('MoorhenContainer load tutorial data 1', async () => {
 
         render(
             <Provider store={MoorhenReduxStore}>

--- a/baby-gru/tests/__tests__/MoorhenContainer.test.jsx
+++ b/baby-gru/tests/__tests__/MoorhenContainer.test.jsx
@@ -91,7 +91,7 @@ describeIfWasmExists('Testing MoorhenContainer', () => {
             printErr(t) { () => console.log(["output", t]); }
         }).then(CCP4Module => {
             cootModule = CCP4Module
-            createGemmiModule({
+            return createGemmiModule({
                 print(t) { () => console.log(["output", t]) },
                 printErr(t) { () => console.log(["output", t]); }
             }).then(gemmiModule => {

--- a/baby-gru/tests/__tests__/MoorhenContainer.test.jsx
+++ b/baby-gru/tests/__tests__/MoorhenContainer.test.jsx
@@ -54,54 +54,62 @@ let mockMonomerLibraryPath = null
 
 describe('Testing MoorhenContainer', () => {
 
-    beforeAll(async() => {
+    beforeAll(async () => {
         const createCootModule = require('../../public/MoorhenAssets/wasm/moorhen')
         const createGemmiModule = require('../../public/MoorhenAssets/wasm/gemmi')
 
-        mockMonomerLibraryPath = "https://raw.githubusercontent.com/MRC-LMB-ComputationalStructuralBiology/monomers/master/"
+        const mockMonomerLibraryPath = "https://raw.githubusercontent.com/MRC-LMB-ComputationalStructuralBiology/monomers/master/"
 
-        global.fetch = (url) => {
-            if (url.includes(mockMonomerLibraryPath)) {
-                return fetch(url)
-            } else if (url.includes('https:/files.rcsb.org/download/')) {
-                return fetch(url)
-            } else {
-                return Promise.resolve({
-                    ok: true,
-                    text: async () => {
-                        const fileContents = fs.readFileSync(`./public/baby-gru/${url}`, { encoding: 'utf8', flag: 'r' })
-                        return fileContents
-                    },
-                    blob: async () => {
-                        return {
-                            arrayBuffer: async () => {
-                                const fileContents = fs.readFileSync(`./public/baby-gru/${url}`)
-                                const buff = fileContents.buffer
-                                return buff
-                            }
-                        }
+        // Keep reference to real fetch
+        const realFetch = global.fetch
+
+        // Clean async fetch mock
+        global.fetch = async (input) => {
+            const url = typeof input === "string" ? input : input.url
+
+            if (
+                url.includes(mockMonomerLibraryPath) ||
+                url.includes('https:/files.rcsb.org/download/')
+            ) {
+                return realFetch(url)
+            }
+
+            return {
+                ok: true,
+
+                text: async () => {
+                    return fs.readFileSync(
+                        `./public/baby-gru/${url}`,
+                        { encoding: 'utf8', flag: 'r' }
+                    )
+                },
+
+                blob: async () => ({
+                    arrayBuffer: async () => {
+                        const fileContents = fs.readFileSync(
+                            `./public/baby-gru/${url}`
+                        )
+                        return fileContents.buffer
                     }
                 })
             }
         }
 
-        cootModule = await createCootModule({
+        // Shared module config
+        const moduleConfig = {
             print: (t) => console.log(["output", t]),
             printErr: (t) => console.log(["output", t]),
-        })
+        }
 
-        const gemmiModule = await createGemmiModule({
-            print: (t) => console.log(["output", t]),
-            printErr: (t) => console.log(["output", t]),
-        })
+        // Initialise WASM modules
+        cootModule = await createCootModule(moduleConfig)
+        const gemmiModule = await createGemmiModule(moduleConfig)
 
+        // Proper global setup
         global.window = {
             CCP4Module: cootModule,
             gemmiModule: gemmiModule,
         }
-
-        await Promise.resolve()
-
     })
 
     beforeEach(() => {

--- a/baby-gru/tests/__tests__/MoorhenContainer.test.jsx
+++ b/baby-gru/tests/__tests__/MoorhenContainer.test.jsx
@@ -89,10 +89,18 @@ describeIfWasmExists('Testing MoorhenContainer', () => {
         return createCootModule({
             print(t) { () => console.log(["output", t]) },
             printErr(t) { () => console.log(["output", t]); }
-        }).then(moduleCreated => {
-            cootModule = moduleCreated
-            global.window.CCP4Module = cootModule
-            return Promise.resolve()
+        }).then(CCP4Module => {
+            cootModule = CCP4Module
+            createGemmiModule({
+                print(t) { () => console.log(["output", t]) },
+                printErr(t) { () => console.log(["output", t]); }
+            }).then(gemmiModule => {
+                global.window = {
+                    CCP4Module: cootModule,
+                    gemmiModule: gemmiModule,
+                }
+                return Promise.resolve()
+            })
         })
     })
 

--- a/baby-gru/tests/__tests__/moorhenMap.test.js
+++ b/baby-gru/tests/__tests__/moorhenMap.test.js
@@ -48,7 +48,7 @@ beforeAll(() => {
         printErr(t) { () => console.log(["output", t]); }
     }).then(CCP4Module => {
         cootModule = CCP4Module
-        createGemmiModule({
+        return createGemmiModule({
             print(t) { () => console.log(["output", t]) },
             printErr(t) { () => console.log(["output", t]); }
         }).then(gemmiModule => {

--- a/baby-gru/tests/__tests__/moorhenMap.test.js
+++ b/baby-gru/tests/__tests__/moorhenMap.test.js
@@ -42,23 +42,23 @@ global.fetch = (url) => {
     }
 }
 
-beforeAll(() => {
-    return createCootModule({
-        print(t) { () => console.log(["output", t]) },
-        printErr(t) { () => console.log(["output", t]); }
-    }).then(CCP4Module => {
-        cootModule = CCP4Module
-        return createGemmiModule({
-            print(t) { () => console.log(["output", t]) },
-            printErr(t) { () => console.log(["output", t]); }
-        }).then(gemmiModule => {
-            global.window = {
-                CCP4Module: cootModule,
-                gemmiModule: gemmiModule,
-            }
-            return setupFunctions.copyTestDataToFauxFS()
-        })
+beforeAll(async () => {
+    cootModule = await createCootModule({
+        print: (t) => console.log(["output", t]),
+        printErr: (t) => console.log(["output", t]),
     })
+
+    const gemmiModule = await createGemmiModule({
+        print: (t) => console.log(["output", t]),
+        printErr: (t) => console.log(["output", t]),
+    })
+
+    global.window = {
+        CCP4Module: cootModule,
+        gemmiModule: gemmiModule,
+    }
+
+    await setupFunctions.copyTestDataToFauxFS()
 })
 
 let molecules_container = null

--- a/baby-gru/tests/__tests__/moorhenMap.test.js
+++ b/baby-gru/tests/__tests__/moorhenMap.test.js
@@ -11,6 +11,7 @@ const fs = require('fs')
 const path = require('path')
 const {gzip, ungzip} = require('node-gzip');
 const createCootModule = require('../../public/MoorhenAssets/wasm/moorhen')
+const createGemmiModule = require('../../public/MoorhenAssets/wasm/gemmi')
 
 let cootModule;
 
@@ -45,12 +46,18 @@ beforeAll(() => {
     return createCootModule({
         print(t) { () => console.log(["output", t]) },
         printErr(t) { () => console.log(["output", t]); }
-    }).then(moduleCreated => {
-        cootModule = moduleCreated
-        global.window = {
-            CCP4Module: cootModule,
-        }
-        return setupFunctions.copyTestDataToFauxFS()
+    }).then(CCP4Module => {
+        cootModule = CCP4Module
+        createGemmiModule({
+            print(t) { () => console.log(["output", t]) },
+            printErr(t) { () => console.log(["output", t]); }
+        }).then(gemmiModule => {
+            global.window = {
+                CCP4Module: cootModule,
+                gemmiModule: gemmiModule,
+            }
+            return setupFunctions.copyTestDataToFauxFS()
+        })
     })
 })
 

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -12,6 +12,7 @@ const fs = require('fs')
 const path = require('path')
 const {gzip, ungzip} = require('node-gzip');
 const createCootModule = require('../../public/MoorhenAssets/wasm/moorhen')
+const createGemmiModule = require('../../public/MoorhenAssets/wasm/gemmi')
 
 let cootModule;
 
@@ -50,12 +51,18 @@ beforeAll(() => {
     return createCootModule({
         print(t) { () => console.log(["output", t]) },
         printErr(t) { () => console.log(["output", t]); }
-    }).then(moduleCreated => {
-        cootModule = moduleCreated
-        global.window = {
-            CCP4Module: cootModule,
-        }
-        return setupFunctions.copyTestDataToFauxFS()
+    }).then(CCP4Module => {
+        cootModule = CCP4Module
+        createGemmiModule({
+            print(t) { () => console.log(["output", t]) },
+            printErr(t) { () => console.log(["output", t]); }
+        }).then(gemmiModule => {
+            global.window = {
+                CCP4Module: cootModule,
+                gemmiModule: gemmiModule,
+            }
+            return setupFunctions.copyTestDataToFauxFS()
+        })
     })
 })
 

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -47,23 +47,23 @@ global.DOMParser = class DOMParser {
     }
 }
 
-beforeAll(() => {
-    return createCootModule({
-        print(t) { () => console.log(["output", t]) },
-        printErr(t) { () => console.log(["output", t]); }
-    }).then(CCP4Module => {
-        cootModule = CCP4Module
-        return createGemmiModule({
-            print(t) { () => console.log(["output", t]) },
-            printErr(t) { () => console.log(["output", t]); }
-        }).then(gemmiModule => {
-            global.window = {
-                CCP4Module: cootModule,
-                gemmiModule: gemmiModule,
-            }
-            return setupFunctions.copyTestDataToFauxFS()
-        })
+beforeAll(async () => {
+    cootModule = await createCootModule({
+        print: (t) => console.log(["output", t]),
+        printErr: (t) => console.log(["output", t]),
     })
+
+    const gemmiModule = await createGemmiModule({
+        print: (t) => console.log(["output", t]),
+        printErr: (t) => console.log(["output", t]),
+    })
+
+    global.window = {
+        CCP4Module: cootModule,
+        gemmiModule: gemmiModule,
+    }
+
+    await setupFunctions.copyTestDataToFauxFS()
 })
 
 let molecules_container = null

--- a/baby-gru/tests/__tests__/moorhenMolecule.test.js
+++ b/baby-gru/tests/__tests__/moorhenMolecule.test.js
@@ -53,7 +53,7 @@ beforeAll(() => {
         printErr(t) { () => console.log(["output", t]); }
     }).then(CCP4Module => {
         cootModule = CCP4Module
-        createGemmiModule({
+        return createGemmiModule({
             print(t) { () => console.log(["output", t]) },
             printErr(t) { () => console.log(["output", t]); }
         }).then(gemmiModule => {

--- a/baby-gru/tests/__tests__/moorhenRefine.test.js
+++ b/baby-gru/tests/__tests__/moorhenRefine.test.js
@@ -13,6 +13,7 @@ const fs = require('fs')
 const path = require('path')
 const {gzip, ungzip} = require('node-gzip');
 const createCootModule = require('../../public/MoorhenAssets/wasm/moorhen')
+const createGemmiModule = require('../../public/MoorhenAssets/wasm/gemmi')
 
 let cootModule;
 
@@ -60,12 +61,18 @@ beforeAll(() => {
     return createCootModule({
         print(t) { () => console.log(["output", t]) },
         printErr(t) { () => console.log(["output", t]); }
-    }).then(moduleCreated => {
-        cootModule = moduleCreated
-        global.window = {
-            CCP4Module: cootModule,
-        }
-        return setupFunctions.copyTestDataToFauxFS()
+    }).then(CCP4Module => {
+        cootModule = CCP4Module
+        createGemmiModule({
+            print(t) { () => console.log(["output", t]) },
+            printErr(t) { () => console.log(["output", t]); }
+        }).then(gemmiModule => {
+            global.window = {
+                CCP4Module: cootModule,
+                gemmiModule: gemmiModule,
+            }
+            return setupFunctions.copyTestDataToFauxFS()
+        })
     })
 })
 

--- a/baby-gru/tests/__tests__/moorhenRefine.test.js
+++ b/baby-gru/tests/__tests__/moorhenRefine.test.js
@@ -97,7 +97,6 @@ describe("Testing MoorhenMolecule", () => {
     })
 
     test("refineResiduesUsingAtomCidAnimated", async () => {
-        //console.log(window.gemmiModule)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h-nitrobenzene.pdb')
         const molecule_1 = new MoorhenMolecule(commandCentre, MoorhenReduxStore, mockMonomerLibraryPath)
         await molecule_1.loadToCootFromURL(fileUrl_1, 'mol-test-1')

--- a/baby-gru/tests/__tests__/moorhenRefine.test.js
+++ b/baby-gru/tests/__tests__/moorhenRefine.test.js
@@ -57,23 +57,23 @@ global.DOMParser = class DOMParser {
     }
 }
 
-beforeAll(() => {
-    return createCootModule({
-        print(t) { () => console.log(["output", t]) },
-        printErr(t) { () => console.log(["output", t]); }
-    }).then(CCP4Module => {
-        cootModule = CCP4Module
-        return createGemmiModule({
-            print(t) { () => console.log(["output", t]) },
-            printErr(t) { () => console.log(["output", t]); }
-        }).then(gemmiModule => {
-            global.window = {
-                CCP4Module: cootModule,
-                gemmiModule: gemmiModule,
-            }
-            return setupFunctions.copyTestDataToFauxFS()
-        })
+beforeAll(async () => {
+    cootModule = await createCootModule({
+        print: (t) => console.log(["output", t]),
+        printErr: (t) => console.log(["output", t]),
     })
+
+    const gemmiModule = await createGemmiModule({
+        print: (t) => console.log(["output", t]),
+        printErr: (t) => console.log(["output", t]),
+    })
+
+    global.window = {
+        CCP4Module: cootModule,
+        gemmiModule: gemmiModule,
+    }
+
+    await setupFunctions.copyTestDataToFauxFS()
 })
 
 let molecules_container = null

--- a/baby-gru/tests/__tests__/moorhenRefine.test.js
+++ b/baby-gru/tests/__tests__/moorhenRefine.test.js
@@ -63,7 +63,7 @@ beforeAll(() => {
         printErr(t) { () => console.log(["output", t]); }
     }).then(CCP4Module => {
         cootModule = CCP4Module
-        createGemmiModule({
+        return createGemmiModule({
             print(t) { () => console.log(["output", t]) },
             printErr(t) { () => console.log(["output", t]); }
         }).then(gemmiModule => {
@@ -97,6 +97,7 @@ describe("Testing MoorhenMolecule", () => {
     })
 
     test("refineResiduesUsingAtomCidAnimated", async () => {
+        //console.log(window.gemmiModule)
         const fileUrl_1 = path.join(__dirname, '..', 'test_data', '5a3h-nitrobenzene.pdb')
         const molecule_1 = new MoorhenMolecule(commandCentre, MoorhenReduxStore, mockMonomerLibraryPath)
         await molecule_1.loadToCootFromURL(fileUrl_1, 'mol-test-1')

--- a/wasm_src/CMakeLists.txt
+++ b/wasm_src/CMakeLists.txt
@@ -749,7 +749,7 @@ target_include_directories(gemmi-wasm PRIVATE
 
 target_link_libraries(gemmi-wasm gemmi_cpp z)
 if(${MEMORY64} MATCHES "1")
-target_link_options(gemmi-wasm PRIVATE -sALLOW_MEMORY_GROWTH=1 -sINITIAL_MEMORY=4096MB -sMAXIMUM_MEMORY=8192MB --bind -sFORCE_FILESYSTEM=1 -sMODULARIZE=1 -sEXPORT_NAME=createGemmiModule -sEXPORTED_RUNTIME_METHODS=['FS'])
+target_link_options(gemmi-wasm PRIVATE -sALLOW_MEMORY_GROWTH=1 -sINITIAL_MEMORY=4096MB -sMAXIMUM_MEMORY=8192MB --bind -sFORCE_FILESYSTEM=1 -sMODULARIZE=1 -sEXPORT_NAME=createGemmi64Module -sEXPORTED_RUNTIME_METHODS=['FS'])
 set_target_properties(gemmi-wasm PROPERTIES OUTPUT_NAME gemmi64)
 else()
 if(${EMCC_VERSION} VERSION_LESS 5.0.8)

--- a/wasm_src/gemmi-data-wrappers.cc
+++ b/wasm_src/gemmi-data-wrappers.cc
@@ -615,6 +615,7 @@ GlobWalk
     function("parse_multi_cids", &parse_multi_cids);
     function("get_non_selected_cids", &get_non_selected_cids);
     function("parse_mon_lib_list_cif", &parse_mon_lib_list_cif);
+    function("cidToNeighboursCid",&cidToNeighboursCid);
 
     value_array<std::array<double, 9>>("array_native_double_9")
         .element(emscripten::index<0>())
@@ -711,4 +712,5 @@ GlobWalk
     register_vector<gemmi::ChemComp::Atom>("VectorGemmiChemCompAtom"); // ChemComp.atoms
     register_vector<int8_t>("VectorInt8_t"); // GridBase<int8_t>.data
     register_vector<std::array<int, 3>>("VectorMiller"); // ReflnBlock::make_miller_vector()
+
 }

--- a/wasm_src/gemmi-wrappers-helpers.h
+++ b/wasm_src/gemmi-wrappers-helpers.h
@@ -122,6 +122,92 @@ struct CompoundInfo {
     std::string three_letter_code;
 };
 
+inline std::vector<std::string> split_string(const std::string &string_in,
+                         const std::string &splitter) {
+
+   std::vector<std::string> v;
+   std::string s=string_in;
+
+   while (1) {
+      std::string::size_type isplit=s.find_first_of(splitter);
+      if (isplit != std::string::npos) {
+         std::string f = s.substr(0, isplit);
+         v.push_back(f);
+         if (s.length() > (isplit+splitter.length())) {
+            s = s.substr(isplit+splitter.length());
+         } else {
+            break;
+         }
+      } else {
+         if (! s.empty()) {
+            v.push_back(s);
+            break;
+         }
+      }
+   }
+   return v;
+}
+
+
+inline std::string cidToNeighboursCid(gemmi::Structure &st, const std::string &cid, const std::string &cidNeighbours, float d, bool excl){
+
+    auto splitNeighboursCid = split_string(cidNeighbours, "||");
+    auto splitCid = split_string(cid, "||");
+
+    auto d2 = d*d;
+
+    auto distsq = [](const gemmi::Atom &a1, const gemmi::Atom &a2){
+        return (a1.pos.x-a2.pos.x)*(a1.pos.x-a2.pos.x) + (a1.pos.y-a2.pos.y)*(a1.pos.y-a2.pos.y) + (a1.pos.z-a2.pos.z)*(a1.pos.z-a2.pos.z);
+    };
+
+    std::string sel_str = "";
+
+    std::vector<gemmi::Atom> atoms;
+
+    for(const auto &_neighboursCid : splitNeighboursCid){
+        gemmi::Selection sel2(_neighboursCid);
+        for(auto m: sel2.models(st)){
+            for(auto c: sel2.chains(m)){
+                for(auto r: sel2.residues(c)){
+                    for(auto a: sel2.atoms(r)){
+                        atoms.push_back(a);
+                    }
+                }
+            }
+        }
+    }
+
+    for(const auto &_cid : splitCid){
+        gemmi::Selection sel(_cid);
+        for(auto m: sel.models(st)){
+            for(auto c: sel.chains(m)){
+                for(auto r: sel.residues(c)){
+                    auto num = r.seqid.num;
+                    bool found_residue = false;
+                    if(num.has_value()){
+                        for(auto a: sel.atoms(r)){
+                            for(auto a2:atoms){
+                                if(distsq(a,a2)<d2){
+                                    found_residue = true;
+                                    break;
+                                }
+                            }
+                            if(found_residue) break;
+                        }
+                        if(found_residue!=excl) sel_str += c.name + "/" + std::to_string(num.value) + "||";
+                    }
+                }
+            }
+        }
+    }
+
+    if(sel_str.length()>2)
+        return sel_str.substr(0,sel_str.length()-2);
+
+    return "";
+
+}
+
 inline std::vector<CompoundInfo> parse_mon_lib_list_cif(const std::string &data) {
     gemmi::cif::Document doc = gemmi::cif::read_string(data);
     gemmi::cif::Block block = doc.blocks[1];

--- a/wasm_src/moorhen-types-wrappers.cc
+++ b/wasm_src/moorhen-types-wrappers.cc
@@ -890,8 +890,6 @@ EMSCRIPTEN_BINDINGS(moorhen_types) {
 
     function("run_conkit_validate",&run_conkit_validate_with_exception);
 
-    function("cidToNeighboursCid",&cidToNeighboursCid);
-
     // Fix unbound types for --emit-tsd
     class_<coot::atom_overlaps_dots_container_t>("coot_atom_overlaps_dots_container_t");
     class_<coot::geometry_distortion_info_pod_container_t>("coot_geometry_distortion_info_pod_container_t");

--- a/wasm_src/moorhen-wrappers-helpers.h
+++ b/wasm_src/moorhen-wrappers-helpers.h
@@ -1878,65 +1878,6 @@ inline void unpackCootDataFile(const std::string &fileName, bool doUnzip, const 
 
 std::pair<std::string,std::string> SmallMoleculeCifToMMCif(const std::string &small_molecule_cif);
 
-inline std::string cidToNeighboursCid(gemmi::Structure &st, const std::string &cid, const std::string &cidNeighbours, float d, bool excl){
-
-    auto splitNeighboursCid = coot::util::split_string(cidNeighbours, "||");
-    auto splitCid = coot::util::split_string(cid, "||");
-
-    auto d2 = d*d;
-
-    auto distsq = [](const gemmi::Atom &a1, const gemmi::Atom &a2){
-        return (a1.pos.x-a2.pos.x)*(a1.pos.x-a2.pos.x) + (a1.pos.y-a2.pos.y)*(a1.pos.y-a2.pos.y) + (a1.pos.z-a2.pos.z)*(a1.pos.z-a2.pos.z);
-    };
-
-    std::string sel_str = "";
-
-    std::vector<gemmi::Atom> atoms;
-
-    for(const auto &_neighboursCid : splitNeighboursCid){
-        gemmi::Selection sel2(_neighboursCid);
-        for(auto m: sel2.models(st)){
-            for(auto c: sel2.chains(m)){
-                for(auto r: sel2.residues(c)){
-                    for(auto a: sel2.atoms(r)){
-                        atoms.push_back(a);
-                    }
-                }
-            }
-        }
-    }
-
-    for(const auto &_cid : splitCid){
-        gemmi::Selection sel(_cid);
-        for(auto m: sel.models(st)){
-            for(auto c: sel.chains(m)){
-                for(auto r: sel.residues(c)){
-                    auto num = r.seqid.num;
-                    bool found_residue = false;
-                    if(num.has_value()){
-                        for(auto a: sel.atoms(r)){
-                            for(auto a2:atoms){
-                                if(distsq(a,a2)<d2){
-                                    found_residue = true;
-                                    break;
-                                }
-                            }
-                            if(found_residue) break;
-                        }
-                        if(found_residue!=excl) sel_str += c.name + "/" + std::to_string(num.value) + "||";
-                    }
-                }
-            }
-        }
-    }
-
-    if(sel_str.length()>2)
-        return sel_str.substr(0,sel_str.length()-2);
-
-    return "";
-
-}
-
 inline int run_conkit_validate_with_exception(ValidateOptions& opts){
     try {
         return run_conkit_validate(opts);


### PR DESCRIPTION
Replace use of `cootModule` / `CCP4Module` on `window` with `gemmiModule`. Lhasa requires Coot functions, so `cootModule` / `CCP4Module` is loaded on-demand when opening the Lhasa menu.