### PR TITLE
Surface silent failures when starting Drag atoms

### DIFF
--- a/baby-gru/src/components/context-menu/MoorhenContextButtonBase.tsx
+++ b/baby-gru/src/components/context-menu/MoorhenContextButtonBase.tsx
@@ -1,5 +1,6 @@
 import { useDispatch, useSelector } from "react-redux";
 import { useCallback, useEffect, useRef } from "react";
+import { enqueueSnackbar } from "@/store";
 import { useCommandCentre } from "../../InstanceManager";
 import { setHoveredAtom } from "../../store/hoveringStatesSlice";
 import { triggerUpdate } from "../../store/moleculeMapUpdateSlice";
@@ -194,7 +195,15 @@ export const MoorhenContextButtonBase = (props: {
             );
             setTimeout(() => props.setShowOverlay(true), 50);
         } else if (props.nonCootCommand) {
-            await props.nonCootCommand(props.selectedMolecule, props.chosenAtom);
+            try {
+                await props.nonCootCommand(props.selectedMolecule, props.chosenAtom);
+            } catch (err) {
+                // Never leave the context menu stuck open with no feedback if the
+                // action throws (e.g. a backend query fails mid-setup).
+                console.error("Context menu action failed", err);
+                dispatch(enqueueSnackbar({ message: "Action could not be completed", variant: "warning" }));
+                props.setShowContextMenu(false);
+            }
         } else if (props.cootCommandInput) {
             await doEdit(props.cootCommandInput);
         }

--- a/baby-gru/src/components/context-menu/MoorhenDragAtomsButton.tsx
+++ b/baby-gru/src/components/context-menu/MoorhenDragAtomsButton.tsx
@@ -1,6 +1,6 @@
 import { batch, useDispatch, useSelector } from "react-redux";
 import { useCallback, useRef } from "react";
-import { setShownControl } from "@/store";
+import { enqueueSnackbar, setShownControl } from "@/store";
 import { useCommandCentre } from "../../InstanceManager";
 import { setIsDraggingAtoms } from "../../store/generalStatesSlice";
 import { setHoveredAtom } from "../../store/hoveringStatesSlice";
@@ -38,31 +38,28 @@ export const MoorhenDragAtomsButton = (props: ContextButtonProps) => {
                 selectionType = refinementSelection;
             }
 
