### PR TITLE
Do not show UOY/MRC/CCP4 banner when not York hosted.

### DIFF
--- a/baby-gru/src/components/webMG/Moorhen2DOverlay.tsx
+++ b/baby-gru/src/components/webMG/Moorhen2DOverlay.tsx
@@ -646,8 +646,7 @@ export const Moorhen2DOverlay = ((props) => {
 
     const store = useStore<RootState>()
 
-    //const [ isLegalVisible, setIsLegalVisible ] = useState(window.location.hostname==="moorhen.hosted.york.ac.uk" ? true : false)
-    const [ isLegalVisible, setIsLegalVisible ] = useState(window.location.hostname==="moorhen.hosted.york.ac.uk" ? true : true)
+    const [ isLegalVisible, setIsLegalVisible ] = useState(window.location.hostname==="moorhen.hosted.york.ac.uk" ? true : false)
     const [ legalOffset, setLegalOffset ] = useState<number>(50)
 
     const width = useSelector((state: moorhen.State) => state.sceneSettings.GlViewportWidth)


### PR DESCRIPTION
Fixes a problem that was accidentally introduced during debugging.