### PR TITLE
React re-render & lifecycle fixes for the WebGL viewer

### DIFF
--- a/baby-gru/src/WebGLgComponents/mgWebGL.tsx
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.tsx
@@ -587,6 +587,24 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
         }
     }
 
+    // render() only produces the <canvas> (size from constructor-time state,
+    // stable ref), so parent re-renders never change our output. BUT
+    // shouldComponentUpdate:false also skips componentDidUpdate - so we must
+    // return true for every prop componentDidUpdate reacts to (width/height and
+    // the display toggles), or those changes would be silently dropped. For all
+    // other prop churn from the (frequently re-rendering) MoorhenWebMG wrapper,
+    // skipping is free. Draws happen imperatively via glRef.current, not render().
+    shouldComponentUpdate(nextProps: webGL.MGWebGLPropsInterface) {
+        return nextProps.width !== this.props.width
+            || nextProps.height !== this.props.height
+            || nextProps.showScaleBar !== this.props.showScaleBar
+            || nextProps.showCrosshairs !== this.props.showCrosshairs
+            || nextProps.showAxes !== this.props.showAxes
+            || nextProps.showFPS !== this.props.showFPS
+            || nextProps.mapLineWidth !== this.props.mapLineWidth
+            || nextProps.reContourMapOnlyOnMouseUp !== this.props.reContourMapOnlyOnMouseUp;
+    }
+
     render() {
         return <canvas ref={this.canvasRef} height={this.state.width} width={this.state.height} />;
     }

