### PR TITLE
Fix "Drag atoms" on residues with alternate conformations

### DIFF
--- a/baby-gru/src/components/context-menu/MoorhenDragAtomsButton.tsx
+++ b/baby-gru/src/components/context-menu/MoorhenDragAtomsButton.tsx
@@ -77,7 +77,7 @@ export const MoorhenDragAtomsButton = (props: ContextButtonProps) => {
             }
 
             if (selectionType !== "SPHERE") {
-                fragmentCid.current = [`//${chosenAtom.chain_id}/${start}-${stop}/*`];
+                fragmentCid.current = [`//${chosenAtom.chain_id}/${start}-${stop}/*:*`];
             } else {
                 fragmentCid.current = sphereResidueCids;
             }

--- a/baby-gru/src/components/snack-bars/PopupControls/AcceptRejectDragAtoms.tsx
+++ b/baby-gru/src/components/snack-bars/PopupControls/AcceptRejectDragAtoms.tsx
@@ -100,7 +100,7 @@ export const AcceptRejectDragAtoms = () => {
                     command: "add_target_position_restraint_and_refine",
                     commandArgs: [
                         moltenFragmentRef.current.molNo,
-                        `//${chosenAtom.chain_id}/${chosenAtom.res_no}/${chosenAtom.atom_name}`,
+                        `//${chosenAtom.chain_id}/${chosenAtom.res_no}/${chosenAtom.atom_name}${chosenAtom.alt_conf ? `:${chosenAtom.alt_conf}` : ""}`,
                         movedAtoms[0][0].x,
                         movedAtoms[0][0].y,
                         movedAtoms[0][0].z,


### PR DESCRIPTION
### Problem (user-facing)
Right-click a residue that has an **alternate conformation** → **Drag atoms**, and the **entire residue disappears** — you're left dragging only the two neighbouring residues, with the backbone visibly disconnected. On the rarer occasions it did start, dragging one conformer **moved both** duplicates together instead of independently. This is an obvious, reproducible bug that hits a routine model-building action, and it is present on `main`.

### Root cause
The drag builds a molten fragment from a selection CID. The SINGLE/TRIPLE path used `//chain/start-stop/*`. Coot's mmdb `Select` treats a CID with **no alt-loc token** as *blank alt-loc only*, so every alternate-conformation atom is silently dropped when the fragment is copied — while the parent-hide removes all of them, so the residue vanishes. The SPHERE path already appends `:*` for exactly this reason (`MoorhenMolecule.getNeighborResiduesCids`); the SINGLE/TRIPLE path never did.

Diagnostics confirmed it (GLU with A/B confs): the parent selection reported `15 atoms alt{B:6,A:6,-:3}`, but the molten copy came back `3 atoms alt{-:3}` — only the shared backbone survived.

### Fix (2 lines)
1. **`MoorhenDragAtomsButton.tsx`** — append the alt-loc wildcard: `//chain/start-stop/*:*`, so both conformers are copied into the molten fragment. `:*` also matches the blank alt-loc, so normal residues are unaffected.
2. **`AcceptRejectDragAtoms.tsx`** — include the picked atom's alt-loc in the `add_target_position_restraint_and_refine` CID, so dragging one conformer restrains only that conformer. No-op when the atom has no alt-loc.

### Testing
Verified in-app: the alt-conf residue now stays visible with both conformers, and each conformer drags independently. Non-alt-conf residues behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)