### PR TITLE
No dictionary warning

### DIFF
--- a/baby-gru/src/InstanceManager/CommandCentre/CootWorker.ts
+++ b/baby-gru/src/InstanceManager/CommandCentre/CootWorker.ts
@@ -198,9 +198,9 @@ const instancedMeshToMeshData = (instanceMesh: libcootApi.InstancedMeshT, perm: 
                 thisInstance_colours.push(instDataColour[3])
 
                 const instDataSize = inst_data.size
-                thisInstance_sizes.push(instDataSize[0])
-                thisInstance_sizes.push(instDataSize[1])
-                thisInstance_sizes.push(instDataSize[2])
+                thisInstance_sizes.push(Math.abs(instDataSize[0]))
+                thisInstance_sizes.push(Math.abs(instDataSize[1]))
+                thisInstance_sizes.push(Math.abs(instDataSize[2]))
 
                 thisInstance_orientations.push(...[
                     1.0, 0.0, 0.0, 0.0,

--- a/baby-gru/src/components/card/MoleculeCard/RepresentationChip.tsx
+++ b/baby-gru/src/components/card/MoleculeCard/RepresentationChip.tsx
@@ -13,6 +13,7 @@ import { AddCustomRepresentationCard } from "./addRepresentation/AddRepresentati
 import "./representation.css";
 import { parseCid } from "@/utils/utils";
 import { useCommandCentre } from "../../../InstanceManager";
+import { useMoleculeChanged } from "@/hooks/usMolleculeChange";
 
 export const CustomRepresentationChip = (props: {
     addColourRulesAnchorDivRef: React.RefObject<HTMLDivElement>;
@@ -37,6 +38,8 @@ export const CustomRepresentationChip = (props: {
     const isMoleculeVisible = useSelector((state: RootState) => state.molecules.visibleMolecules.some(molNo => molNo === molecule.molNo));
     const chipStyle = getChipStyle(representation.colourRules, representationIsVisible && isMoleculeVisible, isDark);
     if (!isMoleculeVisible) chipStyle["opacity"] = "0.3";
+
+    const moleculeChange = useMoleculeChanged();
 
     const handleVisibility = useCallback(() => {
         if (isMoleculeVisible) {
@@ -64,7 +67,7 @@ export const CustomRepresentationChip = (props: {
             }
         }
         checkMonomerStatus()
-    }, [molecule,representation]);
+    }, [molecule.ligandDicts,moleculeChange]);
 
     const handleDelete = useCallback(() => {
         if (representation.style === "adaptativeBonds") {

--- a/baby-gru/src/components/card/MoleculeCard/RepresentationChip.tsx
+++ b/baby-gru/src/components/card/MoleculeCard/RepresentationChip.tsx
@@ -1,5 +1,5 @@
 import { useDispatch, useSelector } from "react-redux";
-import { useCallback, useState } from "react";
+import { useCallback, useState, useEffect } from "react";
 import { MoorhenButton, MoorhenNumberInput, MoorhenPopoverButton } from "@/components/inputs";
 import { MoorhenStack, MoorhenTooltip } from "@/components/interface-base";
 import { usePaths } from "../../../InstanceManager";
@@ -12,6 +12,7 @@ import { representationLabelMapping } from "../../../utils/enums";
 import { AddCustomRepresentationCard } from "./addRepresentation/AddRepresentationCard";
 import "./representation.css";
 import { parseCid } from "@/utils/utils";
+import { useCommandCentre } from "../../../InstanceManager";
 
 export const CustomRepresentationChip = (props: {
     addColourRulesAnchorDivRef: React.RefObject<HTMLDivElement>;
@@ -23,8 +24,10 @@ export const CustomRepresentationChip = (props: {
     if (representation.interfaceOption.visible === undefined) {
         representation.interfaceOption.visible = representation.visible;
     }
+    const commandCentre = useCommandCentre()
     const [representationIsVisible, setRepresentationIsVisible] = useState<boolean>(representation.interfaceOption.visible);
     const [reload, setReload] = useState<boolean>(false);
+    const [monomersWarning, setMonomersWarning] = useState<string>("");
     const modelSelector = representation.cid.split("/")[1] !== "*" ? parseInt(representation.cid.split("/")[1]) : 0;
 
     const models = molecule.numberOfModels;
@@ -42,6 +45,26 @@ export const CustomRepresentationChip = (props: {
             setRepresentationIsVisible(!representationIsVisible);
         }
     }, [isMoleculeVisible, representationIsVisible]);
+
+    useEffect(() => {
+        const checkMonomerStatus = async() => {
+            const unknownMonomersStatus = await commandCentre.current.cootCommand(
+                {
+                    returnType: "string_array",
+                    command: "get_residue_names_with_no_dictionary",
+                    commandArgs: [molecule.molNo ],
+                },
+                false
+            );
+            const unknownMonomers = unknownMonomersStatus.data.result.result
+            if(unknownMonomers.length>0){
+                setMonomersWarning(" (missing dictionary)")
+            } else {
+                setMonomersWarning("")
+            }
+        }
+        checkMonomerStatus()
+    }, [molecule,representation]);
 
     const handleDelete = useCallback(() => {
         if (representation.style === "adaptativeBonds") {
@@ -118,7 +141,7 @@ export const CustomRepresentationChip = (props: {
         <div className="moorhen__representation-chip" style={chipStyle}>
             <MoorhenStack align="center" direction="row" justify="center" gap="0.2rem">
                 <div style={{ flexGrow: 1, textAlign: "left", textOverflow: "ellipsis", overflow: "hidden", whiteSpace: "nowrap" }}>
-                    <b>{`${representationLabelMapping[representation.style]}`}</b>
+                    <b>{`${representationLabelMapping[representation.style]}${monomersWarning}`}</b>
                     <br />
                     <MoorhenTooltip tooltip={<>{selectionName}</>}>
                         <div style={{ flexGrow: 1, textAlign: "left", textOverflow: "ellipsis", overflow: "hidden", whiteSpace: "nowrap" }}>

--- a/baby-gru/src/components/menu-item/ImportLigandDictionary.tsx
+++ b/baby-gru/src/components/menu-item/ImportLigandDictionary.tsx
@@ -88,7 +88,7 @@ const ImportLigandDictionary = (props: {
                 );
             }
 
-            if (createRef.current) {
+            if (createRef.current&&createInstance) {
                 const instanceName = tlc;
                 const result = (await commandCentre.cootCommand(
                     {
@@ -124,7 +124,7 @@ const ImportLigandDictionary = (props: {
 
             [...new Set(molNosToUpdate)].map(molNo => dispatch(triggerUpdate(molNo)));
         },
-        [moleculeSelectValueRef, createRef, molecules, commandCentre, tlc, backgroundColor, defaultBondSmoothness, addToMoleculeValueRef]
+        [moleculeSelectValueRef, createRef, molecules, commandCentre, tlc, backgroundColor, defaultBondSmoothness, addToMoleculeValueRef, createInstance]
     );
 
     const popoverContent = (

--- a/baby-gru/src/utils/MoorhenMolecule.ts
+++ b/baby-gru/src/utils/MoorhenMolecule.ts
@@ -2102,6 +2102,7 @@ export class MoorhenMolecule {
             const reassembledCif = unindentedLines.join("\n");
             this.ligandDicts[comp_id] = reassembledCif;
         }
+        this.moorhenInstance.triggerMoleculeChanged(this.uniqueId)
     }
 
     /**

--- a/baby-gru/src/utils/Representation/MoorhenMoleculeRepresentation.ts
+++ b/baby-gru/src/utils/Representation/MoorhenMoleculeRepresentation.ts
@@ -843,20 +843,20 @@ export class MoleculeRepresentation {
             );
         }
 
-        const unknownMonomersStatus = await this.commandCentre.cootCommand(
-            {
-                returnType: "string_array",
-                command: "get_residue_names_with_no_dictionary",
-                commandArgs: [this.parentMolecule.molNo ],
-            },
-            false
-        );
-        const unknownMonomers = unknownMonomersStatus.data.result.result
-
-        if(unknownMonomers.length>0){
-            this.parentMolecule.store.dispatch(enqueueSnackbar({ message: `Show monomers have no dictionary description. Some atoms/bonds may be drawn oddly.`, variant: "info" }));
+        if(_style!=="hover"){
+            const unknownMonomersStatus = await this.commandCentre.cootCommand(
+                {
+                    returnType: "string_array",
+                    command: "get_residue_names_with_no_dictionary",
+                    commandArgs: [this.parentMolecule.molNo ],
+                },
+                false
+            );
+            const unknownMonomers = unknownMonomersStatus.data.result.result
+            if(unknownMonomers.length>0){
+                this.parentMolecule.store.dispatch(enqueueSnackbar({ message: `Show monomers (${unknownMonomers.join(",")}) have no dictionary description. Some atoms/bonds may be drawn oddly.`, variant: "warning" }));
+            }
         }
-
 
         return objects;
     }

--- a/baby-gru/src/utils/Representation/MoorhenMoleculeRepresentation.ts
+++ b/baby-gru/src/utils/Representation/MoorhenMoleculeRepresentation.ts
@@ -1,6 +1,7 @@
 import { batch } from "react-redux";
 import { appendOtherData, buildBuffers } from "../../WebGLgComponents/buildBuffers";
 import { setDisplayBuffers, setLabelBuffers, setRequestDrawScene } from "../../store/glRefSlice";
+import { enqueueSnackbar  } from '@/store';
 import { gemmi } from "../../types/gemmi";
 import { libcootApi } from "../../types/libcoot";
 import { webGL } from "../../types/mgWebGL";
@@ -841,6 +842,21 @@ export class MoleculeRepresentation {
                 false
             );
         }
+
+        const unknownMonomersStatus = await this.commandCentre.cootCommand(
+            {
+                returnType: "string_array",
+                command: "get_residue_names_with_no_dictionary",
+                commandArgs: [this.parentMolecule.molNo ],
+            },
+            false
+        );
+        const unknownMonomers = unknownMonomersStatus.data.result.result
+
+        if(unknownMonomers.length>0){
+            this.parentMolecule.store.dispatch(enqueueSnackbar({ message: `Show monomers have no dictionary description. Some atoms/bonds may be drawn oddly.`, variant: "info" }));
+        }
+
 
         return objects;
     }


### PR DESCRIPTION
* Displays a warning toast when a molecule is loaded that does not have dictionary descriptions for all monomers.
* Display a warning in all the Representation chips of the molecule until the dictionary is loaded.
* Fix the "Create instance on read" checkbox in "Import dictionary".