--- a/baby-gru/src/WebGLgComponents/mgWebGL.tsx
+++ b/baby-gru/src/WebGLgComponents/mgWebGL.tsx
@@ -107,7 +107,7 @@ import { doSpinTestFrame, startSpinTest, stopSpinTest, setOrientationFrame, setO
 import { drawTransparent, drawImagesAndText, drawTexturedShapes, drawTextLabels, drawDistancesAndLabels, drawCircles, drawLineMeasures, drawCrosshairs, drawMouseTrack, drawFPSMeter, drawTextOverlays } from './mgWebGLParts/overlays'
 import { drawBuffer, drawMaxElementsUInt, setupModelViewTransformMatrixInteractive, drawTransformMatrixInteractive, drawTransformMatrix, drawTransformMatrixInteractivePMV, drawTransformMatrixPMV } from './mgWebGLParts/bufferDraw'
 import { drawPeel, drawTriangles, drawScene, applySymmetryMatrix, bindFramebufferDrawBuffers } from './mgWebGLParts/drawCore'
-import { initInstanceState, initGraphicsContext, attachCanvasListeners, initGraphics } from './mgWebGLParts/lifecycle'
+import { initInstanceState, initGraphicsContext, attachCanvasListeners, detachCanvasListeners, initGraphics } from './mgWebGLParts/lifecycle'
 import { getDeviceScale} from './webGLUtils'
 import {getShader, initInstancedOutlineShaders, initInstancedShadowShaders, initShadowShaders, initEdgeDetectShader, initSSAOShader, initBlurXShader, initBlurYShader, initSimpleBlurXShader, initSimpleBlurYShader, initOverlayShader, initRenderFrameBufferShaders, initCirclesShaders, initTextInstancedShaders, initTextBackgroundShaders, initOutlineShaders, initGBufferShadersPerfectSphere, initGBufferShadersInstanced, initGBufferShaders, initShadersDepthPeelAccum, initShadersTextured, initShaders, initShadersInstanced, initGBufferThickLineNormalShaders, initThickLineNormalShaders, initThickLineShaders, initLineShaders, initDepthShadowPerfectSphereShaders, initPerfectSphereOutlineShaders, initPerfectSphereShaders, initImageShaders, initTwoDShapesShaders, initPointSpheresShaders } from './mgWebGLShaders'
 import { Dispatch, Store } from '@reduxjs/toolkit';
@@ -243,6 +243,11 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
         doCrossEyedStereo: boolean;
         doAnaglyphStereo: boolean;
         doneEvents: boolean;
+        // Teardown bookkeeping (componentWillUnmount): the canvas listeners to
+        // remove, and the two interval ids to clear, so nothing leaks on unmount.
+        canvasEventListeners: [string, (e: any) => void][];
+        fpsIntervalId: ReturnType<typeof setInterval>;
+        drawDirtyIntervalId: ReturnType<typeof setInterval>;
         fpsText: string;
         measurePointsArray: any[];
         mspfArray: number[];
@@ -545,7 +550,7 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
         this.store = props.store;
         this.dispatch = props.dispatch
 
-        setInterval(() => {
+        this.fpsIntervalId = setInterval(() => {
             if(!this.gl) return;
             const sum = this.mspfArray.reduce((a, b) => a + b, 0);
             const avg = (sum / this.mspfArray.length) || 0;
@@ -798,6 +803,16 @@ export class MGWebGL extends React.Component implements webGL.MGWebGL {
         initGraphicsContext(this)
         attachCanvasListeners(this)
         initGraphics(this)
+    }
+
+    componentWillUnmount() {
+        // Teardown counterpart to componentDidMount. Without this the canvas
+        // listeners and the two intervals (FPS text every 1s, drawSceneIfDirty
+        // every 16ms) leaked on unmount / remount - the ~62/s redraw tick kept
+        // firing for the lifetime of the page.
+        detachCanvasListeners(this)
+        if (this.fpsIntervalId !== undefined) clearInterval(this.fpsIntervalId)
+        if (this.drawDirtyIntervalId !== undefined) clearInterval(this.drawDirtyIntervalId)
     }
 
     initializeShaders() : void {

--- a/baby-gru/src/WebGLgComponents/mgWebGLParts/lifecycle.ts
+++ b/baby-gru/src/WebGLgComponents/mgWebGLParts/lifecycle.ts
@@ -228,142 +228,178 @@ export function initGraphicsContext(self: MGWebGL): void {
     const extensionArray = self.gl.getSupportedExtensions();
 }
 
-/** Phase 3 — attach all canvas mouse / touch / wheel / key listeners, once. */
+/**
+ * Phase 3 — attach all canvas mouse / touch / wheel / key listeners, once.
+ *
+ * Handlers are captured as named consts and recorded in
+ * self.canvasEventListeners so detachCanvasListeners() can remove the exact
+ * same references on unmount (anonymous inline handlers can't be removed). The
+ * handler bodies are unchanged from the original inline versions.
+ */
 export function attachCanvasListeners(self: MGWebGL): void {
     if (self.doneEvents === undefined) {
-        self.canvas.addEventListener("mousedown",
-            function (evt) {
-                if (self.keysDown['dist_ang_2d']) {
-                    self.doMouseDownMeasure(evt, self);
-                } else {
-                    self.doMouseDown(evt, self);
-                }
+
+        const onMouseDown = function (evt) {
+            if (self.keysDown['dist_ang_2d']) {
+                self.doMouseDownMeasure(evt, self);
+            } else {
+                self.doMouseDown(evt, self);
+            }
+            evt.stopPropagation();
+        };
+
+        const onMouseUp = function (evt) {
+            if (self.keysDown['dist_ang_2d']) {
+                self.doMouseUpMeasure(evt, self);
+            } else {
+                self.doMouseUp(evt, self);
+            }
+        };
+
+        const onContextMenu = function (evt) {
+            self.doRightClick(evt, self);
+            evt.stopPropagation();
+            evt.preventDefault();
+        };
+
+        const onMouseDownClick = function (evt) {
+            if (evt.which === 1) {
+                self.doClick(evt, self);
                 evt.stopPropagation();
-            },
-            false);
-            self.canvas.addEventListener("mouseup",
-            function (evt) {
-                if (self.keysDown['dist_ang_2d']) {
-                    self.doMouseUpMeasure(evt, self);
-                } else {
-                    self.doMouseUp(evt, self);
-                }
-            },
-            false);
-        self.canvas.addEventListener("contextmenu",
-            function (evt) {
+            } else if (evt.which === 2) {
+                evt.stopPropagation();
+                evt.preventDefault();
+            } else {
                 self.doRightClick(evt, self);
                 evt.stopPropagation();
                 evt.preventDefault();
-            },
-            false);
-        self.canvas.addEventListener("mousedown",
-            function (evt) {
-                if (evt.which === 1) {
-                    self.doClick(evt, self);
-                    evt.stopPropagation();
-                } else if (evt.which === 2) {
-                    evt.stopPropagation();
-                    evt.preventDefault();
-                } else {
-                    self.doRightClick(evt, self);
-                    evt.stopPropagation();
-                    evt.preventDefault();
-                }
-            },
-            false);
-        self.canvas.addEventListener("dblclick",
-            function (evt) {
-                self.doDoubleClick(evt, self);
-                evt.stopPropagation();
-            },
-            false);
-        console.log("addEventListener");
-        self.canvas.addEventListener("mousemove",
-            function (evt) {
-                if (self.keysDown['dist_ang_2d']) {
-                    self.doMouseMoveMeasure(evt, self);
-                } else {
-                    self.doMouseMove(evt, self);
-                }
-                evt.stopPropagation();
-            },
-            false);
-        self.canvas.addEventListener("mouseenter",
-            function (evt) {
-                document.onkeydown = function (evt2) {
-                    self.handleKeyDown(evt2, self);
-                }
-                document.onkeyup = function (evt2) {
-                    self.handleKeyUp(evt2, self);
-                }
-            },
-            false);
-        self.canvas.addEventListener("mouseleave",
-            function (evt) {
-                document.onkeydown = function (evt2) {
-                }
-            },
-            false);
-        self.canvas.addEventListener("wheel",
-            function (evt) {
-                self.doWheel(evt);
-                evt.stopPropagation();
-                evt.preventDefault();
-            },
-            false);
-        self.canvas.addEventListener('touchstart',
-            function (e) {
-                const touchobj = e.changedTouches[0];
-                const evt = { pageX: touchobj.pageX, pageY: touchobj.pageY, shiftKey: false, altKey: false, button: 0 };
-                //alert(e.changedTouches.length)
-                if (e.changedTouches.length === 2) {
-                    evt.shiftKey = true;
-                    evt.altKey = true;
-                }
-                self.doMouseDown(evt, self);
-                self.mouseDownedAt = (e.timeStamp)
-                e.stopPropagation();
-                e.preventDefault();
-                // Create a timeout that will check if the user is holding down on the same spot to open the context menu
-                setTimeout(() => {
-                    if (self.mouseDown && !self.mouseMoved) {
-                        self.doRightClick(evt, self);
-                    }
-                }, 1000)
-            }, false)
+            }
+        };
 
-        self.canvas.addEventListener('touchmove',
-            function (e) {
-                const touchobj = e.touches[0]; // reference first touch point for this event
-                const evt = { pageX: touchobj.pageX, pageY: touchobj.pageY, shiftKey: false, altKey: false, buttons: 1 };
-                if (e.touches.length === 2) {
-                    evt.shiftKey = true;
-                    evt.altKey = true;
-                }
+        const onDblClick = function (evt) {
+            self.doDoubleClick(evt, self);
+            evt.stopPropagation();
+        };
+
+        const onMouseMove = function (evt) {
+            if (self.keysDown['dist_ang_2d']) {
+                self.doMouseMoveMeasure(evt, self);
+            } else {
                 self.doMouseMove(evt, self);
-                e.stopPropagation();
-                e.preventDefault();
-            }, false)
+            }
+            evt.stopPropagation();
+        };
 
-        self.canvas.addEventListener('touchend',
-            function (e) {
-                const touchobj = e.changedTouches[0]; // reference first touch point for this event
-                const evt = { pageX: touchobj.pageX, pageY: touchobj.pageY, shiftKey: false, altKey: false, button: 0 };
-                if (e.changedTouches.length === 2) {
-                    evt.shiftKey = true;
-                    evt.altKey = true;
+        const onMouseEnter = function (evt) {
+            document.onkeydown = function (evt2) {
+                self.handleKeyDown(evt2, self);
+            }
+            document.onkeyup = function (evt2) {
+                self.handleKeyUp(evt2, self);
+            }
+        };
+
+        const onMouseLeave = function (evt) {
+            document.onkeydown = function (evt2) {
+            }
+        };
+
+        const onWheel = function (evt) {
+            self.doWheel(evt);
+            evt.stopPropagation();
+            evt.preventDefault();
+        };
+
+        const onTouchStart = function (e) {
+            const touchobj = e.changedTouches[0];
+            const evt = { pageX: touchobj.pageX, pageY: touchobj.pageY, shiftKey: false, altKey: false, button: 0 };
+            //alert(e.changedTouches.length)
+            if (e.changedTouches.length === 2) {
+                evt.shiftKey = true;
+                evt.altKey = true;
+            }
+            self.doMouseDown(evt, self);
+            self.mouseDownedAt = (e.timeStamp)
+            e.stopPropagation();
+            e.preventDefault();
+            // Create a timeout that will check if the user is holding down on the same spot to open the context menu
+            setTimeout(() => {
+                if (self.mouseDown && !self.mouseMoved) {
+                    self.doRightClick(evt, self);
                 }
-                const deltaTime = e.timeStamp - self.mouseDownedAt;
-                if (deltaTime < 300) {
-                    self.doClick(evt, self);
-                }
-                self.doMouseUp(evt, self);
-                e.stopPropagation();
-                e.preventDefault();
-            }, false)
+            }, 1000)
+        };
+
+        const onTouchMove = function (e) {
+            const touchobj = e.touches[0]; // reference first touch point for this event
+            const evt = { pageX: touchobj.pageX, pageY: touchobj.pageY, shiftKey: false, altKey: false, buttons: 1 };
+            if (e.touches.length === 2) {
+                evt.shiftKey = true;
+                evt.altKey = true;
+            }
+            self.doMouseMove(evt, self);
+            e.stopPropagation();
+            e.preventDefault();
+        };
+
+        const onTouchEnd = function (e) {
+            const touchobj = e.changedTouches[0]; // reference first touch point for this event
+            const evt = { pageX: touchobj.pageX, pageY: touchobj.pageY, shiftKey: false, altKey: false, button: 0 };
+            if (e.changedTouches.length === 2) {
+                evt.shiftKey = true;
+                evt.altKey = true;
+            }
+            const deltaTime = e.timeStamp - self.mouseDownedAt;
+            if (deltaTime < 300) {
+                self.doClick(evt, self);
+            }
+            self.doMouseUp(evt, self);
+            e.stopPropagation();
+            e.preventDefault();
+        };
+
+        // Record every binding so detachCanvasListeners can remove the exact refs.
+        // Order/args preserved from the original addEventListener calls.
+        self.canvasEventListeners = [
+            ["mousedown", onMouseDown],
+            ["mouseup", onMouseUp],
+            ["contextmenu", onContextMenu],
+            ["mousedown", onMouseDownClick],
+            ["dblclick", onDblClick],
+            ["mousemove", onMouseMove],
+            ["mouseenter", onMouseEnter],
+            ["mouseleave", onMouseLeave],
+            ["wheel", onWheel],
+            ["touchstart", onTouchStart],
+            ["touchmove", onTouchMove],
+            ["touchend", onTouchEnd],
+        ];
+
+        console.log("addEventListener");
+        for (const [type, handler] of self.canvasEventListeners) {
+            self.canvas.addEventListener(type, handler, false);
+        }
     }
     self.doneEvents = true;
+}
+
+/**
+ * Teardown counterpart to attachCanvasListeners — remove every canvas listener
+ * that was recorded, and clear the document-level key handlers that mouseenter
+ * installs. Called from MGWebGL.componentWillUnmount so listeners don't leak
+ * across unmount / remount.
+ */
+export function detachCanvasListeners(self: MGWebGL): void {
+    if (self.canvasEventListeners && self.canvas) {
+        for (const [type, handler] of self.canvasEventListeners) {
+            self.canvas.removeEventListener(type, handler, false);
+        }
+    }
+    self.canvasEventListeners = [];
+    // mouseenter set these on document; drop them so they don't outlive us.
+    document.onkeydown = null;
+    document.onkeyup = null;
+    self.doneEvents = undefined;
 }
 
 /** Phase 4 — extensions, shaders, framebuffers, buffers, textures, first draw. */
@@ -422,7 +458,7 @@ export function initGraphics(self: MGWebGL): void {
         }
     }
 
-    setInterval(function () { self.drawSceneIfDirty() }, 16);
+    self.drawDirtyIntervalId = setInterval(function () { self.drawSceneIfDirty() }, 16);
     self.initializeShaders();
 
     self.textLegends = [];

--- a/baby-gru/src/components/webMG/MoorhenWebMG.tsx
+++ b/baby-gru/src/components/webMG/MoorhenWebMG.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, forwardRef, useState, useReducer } from 'react';
+import { useEffect, useCallback, useMemo, forwardRef, useState, useReducer } from 'react';
 import { useDispatch, useSelector, useStore } from 'react-redux';
 import * as quat4 from 'gl-matrix/quat';
 import { ScreenRecorder } from '../../utils/MoorhenScreenRecorder';
@@ -99,6 +99,11 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
     const mouseSensitivity = useSelector((state: moorhen.State) => state.mouseSettings.mouseSensitivity)
     const zoomWheelSensitivityFactor = useSelector((state: moorhen.State) => state.mouseSettings.zoomWheelSensitivityFactor)
     const shortCuts = useSelector((state: moorhen.State) => state.shortcutSettings.shortCuts)
+    // Stabilise props passed to <MGWebGL>: parse the accelerators once per change of
+    // shortCuts (not every render), and keep a single no-op identity. Without this the
+    // class re-renders on every parent render because these props change by identity.
+    const keyboardAccelerators = useMemo(() => JSON.parse(shortCuts as string), [shortCuts])
+    const noopMessageChanged = useCallback(() => { }, [])
     const shortcutOnHoveredAtom = useSelector((state: moorhen.State) => state.shortcutSettings.shortcutOnHoveredAtom)
     const showShortcutToast = useSelector((state: moorhen.State) => state.shortcutSettings.showShortcutToast)
     const mapLineWidth = useSelector((state: moorhen.State) => state.mapContourSettings.mapLineWidth)
@@ -731,10 +736,10 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
                     onOriginChanged={onOriginChanged}
                     onQuatChanged={onQuatChanged}
                     cursorPositionChanged={cursorPositionChanged}
-                    messageChanged={(d) => { }}
+                    messageChanged={noopMessageChanged}
                     mouseSensitivityFactor={mouseSensitivity}
                     zoomWheelSensitivityFactor={zoomWheelSensitivityFactor}
-                    keyboardAccelerators={JSON.parse(shortCuts as string)}
+                    keyboardAccelerators={keyboardAccelerators}
                     showCrosshairs={drawCrosshairs}
                     showScaleBar={drawScaleBar}
                     showAxes={drawAxes}

--- a/baby-gru/src/components/webMG/MoorhenWebMG.tsx
+++ b/baby-gru/src/components/webMG/MoorhenWebMG.tsx
@@ -18,6 +18,8 @@ import { DisplayBuffer } from '../../WebGLgComponents/displayBuffer'
 import { Moorhen2DOverlay } from './Moorhen2DOverlay';
 import { RootState } from '../../store/MoorhenReduxStore';
 import { DrawHoverAtom } from './HoverAtom';
+import { EdgeDetectSync } from './glRefSync/EdgeDetectSync';
+import { SceneRenderSettingsSync } from './glRefSync/SceneRenderSettingsSync';
 
 
 interface MoorhenWebMGPropsInterface {
@@ -67,34 +69,7 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
     const drawCrosshairs = useSelector((state: moorhen.State) => state.sceneSettings.drawCrosshairs)
     const drawFPS = useSelector((state: moorhen.State) => state.sceneSettings.drawFPS)
     const drawAxes = useSelector((state: moorhen.State) => state.sceneSettings.drawAxes)
-    const doSSAO = useSelector((state: moorhen.State) => state.sceneSettings.doSSAO)
-    const doEdgeDetect = useSelector((state: moorhen.State) => state.sceneSettings.doEdgeDetect)
-    const edgeDetectDepthThreshold = useSelector((state: moorhen.State) => state.sceneSettings.edgeDetectDepthThreshold)
-    const edgeDetectNormalThreshold = useSelector((state: moorhen.State) => state.sceneSettings.edgeDetectNormalThreshold)
-    const edgeDetectDepthScale = useSelector((state: moorhen.State) => state.sceneSettings.edgeDetectDepthScale)
-    const edgeDetectNormalScale = useSelector((state: moorhen.State) => state.sceneSettings.edgeDetectNormalScale)
-    const ssaoRadius = useSelector((state: moorhen.State) => state.sceneSettings.ssaoRadius)
-    const ssaoBias = useSelector((state: moorhen.State) => state.sceneSettings.ssaoBias)
     const resetClippingFogging = useSelector((state: moorhen.State) => state.sceneSettings.resetClippingFogging)
-    const clipCap = useSelector((state: moorhen.State) => state.sceneSettings.clipCap)
-    const doPerspectiveProjection = useSelector((state: moorhen.State) => state.sceneSettings.doPerspectiveProjection)
-    const useOffScreenBuffers = useSelector((state: moorhen.State) => state.sceneSettings.useOffScreenBuffers)
-    const doShadowDepthDebug = useSelector((state: moorhen.State) => state.sceneSettings.doShadowDepthDebug)
-    const doShadow = useSelector((state: moorhen.State) => state.sceneSettings.doShadow)
-    const doSpin = useSelector((state: moorhen.State) => state.sceneSettings.doSpin)
-    const doAnaglyphStereo = useSelector((state: moorhen.State) => state.sceneSettings.doAnaglyphStereo)
-    const doCrossEyedStereo = useSelector((state: moorhen.State) => state.sceneSettings.doCrossEyedStereo)
-    const doSideBySideStereo = useSelector((state: moorhen.State) => state.sceneSettings.doSideBySideStereo)
-    const doThreeWayView = useSelector((state: moorhen.State) => state.sceneSettings.doThreeWayView)
-    const multiViewRows = useSelector((state: moorhen.State) => state.sceneSettings.multiViewRows)
-    const multiViewColumns = useSelector((state: moorhen.State) => state.sceneSettings.multiViewColumns)
-    const threeWayViewOrder = useSelector((state: moorhen.State) => state.sceneSettings.threeWayViewOrder)
-    const specifyMultiViewRowsColumns = useSelector((state: moorhen.State) => state.sceneSettings.specifyMultiViewRowsColumns)
-    const doMultiView = useSelector((state: moorhen.State) => state.sceneSettings.doMultiView)
-    const drawEnvBOcc = useSelector((state: moorhen.State) => state.sceneSettings.drawEnvBOcc)
-    const doOutline = useSelector((state: moorhen.State) => state.sceneSettings.doOutline)
-    const depthBlurRadius = useSelector((state: moorhen.State) => state.sceneSettings.depthBlurRadius)
-    const depthBlurDepth = useSelector((state: moorhen.State) => state.sceneSettings.depthBlurDepth)
     const atomLabelDepthMode = useSelector((state: moorhen.State) => state.labelSettings.atomLabelDepthMode)
     const mouseSensitivity = useSelector((state: moorhen.State) => state.mouseSettings.mouseSensitivity)
     const zoomWheelSensitivityFactor = useSelector((state: moorhen.State) => state.mouseSettings.zoomWheelSensitivityFactor)
@@ -228,27 +203,6 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
        }
     }, [])
 
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.doPerspectiveProjection = doPerspectiveProjection
-            glRef.current.clearTextPositionBuffers()
-            glRef.current.drawScene()
-        }
-    }, [doPerspectiveProjection])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setShadowDepthDebug(doShadowDepthDebug)
-            glRef.current.drawScene()
-        }
-    }, [doShadowDepthDebug])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setOutlinesOn(doOutline)
-            glRef.current.drawScene()
-        }
-    }, [doOutline])
 
     /*
     useEffect(() => {
@@ -285,155 +239,10 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
         }
     }, [elementsIndicesRestrict])
 
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setSSAOOn(doSSAO)
-            glRef.current.drawScene()
-        }
-    }, [doSSAO])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setEdgeDetectOn(doEdgeDetect)
-            glRef.current.drawScene()
-        }
-    }, [doEdgeDetect])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setEdgeDetectDepthThreshold(edgeDetectDepthThreshold)
-            glRef.current.drawScene()
-        }
-    }, [edgeDetectDepthThreshold])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setEdgeDetectNormalThreshold(edgeDetectNormalThreshold)
-            glRef.current.drawScene()
-        }
-    }, [edgeDetectNormalThreshold])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setEdgeDetectDepthScale(edgeDetectDepthScale)
-            glRef.current.drawScene()
-        }
-    }, [edgeDetectDepthScale])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setEdgeDetectNormalScale(edgeDetectNormalScale)
-            glRef.current.drawScene()
-        }
-    }, [edgeDetectNormalScale])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setShadowsOn(doShadow)
-            glRef.current.drawScene()
-        }
-    }, [doShadow])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setDrawEnvBOcc(drawEnvBOcc)
-            glRef.current.handleOriginUpdated(false)
-            glRef.current.drawScene()
-        }
-    }, [drawEnvBOcc])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setThreeWayViewOrder(threeWayViewOrder)
-            glRef.current.setupThreeWayTransformations()
-            glRef.current.drawScene()
-        }
-    }, [threeWayViewOrder])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setMultiViewRowsColumns([multiViewRows,multiViewColumns])
-            glRef.current.setSpecifyMultiViewRowsColumns(specifyMultiViewRowsColumns)
-            glRef.current.drawScene()
-        }
-    }, [multiViewRows,multiViewColumns,specifyMultiViewRowsColumns])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setDoThreeWayView(doThreeWayView)
-            glRef.current.drawScene()
-        }
-    }, [doThreeWayView])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setDoSideBySideStereo(doSideBySideStereo)
-            glRef.current.drawScene()
-        }
-    }, [doSideBySideStereo])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setDoMultiView(doMultiView)
-            glRef.current.drawScene()
-        }
-    }, [doMultiView])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setDoCrossEyedStereo(doCrossEyedStereo)
-            glRef.current.drawScene()
-        }
-    }, [doCrossEyedStereo])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setDoAnaglyphStereo(doAnaglyphStereo)
-            glRef.current.drawScene()
-        }
-    }, [doAnaglyphStereo])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setSpinTestState(doSpin)
-            glRef.current.drawScene()
-        }
-    }, [doSpin])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function' && ssaoBias != null) {
-            glRef.current.setSSAOBias(ssaoBias)
-            glRef.current.drawScene()
-        }
-    }, [ssaoBias])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function' && ssaoRadius != null) {
-            glRef.current.setSSAORadius(ssaoRadius)
-            glRef.current.drawScene()
-        }
-    }, [ssaoRadius])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.setBlurSize(depthBlurRadius)
-            glRef.current.drawScene()
-        }
-    }, [depthBlurRadius])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.blurDepth = depthBlurDepth
-            glRef.current.drawScene()
-        }
-    }, [depthBlurDepth])
-
-    useEffect(() => {
-        if(glRef !== null && typeof glRef !== 'function') {
-            glRef.current.useOffScreenBuffers = useOffScreenBuffers
-            glRef.current.drawScene()
-        }
-    }, [useOffScreenBuffers])
+    // SSAO / shadow / env-B-occ / stereo / multi-view / spin / depth-blur scene
+    // settings are synced by <SceneRenderSettingsSync/> (mounted below), and
+    // edge-detect by <EdgeDetectSync/>, so changing any of them re-renders only
+    // that headless component rather than this 770-line one.
 
     const handleWindowResized = useCallback(() => {
         if (glRef !== null && typeof glRef !== 'function') {
@@ -558,12 +367,6 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
 
     }, [handleRightClick]);
 
-    useEffect(() => {
-        if (glRef !== null && typeof glRef !== 'function' && glRef.current) {
-            glRef.current.clipCapPerfectSpheres = clipCap
-            glRef.current.drawScene()
-        }
-    }, [clipCap, glRef])
 
     useEffect(() => {
         if (glRef !== null && typeof glRef !== 'function' && glRef.current) {
@@ -727,6 +530,8 @@ export const MoorhenWebMG = forwardRef<webGL.MGWebGL, MoorhenWebMGPropsInterface
     }, [zoom,quat,originState])
 
     return  <>
+                <EdgeDetectSync glRef={glRef} />
+                <SceneRenderSettingsSync glRef={glRef} />
                 <figure style={{position: "absolute", top: 0, left: 0, width: `${width}px`, height: `${height}px`, margin: "0px"}}>
                 <MGWebGL
                     ref={glRef}

--- a/baby-gru/src/components/webMG/glRefSync/EdgeDetectSync.tsx
+++ b/baby-gru/src/components/webMG/glRefSync/EdgeDetectSync.tsx
@@ -1,0 +1,58 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { moorhen } from '../../../types/moorhen';
+import { MGWebGL } from '../../../WebGLgComponents/mgWebGL';
+
+/**
+ * Headless sync component: mirrors the edge-detect scene settings onto the
+ * WebGL instance. Extracted from MoorhenWebMG so that an edge-detect setting
+ * change re-renders only this tiny null-rendering component (which subscribes
+ * to just those slices), not the whole 770-line MoorhenWebMG.
+ *
+ * Behaviour is identical to the original inline effects: each setting drives
+ * one glRef setter followed by a redraw. `glRef` is passed down unchanged.
+ */
+export const EdgeDetectSync = ({ glRef }: { glRef: React.Ref<MGWebGL> }) => {
+    const doEdgeDetect = useSelector((state: moorhen.State) => state.sceneSettings.doEdgeDetect)
+    const edgeDetectDepthThreshold = useSelector((state: moorhen.State) => state.sceneSettings.edgeDetectDepthThreshold)
+    const edgeDetectNormalThreshold = useSelector((state: moorhen.State) => state.sceneSettings.edgeDetectNormalThreshold)
+    const edgeDetectDepthScale = useSelector((state: moorhen.State) => state.sceneSettings.edgeDetectDepthScale)
+    const edgeDetectNormalScale = useSelector((state: moorhen.State) => state.sceneSettings.edgeDetectNormalScale)
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setEdgeDetectOn(doEdgeDetect)
+            glRef.current.drawScene()
+        }
+    }, [doEdgeDetect])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setEdgeDetectDepthThreshold(edgeDetectDepthThreshold)
+            glRef.current.drawScene()
+        }
+    }, [edgeDetectDepthThreshold])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setEdgeDetectNormalThreshold(edgeDetectNormalThreshold)
+            glRef.current.drawScene()
+        }
+    }, [edgeDetectNormalThreshold])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setEdgeDetectDepthScale(edgeDetectDepthScale)
+            glRef.current.drawScene()
+        }
+    }, [edgeDetectDepthScale])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setEdgeDetectNormalScale(edgeDetectNormalScale)
+            glRef.current.drawScene()
+        }
+    }, [edgeDetectNormalScale])
+
+    return null
+}