+            // Clamp neighbour lookups to the chain ends so residues near a terminus
+            // can't index past the sequence array (which would read undefined.resNum).
+            const neighbourResNum = (offset: number) =>
+                selectedSequence.sequence[Math.min(Math.max(selectedResidueIndex + offset, 0), selectedSequence.sequence.length - 1)]
+                    .resNum;
+
             switch (selectionType) {
                 case "SINGLE":
                     start = chosenAtom.res_no;
                     stop = chosenAtom.res_no;
                     break;
                 case "TRIPLE":
-                    start = selectedResidueIndex !== 0 ? selectedSequence.sequence[selectedResidueIndex - 1].resNum : chosenAtom.res_no;
-                    stop =
-                        selectedResidueIndex < selectedSequence.sequence.length - 1
-                            ? selectedSequence.sequence[selectedResidueIndex + 1].resNum
-                            : chosenAtom.res_no;
+                    start = neighbourResNum(-1);
+                    stop = neighbourResNum(1);
                     break;
                 case "QUINTUPLE":
-                    start = selectedResidueIndex !== 0 ? selectedSequence.sequence[selectedResidueIndex - 2].resNum : chosenAtom.res_no;
-                    stop =
-                        selectedResidueIndex < selectedSequence.sequence.length - 2
-                            ? selectedSequence.sequence[selectedResidueIndex + 2].resNum
-                            : selectedSequence.sequence[selectedResidueIndex - 1].resNum;
+                    start = neighbourResNum(-2);
+                    stop = neighbourResNum(2);
                     break;
                 case "HEPTUPLE":
-                    start = selectedResidueIndex !== 0 ? selectedSequence.sequence[selectedResidueIndex - 3].resNum : chosenAtom.res_no;
-                    stop =
-                        selectedResidueIndex < selectedSequence.sequence.length - 3
-                            ? selectedSequence.sequence[selectedResidueIndex + 3].resNum
-                            : selectedSequence.sequence[selectedResidueIndex - 1].resNum;
+                    start = neighbourResNum(-3);
+                    stop = neighbourResNum(3);
                     break;
                 case "SPHERE":
                     sphereResidueCids = await molecule.getNeighborResiduesCids(chosenAtom.cid, 6);
@@ -72,7 +69,14 @@ export const MoorhenDragAtomsButton = (props: ContextButtonProps) => {
                     break;
             }
 
-            if (!sphereResidueCids && (!start || !stop)) {
+            const invalidSelection =
+                selectionType === "SPHERE"
+                    ? !sphereResidueCids || sphereResidueCids.length === 0
+                    : typeof start === "undefined" || typeof stop === "undefined";
+            if (invalidSelection) {
+                // Don't silently swallow the click: tell the user and close the menu.
+                dispatch(enqueueSnackbar({ message: "Could not determine a residue selection to drag", variant: "warning" }));
+                props.setShowContextMenu(false);
                 return;
             }
 

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -562,7 +562,14 @@ export class MoorhenMolecule {
             false
         )) as moorhen.WorkerResponse<string>;
 
-        const multiCidRanges: string[] = response.data.result.result.split("||");
+        // Guard against a missing/empty backend response so callers get an empty
+        // list to handle rather than a thrown "cannot read .split of undefined".
+        const rawResult = response?.data?.result?.result;
+        if (typeof rawResult !== "string" || rawResult.length === 0) {
+            return [];
+        }
+
+        const multiCidRanges: string[] = rawResult.split("||");
         const fixedAltConf = multiCidRanges.map(cid => `${cid}:*`);
         return fixedAltConf;
     }


### PR DESCRIPTION
### Problem (user-facing)
"Drag atoms" from the residue context menu sometimes appeared to do nothing — the toolbox stayed open and no drag started, while other menu actions still worked. Because it left no message, it read as an intermittent "can't select drag atoms".

The reachable trigger is a failure *during setup* that isn't surfaced: e.g. the Sphere-zone neighbour query throwing, or no draggable selection being computed. On an unhandled rejection the menu is never closed, so the click looks dead.

### Changes
- **`MoorhenContextButtonBase`** — wrap the `nonCootCommand` invocation so any throw shows a warning snackbar and closes the context menu, instead of leaving it stuck open on an unhandled rejection. This is a generic net for every `nonCootCommand` context button.
- **`MoorhenDragAtomsButton`** — when no draggable selection can be computed, warn and close the menu rather than returning silently. Neighbour-residue lookups are refactored through a small clamped helper so a residue near a chain terminus can't index past the sequence array.
- **`MoorhenMolecule.getNeighborResiduesCids`** — return an empty list on an empty/malformed backend response rather than throwing on `.split()`.

### Note on the clamped neighbour lookups
The refinement-selection UI currently exposes **Single / Adjacent / Sphere**. The wider **QUINTUPLE (i±2)** and **HEPTUPLE (i±3)** zones still exist in the code and settings types but aren't presently offered in that menu. The clamped lookups keep those paths correct (no terminus underflow) should the wider zones be re-exposed — deliberate defensive coverage, not a change to the current options.

### Scope / relationship to #636
Independent of the alt-conf fix in #636 — this branch does not touch the fragment-selection CID, so the two merge cleanly. Typechecks clean (`tsc --noEmit`, project-wide, 0 errors).

### Testing note
These harden intermittent/silent failure paths, which are inherently hard to reproduce on demand. The changes are defensive and behaviour-preserving on the success path; the intent is that any future failure becomes a visible toast + closed menu rather than a dead click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)