### PR TITLE
HBAO ambient-occlusion prototype (toggleable vs SSAO)

### DIFF
--- a/baby-gru/src/WebGLgComponents/mgWebGL.tsx
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.tsx
@@ -16,6 +16,7 @@ import { blur_y_simple_fragment_shader_source as blur_y_simple_fragment_shader_s
 import { blur_vertex_shader_source as blur_vertex_shader_source_webgl2 } from './webgl-2/blur-vertex-shader.js';
 import { overlay_fragment_shader_source as overlay_fragment_shader_source_webgl2 } from './webgl-2/overlay-fragment-shader.js';
 import { ssao_fragment_shader_source as ssao_fragment_shader_source_webgl2 } from './webgl-2/ssao-fragment-shader.js';
+import { hbao_fragment_shader_source as hbao_fragment_shader_source_webgl2 } from './webgl-2/hbao-fragment-shader.js';
 import { edge_detect_fragment_shader_source as edge_detect_fragment_shader_source_webgl2 } from './webgl-2/edge-detect-fragment-shader.js';
 import { blur_x_fragment_shader_source as blur_x_fragment_shader_source_webgl2 } from './webgl-2/blur_x-fragment-shader.js';
 import { blur_y_fragment_shader_source as blur_y_fragment_shader_source_webgl2 } from './webgl-2/blur_y-fragment-shader.js';
@@ -109,7 +110,7 @@ import { drawBuffer, drawMaxElementsUInt, setupModelViewTransformMatrixInteracti
 import { drawPeel, drawTriangles, drawScene, applySymmetryMatrix, bindFramebufferDrawBuffers } from './mgWebGLParts/drawCore'
 import { initInstanceState, initGraphicsContext, attachCanvasListeners, initGraphics } from './mgWebGLParts/lifecycle'
 import { getDeviceScale} from './webGLUtils'
-import {getShader, initInstancedOutlineShaders, initInstancedShadowShaders, initShadowShaders, initEdgeDetectShader, initSSAOShader, initBlurXShader, initBlurYShader, initSimpleBlurXShader, initSimpleBlurYShader, initOverlayShader, initRenderFrameBufferShaders, initCirclesShaders, initTextInstancedShaders, initTextBackgroundShaders, initOutlineShaders, initGBufferShadersPerfectSphere, initGBufferShadersInstanced, initGBufferShaders, initShadersDepthPeelAccum, initShadersTextured, initShaders, initShadersInstanced, initGBufferThickLineNormalShaders, initThickLineNormalShaders, initThickLineShaders, initLineShaders, initDepthShadowPerfectSphereShaders, initPerfectSphereOutlineShaders, initPerfectSphereShaders, initImageShaders, initTwoDShapesShaders, initPointSpheresShaders } from './mgWebGLShaders'
+import {getShader, initInstancedOutlineShaders, initInstancedShadowShaders, initShadowShaders, initEdgeDetectShader, initSSAOShader, initHBAOShader, initBlurXShader, initBlurYShader, initSimpleBlurXShader, initSimpleBlurYShader, initOverlayShader, initRenderFrameBufferShaders, initCirclesShaders, initTextInstancedShaders, initTextBackgroundShaders, initOutlineShaders, initGBufferShadersPerfectSphere, initGBufferShadersInstanced, initGBufferShaders, initShadersDepthPeelAccum, initShadersTextured, initShaders, initShadersInstanced, initGBufferThickLineNormalShaders, initThickLineNormalShaders, initThickLineShaders, initLineShaders, initDepthShadowPerfectSphereShaders, initPerfectSphereOutlineShaders, initPerfectSphereShaders, initImageShaders, initTwoDShapesShaders, initPointSpheresShaders } from './mgWebGLShaders'
 import { Dispatch, Store } from '@reduxjs/toolkit';
 import { Root } from 'react-dom/client';
 import { RootState } from '@/store/MoorhenReduxStore';
@@ -248,6 +249,9 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
         mspfArray: number[];
         ssaoRadius: number;
         ssaoBias: number;
+        useHBAO: boolean;        // HBAO prototype: use horizon-based AO instead of sampled SSAO
+        ssaoStrength: number;    // HBAO darkening amount 0..1 (honest version of ssaoBias)
+        ssaoQuality: number;     // HBAO quality tier: 0=Low, 1=Med, 2=High
         radius: number;
         reContourMapOnlyOnMouseUp: boolean;
         showAxes: boolean;
@@ -382,6 +386,7 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
         shaderProgramGBuffersPerfectSpheres: webGL.ShaderGBuffersPerfectSpheres;
         shaderProgramGBuffersThickLinesNormal: webGL.ShaderGBuffersThickLinesNormal;
         shaderProgramSSAO: webGL.ShaderSSAO;
+        shaderProgramHBAO: any; // HBAO prototype shader program (WebGL2 only)
         shaderProgramEdgeDetect: webGL.ShaderEdgeDetect;
         shaderProgramBlurX: webGL.ShaderBlurX;
         shaderProgramBlurY: webGL.ShaderBlurY;
@@ -600,6 +605,22 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
 
     setSSAOBias(bias) {
         this.ssaoBias = bias;
+    }
+
+    // HBAO prototype controls
+    setUseHBAO(useHBAO: boolean) {
+        this.useHBAO = useHBAO;
+        this.drawScene();
+    }
+
+    setSSAOStrength(strength: number) {
+        this.ssaoStrength = strength;
+        this.drawScene();
+    }
+
+    setSSAOQuality(quality: number) {
+        this.ssaoQuality = quality;
+        this.drawScene();
     }
 
     setBlurSize(blurSize) {
@@ -825,6 +846,7 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
         this.doRedraw = false;
 
         let ssao_fragment_shader_source = ssao_fragment_shader_source_webgl1;
+        let hbao_fragment_shader_source = null; // HBAO prototype: WebGL2 only
         let edge_detect_fragment_shader_source = edge_detect_fragment_shader_source_webgl1;
         let blur_vertex_shader_source = blur_vertex_shader_source_webgl1;
         let blur_x_fragment_shader_source = blur_x_fragment_shader_source_webgl1;
@@ -868,6 +890,7 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
 
         if(this.WEBGL2){
             ssao_fragment_shader_source = ssao_fragment_shader_source_webgl2;
+            hbao_fragment_shader_source = hbao_fragment_shader_source_webgl2;
             edge_detect_fragment_shader_source = edge_detect_fragment_shader_source_webgl2;
             blur_vertex_shader_source = blur_vertex_shader_source_webgl2;
             blur_x_fragment_shader_source = blur_x_fragment_shader_source_webgl2;
@@ -958,6 +981,10 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
         this.shaderProgramOverlay = initOverlayShader(blurVertexShader, overlayFragmentShader, this.gl);
         this.shaderProgramBlurX = initBlurXShader(blurVertexShader, blurXFragmentShader, this.gl, this.WEBGL2);
         this.shaderProgramSSAO = initSSAOShader(blurVertexShader, ssaoFragmentShader, this.gl, this.WEBGL2);
+        if(this.WEBGL2 && hbao_fragment_shader_source){
+            const hbaoFragmentShader = getShader(this.gl, hbao_fragment_shader_source, "fragment");
+            this.shaderProgramHBAO = initHBAOShader(blurVertexShader, hbaoFragmentShader, this.gl, this.WEBGL2);
+        }
         this.shaderProgramEdgeDetect = initEdgeDetectShader(blurVertexShader, edgeDetectFragmentShader, this.gl);
         this.shaderProgramBlurY = initBlurYShader(blurVertexShader, blurYFragmentShader, this.gl, this.WEBGL2);
         this.shaderProgramSimpleBlurX = initSimpleBlurXShader(blurVertexShader, simpleBlurXFragmentShader, this.gl, this.WEBGL2);

--- a/baby-gru/src/WebGLgComponents/mgWebGLParts/drawCore.ts
+++ b/baby-gru/src/WebGLgComponents/mgWebGLParts/drawCore.ts
@@ -1180,23 +1180,42 @@ export function drawScene(self: MGWebGL) : void {
             if(!self.ssaoFramebuffer) self.createSSAOFramebufferBuffer();
             if(!self.offScreenFramebufferSimpleBlurX) self.createSimpleBlurOffScreeenBuffers();
 
-            self.gl.bindFramebuffer(self.gl.FRAMEBUFFER, self.ssaoFramebuffer);
-            self.gl.useProgram(self.shaderProgramSSAO);
-            self.gl.bindBuffer(self.gl.UNIFORM_BUFFER, self.ssaoKernelBuffer);
-            self.gl.uniform1i(self.shaderProgramSSAO.gPositionTexture,0);
-            self.gl.uniform1i(self.shaderProgramSSAO.gNormalTexture,1);
-            self.gl.uniform1i(self.shaderProgramSSAO.texNoiseTexture,2);
+            // HBAO prototype: flip the AO pass to the horizon-based shader when
+            // useHBAO is set and its program compiled. Both shaders share this
+            // pass's scaffolding (framebuffer, G-buffer/noise textures, tile
+            // uniforms, fullscreen-quad draw, blur) - only the program and a few
+            // uniforms differ, so we alias the active program as `ao` here.
+            const usingHBAO = self.useHBAO && self.shaderProgramHBAO;
+            const ao = usingHBAO ? self.shaderProgramHBAO : self.shaderProgramSSAO;
 
-            self.gl.uniform1f(self.shaderProgramSSAO.depthBufferSize,b+f);
+            self.gl.bindFramebuffer(self.gl.FRAMEBUFFER, self.ssaoFramebuffer);
+            self.gl.useProgram(ao);
+            self.gl.bindBuffer(self.gl.UNIFORM_BUFFER, self.ssaoKernelBuffer);
+            self.gl.uniform1i(ao.gPositionTexture,0);
+            self.gl.uniform1i(ao.gNormalTexture,1);
+            self.gl.uniform1i(ao.texNoiseTexture,2);
+
+            self.gl.uniform1f(ao.depthBufferSize,b+f);
             if(self.doPerspectiveProjection){
-                self.gl.uniform1f(self.shaderProgramSSAO.depthFactor,1.0/80.0);
-                self.gl.uniform1f(self.shaderProgramSSAO.radius,self.ssaoRadius*2.0);
+                self.gl.uniform1f(ao.depthFactor,1.0/80.0);
+                self.gl.uniform1f(ao.radius,self.ssaoRadius*2.0);
             } else {
-                self.gl.uniform1f(self.shaderProgramSSAO.depthFactor,1.0);
-                self.gl.uniform1f(self.shaderProgramSSAO.radius,self.ssaoRadius/self.zoom);
+                self.gl.uniform1f(ao.depthFactor,1.0);
+                self.gl.uniform1f(ao.radius,self.ssaoRadius/self.zoom);
             }
 
-            self.gl.uniform1f(self.shaderProgramSSAO.bias,self.ssaoBias);
+            if(usingHBAO){
+                // Quality tier -> (directions, steps). Kept <= the shader's
+                // MAX_DIRECTIONS/MAX_STEPS (12).
+                const tiers = [ [4,4], [6,6], [8,8] ];
+                const tier = tiers[Math.max(0, Math.min(2, self.ssaoQuality|0))];
+                self.gl.uniform1i(ao.numDirections, tier[0]);
+                self.gl.uniform1i(ao.numSteps, tier[1]);
+                self.gl.uniform1f(ao.strength, self.ssaoStrength);
+                self.gl.uniform1f(ao.angleBias, 0.30); // ~17 deg, rejects self-occlusion
+            } else {
+                self.gl.uniform1f(ao.bias,self.ssaoBias);
+            }
             self.gl.activeTexture(self.gl.TEXTURE0);
             self.gl.bindTexture(self.gl.TEXTURE_2D, self.gBufferPositionTexture);
             self.gl.activeTexture(self.gl.TEXTURE1);
@@ -1206,25 +1225,25 @@ export function drawScene(self: MGWebGL) : void {
 
             for(let i = 0; i<16; i++)
                 self.gl.disableVertexAttribArray(i);
-            self.gl.enableVertexAttribArray(self.shaderProgramSSAO.vertexTextureAttribute);
-            self.gl.enableVertexAttribArray(self.shaderProgramSSAO.vertexPositionAttribute);
+            self.gl.enableVertexAttribArray(ao.vertexTextureAttribute);
+            self.gl.enableVertexAttribArray(ao.vertexPositionAttribute);
 
             //These things probably need tweaking in the SSAO multiview case
-            self.gl.uniform1f(self.shaderProgramSSAO.tileScaleBase_x,0.0);
-            self.gl.uniform1f(self.shaderProgramSSAO.tileScaleBase_y,0.0);
+            self.gl.uniform1f(ao.tileScaleBase_x,0.0);
+            self.gl.uniform1f(ao.tileScaleBase_y,0.0);
 
             if(self.doThreeWayView) {
-                self.gl.uniform1f(self.shaderProgramSSAO.tileScale_x,0.5);
-                self.gl.uniform1f(self.shaderProgramSSAO.tileScale_y,0.5);
+                self.gl.uniform1f(ao.tileScale_x,0.5);
+                self.gl.uniform1f(ao.tileScale_y,0.5);
             } else if(self.doSideBySideStereo||self.doCrossEyedStereo) {
-                self.gl.uniform1f(self.shaderProgramSSAO.tileScale_x,0.5);
-                self.gl.uniform1f(self.shaderProgramSSAO.tileScale_y,1.0);
+                self.gl.uniform1f(ao.tileScale_x,0.5);
+                self.gl.uniform1f(ao.tileScale_y,1.0);
             } else if(self.doMultiView&&multi_rows_cols.rows>0&&multi_rows_cols.cols>0) {
-                self.gl.uniform1f(self.shaderProgramSSAO.tileScale_x,1.0/multi_rows_cols.cols);
-                self.gl.uniform1f(self.shaderProgramSSAO.tileScale_y,1.0/multi_rows_cols.rows);
+                self.gl.uniform1f(ao.tileScale_x,1.0/multi_rows_cols.cols);
+                self.gl.uniform1f(ao.tileScale_y,1.0/multi_rows_cols.rows);
             } else {
-                self.gl.uniform1f(self.shaderProgramSSAO.tileScale_x,1.0);
-                self.gl.uniform1f(self.shaderProgramSSAO.tileScale_y,1.0);
+                self.gl.uniform1f(ao.tileScale_x,1.0);
+                self.gl.uniform1f(ao.tileScale_y,1.0);
             }
 
             self.gl.viewport(0, 0, self.ssaoFramebuffer.width, self.ssaoFramebuffer.height);
@@ -1237,13 +1256,20 @@ export function drawScene(self: MGWebGL) : void {
             } else {
                 mat4.ortho(paintPMatrix, -1 , 1 , -1, 1, 0.1, 1000.0);
             }
-            self.gl.uniformMatrix4fv(self.shaderProgramSSAO.pMatrixUniform, false, paintPMatrix);
-            self.gl.uniformMatrix4fv(self.shaderProgramSSAO.mvMatrixUniform, false, paintMvMatrix);
+            self.gl.uniformMatrix4fv(ao.pMatrixUniform, false, paintPMatrix);
+            self.gl.uniformMatrix4fv(ao.mvMatrixUniform, false, paintMvMatrix);
 
             self.gl.clearBufferfv(self.gl.COLOR, 0, [1.0, 0.0, 1.0, 1.0]);
             bindFramebufferDrawBuffers(self);
 
-            self.bindSSAOBuffers()
+            if(usingHBAO){
+                // HBAO doesn't use the SSAO kernel UBO. Crucially, bindSSAOBuffers()
+                // does gl.useProgram(shaderProgramSSAO) internally, so calling it here
+                // would silently switch the draw back to SSAO - re-assert HBAO instead.
+                self.gl.useProgram(ao);
+            } else {
+                self.bindSSAOBuffers()
+            }
 
             if (self.ext) {
                 self.gl.drawElements(self.gl.TRIANGLES, 6, self.gl.UNSIGNED_INT, 0);

--- a/baby-gru/src/WebGLgComponents/mgWebGLParts/lifecycle.ts
+++ b/baby-gru/src/WebGLgComponents/mgWebGLParts/lifecycle.ts
@@ -453,6 +453,11 @@ export function initGraphics(self: MGWebGL): void {
 
     self.ssaoRadius = 0.4;
     self.ssaoBias = 1.0;
+    // HBAO prototype defaults (WebGL2). useHBAO flag flips the AO pass between the
+    // classic sampled SSAO and the horizon-based shader for live A/B comparison.
+    self.useHBAO = false;
+    self.ssaoStrength = 1.0;   // full darkening
+    self.ssaoQuality = 1;      // 0=Low, 1=Med, 2=High
     if(self.WEBGL2) self.initializeSSAOBuffers();
 
     self.buildBuffers();

--- a/baby-gru/src/WebGLgComponents/mgWebGLShaders.ts
+++ b/baby-gru/src/WebGLgComponents/mgWebGLShaders.ts
@@ -262,6 +262,53 @@ export function initSSAOShader(vertexShaderSSAO, fragmentShaderSSAO, gl, WEBGL2)
 
 }
 
+// HBAO prototype - mirrors initSSAOShader but for the horizon-based occlusion
+// shader (hbao-fragment-shader.js). Reuses the same vertex shader and the same
+// gPosition/gNormal/texNoise/pMatrix/radius/tile inputs; drops the samples UBO
+// and `bias`/`zoom`; adds the strength + quality-tier (numDirections/numSteps)
+// + angleBias uniforms.
+export function initHBAOShader(vertexShaderHBAO, fragmentShaderHBAO, gl, WEBGL2) {
+    const shaderProgramHBAO = gl.createProgram();
+    gl.attachShader(shaderProgramHBAO, vertexShaderHBAO);
+    gl.attachShader(shaderProgramHBAO, fragmentShaderHBAO);
+    gl.bindAttribLocation(shaderProgramHBAO, 0, "aVertexPosition");
+    gl.bindAttribLocation(shaderProgramHBAO, 3, "aVertexTexture");
+    gl.linkProgram(shaderProgramHBAO);
+    if (!gl.getProgramParameter(shaderProgramHBAO, gl.LINK_STATUS)) {
+        alert("Could not initialise shaders (initHBAOShader)");
+        console.log(gl.getProgramInfoLog(shaderProgramHBAO));
+    }
+
+    gl.useProgram(shaderProgramHBAO);
+
+    shaderProgramHBAO.vertexPositionAttribute = gl.getAttribLocation(shaderProgramHBAO, "aVertexPosition");
+    gl.enableVertexAttribArray(shaderProgramHBAO.vertexPositionAttribute);
+
+    shaderProgramHBAO.vertexTextureAttribute = gl.getAttribLocation(shaderProgramHBAO, "aVertexTexture");
+    gl.enableVertexAttribArray(shaderProgramHBAO.vertexTextureAttribute);
+
+    shaderProgramHBAO.pMatrixUniform = gl.getUniformLocation(shaderProgramHBAO, "uPMatrix");
+    shaderProgramHBAO.mvMatrixUniform = gl.getUniformLocation(shaderProgramHBAO, "uMVMatrix");
+
+    shaderProgramHBAO.gPositionTexture = gl.getUniformLocation(shaderProgramHBAO, "gPosition");
+    shaderProgramHBAO.gNormalTexture = gl.getUniformLocation(shaderProgramHBAO, "gNormal");
+    shaderProgramHBAO.texNoiseTexture = gl.getUniformLocation(shaderProgramHBAO, "texNoise");
+    shaderProgramHBAO.radius = gl.getUniformLocation(shaderProgramHBAO, "radius");
+    shaderProgramHBAO.strength = gl.getUniformLocation(shaderProgramHBAO, "strength");
+    shaderProgramHBAO.depthFactor = gl.getUniformLocation(shaderProgramHBAO, "depthFactor");
+    shaderProgramHBAO.depthBufferSize = gl.getUniformLocation(shaderProgramHBAO, "depthBufferSize");
+    shaderProgramHBAO.numDirections = gl.getUniformLocation(shaderProgramHBAO, "numDirections");
+    shaderProgramHBAO.numSteps = gl.getUniformLocation(shaderProgramHBAO, "numSteps");
+    shaderProgramHBAO.angleBias = gl.getUniformLocation(shaderProgramHBAO, "angleBias");
+    shaderProgramHBAO.tileScale_x = gl.getUniformLocation(shaderProgramHBAO, "tileScale_x");
+    shaderProgramHBAO.tileScale_y = gl.getUniformLocation(shaderProgramHBAO, "tileScale_y");
+    shaderProgramHBAO.tileScaleBase_x = gl.getUniformLocation(shaderProgramHBAO, "tileScaleBase_x");
+    shaderProgramHBAO.tileScaleBase_y = gl.getUniformLocation(shaderProgramHBAO, "tileScaleBase_y");
+
+    return shaderProgramHBAO
+
+}
+
 export function initBlurXShader(vertexShaderBlurX, fragmentShaderBlurX, gl, WEBGL2) {
     const shaderProgramBlurX = gl.createProgram();
 

--- a/baby-gru/src/WebGLgComponents/webgl-2/hbao-fragment-shader.js
+++ b/baby-gru/src/WebGLgComponents/webgl-2/hbao-fragment-shader.js
@@ -1,0 +1,153 @@
+// Horizon-Based Ambient Occlusion (HBAO) fragment shader.
+//
+// Prototype replacement for the classic hemisphere-kernel SSAO in
+// ssao-fragment-shader.js. It reads the SAME G-buffer inputs (gPosition,
+// gNormal) and the SAME per-pixel rotation noise (texNoise), and writes the
+// same single-channel occlusion result, so it drops into the existing AO pass
+// in drawScene with only the shader program + a few uniforms swapped.
+//
+// Instead of scattering point samples through a hemisphere, HBAO marches along
+// `numDirections` screen-space directions, taking `numSteps` steps along each,
+// and tracks the largest horizon (elevation) angle it can see. The occlusion is
+// the integral of that horizon against the surface tangent - which is why it
+// looks much cleaner per sample than sampled SSAO, and why quality scales simply
+// with numDirections x numSteps (the Low/Med/High tiers).
+//
+// Parameters (see the AO pass in drawCore.ts):
+//   radius        - view-space search radius (from ssaoRadius, same as SSAO)
+//   strength      - darkening amount 0..1 (the honest version of SSAO's "bias")
+//   numDirections - directions to march (quality tier)
+//   numSteps      - steps per direction (quality tier)
+//   angleBias     - rejects near-tangent self-occlusion on low-tessellation
+//                   surfaces; a fixed constant, not user-exposed.
+
+var hbao_fragment_shader_source = `#version 300 es\n
+precision mediump float;
+
+out vec4 fragColor;
+
+uniform sampler2D gPosition;
+uniform sampler2D gNormal;
+uniform sampler2D texNoise;
+
+uniform float radius;
+uniform float strength;      // AO intensity: 1.0 = full, 0.0 = none
+uniform float depthFactor;
+uniform float depthBufferSize;
+
+// Quality dial (directions x steps). Set from the Low/Med/High tier.
+uniform int numDirections;
+uniform int numSteps;
+uniform float angleBias;     // radians; fixed constant from the app
+
+// For multiview, the x,y scaling (identical to the SSAO shader).
+uniform float tileScale_x;
+uniform float tileScale_y;
+uniform float tileScaleBase_x;
+uniform float tileScaleBase_y;
+
+in vec2 out_TexCoord0;
+in mediump mat4 pMatrix;
+
+const float PI = 3.14159265;
+const int MAX_DIRECTIONS = 12;
+const int MAX_STEPS = 12;
+
+void main() {
+
+    vec4 normal_all = texture(gNormal, out_TexCoord0);
+
+    // Background / empty texels: fully lit, exactly like the SSAO shader.
+    if (normal_all.a <= 0.9) {
+        fragColor = vec4(1.0, 1.0, 1.0, 1.0);
+        return;
+    }
+
+    vec3 normal  = normalize(normal_all.rgb);
+    vec3 fragPos = depthFactor * texture(gPosition, out_TexCoord0).xyz;
+
+    // Per-pixel rotation + step jitter so the few directions don't band. The
+    // 4x4 texNoise alone repeats on a regular grid (visible diagonal streaks);
+    // mixing it with a per-fragment hash breaks that up, and the blur pass then
+    // resolves the resulting fine noise into smooth gradients.
+    vec3 randomVec = texture(texNoise, gl_FragCoord.xy / vec2(4.0)).xyz;
+    float hash = fract(sin(dot(gl_FragCoord.xy, vec2(12.9898, 78.233))) * 43758.5453);
+    float rndAngle = (randomVec.x + hash) * 2.0 * PI;
+    float stepJitter = 0.5 + 0.5 * hash;   // 0.5..1.0, offsets where each ray starts
+
+    float nTiles_x = 1.0 / tileScale_x;
+    float nTiles_y = 1.0 / tileScale_y;
+    float tileOffset_x = tileScaleBase_x + tileScale_x * floor(out_TexCoord0.x * nTiles_x);
+    float tileOffset_y = tileScaleBase_y + tileScale_y * floor(out_TexCoord0.y * nTiles_y);
+    vec2 tileOffset = vec2(tileOffset_x, tileOffset_y);
+
+    // March in SCREEN space. The search reach is a fraction of the screen
+    // (texture-coord units, so resolution-aware), NOT the view-space radius
+    // directly - mixing those spaces was the bug that made occlusion ~0.
+    // The view-space radius only scales how big that screen reach is, softly.
+    // Wider screen reach so deeper crevices are actually sampled.
+    float screenReach = 0.15 * clamp(radius, 0.05, 4.0);   // ~15% of screen at radius 1
+    float stepUV = screenReach / float(max(numSteps, 1));
+
+    // World-space falloff distance: occluders beyond this stop counting.
+    float worldRadius = max(radius, 1e-3);
+    float biasSin = sin(angleBias);
+
+    float occlusion = 0.0;
+    float dirCount = 0.0;
+
+    for (int d = 0; d < MAX_DIRECTIONS; ++d) {
+        if (d >= numDirections) break;
+        dirCount += 1.0;
+
+        float theta = (float(d) / float(numDirections)) * 2.0 * PI + rndAngle;
+        vec2 dir = vec2(cos(theta), sin(theta));
+
+        // Combine the horizon (highest occluder) with an accumulated contribution
+        // so broad shallow concavities darken too, not just sharp pits.
+        float maxSin = biasSin;
+        float accum = 0.0;
+        float accumW = 0.0;
+
+        for (int s = 1; s <= MAX_STEPS; ++s) {
+            if (s > numSteps) break;
+
+            vec2 sampleUV = out_TexCoord0 + dir * stepUV * (float(s) - 1.0 + stepJitter);
+            vec2 tiledUV = vec2(tileScale_x * sampleUV.x, tileScale_y * sampleUV.y) + tileOffset;
+
+            vec3 samplePos = depthFactor * texture(gPosition, tiledUV).xyz;
+            vec3 diff = samplePos - fragPos;
+            float dist = length(diff);
+
+            if (dist < 1e-4) continue;
+
+            // How far above the tangent plane this neighbour sits.
+            float sinElevation = dot(diff, normal) / dist;
+
+            // Distance falloff: neighbours beyond worldRadius fade to nothing.
+            float falloff = clamp(1.0 - dist / worldRadius, 0.0, 1.0);
+
+            maxSin = max(maxSin, sinElevation);            // horizon (not falloff-weighted)
+            accum += max(sinElevation - biasSin, 0.0) * falloff;
+            accumW += 1.0;
+        }
+
+        // Horizon rise above the tangent, plus the averaged shallow contribution.
+        float horizon = clamp(maxSin - biasSin, 0.0, 1.0);
+        float broad = accumW > 0.0 ? accum / accumW : 0.0;
+        occlusion += 0.5 * horizon + 0.5 * broad;
+    }
+
+    occlusion = occlusion / max(dirCount, 1.0);
+
+    // Gain lifts the raw horizon occlusion into a visible range; strength then
+    // scales it 0..1 as the user control. (Gain is a fixed shaping constant.)
+    float gain = 4.0;
+    float ao = 1.0 - clamp(occlusion * gain, 0.0, 1.0) * strength;
+    ao = clamp(ao, 0.0, 1.0);
+
+    fragColor = vec4(ao, ao, ao, 1.0);
+}
+`;
+
+export {hbao_fragment_shader_source};

--- a/baby-gru/src/components/modal/MoorhenSceneSettingsModal.tsx
+++ b/baby-gru/src/components/modal/MoorhenSceneSettingsModal.tsx
@@ -28,6 +28,9 @@ import {
     setResetClippingFogging,
     setSsaoBias,
     setSsaoRadius,
+    setUseHBAO,
+    setSsaoStrength,
+    setSsaoQuality,
     setUseOffScreenBuffers,
 } from "../../store/sceneSettingsSlice";
 import { moorhen } from "../../types/moorhen";
@@ -114,6 +117,9 @@ const OcclusionPanel = () => {
     const doSSAO = useSelector((state: moorhen.State) => state.sceneSettings.doSSAO);
     const ssaoRadius = useSelector((state: moorhen.State) => state.sceneSettings.ssaoRadius);
     const ssaoBias = useSelector((state: moorhen.State) => state.sceneSettings.ssaoBias);
+    const useHBAO = useSelector((state: moorhen.State) => state.sceneSettings.useHBAO);
+    const ssaoStrength = useSelector((state: moorhen.State) => state.sceneSettings.ssaoStrength);
+    const ssaoQuality = useSelector((state: moorhen.State) => state.sceneSettings.ssaoQuality);
 
     return (
         <MoorhenStack direction="vertical" card={true}>
@@ -137,16 +143,41 @@ const OcclusionPanel = () => {
                 stepButtons={0.1}
                 decimalPlaces={1}
             />
+
+            {/* HBAO prototype (WebGL2). Toggle flips the AO pass between the
+                classic sampled SSAO and the horizon-based shader for live A/B. */}
+            <MoorhenToggle
+                type="switch"
+                checked={useHBAO}
+                disabled={!doSSAO}
+                onChange={() => {
+                    dispatch(setUseHBAO(!useHBAO));
+                }}
+                label="Use HBAO (prototype)"
+            />
+
             <MoorhenSlider
                 minVal={0.0}
                 maxVal={1.0}
                 scale="linear"
                 isDisabled={!doSSAO}
-                sliderTitle="Occlusion effect"
-                value={ssaoBias}
-                setValue={val => dispatch(setSsaoBias(val))}
+                sliderTitle={useHBAO ? "Strength" : "Occlusion effect"}
+                value={useHBAO ? ssaoStrength : ssaoBias}
+                setValue={val => dispatch(useHBAO ? setSsaoStrength(val) : setSsaoBias(val))}
                 stepButtons={0.1}
                 decimalPlaces={1}
+            />
+
+            <MoorhenSlider
+                minVal={0}
+                maxVal={2}
+                scale="linear"
+                isDisabled={!doSSAO || !useHBAO}
+                sliderTitle="HBAO quality (0 Low · 1 Med · 2 High)"
+                value={ssaoQuality}
+                setValue={val => dispatch(setSsaoQuality(Math.round(val)))}
+                stepButtons={1}
+                decimalPlaces={0}
             />
         </MoorhenStack>
     );

--- a/baby-gru/src/components/webMG/MoorhenWebMG.tsx
+++ b/baby-gru/src/components/webMG/MoorhenWebMG.tsx
@@ -75,6 +75,9 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
     const edgeDetectNormalScale = useSelector((state: moorhen.State) => state.sceneSettings.edgeDetectNormalScale)
     const ssaoRadius = useSelector((state: moorhen.State) => state.sceneSettings.ssaoRadius)
     const ssaoBias = useSelector((state: moorhen.State) => state.sceneSettings.ssaoBias)
+    const useHBAO = useSelector((state: moorhen.State) => state.sceneSettings.useHBAO)
+    const ssaoStrength = useSelector((state: moorhen.State) => state.sceneSettings.ssaoStrength)
+    const ssaoQuality = useSelector((state: moorhen.State) => state.sceneSettings.ssaoQuality)
     const resetClippingFogging = useSelector((state: moorhen.State) => state.sceneSettings.resetClippingFogging)
     const clipCap = useSelector((state: moorhen.State) => state.sceneSettings.clipCap)
     const doPerspectiveProjection = useSelector((state: moorhen.State) => state.sceneSettings.doPerspectiveProjection)
@@ -408,6 +411,24 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
             glRef.current.drawScene()
         }
     }, [ssaoRadius])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function' && useHBAO != null) {
+            glRef.current.setUseHBAO(useHBAO)
+        }
+    }, [useHBAO])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function' && ssaoStrength != null) {
+            glRef.current.setSSAOStrength(ssaoStrength)
+        }
+    }, [ssaoStrength])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function' && ssaoQuality != null) {
+            glRef.current.setSSAOQuality(ssaoQuality)
+        }
+    }, [ssaoQuality])
 
     useEffect(() => {
         if(glRef !== null && typeof glRef !== 'function') {

--- a/baby-gru/src/store/sceneSettingsSlice.ts
+++ b/baby-gru/src/store/sceneSettingsSlice.ts
@@ -14,6 +14,9 @@ const initialState: {
     depthBlurDepth: number;
     ssaoBias: number;
     ssaoRadius: number;
+    useHBAO: boolean;      // HBAO prototype: horizon-based AO instead of sampled SSAO
+    ssaoStrength: number;  // HBAO darkening 0..1
+    ssaoQuality: number;   // HBAO quality tier: 0=Low, 1=Med, 2=High
     doShadowDepthDebug: boolean;
     doShadow: boolean;
     doSSAO: boolean;
@@ -59,6 +62,9 @@ const initialState: {
     edgeDetectNormalScale: null,
     ssaoRadius: null,
     ssaoBias: null,
+    useHBAO: false,
+    ssaoStrength: 1.0,
+    ssaoQuality: 1,
     resetClippingFogging: null,
     clipCap: null,
     doPerspectiveProjection: null,
@@ -153,6 +159,18 @@ const sceneSettingsSlice = createSlice({
         // API
         setSsaoRadius: (state, action: PayloadAction<number>) => {
             state.ssaoRadius = action.payload;
+        },
+        // API
+        setUseHBAO: (state, action: PayloadAction<boolean>) => {
+            state.useHBAO = action.payload;
+        },
+        // API
+        setSsaoStrength: (state, action: PayloadAction<number>) => {
+            state.ssaoStrength = action.payload;
+        },
+        // API
+        setSsaoQuality: (state, action: PayloadAction<number>) => {
+            state.ssaoQuality = action.payload;
         },
         // API
         setSsaoBias: (state, action: PayloadAction<number>) => {
@@ -271,6 +289,9 @@ export const {
     setDoSSAO,
     setSsaoRadius,
     setSsaoBias,
+    setUseHBAO,
+    setSsaoStrength,
+    setSsaoQuality,
     setResetClippingFogging,
     setClipCap,
     resetSceneSettings,


### PR DESCRIPTION
## HBAO ambient-occlusion prototype

> **Draft — for feedback, not merge.** Based on `refactor/mgwebgl-camera-collaborator` (#625), not `main`, so the diff shows only the HBAO work. Merge the refactor first, then rebase this.

A horizon-based ambient occlusion (HBAO) alternative to the current hemisphere-kernel SSAO, **toggleable live** so the two can be A/B compared on the same scene. Built on the refactor's now-isolated AO pass — swapping AO turned out to be "a shader + a few uniforms", not surgery.

📄 **[AO swap map & why HBAO](https://claude.ai/code/artifact/54dd7dfc-299a-46a6-85a9-4dbc4c7a67b2)** — the technique comparison and what a swap touches.

### What's here
- `webgl-2/hbao-fragment-shader.js` — marches N screen-space directions × M steps, tracking the horizon; reuses the existing `gPosition`/`gNormal` G-buffer + `texNoise`, with per-fragment jitter to break banding (the existing blur pass resolves the residual).
- `initHBAOShader` in `mgWebGLShaders.ts` — mirrors `initSSAOShader` (drops the samples UBO; adds strength / directions / steps / angleBias).
- `drawCore.ts` AO pass picks HBAO vs SSAO via `self.useHBAO`, sharing all the framebuffer / texture / tile / blur scaffolding.

### Cleaner parameters than SSAO
The controls were rethought, not copied: **radius** (unchanged 0–2, so saved settings carry over), **Strength** (an honest 0–1 intensity — replaces the mislabelled "bias"), and a **Low/Med/High Quality** tier (directions × steps). One genuinely-technical param (`angleBias`) is a fixed constant, not exposed.

### Status / caveats
- WebGL2 only (matches the existing AO pass gating).
- **Prototype**: the shader constants (screen reach, gain, angleBias) are tuned by eye — open to refinement. Verified rendering correctly in-app (SSAO ↔ HBAO toggle, strength/radius/quality all respond).
- One implementation note worth flagging for reviewers: `bindSSAOBuffers()` calls `gl.useProgram(SSAO)` internally, so the HBAO path re-asserts its program before the draw — see the comment in `drawCore.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