--- a/baby-gru/src/components/webMG/glRefSync/SceneRenderSettingsSync.tsx
+++ b/baby-gru/src/components/webMG/glRefSync/SceneRenderSettingsSync.tsx
@@ -1,0 +1,185 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { moorhen } from '../../../types/moorhen';
+import { MGWebGL } from '../../../WebGLgComponents/mgWebGL';
+
+/**
+ * Headless sync component: mirrors the scene-render settings (SSAO, shadows,
+ * environment B-occ, stereo / multi-view, spin, depth blur) onto the WebGL
+ * instance. Extracted from MoorhenWebMG so a change to any of these re-renders
+ * only this tiny null-rendering component, not the whole 770-line parent.
+ *
+ * Each effect is copied verbatim from the original inline effects (same guards,
+ * same setter-or-field-assignment, same dependency arrays), so behaviour is
+ * identical - only the component the subscription lives in has changed.
+ */
+export const SceneRenderSettingsSync = ({ glRef }: { glRef: React.Ref<MGWebGL> }) => {
+    const doSSAO = useSelector((state: moorhen.State) => state.sceneSettings.doSSAO)
+    const ssaoRadius = useSelector((state: moorhen.State) => state.sceneSettings.ssaoRadius)
+    const ssaoBias = useSelector((state: moorhen.State) => state.sceneSettings.ssaoBias)
+    const doShadow = useSelector((state: moorhen.State) => state.sceneSettings.doShadow)
+    const doSpin = useSelector((state: moorhen.State) => state.sceneSettings.doSpin)
+    const doAnaglyphStereo = useSelector((state: moorhen.State) => state.sceneSettings.doAnaglyphStereo)
+    const doCrossEyedStereo = useSelector((state: moorhen.State) => state.sceneSettings.doCrossEyedStereo)
+    const doSideBySideStereo = useSelector((state: moorhen.State) => state.sceneSettings.doSideBySideStereo)
+    const doThreeWayView = useSelector((state: moorhen.State) => state.sceneSettings.doThreeWayView)
+    const multiViewRows = useSelector((state: moorhen.State) => state.sceneSettings.multiViewRows)
+    const multiViewColumns = useSelector((state: moorhen.State) => state.sceneSettings.multiViewColumns)
+    const threeWayViewOrder = useSelector((state: moorhen.State) => state.sceneSettings.threeWayViewOrder)
+    const specifyMultiViewRowsColumns = useSelector((state: moorhen.State) => state.sceneSettings.specifyMultiViewRowsColumns)
+    const doMultiView = useSelector((state: moorhen.State) => state.sceneSettings.doMultiView)
+    const drawEnvBOcc = useSelector((state: moorhen.State) => state.sceneSettings.drawEnvBOcc)
+    const useOffScreenBuffers = useSelector((state: moorhen.State) => state.sceneSettings.useOffScreenBuffers)
+    const depthBlurRadius = useSelector((state: moorhen.State) => state.sceneSettings.depthBlurRadius)
+    const depthBlurDepth = useSelector((state: moorhen.State) => state.sceneSettings.depthBlurDepth)
+    const doPerspectiveProjection = useSelector((state: moorhen.State) => state.sceneSettings.doPerspectiveProjection)
+    const doShadowDepthDebug = useSelector((state: moorhen.State) => state.sceneSettings.doShadowDepthDebug)
+    const doOutline = useSelector((state: moorhen.State) => state.sceneSettings.doOutline)
+    const clipCap = useSelector((state: moorhen.State) => state.sceneSettings.clipCap)
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setSSAOOn(doSSAO)
+            glRef.current.drawScene()
+        }
+    }, [doSSAO])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setShadowsOn(doShadow)
+            glRef.current.drawScene()
+        }
+    }, [doShadow])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setDrawEnvBOcc(drawEnvBOcc)
+            glRef.current.handleOriginUpdated(false)
+            glRef.current.drawScene()
+        }
+    }, [drawEnvBOcc])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setThreeWayViewOrder(threeWayViewOrder)
+            glRef.current.setupThreeWayTransformations()
+            glRef.current.drawScene()
+        }
+    }, [threeWayViewOrder])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setMultiViewRowsColumns([multiViewRows,multiViewColumns])
+            glRef.current.setSpecifyMultiViewRowsColumns(specifyMultiViewRowsColumns)
+            glRef.current.drawScene()
+        }
+    }, [multiViewRows,multiViewColumns,specifyMultiViewRowsColumns])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setDoThreeWayView(doThreeWayView)
+            glRef.current.drawScene()
+        }
+    }, [doThreeWayView])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setDoSideBySideStereo(doSideBySideStereo)
+            glRef.current.drawScene()
+        }
+    }, [doSideBySideStereo])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setDoMultiView(doMultiView)
+            glRef.current.drawScene()
+        }
+    }, [doMultiView])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setDoCrossEyedStereo(doCrossEyedStereo)
+            glRef.current.drawScene()
+        }
+    }, [doCrossEyedStereo])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setDoAnaglyphStereo(doAnaglyphStereo)
+            glRef.current.drawScene()
+        }
+    }, [doAnaglyphStereo])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setSpinTestState(doSpin)
+            glRef.current.drawScene()
+        }
+    }, [doSpin])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function' && ssaoBias != null) {
+            glRef.current.setSSAOBias(ssaoBias)
+            glRef.current.drawScene()
+        }
+    }, [ssaoBias])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function' && ssaoRadius != null) {
+            glRef.current.setSSAORadius(ssaoRadius)
+            glRef.current.drawScene()
+        }
+    }, [ssaoRadius])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setBlurSize(depthBlurRadius)
+            glRef.current.drawScene()
+        }
+    }, [depthBlurRadius])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.blurDepth = depthBlurDepth
+            glRef.current.drawScene()
+        }
+    }, [depthBlurDepth])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.useOffScreenBuffers = useOffScreenBuffers
+            glRef.current.drawScene()
+        }
+    }, [useOffScreenBuffers])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.doPerspectiveProjection = doPerspectiveProjection
+            glRef.current.clearTextPositionBuffers()
+            glRef.current.drawScene()
+        }
+    }, [doPerspectiveProjection])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setShadowDepthDebug(doShadowDepthDebug)
+            glRef.current.drawScene()
+        }
+    }, [doShadowDepthDebug])
+
+    useEffect(() => {
+        if(glRef !== null && typeof glRef !== 'function') {
+            glRef.current.setOutlinesOn(doOutline)
+            glRef.current.drawScene()
+        }
+    }, [doOutline])
+
+    useEffect(() => {
+        if (glRef !== null && typeof glRef !== 'function' && glRef.current) {
+            glRef.current.clipCapPerfectSpheres = clipCap
+            glRef.current.drawScene()
+        }
+    }, [clipCap, glRef])
+
+    return null
+}


