### PR TITLE
loadToCootFromMtzData returns an un-initialised map (inconsistent with loadToCootFromMapData)

### DIFF
--- a/baby-gru/src/utils/MoorhenMap.ts
+++ b/baby-gru/src/utils/MoorhenMap.ts
@@ -319,6 +319,13 @@ export class MoorhenMap {
                 map.isDifference = selectedColumns.isDifference;
             }
             map.dataOrigin = "mtz";
+            const header = await readMTZHeader(data);
+            if (typeof header !== "number") {
+                map.fileHeader = header;
+                await map.initialise();
+            } else {
+                console.warn("Could not read MTZ header; skipping map.initialise() (contour stats may be unset)");
+            }
             return map;
         } catch (err) {
             return Promise.reject(err);


### PR DESCRIPTION
## Summary

The static factory `MoorhenMap.loadToCootFromMtzData(...)` loads the map into coot but **never sets `fileHeader` and never calls `initialise()`**. Its sibling `loadToCootFromMapData(...)` does both. Because `initialise()` is what computes `mapRmsd` / `suggestedContourLevel` / `mapCentre` / `suggestedRadius`, any map created from MTZ data via this factory comes back with `mapRmsd === null` and `suggestedContourLevel === null`.

Downstream, `MoorhenMapManager`'s mount effect sets the initial contour level to `1 * map.mapRmsd` for a normal xtal map (and `3 * map.mapRmsd` for a difference map). With `mapRmsd === null` that evaluates to **0**, so the map contours at zero and the whole cell fills with noise-level density.

This only bites callers who use the factory directly (e.g. `MoorhenMap.loadToCootFromMtzData(...)` → `dispatch(addMap(...))`) rather than going through `instance.files.loadFiles()`. CCP4i2 is one such caller and currently papers over it client-side.

This is best read as an **inconsistency between two sibling factories from an in-progress refactor**, not a wrong line of code — `MoorhenMapManager` already carries `/* this should be moved to map initialisation in the moorhen instance */`.

## The fix

`readMTZHeader` (`baby-gru/src/utils/mapHeaders.ts`) accepts `File | ArrayBuffer | Uint8Array`, so the incoming `data` is passed straight in (no `File` wrapping), then `fileHeader` is set and `initialise()` awaited — mirroring `loadToCootFromMapData`. The `readMTZHeader` numeric error sentinel is guarded so a header-parse failure only skips the suggested stats rather than throwing out of the loader (matches the loader's existing "load succeeds even if extras fail" tolerance).

## Open question for the reviewer

This is deliberately the smallest, lowest-risk option. The underlying question is **where should `initialise()` live?**

1. **Keep it in the factories (this PR).** Both `loadToCootFrom*Data` methods return a fully-initialised map. Matches today's `loadToCootFromMapData`.
2. **Pull it up into `loadFiles`/the instance.** Make the factories pure "load the grid, set molNo" primitives and have the instance own initialisation — the direction the `MoorhenMapManager` TODO points at. If that's the intent, `loadToCootFromMapData` calling `initialise()` internally is the anomaly, and the fix is to *remove* it there and add it to the instance load path.

This PR takes option 1 because it's the minimal change that stops MTZ maps contouring at 0 and can't regress the map-file path. Happy to reshape as option 2 if that's the preferred long-term home. Whatever we pick, the two factories should agree.

## How to verify

1. Load an MTZ (2Fo-Fc + Fo-Fc) via a path that hits `loadToCootFromMtzData`.
2. Before: `map.mapRmsd === null`, map contours at ~0 (whole cell filled). After: `map.mapRmsd` is a sensible float, `suggestedContourLevel` is set, and `MoorhenMapManager` contours the 2Fo-Fc near ~1σ and the Fo-Fc near ~3σ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)