### PR TITLE
Bump to 1.0.0-beta.2

### DIFF
--- a/baby-gru/package-lock.json
+++ b/baby-gru/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "moorhen",
-    "version": "1.0.0-beta.1",
+    "version": "1.0.0-beta.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "moorhen",
-            "version": "1.0.0-beta.1",
+            "version": "1.0.0-beta.2",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@apollo/client": "^3.13.8",

--- a/baby-gru/package.json
+++ b/baby-gru/package.json
@@ -1,6 +1,6 @@
 {
     "name": "moorhen",
-    "version": "1.0.0-beta.1",
+    "version": "1.0.0-beta.2",
     "private": false,
     "typesVersions": {
         "*": {


### PR DESCRIPTION
Bump to 1.0.0-beta.2. To be accepted after 656 (and possibly 655).