### PR DESCRIPTION
## React re-render & lifecycle fixes for the WebGL viewer

> **Draft — for feedback.** Based on `refactor/mgwebgl-camera-collaborator` (#625), not `main`, so the diff shows only these three commits. Merge the refactor first, then rebase.

Three small, independent runtime-health fixes surfaced by the mgWebGL refactor. None converts `MGWebGL` to/from a class — the ref-wrapped imperative canvas pattern is kept; the wins are in the wiring around it.

📄 **[The re-render analysis](https://claude.ai/code/artifact/3d1e7a63-223d-4bb0-acfe-f01c90ee036e)** — verdict (no death spiral; real diffuse inefficiency) and the reasoning behind these fixes.

### 1. Stop `MGWebGL` re-rendering on every parent render (`a0ac5aae`)
`MoorhenWebMG` (~80 `useSelector`s) re-renders on any subscribed state change; each time, `MGWebGL` re-reconciled because two props were freshly allocated every render (`keyboardAccelerators={JSON.parse(...)}`, `messageChanged={(d)=>{}}`). Memoized both, and added a `shouldComponentUpdate` that returns true for exactly the props `componentDidUpdate` reacts to (verified against it, so no display toggle is dropped). The WebGL frame is drawn imperatively via `glRef.current`, never through `render()`, so this only removes wasted reconciliation.

### 2. Headless `glRefSync/` components (`8129e200`)
Carved the scene-setting → glRef sync effects out of the 770-line `MoorhenWebMG` into null-rendering children (`EdgeDetectSync`, `SceneRenderSettingsSync`). Now a change to SSAO/stereo/depth-blur/etc. re-renders only its small sync component, not the parent. Each effect is copied **verbatim** (same guards/deps), so behaviour is identical — only where the subscription lives changed. **MoorhenWebMG: 770 → 575 lines, 77 → 50 selectors, 58 → 33 effects.**

### 3. `componentWillUnmount` teardown (`f03e8061`)
`MGWebGL` attached all canvas listeners and started two intervals at mount but never cleaned them up (no unmount handler at all) — on unmount the listeners leaked and the `drawSceneIfDirty` tick kept firing ~62×/s for the page lifetime. Added removable named handlers + a `detachCanvasListeners`, captured both interval ids, and a `componentWillUnmount` that clears them. **Mostly matters for embedded / web-component / multi-instance / StrictMode use** — the standalone app keeps `MGWebGL` mounted for the page lifetime, so it rarely triggers, but the leak was real.

### Verification
Typechecks clean. Verified in-app: display toggles (scale bar), SSAO/depth-blur/three-way/edge-detect (still driven from the sync components), and full interaction (rotate/pan/zoom/pick/context-menu/keyboard) after the listener rewrite. The re-render win itself is best seen in the React DevTools Profiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
